### PR TITLE
ModelCache: Separate out a cache key and init args

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -91,7 +91,7 @@ class TestModel(unittest.TestCase):
             self.model.get_relation('db2')
 
     def test_relation_data(self):
-        random_unit = self.model._cache.get(op.model.Unit, 'randomunit/0')
+        random_unit = self.model._cache.get(op.model.CacheKey(op.model.Unit, 'randomunit/0'), 'randomunit/0', self.model._cache)
         with self.assertRaises(KeyError):
             self.model.get_relation('db1').data[random_unit]
         remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0', self.model.get_relation('db1').units))


### PR DESCRIPTION
Currently args to the get method of ModelCache are used both for lookup
in the cache and for passing arguments to `__init__`. This change
introduces a separate type called CacheKey in order to make it clear
which arguments will be used for lookup versus the ones that will be
passed into `__init__`.