### PR TITLE
Refactor entry point handling

### DIFF
--- a/op/framework.py
+++ b/op/framework.py
@@ -4,6 +4,7 @@ import marshal
 import types
 import sqlite3
 import collections
+import collections.abc
 import keyword
 
 
@@ -671,7 +672,7 @@ def _unwrap_stored(parent_data, value):
     return value
 
 
-class StoredDict(collections.MutableMapping):
+class StoredDict(collections.abc.MutableMapping):
 
     def __init__(self, stored_data, under):
         self._stored_data = stored_data
@@ -701,7 +702,7 @@ class StoredDict(collections.MutableMapping):
             return NotImplemented
 
 
-class StoredList(collections.MutableSequence):
+class StoredList(collections.abc.MutableSequence):
 
     def __init__(self, stored_data, under):
         self._stored_data = stored_data
@@ -766,7 +767,7 @@ class StoredList(collections.MutableSequence):
             return NotImplemented
 
 
-class StoredSet(collections.MutableSet):
+class StoredSet(collections.abc.MutableSet):
 
     def __init__(self, stored_data, under):
         self._stored_data = stored_data

--- a/test/charms/test_main/hooks/install
+++ b/test/charms/test_main/hooks/install
@@ -1,1 +1,1 @@
-../lib/op/main.py
+../lib/charm.py

--- a/test/charms/test_main/lib/charm.py
+++ b/test/charms/test_main/lib/charm.py
@@ -5,6 +5,7 @@ import base64
 import pickle
 
 from op.charm import CharmBase
+from op.main import main
 
 import logging
 
@@ -94,3 +95,7 @@ class Charm(CharmBase):
         self._state['observed_event_types'].append(type(event))
         self._state['ha_relation_broken_data'] = event.snapshot()
         self._write_state()
+
+
+if __name__ == '__main__':
+    main(Charm)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -45,7 +45,7 @@ class SymlinkTargetError(Exception):
 
 class TestMain(unittest.TestCase):
 
-    MAIN_PY_RELPATH = '../lib/op/main.py'
+    CHARM_PY_RELPATH = '../lib/charm.py'
 
     @classmethod
     def _clear_unit_db(cls):
@@ -84,8 +84,8 @@ class TestMain(unittest.TestCase):
         for f in files:
             absolute_path = Path(r) / f
             if absolute_path.name == 'install' and absolute_path.is_symlink():
-                if os.readlink(absolute_path) != cls.MAIN_PY_RELPATH:
-                    raise SymlinkTargetError(f'"{absolute_path.name}" link does not point to {cls.MAIN_PY_RELPATH}')
+                if os.readlink(absolute_path) != cls.CHARM_PY_RELPATH:
+                    raise SymlinkTargetError(f'"{absolute_path.name}" link does not point to {cls.CHARM_PY_RELPATH}')
             elif absolute_path.name.endswith('-storage-attached') and absolute_path.is_symlink():
                 if os.readlink(absolute_path) != 'install':
                     raise SymlinkTargetError(f'"{absolute_path.name}" link does not point to "install"')
@@ -216,7 +216,7 @@ class TestMain(unittest.TestCase):
         # The symlink is expected to be present in the source tree.
         self.assertTrue(install_link_path.exists())
         # It has to point to main.py in the lib directory of the charm.
-        self.assertEqual(os.readlink(install_link_path), self.MAIN_PY_RELPATH)
+        self.assertEqual(os.readlink(install_link_path), self.CHARM_PY_RELPATH)
 
         def _assess_setup_hooks(event_name):
             event_hook = JUJU_CHARM_DIR / f'hooks/{event_name}'
@@ -236,7 +236,7 @@ class TestMain(unittest.TestCase):
                 self.assertTrue(os.path.exists(event_hook))
                 self.assertEqual(os.readlink(event_hook), 'install')
                 self.assertEqual(os.readlink('hooks/install'),
-                                 self.MAIN_PY_RELPATH)
+                                 self.CHARM_PY_RELPATH)
 
         # Assess 'install' first because upgrade-charm or other
         # events cannot be handled before install creates symlinks for them.

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -9,7 +9,7 @@ import op.model
 # through the actual subprocess calls. Either this class could implement these functions as executables
 # that were called via subprocess, or more simple tests that just test through ModelBackend while leaving
 # these tests alone, depending on what proves easier.
-class TestModelBackend:
+class FakeModelBackend:
     def __init__(self):
         self.relation_set_calls = []
 
@@ -64,7 +64,7 @@ class TestModelBackend:
 
 class TestModel(unittest.TestCase):
     def setUp(self):
-        self.backend = TestModelBackend()
+        self.backend = FakeModelBackend()
         self.model = op.model.Model('myapp/0', ['db0', 'db1', 'db2'], self.backend)
 
     def test_model(self):


### PR DESCRIPTION
By making the user code the target of the symlinks and relying on them to call into the framework (and explicitly passing in the charm class), we can eliminate the need to do path manipulation or require specific file and class names. It also frees us up to package the framework as a proper Python package and use standard dependency management tools.

This also includes fixing a few warnings that were picked up when I happened to use [`pytest`](https://docs.pytest.org/) rather than the plain `unittest` runner.

With this change, the hooks will instead point to the file containing the charm class, which would look like this:

```python
from op.charm import CharmBase
from op.main import main


class MyCharm(CharmBase):
    # ...


if __name__ == '__main__':
    main(MyCharm)
```