### PR TITLE
Add status property to units and applications

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -105,7 +105,7 @@ class TestModel(unittest.TestCase):
             self.model.get_relation('db2')
 
     def test_relation_data(self):
-        random_unit = self.model._cache.get(juju.model.Unit, 'randomunit/0', False, self.model._backend)
+        random_unit = self.model._cache.get(juju.model.CacheKey(juju.model.Unit, 'randomunit/0'), 'randomunit/0', False, self.model._backend, self.model._cache)
         with self.assertRaises(KeyError):
             self.model.get_relation('db1').data[random_unit]
         remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0', self.model.get_relation('db1').units))

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -217,6 +217,32 @@ class TestModel(unittest.TestCase):
         remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0', self.model.get_relation('db1').units))
         self.assertIsInstance(remoteapp1_0.status, juju.model.Unknown)
 
+        test_statuses = (
+            juju.model.Status('active', 'deadbeefcafe'),
+            juju.model.Unknown(),
+            juju.model.Active('Ready'),
+            juju.model.Maintenance('Upgrading software'),
+            juju.model.Blocked('Awaiting manual resolution'),
+            juju.model.Waiting('Awaiting related app updates'),
+        )
+
+        for target_status in test_statuses:
+            with self.assertRaises(RuntimeError):
+                remoteapp1_0.status = target_status
+
     def test_remote_app_status(self):
         remoteapp1 = next(filter(lambda u: u.name == 'remoteapp1', self.model.get_relation('db1').apps))
         self.assertIsInstance(remoteapp1.status, juju.model.Unknown)
+
+        test_statuses = (
+            juju.model.Status('active', 'deadbeefcafe'),
+            juju.model.Unknown(),
+            juju.model.Active('Ready'),
+            juju.model.Maintenance('Upgrading software'),
+            juju.model.Blocked('Awaiting manual resolution'),
+            juju.model.Waiting('Awaiting related app updates'),
+        )
+
+        for target_status in test_statuses:
+            with self.assertRaises(RuntimeError):
+                remoteapp1.status = target_status


### PR DESCRIPTION
In order to allow status assignment for units and applications a status
descriptor is used.

Status for remote units and applications is set to unknown. While it is
possible to retrieve remote unit status via goal-state (but not
remote application status), this change does not aim to address this
case.