### PR TITLE
Use addCleanup instead of tearDown.

### DIFF
--- a/op/framework.py
+++ b/op/framework.py
@@ -165,7 +165,7 @@ class HandleKind:
     """Helper descriptor to define the Object.handle_kind field.
 
     The handle_kind for an object defaults to its type name, but it may
-    be explicitly overriden if desired.
+    be explicitly overridden if desired.
     """
 
     def __get__(self, obj, obj_type):

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -22,6 +22,7 @@ class TestCharm(unittest.TestCase):
         os.environ['JUJU_UNIT_NAME'] = 'local/0'
 
         self.tmpdir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmpdir)
         self.meta = CharmMeta()
 
         class CustomEvent(EventBase):
@@ -34,13 +35,11 @@ class TestCharm(unittest.TestCase):
         # We use a subclass temporarily to prevent these side effects from leaking.
         CharmBase.on = TestCharmEvents()
 
-    def tearDown(self):
-        shutil.rmtree(self.tmpdir)
-        os.environ['PATH'] = self._path
-
-        del os.environ['JUJU_UNIT_NAME']
-
-        CharmBase.on = CharmEvents()
+        def cleanup():
+            os.environ['PATH'] = self._path
+            del os.environ['JUJU_UNIT_NAME']
+            CharmBase.on = CharmEvents()
+        self.addCleanup(cleanup)
 
     def create_framework(self):
         model = Model('local/0', list(self.meta.relations), ModelBackend())

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -14,9 +14,7 @@ class TestFramework(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = Path(tempfile.mkdtemp())
-
-    def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.addCleanup(shutil.rmtree, self.tmpdir)
 
     def create_framework(self):
         framework = Framework(self.tmpdir / "framework.data", self.tmpdir, None, None)
@@ -501,9 +499,7 @@ class TestStoredState(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = Path(tempfile.mkdtemp())
-
-    def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        self.addCleanup(shutil.rmtree, self.tmpdir)
 
     def create_framework(self):
         framework = Framework(self.tmpdir / "framework.data", self.tmpdir, None, None)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -63,6 +63,7 @@ class TestMain(unittest.TestCase):
         os.chdir(JUJU_CHARM_DIR)
         _, tmp_file = tempfile.mkstemp()
         self._state_file = Path(tmp_file)
+        self.addCleanup(self._state_file.unlink)
 
         # Relations events are defined dynamically and modify the class attributes.
         # We use a subclass temporarily to prevent these side effects from leaking.
@@ -70,13 +71,11 @@ class TestMain(unittest.TestCase):
             pass
         CharmBase.on = TestCharmEvents()
 
-    def tearDown(self):
-        self._clear_unit_db()
-        self._clear_symlinks()
-
-        self._state_file.unlink()
-
-        CharmBase.on = CharmEvents()
+        def cleanup():
+            self._clear_unit_db()
+            self._clear_symlinks()
+            CharmBase.on = CharmEvents()
+        self.addCleanup(cleanup)
 
     @classmethod
     def _clear_symlinks(cls):


### PR DESCRIPTION
Using addCleanup makes sure the cleanups happen in the right order (LIFO).
If you mix addCleanup with tearDown they don't happen in predictable ordering.
(tearDown happens before addCleanup triggers).