### PR TITLE
Run python-black over the source tree.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+/sandbox

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ python:
 
 install:
     - sudo apt update
-    - sudo apt install flake8
+    - pip3 install black
     - pip3 install pyyaml
 
 script:
     - python3 -m unittest
-    - flake8
+    - black --diff --check .

--- a/op/charm.py
+++ b/op/charm.py
@@ -8,29 +8,38 @@ class HookEvent(EventBase):
 class InstallEvent(HookEvent):
     pass
 
+
 class StartEvent(HookEvent):
     pass
+
 
 class StopEvent(HookEvent):
     pass
 
+
 class ConfigChangedEvent(HookEvent):
     pass
+
 
 class UpdateStatusEvent(HookEvent):
     pass
 
+
 class UpgradeCharmEvent(HookEvent):
     pass
+
 
 class PreSeriesUpgradeEvent(HookEvent):
     pass
 
+
 class PostSeriesUpgradeEvent(HookEvent):
     pass
 
+
 class LeaderElectedEvent(HookEvent):
     pass
+
 
 class LeaderSettingsChangedEvent(HookEvent):
     pass
@@ -43,12 +52,15 @@ class RelationEvent(HookEvent):
 
     def snapshot(self):
         return {
-            'relation_name': self.relation.name,
-            'relation_id': self.relation.id,
+            "relation_name": self.relation.name,
+            "relation_id": self.relation.id,
         }
 
     def restore(self, snapshot):
-        self.relation = self.framework.model.get_relation(snapshot['relation_name'], snapshot['relation_id'])
+        self.relation = self.framework.model.get_relation(
+            snapshot["relation_name"], snapshot["relation_id"]
+        )
+
 
 class RelationUnitEvent(RelationEvent):
     def __init__(self, handle, relation, unit):
@@ -57,21 +69,25 @@ class RelationUnitEvent(RelationEvent):
 
     def snapshot(self):
         snapshot = super().snapshot()
-        snapshot['unit_name'] = self.unit.name
+        snapshot["unit_name"] = self.unit.name
         return snapshot
 
     def restore(self, snapshot):
         super().restore(snapshot)
-        self.unit = self.framework.model.get_unit(snapshot['unit_name'])
+        self.unit = self.framework.model.get_unit(snapshot["unit_name"])
+
 
 class RelationJoinedEvent(RelationUnitEvent):
     pass
 
+
 class RelationChangedEvent(RelationUnitEvent):
     pass
 
+
 class RelationDepartedEvent(RelationUnitEvent):
     pass
+
 
 class RelationBrokenEvent(RelationEvent):
     pass
@@ -80,8 +96,10 @@ class RelationBrokenEvent(RelationEvent):
 class StorageEvent(HookEvent):
     pass
 
+
 class StorageAttachedEvent(StorageEvent):
     pass
+
 
 class StorageDetachingEvent(StorageEvent):
     pass
@@ -109,16 +127,28 @@ class CharmBase(Object):
         super().__init__(framework, key)
 
         for relation_name in self.framework.meta.relations:
-            relation_name = relation_name.replace('-', '_')
-            self.on.define_event(f'{relation_name}_relation_joined', RelationJoinedEvent)
-            self.on.define_event(f'{relation_name}_relation_changed', RelationChangedEvent)
-            self.on.define_event(f'{relation_name}_relation_departed', RelationDepartedEvent)
-            self.on.define_event(f'{relation_name}_relation_broken', RelationBrokenEvent)
+            relation_name = relation_name.replace("-", "_")
+            self.on.define_event(
+                f"{relation_name}_relation_joined", RelationJoinedEvent
+            )
+            self.on.define_event(
+                f"{relation_name}_relation_changed", RelationChangedEvent
+            )
+            self.on.define_event(
+                f"{relation_name}_relation_departed", RelationDepartedEvent
+            )
+            self.on.define_event(
+                f"{relation_name}_relation_broken", RelationBrokenEvent
+            )
 
         for storage_name in self.framework.meta.storage:
-            storage_name = storage_name.replace('-', '_')
-            self.on.define_event(f'{storage_name}_storage_attached', StorageAttachedEvent)
-            self.on.define_event(f'{storage_name}_storage_detaching', StorageDetachingEvent)
+            storage_name = storage_name.replace("-", "_")
+            self.on.define_event(
+                f"{storage_name}_storage_attached", StorageAttachedEvent
+            )
+            self.on.define_event(
+                f"{storage_name}_storage_detaching", StorageDetachingEvent
+            )
 
 
 class CharmMeta:
@@ -133,80 +163,100 @@ class CharmMeta:
     requires, provides, and peers RelationMeta items.  If needed, the role of
     the relation definition can be obtained from its role attribute.
     """
+
     def __init__(self, raw=None):
         raw = raw or {}
-        self.name = raw.get('name', '')
-        self.summary = raw.get('summary', '')
-        self.description = raw.get('description', '')
+        self.name = raw.get("name", "")
+        self.summary = raw.get("summary", "")
+        self.description = raw.get("description", "")
         self.maintainers = []
-        if 'maintainer' in raw:
-            self.maintainers.append(raw['maintainer'])
-        if 'maintainers' in raw:
-            self.maintainers.extend(raw['maintainers'])
-        self.tags = raw.get('tags', [])
-        self.terms = raw.get('terms', [])
-        self.series = raw.get('series', [])
-        self.subordinate = raw.get('subordinate', False)
-        self.min_juju_version = raw.get('min-juju-version')
-        self.requires = {name: RelationMeta('requires', name, rel)
-                         for name, rel in raw.get('requires', {}).items()}
-        self.provides = {name: RelationMeta('provides', name, rel)
-                         for name, rel in raw.get('provides', {}).items()}
-        self.peers = {name: RelationMeta('peers', name, rel)
-                      for name, rel in raw.get('peers', {}).items()}
+        if "maintainer" in raw:
+            self.maintainers.append(raw["maintainer"])
+        if "maintainers" in raw:
+            self.maintainers.extend(raw["maintainers"])
+        self.tags = raw.get("tags", [])
+        self.terms = raw.get("terms", [])
+        self.series = raw.get("series", [])
+        self.subordinate = raw.get("subordinate", False)
+        self.min_juju_version = raw.get("min-juju-version")
+        self.requires = {
+            name: RelationMeta("requires", name, rel)
+            for name, rel in raw.get("requires", {}).items()
+        }
+        self.provides = {
+            name: RelationMeta("provides", name, rel)
+            for name, rel in raw.get("provides", {}).items()
+        }
+        self.peers = {
+            name: RelationMeta("peers", name, rel)
+            for name, rel in raw.get("peers", {}).items()
+        }
         self.relations = {}
         self.relations.update(self.requires)
         self.relations.update(self.provides)
         self.relations.update(self.peers)
-        self.storage = {name: StorageMeta(name, store)
-                        for name, store in raw.get('storage', {}).items()}
-        self.resources = {name: ResourceMeta(name, res)
-                          for name, res in raw.get('resources', {}).items()}
-        self.payloads = {name: PayloadMeta(name, payload)
-                         for name, payload in raw.get('payloads', {}).items()}
-        self.extra_bindings = raw.get('extra-bindings', [])
+        self.storage = {
+            name: StorageMeta(name, store)
+            for name, store in raw.get("storage", {}).items()
+        }
+        self.resources = {
+            name: ResourceMeta(name, res)
+            for name, res in raw.get("resources", {}).items()
+        }
+        self.payloads = {
+            name: PayloadMeta(name, payload)
+            for name, payload in raw.get("payloads", {}).items()
+        }
+        self.extra_bindings = raw.get("extra-bindings", [])
 
 
 class RelationMeta:
     """Object containing metadata about a relation definition."""
+
     def __init__(self, role, relation_name, raw):
         self.role = role
         self.relation_name = relation_name
-        self.interface_name = raw['interface']
-        self.scope = raw.get('scope')
+        self.interface_name = raw["interface"]
+        self.scope = raw.get("scope")
 
 
 class StorageMeta:
     """Object containing metadata about a storage definition."""
+
     def __init__(self, name, raw):
         self.storage_name = name
-        self.type = raw['type']
-        self.description = raw.get('description', '')
-        self.shared = raw.get('shared', False)
-        self.read_only = raw.get('read-only', False)
-        self.minimum_size = raw.get('minimum-size')
-        self.location = raw.get('location')
+        self.type = raw["type"]
+        self.description = raw.get("description", "")
+        self.shared = raw.get("shared", False)
+        self.read_only = raw.get("read-only", False)
+        self.minimum_size = raw.get("minimum-size")
+        self.location = raw.get("location")
         self.multiple_range = None
-        if 'multiple' in raw:
-            range = raw['multiple']['range']
-            if '-' not in range:
+        if "multiple" in raw:
+            range = raw["multiple"]["range"]
+            if "-" not in range:
                 self.multiple_range = (int(range), int(range))
             else:
-                range = range.split('-')
-                self.multiple_range = (int(range[0]), int(range[1]) if range[1] else None)
+                range = range.split("-")
+                self.multiple_range = (
+                    int(range[0]),
+                    int(range[1]) if range[1] else None,
+                )
 
 
 class ResourceMeta:
     """Object containing metadata about a resource definition."""
+
     def __init__(self, name, raw):
         self.resource_name = name
-        self.type = raw['type']
-        self.filename = raw['filename']
-        self.description = raw.get('description', '')
+        self.type = raw["type"]
+        self.filename = raw["filename"]
+        self.description = raw.get("description", "")
 
 
 class PayloadMeta:
     """Object containing metadata about a payload definition."""
+
     def __init__(self, name, raw):
         self.payload_name = name
-        self.type = raw['type']
+        self.type = raw["type"]

--- a/op/charm.py
+++ b/op/charm.py
@@ -57,9 +57,7 @@ class RelationEvent(HookEvent):
         }
 
     def restore(self, snapshot):
-        self.relation = self.framework.model.get_relation(
-            snapshot["relation_name"], snapshot["relation_id"]
-        )
+        self.relation = self.framework.model.get_relation(snapshot["relation_name"], snapshot["relation_id"])
 
 
 class RelationUnitEvent(RelationEvent):
@@ -128,27 +126,15 @@ class CharmBase(Object):
 
         for relation_name in self.framework.meta.relations:
             relation_name = relation_name.replace("-", "_")
-            self.on.define_event(
-                f"{relation_name}_relation_joined", RelationJoinedEvent
-            )
-            self.on.define_event(
-                f"{relation_name}_relation_changed", RelationChangedEvent
-            )
-            self.on.define_event(
-                f"{relation_name}_relation_departed", RelationDepartedEvent
-            )
-            self.on.define_event(
-                f"{relation_name}_relation_broken", RelationBrokenEvent
-            )
+            self.on.define_event(f"{relation_name}_relation_joined", RelationJoinedEvent)
+            self.on.define_event(f"{relation_name}_relation_changed", RelationChangedEvent)
+            self.on.define_event(f"{relation_name}_relation_departed", RelationDepartedEvent)
+            self.on.define_event(f"{relation_name}_relation_broken", RelationBrokenEvent)
 
         for storage_name in self.framework.meta.storage:
             storage_name = storage_name.replace("-", "_")
-            self.on.define_event(
-                f"{storage_name}_storage_attached", StorageAttachedEvent
-            )
-            self.on.define_event(
-                f"{storage_name}_storage_detaching", StorageDetachingEvent
-            )
+            self.on.define_event(f"{storage_name}_storage_attached", StorageAttachedEvent)
+            self.on.define_event(f"{storage_name}_storage_detaching", StorageDetachingEvent)
 
 
 class CharmMeta:
@@ -179,34 +165,16 @@ class CharmMeta:
         self.series = raw.get("series", [])
         self.subordinate = raw.get("subordinate", False)
         self.min_juju_version = raw.get("min-juju-version")
-        self.requires = {
-            name: RelationMeta("requires", name, rel)
-            for name, rel in raw.get("requires", {}).items()
-        }
-        self.provides = {
-            name: RelationMeta("provides", name, rel)
-            for name, rel in raw.get("provides", {}).items()
-        }
-        self.peers = {
-            name: RelationMeta("peers", name, rel)
-            for name, rel in raw.get("peers", {}).items()
-        }
+        self.requires = {name: RelationMeta("requires", name, rel) for name, rel in raw.get("requires", {}).items()}
+        self.provides = {name: RelationMeta("provides", name, rel) for name, rel in raw.get("provides", {}).items()}
+        self.peers = {name: RelationMeta("peers", name, rel) for name, rel in raw.get("peers", {}).items()}
         self.relations = {}
         self.relations.update(self.requires)
         self.relations.update(self.provides)
         self.relations.update(self.peers)
-        self.storage = {
-            name: StorageMeta(name, store)
-            for name, store in raw.get("storage", {}).items()
-        }
-        self.resources = {
-            name: ResourceMeta(name, res)
-            for name, res in raw.get("resources", {}).items()
-        }
-        self.payloads = {
-            name: PayloadMeta(name, payload)
-            for name, payload in raw.get("payloads", {}).items()
-        }
+        self.storage = {name: StorageMeta(name, store) for name, store in raw.get("storage", {}).items()}
+        self.resources = {name: ResourceMeta(name, res) for name, res in raw.get("resources", {}).items()}
+        self.payloads = {name: PayloadMeta(name, payload) for name, payload in raw.get("payloads", {}).items()}
         self.extra_bindings = raw.get("extra-bindings", [])
 
 

--- a/op/main.py
+++ b/op/main.py
@@ -49,26 +49,18 @@ def _handle_event_link(charm_dir, bound_event):
         # Non-symlink entries and the ones not pointing to "install"
         # need to be removed.
         if not event_hook_path.is_symlink():
-            debugf(
-                f"Hook entry at {event_hook_path} is not a symlink:"
-                " attempting to remove it."
-            )
+            debugf(f"Hook entry at {event_hook_path} is not a symlink:" " attempting to remove it.")
             # May raise IsADirectoryError, e.g. in case it is a directory which
             # is unexpected and left to the developer or operator to handle.
             event_hook_path.unlink()
         elif os.readlink(event_hook_path) != "install":
-            debugf(
-                f"Removing entry {event_hook_path} as it does not point" ' to "install"'
-            )
+            debugf(f"Removing entry {event_hook_path} as it does not point" ' to "install"')
             event_hook_path.unlink()
         else:
             create_link = False
 
     if create_link:
-        debugf(
-            f"Creating a new relative symlink at {event_hook_path}"
-            f' to pointing to "install" located in {charm_dir}/hooks'
-        )
+        debugf(f"Creating a new relative symlink at {event_hook_path}" f' to pointing to "install" located in {charm_dir}/hooks')
         event_hook_path.symlink_to("install")
 
 
@@ -168,9 +160,7 @@ def main():
         # When a charm is force-upgraded and a unit is in an error state Juju does not run upgrade-charm and
         # instead runs the failed hook followed by config-changed. Given the nature of force-upgrading
         # the hook setup code is not triggered on config-changed.
-        if juju_event_name in ("install", "upgrade-charm") or juju_event_name.endswith(
-            "-storage-attached"
-        ):
+        if juju_event_name in ("install", "upgrade-charm") or juju_event_name.endswith("-storage-attached"):
             _setup_hooks(charm_dir, charm)
 
         framework.reemit()

--- a/op/model.py
+++ b/op/model.py
@@ -12,9 +12,7 @@ class Model:
         self._backend = backend
         self.unit = self.get_unit(local_unit_name)
         self.app = self.unit.app
-        self.relations = RelationMapping(
-            relation_names, self.unit, self._backend, self._cache
-        )
+        self.relations = RelationMapping(relation_names, self.unit, self._backend, self._cache)
         self.config = ConfigData(self._backend)
 
     def get_relation(self, relation_name, relation_id=None):
@@ -28,17 +26,13 @@ class Model:
         """
         if relation_id is not None:
             if not isinstance(relation_id, int):
-                raise ModelError(
-                    f"relation id {relation_id} must be an int not {type(relation_id).__name__}"
-                )
+                raise ModelError(f"relation id {relation_id} must be an int not {type(relation_id).__name__}")
             for relation in self.relations[relation_name]:
                 if relation.id == relation_id:
                     return relation
             else:
                 # The relation may be dead, but it is not forgotten.
-                return Relation(
-                    relation_name, relation_id, self.unit, self._backend, self._cache
-                )
+                return Relation(relation_name, relation_id, self.unit, self._backend, self._cache)
         else:
             num_related = len(self.relations[relation_name])
             if num_related == 0:
@@ -147,15 +141,7 @@ class RelationMapping(Mapping):
         if relation_list is None:
             relation_list = self._data[relation_name] = []
             for relation_id in self._backend.relation_ids(relation_name):
-                relation_list.append(
-                    Relation(
-                        relation_name,
-                        relation_id,
-                        self._local_unit,
-                        self._backend,
-                        self._cache,
-                    )
-                )
+                relation_list.append(Relation(relation_name, relation_id, self._local_unit, self._backend, self._cache,))
         return relation_list
 
 
@@ -183,15 +169,8 @@ class Relation:
 class RelationData(Mapping):
     def __init__(self, relation, local_unit, backend):
         self.relation = weakref.proxy(relation)
-        self._data = {
-            local_unit: RelationUnitData(self.relation, local_unit, True, backend)
-        }
-        self._data.update(
-            {
-                unit: RelationUnitData(self.relation, unit, False, backend)
-                for unit in self.relation.units
-            }
-        )
+        self._data = {local_unit: RelationUnitData(self.relation, local_unit, True, backend)}
+        self._data.update({unit: RelationUnitData(self.relation, unit, False, backend) for unit in self.relation.units})
 
     def __contains__(self, key):
         return key in self._data
@@ -257,9 +236,7 @@ class ModelError(Exception):
 
 class TooManyRelatedApps(ModelError):
     def __init__(self, relation_name, num_related, max_supported):
-        super().__init__(
-            f"Too many remote applications on {relation_name} ({num_related} > {max_supported})"
-        )
+        super().__init__(f"Too many remote applications on {relation_name} ({num_related} > {max_supported})")
         self.relation_name = relation_name
         self.num_related = num_related
         self.max_supported = max_supported
@@ -317,9 +294,7 @@ class ModelBackend:
 
     def relation_set(self, relation_id, key, value):
         try:
-            return self._run_no_output(
-                "relation-set", "-r", str(relation_id), f"{key}={value}"
-            )
+            return self._run_no_output("relation-set", "-r", str(relation_id), f"{key}={value}")
         except CalledProcessError as e:
             if b"relation not found" in e.stderr:
                 raise RelationNotFound() from e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+
+[tool.black]
+target-version = ['py36', 'py37']
+line-length = 160
+exclude = '''
+(
+  sandbox
+)
+'''

--- a/test/charms/test_main/lib/charm.py
+++ b/test/charms/test_main/lib/charm.py
@@ -12,30 +12,29 @@ logger = logging.getLogger()
 
 
 class Charm(CharmBase):
-
     def __init__(self, *args):
         super().__init__(*args)
 
         # This environment variable controls the test charm behavior.
-        charm_config = os.environ.get('CHARM_CONFIG')
+        charm_config = os.environ.get("CHARM_CONFIG")
         if charm_config is not None:
             self._charm_config = pickle.loads(base64.b64decode(charm_config))
         else:
             self._charm_config = {}
 
-        self._state_file = self._charm_config.get('STATE_FILE')
+        self._state_file = self._charm_config.get("STATE_FILE")
         self._state = {}
 
-        self._state['on_install'] = []
-        self._state['on_config_changed'] = []
-        self._state['on_update_status'] = []
-        self._state['on_leader_settings_changed'] = []
-        self._state['on_db_relation_joined'] = []
-        self._state['on_mon_relation_changed'] = []
-        self._state['on_ha_relation_broken'] = []
+        self._state["on_install"] = []
+        self._state["on_config_changed"] = []
+        self._state["on_update_status"] = []
+        self._state["on_leader_settings_changed"] = []
+        self._state["on_db_relation_joined"] = []
+        self._state["on_mon_relation_changed"] = []
+        self._state["on_ha_relation_broken"] = []
 
         # Observed event types per invocation. A list is used to preserve the order in which charm handlers have observed the events.
-        self._state['observed_event_types'] = []
+        self._state["observed_event_types"] = []
 
         self.framework.observe(self.on.install, self)
         self.framework.observe(self.on.config_changed, self)
@@ -53,44 +52,44 @@ class Charm(CharmBase):
         Each invocation will override the previous state which is intentional.
         """
         if self._state_file is not None:
-            with open(self._state_file, 'wb') as f:
+            with open(self._state_file, "wb") as f:
                 pickle.dump(self._state, f)
 
     def on_install(self, event):
-        self._state['on_install'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
+        self._state["on_install"].append(type(event))
+        self._state["observed_event_types"].append(type(event))
         self._write_state()
 
     def on_config_changed(self, event):
-        self._state['on_config_changed'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
+        self._state["on_config_changed"].append(type(event))
+        self._state["observed_event_types"].append(type(event))
         event.defer()
         self._write_state()
 
     def on_update_status(self, event):
-        self._state['on_update_status'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
+        self._state["on_update_status"].append(type(event))
+        self._state["observed_event_types"].append(type(event))
         self._write_state()
 
     def on_leader_settings_changed(self, event):
-        self._state['on_leader_settings_changed'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
+        self._state["on_leader_settings_changed"].append(type(event))
+        self._state["observed_event_types"].append(type(event))
         self._write_state()
 
     def on_db_relation_joined(self, event):
-        self._state['on_db_relation_joined'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
-        self._state['db_relation_joined_data'] = event.snapshot()
+        self._state["on_db_relation_joined"].append(type(event))
+        self._state["observed_event_types"].append(type(event))
+        self._state["db_relation_joined_data"] = event.snapshot()
         self._write_state()
 
     def on_mon_relation_changed(self, event):
-        self._state['on_mon_relation_changed'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
-        self._state['mon_relation_changed_data'] = event.snapshot()
+        self._state["on_mon_relation_changed"].append(type(event))
+        self._state["observed_event_types"].append(type(event))
+        self._state["mon_relation_changed_data"] = event.snapshot()
         self._write_state()
 
     def on_ha_relation_broken(self, event):
-        self._state['on_ha_relation_broken'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
-        self._state['ha_relation_broken_data'] = event.snapshot()
+        self._state["on_ha_relation_broken"].append(type(event))
+        self._state["observed_event_types"].append(type(event))
+        self._state["ha_relation_broken_data"] = event.snapshot()
         self._write_state()

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -43,9 +43,7 @@ class TestCharm(unittest.TestCase):
 
     def create_framework(self):
         model = Model("local/0", list(self.meta.relations), ModelBackend())
-        framework = Framework(
-            self.tmpdir / "framework.data", self.tmpdir, self.meta, model
-        )
+        framework = Framework(self.tmpdir / "framework.data", self.tmpdir, self.meta, model)
         self.addCleanup(framework.close)
         return framework
 
@@ -77,18 +75,10 @@ class TestCharm(unittest.TestCase):
                 self.seen = []
                 for rel in ("req1", "req-2", "pro1", "pro-2", "peer1", "peer-2"):
                     # Hook up relation events to generic handler.
-                    self.framework.observe(
-                        self.on[rel].relation_joined, self.on_any_relation
-                    )
-                    self.framework.observe(
-                        self.on[rel].relation_changed, self.on_any_relation
-                    )
-                    self.framework.observe(
-                        self.on[rel].relation_departed, self.on_any_relation
-                    )
-                    self.framework.observe(
-                        self.on[rel].relation_broken, self.on_any_relation
-                    )
+                    self.framework.observe(self.on[rel].relation_joined, self.on_any_relation)
+                    self.framework.observe(self.on[rel].relation_changed, self.on_any_relation)
+                    self.framework.observe(self.on[rel].relation_departed, self.on_any_relation)
+                    self.framework.observe(self.on[rel].relation_broken, self.on_any_relation)
 
             def on_any_relation(self, event):
                 assert event.relation.name == "req1"
@@ -98,18 +88,9 @@ class TestCharm(unittest.TestCase):
         self.meta = CharmMeta(
             {
                 "name": "my-charm",
-                "requires": {
-                    "req1": {"interface": "req1"},
-                    "req-2": {"interface": "req2"},
-                },
-                "provides": {
-                    "pro1": {"interface": "pro1"},
-                    "pro-2": {"interface": "pro2"},
-                },
-                "peers": {
-                    "peer1": {"interface": "peer1"},
-                    "peer-2": {"interface": "peer2"},
-                },
+                "requires": {"req1": {"interface": "req1"}, "req-2": {"interface": "req2"},},
+                "provides": {"pro1": {"interface": "pro1"}, "pro-2": {"interface": "pro2"},},
+                "peers": {"peer1": {"interface": "peer1"}, "peer-2": {"interface": "peer2"},},
             }
         )
 
@@ -185,13 +166,7 @@ class TestCharm(unittest.TestCase):
         charm.on["stor-4"].storage_attached.emit()
 
         self.assertEqual(
-            charm.seen,
-            [
-                "StorageAttachedEvent",
-                "StorageDetachingEvent",
-                "StorageAttachedEvent",
-                "StorageAttachedEvent",
-            ],
+            charm.seen, ["StorageAttachedEvent", "StorageDetachingEvent", "StorageAttachedEvent", "StorageAttachedEvent",],
         )
 
 

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -14,12 +14,11 @@ from op.model import Model, ModelBackend
 
 
 class TestCharm(unittest.TestCase):
-
     def setUp(self):
-        self._path = os.environ['PATH']
-        os.environ['PATH'] = str(Path(__file__).parent / 'bin')
+        self._path = os.environ["PATH"]
+        os.environ["PATH"] = str(Path(__file__).parent / "bin")
 
-        os.environ['JUJU_UNIT_NAME'] = 'local/0'
+        os.environ["JUJU_UNIT_NAME"] = "local/0"
 
         self.tmpdir = Path(tempfile.mkdtemp())
         self.meta = CharmMeta()
@@ -36,22 +35,22 @@ class TestCharm(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
-        os.environ['PATH'] = self._path
+        os.environ["PATH"] = self._path
 
-        del os.environ['JUJU_UNIT_NAME']
+        del os.environ["JUJU_UNIT_NAME"]
 
         CharmBase.on = CharmEvents()
 
     def create_framework(self):
-        model = Model('local/0', list(self.meta.relations), ModelBackend())
-        framework = Framework(self.tmpdir / "framework.data", self.tmpdir, self.meta, model)
+        model = Model("local/0", list(self.meta.relations), ModelBackend())
+        framework = Framework(
+            self.tmpdir / "framework.data", self.tmpdir, self.meta, model
+        )
         self.addCleanup(framework.close)
         return framework
 
     def test_basic(self):
-
         class MyCharm(CharmBase):
-
             def __init__(self, *args):
                 super().__init__(*args)
 
@@ -62,8 +61,8 @@ class TestCharm(unittest.TestCase):
                 self.started = True
 
         events = list(MyCharm.on.events())
-        self.assertIn('install', events)
-        self.assertIn('custom', events)
+        self.assertIn("install", events)
+        self.assertIn("custom", events)
 
         framework = self.create_framework()
         charm = MyCharm(framework, None)
@@ -72,127 +71,128 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(charm.started, True)
 
     def test_relation_events(self):
-
         class MyCharm(CharmBase):
             def __init__(self, *args):
                 super().__init__(*args)
                 self.seen = []
-                for rel in ('req1', 'req-2', 'pro1', 'pro-2', 'peer1', 'peer-2'):
+                for rel in ("req1", "req-2", "pro1", "pro-2", "peer1", "peer-2"):
                     # Hook up relation events to generic handler.
-                    self.framework.observe(self.on[rel].relation_joined, self.on_any_relation)
-                    self.framework.observe(self.on[rel].relation_changed, self.on_any_relation)
-                    self.framework.observe(self.on[rel].relation_departed, self.on_any_relation)
-                    self.framework.observe(self.on[rel].relation_broken, self.on_any_relation)
+                    self.framework.observe(
+                        self.on[rel].relation_joined, self.on_any_relation
+                    )
+                    self.framework.observe(
+                        self.on[rel].relation_changed, self.on_any_relation
+                    )
+                    self.framework.observe(
+                        self.on[rel].relation_departed, self.on_any_relation
+                    )
+                    self.framework.observe(
+                        self.on[rel].relation_broken, self.on_any_relation
+                    )
 
             def on_any_relation(self, event):
-                assert event.relation.name == 'req1'
-                assert event.relation.app.name == 'remote'
+                assert event.relation.name == "req1"
+                assert event.relation.app.name == "remote"
                 self.seen.append(type(event).__name__)
 
-        self.meta = CharmMeta({
-            'name': 'my-charm',
-            'requires': {
-                'req1': {'interface': 'req1'},
-                'req-2': {'interface': 'req2'},
-            },
-            'provides': {
-                'pro1': {'interface': 'pro1'},
-                'pro-2': {'interface': 'pro2'},
-            },
-            'peers': {
-                'peer1': {'interface': 'peer1'},
-                'peer-2': {'interface': 'peer2'},
-            },
-        })
+        self.meta = CharmMeta(
+            {
+                "name": "my-charm",
+                "requires": {
+                    "req1": {"interface": "req1"},
+                    "req-2": {"interface": "req2"},
+                },
+                "provides": {
+                    "pro1": {"interface": "pro1"},
+                    "pro-2": {"interface": "pro2"},
+                },
+                "peers": {
+                    "peer1": {"interface": "peer1"},
+                    "peer-2": {"interface": "peer2"},
+                },
+            }
+        )
 
         charm = MyCharm(self.create_framework(), None)
 
-        rel = charm.framework.model.get_relation('req1', 1)
-        unit = charm.framework.model.get_unit('remote/0')
-        charm.on['req1'].relation_joined.emit(rel, unit)
-        charm.on['req1'].relation_changed.emit(rel, unit)
-        charm.on['req-2'].relation_changed.emit(rel, unit)
-        charm.on['pro1'].relation_departed.emit(rel, unit)
-        charm.on['pro-2'].relation_departed.emit(rel, unit)
-        charm.on['peer1'].relation_broken.emit(rel)
-        charm.on['peer-2'].relation_broken.emit(rel)
+        rel = charm.framework.model.get_relation("req1", 1)
+        unit = charm.framework.model.get_unit("remote/0")
+        charm.on["req1"].relation_joined.emit(rel, unit)
+        charm.on["req1"].relation_changed.emit(rel, unit)
+        charm.on["req-2"].relation_changed.emit(rel, unit)
+        charm.on["pro1"].relation_departed.emit(rel, unit)
+        charm.on["pro-2"].relation_departed.emit(rel, unit)
+        charm.on["peer1"].relation_broken.emit(rel)
+        charm.on["peer-2"].relation_broken.emit(rel)
 
-        self.assertEqual(charm.seen, [
-            'RelationJoinedEvent',
-            'RelationChangedEvent',
-            'RelationChangedEvent',
-            'RelationDepartedEvent',
-            'RelationDepartedEvent',
-            'RelationBrokenEvent',
-            'RelationBrokenEvent',
-        ])
+        self.assertEqual(
+            charm.seen,
+            [
+                "RelationJoinedEvent",
+                "RelationChangedEvent",
+                "RelationChangedEvent",
+                "RelationDepartedEvent",
+                "RelationDepartedEvent",
+                "RelationBrokenEvent",
+                "RelationBrokenEvent",
+            ],
+        )
 
     def test_storage_events(self):
-
         class MyCharm(CharmBase):
             def __init__(self, *args):
                 super().__init__(*args)
                 self.seen = []
-                self.framework.observe(self.on['stor1'].storage_attached, self)
-                self.framework.observe(self.on['stor2'].storage_detaching, self)
-                self.framework.observe(self.on['stor3'].storage_attached, self)
-                self.framework.observe(self.on['stor-4'].storage_attached, self)
+                self.framework.observe(self.on["stor1"].storage_attached, self)
+                self.framework.observe(self.on["stor2"].storage_detaching, self)
+                self.framework.observe(self.on["stor3"].storage_attached, self)
+                self.framework.observe(self.on["stor-4"].storage_attached, self)
 
             def on_stor1_storage_attached(self, event):
-                self.seen.append(f'{type(event).__name__}')
+                self.seen.append(f"{type(event).__name__}")
 
             def on_stor2_storage_detaching(self, event):
-                self.seen.append(f'{type(event).__name__}')
+                self.seen.append(f"{type(event).__name__}")
 
             def on_stor3_storage_attached(self, event):
-                self.seen.append(f'{type(event).__name__}')
+                self.seen.append(f"{type(event).__name__}")
 
             def on_stor_4_storage_attached(self, event):
-                self.seen.append(f'{type(event).__name__}')
+                self.seen.append(f"{type(event).__name__}")
 
-        self.meta = CharmMeta({
-            'name': 'my-charm',
-            'storage': {
-                'stor1': {'type': 'filesystem'},
-                'stor2': {
-                    'type': 'filesystem',
-                    'multiple': {
-                        'range': '2',
-                    },
+        self.meta = CharmMeta(
+            {
+                "name": "my-charm",
+                "storage": {
+                    "stor1": {"type": "filesystem"},
+                    "stor2": {"type": "filesystem", "multiple": {"range": "2",},},
+                    "stor3": {"type": "filesystem", "multiple": {"range": "2-",},},
+                    "stor-4": {"type": "filesystem", "multiple": {"range": "2-4",},},
                 },
-                'stor3': {
-                    'type': 'filesystem',
-                    'multiple': {
-                        'range': '2-',
-                    },
-                },
-                'stor-4': {
-                    'type': 'filesystem',
-                    'multiple': {
-                        'range': '2-4',
-                    },
-                },
-            },
-        })
+            }
+        )
 
-        self.assertIsNone(self.meta.storage['stor1'].multiple_range)
-        self.assertEqual(self.meta.storage['stor2'].multiple_range, (2, 2))
-        self.assertEqual(self.meta.storage['stor3'].multiple_range, (2, None))
-        self.assertEqual(self.meta.storage['stor-4'].multiple_range, (2, 4))
+        self.assertIsNone(self.meta.storage["stor1"].multiple_range)
+        self.assertEqual(self.meta.storage["stor2"].multiple_range, (2, 2))
+        self.assertEqual(self.meta.storage["stor3"].multiple_range, (2, None))
+        self.assertEqual(self.meta.storage["stor-4"].multiple_range, (2, 4))
 
         charm = MyCharm(self.create_framework(), None)
 
-        charm.on['stor1'].storage_attached.emit()
-        charm.on['stor2'].storage_detaching.emit()
-        charm.on['stor3'].storage_attached.emit()
-        charm.on['stor-4'].storage_attached.emit()
+        charm.on["stor1"].storage_attached.emit()
+        charm.on["stor2"].storage_detaching.emit()
+        charm.on["stor3"].storage_attached.emit()
+        charm.on["stor-4"].storage_attached.emit()
 
-        self.assertEqual(charm.seen, [
-            'StorageAttachedEvent',
-            'StorageDetachingEvent',
-            'StorageAttachedEvent',
-            'StorageAttachedEvent',
-        ])
+        self.assertEqual(
+            charm.seen,
+            [
+                "StorageAttachedEvent",
+                "StorageDetachingEvent",
+                "StorageAttachedEvent",
+                "StorageAttachedEvent",
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -56,9 +56,7 @@ class TestFramework(unittest.TestCase):
             framework.load_snapshot(handle)
         except NoSnapshotError as e:
             self.assertEqual(e.handle_path, str(handle))
-            self.assertEqual(
-                str(e), "no snapshot data found for a_foo[some_key] object"
-            )
+            self.assertEqual(str(e), "no snapshot data found for a_foo[some_key] object")
         else:
             self.fail("exception NoSnapshotError not raised")
 
@@ -134,8 +132,7 @@ class TestFramework(unittest.TestCase):
             framework.observe(pub.baz, obs)
         except RuntimeError as e:
             self.assertEqual(
-                str(e),
-                'Observer method not provided explicitly and MyObserver type has no "on_baz" method',
+                str(e), 'Observer method not provided explicitly and MyObserver type has no "on_baz" method',
             )
         else:
             self.fail("RuntimeError not raised")
@@ -347,8 +344,7 @@ class TestFramework(unittest.TestCase):
                 foo = event
 
         self.assertEqual(
-            str(cm.exception.__cause__),
-            "Event(MyEvent) reused as MyEvents.foo and OtherEvents.foo",
+            str(cm.exception.__cause__), "Event(MyEvent) reused as MyEvents.foo and OtherEvents.foo",
         )
 
         with self.assertRaises(RuntimeError) as cm:
@@ -358,8 +354,7 @@ class TestFramework(unittest.TestCase):
                 bar = event
 
         self.assertEqual(
-            str(cm.exception.__cause__),
-            "Event(MyEvent) reused as MyEvents.foo and MyNotifier.bar",
+            str(cm.exception.__cause__), "Event(MyEvent) reused as MyEvents.foo and MyNotifier.bar",
         )
 
     def test_reemit_ignores_unknown_event_type(self):
@@ -584,8 +579,7 @@ class TestStoredState(unittest.TestCase):
             obj.state.foo = CustomObject()
         except AttributeError as e:
             self.assertEqual(
-                str(e),
-                "attribute 'foo' cannot be set to CustomObject: must be int/dict/list/etc",
+                str(e), "attribute 'foo' cannot be set to CustomObject: must be int/dict/list/etc",
             )
         else:
             self.fail("AttributeError not raised")
@@ -600,24 +594,10 @@ class TestStoredState(unittest.TestCase):
                 None,  # Operand B.
                 {},  # Expected result.
                 lambda a, b: None,  # Operation to perform.
-                lambda res, expected_res: self.assertEqual(
-                    res, expected_res
-                ),  # Validation to perform.
+                lambda res, expected_res: self.assertEqual(res, expected_res),  # Validation to perform.
             ),
-            (
-                {},
-                {"a": {}},
-                {"a": {}},
-                lambda a, b: a.update(b),
-                lambda res, expected_res: self.assertEqual(res, expected_res),
-            ),
-            (
-                {"a": {}},
-                {"b": "c"},
-                {"a": {"b": "c"}},
-                lambda a, b: a["a"].update(b),
-                lambda res, expected_res: self.assertEqual(res, expected_res),
-            ),
+            ({}, {"a": {}}, {"a": {}}, lambda a, b: a.update(b), lambda res, expected_res: self.assertEqual(res, expected_res),),
+            ({"a": {}}, {"b": "c"}, {"a": {"b": "c"}}, lambda a, b: a["a"].update(b), lambda res, expected_res: self.assertEqual(res, expected_res),),
             (
                 {"a": {"b": "c"}},
                 {"d": "e"},
@@ -625,89 +605,29 @@ class TestStoredState(unittest.TestCase):
                 lambda a, b: a["a"].update(b),
                 lambda res, expected_res: self.assertEqual(res, expected_res),
             ),
-            (
-                {"a": {"b": "c", "d": "e"}},
-                "d",
-                {"a": {"b": "c"}},
-                lambda a, b: a["a"].pop(b),
-                lambda res, expected_res: self.assertEqual(res, expected_res),
-            ),
-            (
-                [],
-                None,
-                [],
-                lambda a, b: None,
-                lambda res, expected_res: self.assertEqual(res, expected_res),
-            ),
-            (
-                [],
-                "a",
-                ["a"],
-                lambda a, b: a.append(b),
-                lambda res, expected_res: self.assertEqual(res, expected_res),
-            ),
+            ({"a": {"b": "c", "d": "e"}}, "d", {"a": {"b": "c"}}, lambda a, b: a["a"].pop(b), lambda res, expected_res: self.assertEqual(res, expected_res),),
+            ([], None, [], lambda a, b: None, lambda res, expected_res: self.assertEqual(res, expected_res),),
+            ([], "a", ["a"], lambda a, b: a.append(b), lambda res, expected_res: self.assertEqual(res, expected_res),),
             (
                 ["a"],
                 ["c"],
                 ["a", ["c"]],
                 lambda a, b: a.append(b),
-                lambda res, expected_res: (
-                    self.assertEqual(res, expected_res),
-                    self.assertIsInstance(res[1], StoredList),
-                ),
+                lambda res, expected_res: (self.assertEqual(res, expected_res), self.assertIsInstance(res[1], StoredList),),
             ),
-            (
-                ["a", ["c"]],
-                "b",
-                ["b", "a", ["c"]],
-                lambda a, b: a.insert(0, b),
-                lambda res, expected_res: self.assertEqual(res, expected_res),
-            ),
+            (["a", ["c"]], "b", ["b", "a", ["c"]], lambda a, b: a.insert(0, b), lambda res, expected_res: self.assertEqual(res, expected_res),),
             (
                 ["b", "a", ["c"]],
                 ["d"],
                 ["b", ["d"], "a", ["c"]],
                 lambda a, b: a.insert(1, b),
-                lambda res, expected_res: (
-                    self.assertEqual(res, expected_res),
-                    self.assertIsInstance(res[1], StoredList),
-                ),
+                lambda res, expected_res: (self.assertEqual(res, expected_res), self.assertIsInstance(res[1], StoredList),),
             ),
-            (
-                ["b", ["d"], "a", ["c"]],
-                0,
-                [["d"], "a", ["c"]],
-                lambda a, b: a.pop(b),
-                lambda res, expected_res: self.assertEqual(res, expected_res),
-            ),
-            (
-                [["d"], "a", ["c"]],
-                ["d"],
-                ["a", ["c"]],
-                lambda a, b: a.remove(b),
-                lambda res, expected_res: self.assertEqual(res, expected_res),
-            ),
-            (
-                set(),
-                None,
-                set(),
-                lambda a, b: None,
-                lambda res, expected_res: self.assertEqual(res, expected_res),
-            ),
-            (
-                set(),
-                "a",
-                set(["a"]),
-                lambda a, b: a.add(b),
-                lambda res, expected_res: self.assertEqual(res, expected_res),
-            ),
-            (
-                set(["a"]),
-                "a",
-                set(),
-                lambda a, b: a.discard(b),
-                lambda res, expected_res: self.assertEqual(res, expected_res),
-            ),
+            (["b", ["d"], "a", ["c"]], 0, [["d"], "a", ["c"]], lambda a, b: a.pop(b), lambda res, expected_res: self.assertEqual(res, expected_res),),
+            ([["d"], "a", ["c"]], ["d"], ["a", ["c"]], lambda a, b: a.remove(b), lambda res, expected_res: self.assertEqual(res, expected_res),),
+            (set(), None, set(), lambda a, b: None, lambda res, expected_res: self.assertEqual(res, expected_res),),
+            (set(), "a", set(["a"]), lambda a, b: a.add(b), lambda res, expected_res: self.assertEqual(res, expected_res),),
+            (set(["a"]), "a", set(), lambda a, b: a.discard(b), lambda res, expected_res: self.assertEqual(res, expected_res),),
             (
                 set(),
                 {"a"},
@@ -785,16 +705,8 @@ class TestStoredState(unittest.TestCase):
             (
                 {"1"},  # A set to test an operation against (other_set).
                 lambda a, b: a | b,  # An operation to test.
-                {
-                    "1",
-                    "a",
-                    "b",
-                },  # The expected result of operation(obj.state.set, other_set).
-                {
-                    "1",
-                    "a",
-                    "b",
-                },  # The expected result of operation(other_set, obj.state.set).
+                {"1", "a", "b",},  # The expected result of operation(obj.state.set, other_set).
+                {"1", "a", "b",},  # The expected result of operation(other_set, obj.state.set).
             ),
             ({"a", "c"}, lambda a, b: a - b, {"b"}, {"c"}),
             ({"a", "c"}, lambda a, b: a & b, {"a"}, {"a"}),

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -29,9 +29,11 @@ from op.charm import (
 
 # This relies on the expected repository structure to find
 # a path to the charm under test.
-JUJU_CHARM_DIR = Path(f'{__file__}/../charms/test_main').resolve()
+JUJU_CHARM_DIR = Path(f"{__file__}/../charms/test_main").resolve()
 
-charm_spec = importlib.util.spec_from_file_location("charm", str(JUJU_CHARM_DIR / 'lib/charm.py'))
+charm_spec = importlib.util.spec_from_file_location(
+    "charm", str(JUJU_CHARM_DIR / "lib/charm.py")
+)
 charm = importlib.util.module_from_spec(charm_spec)
 charm_spec.loader.exec_module(charm)
 
@@ -45,7 +47,7 @@ class SymlinkTargetError(Exception):
 
 class TestMain(unittest.TestCase):
 
-    MAIN_PY_RELPATH = '../lib/op/main.py'
+    MAIN_PY_RELPATH = "../lib/op/main.py"
 
     @classmethod
     def _clear_unit_db(cls):
@@ -68,6 +70,7 @@ class TestMain(unittest.TestCase):
         # We use a subclass temporarily to prevent these side effects from leaking.
         class TestCharmEvents(CharmEvents):
             pass
+
         CharmBase.on = TestCharmEvents()
 
     def tearDown(self):
@@ -80,22 +83,29 @@ class TestMain(unittest.TestCase):
 
     @classmethod
     def _clear_symlinks(cls):
-        r, _, files = next(os.walk(JUJU_CHARM_DIR / 'hooks'))
+        r, _, files = next(os.walk(JUJU_CHARM_DIR / "hooks"))
         for f in files:
             absolute_path = Path(r) / f
-            if absolute_path.name == 'install' and absolute_path.is_symlink():
+            if absolute_path.name == "install" and absolute_path.is_symlink():
                 if os.readlink(absolute_path) != cls.MAIN_PY_RELPATH:
-                    raise SymlinkTargetError(f'"{absolute_path.name}" link does not point to {cls.MAIN_PY_RELPATH}')
-            elif absolute_path.name.endswith('-storage-attached') and absolute_path.is_symlink():
-                if os.readlink(absolute_path) != 'install':
-                    raise SymlinkTargetError(f'"{absolute_path.name}" link does not point to "install"')
+                    raise SymlinkTargetError(
+                        f'"{absolute_path.name}" link does not point to {cls.MAIN_PY_RELPATH}'
+                    )
+            elif (
+                absolute_path.name.endswith("-storage-attached")
+                and absolute_path.is_symlink()
+            ):
+                if os.readlink(absolute_path) != "install":
+                    raise SymlinkTargetError(
+                        f'"{absolute_path.name}" link does not point to "install"'
+                    )
             else:
                 absolute_path.unlink()
 
     def _read_and_clear_state(self):
         state = None
         if self._state_file.stat().st_size:
-            with open(self._state_file, 'r+b') as state_file:
+            with open(self._state_file, "r+b") as state_file:
                 state = pickle.load(state_file)
                 state_file.truncate()
         return state
@@ -103,22 +113,21 @@ class TestMain(unittest.TestCase):
     def _simulate_event(self, event_name, charm_config):
         event_hook = JUJU_CHARM_DIR / f"hooks/{event_name.replace('_', '-')}"
         env = {
-            'PATH': str(Path(__file__).parent / 'bin'),
-            'JUJU_CHARM_DIR': JUJU_CHARM_DIR,
-            'JUJU_UNIT_NAME': 'test_main/0',
-            'CHARM_CONFIG': charm_config,
+            "PATH": str(Path(__file__).parent / "bin"),
+            "JUJU_CHARM_DIR": JUJU_CHARM_DIR,
+            "JUJU_UNIT_NAME": "test_main/0",
+            "CHARM_CONFIG": charm_config,
         }
-        if 'relation' in event_name:
-            rel_name = event_name.split('_')[0]
-            rel_id = {'db': '1', 'mon': '2', 'ha': '3'}[rel_name]
-            env.update({
-                'JUJU_RELATION': rel_name,
-                'JUJU_RELATION_ID': rel_id,
-            })
-            if 'broken' not in event_name:
-                env.update({
-                    'JUJU_REMOTE_UNIT': 'remote/0',
-                })
+        if "relation" in event_name:
+            rel_name = event_name.split("_")[0]
+            rel_id = {"db": "1", "mon": "2", "ha": "3"}[rel_name]
+            env.update(
+                {"JUJU_RELATION": rel_name, "JUJU_RELATION_ID": rel_id,}
+            )
+            if "broken" not in event_name:
+                env.update(
+                    {"JUJU_REMOTE_UNIT": "remote/0",}
+                )
         # Note that sys.executable is used to make sure we are using the same
         # interpreter for the child process to support virtual environments.
         subprocess.check_call([sys.executable, event_hook], env=env)
@@ -126,92 +135,102 @@ class TestMain(unittest.TestCase):
 
     def test_event_reemitted(self):
         # base64 encoding is used to avoid null bytes.
-        charm_config = base64.b64encode(pickle.dumps({
-            'STATE_FILE': self._state_file,
-        }))
+        charm_config = base64.b64encode(pickle.dumps({"STATE_FILE": self._state_file,}))
 
         # First run "install" to make sure all hooks are set up.
-        state = self._simulate_event('install', charm_config)
-        self.assertEqual(state['observed_event_types'], [InstallEvent])
+        state = self._simulate_event("install", charm_config)
+        self.assertEqual(state["observed_event_types"], [InstallEvent])
 
-        state = self._simulate_event('config-changed', charm_config)
-        self.assertEqual(state['observed_event_types'], [ConfigChangedEvent])
+        state = self._simulate_event("config-changed", charm_config)
+        self.assertEqual(state["observed_event_types"], [ConfigChangedEvent])
 
         # Re-emit should pick the deferred config-changed.
-        state = self._simulate_event('update-status', charm_config)
-        self.assertEqual(state['observed_event_types'], [ConfigChangedEvent, UpdateStatusEvent])
+        state = self._simulate_event("update-status", charm_config)
+        self.assertEqual(
+            state["observed_event_types"], [ConfigChangedEvent, UpdateStatusEvent]
+        )
 
     def test_multiple_events_handled(self):
 
         # Sample events with a different amount of dashes used
         # and with endpoints from different sections of metadata.yaml
         events_under_test = {
-            'install': InstallEvent,
-            'update_status': UpdateStatusEvent,
-            'leader_settings_changed': LeaderSettingsChangedEvent,
-            'db_relation_joined': RelationJoinedEvent,
-            'mon_relation_changed': RelationChangedEvent,
-            'ha_relation_broken': RelationBrokenEvent,
+            "install": InstallEvent,
+            "update_status": UpdateStatusEvent,
+            "leader_settings_changed": LeaderSettingsChangedEvent,
+            "db_relation_joined": RelationJoinedEvent,
+            "mon_relation_changed": RelationChangedEvent,
+            "ha_relation_broken": RelationBrokenEvent,
         }
 
         expected_event_data = {
-            'db_relation_joined': {'relation_name': 'db', 'relation_id': 1, 'unit_name': 'remote/0'},
-            'mon_relation_changed': {'relation_name': 'mon', 'relation_id': 2, 'unit_name': 'remote/0'},
-            'ha_relation_broken': {'relation_name': 'ha', 'relation_id': 3},
+            "db_relation_joined": {
+                "relation_name": "db",
+                "relation_id": 1,
+                "unit_name": "remote/0",
+            },
+            "mon_relation_changed": {
+                "relation_name": "mon",
+                "relation_id": 2,
+                "unit_name": "remote/0",
+            },
+            "ha_relation_broken": {"relation_name": "ha", "relation_id": 3},
         }
 
-        logger.debug(f'Expected events {events_under_test}')
+        logger.debug(f"Expected events {events_under_test}")
 
-        charm_config = base64.b64encode(pickle.dumps({
-            'STATE_FILE': self._state_file,
-        }))
+        charm_config = base64.b64encode(pickle.dumps({"STATE_FILE": self._state_file,}))
 
         # First run "install" to make sure all hooks are set up.
-        self._simulate_event('install', charm_config)
+        self._simulate_event("install", charm_config)
 
         # Simulate hook executions for every event.
         for event_kind, event in events_under_test.items():
             state = self._simulate_event(event_kind, charm_config)
 
-            handled_events = state.get(f'on_{event_kind}', [])
+            handled_events = state.get(f"on_{event_kind}", [])
             # Make sure that a handler for that event was called once.
             self.assertEqual(len(handled_events), 1)
             # Make sure the event handled by the Charm has the right type.
             handled_event_type = handled_events[0]
             self.assertEqual(handled_event_type, event)
 
-            self.assertEqual(state['observed_event_types'], [event])
+            self.assertEqual(state["observed_event_types"], [event])
 
             if event_kind in expected_event_data:
-                self.assertEqual(state[f'{event_kind}_data'], expected_event_data[event_kind])
+                self.assertEqual(
+                    state[f"{event_kind}_data"], expected_event_data[event_kind]
+                )
 
     def test_event_not_implemented(self):
         """Make sure events without implementation do not cause non-zero exit.
         """
-        charm_config = base64.b64encode(pickle.dumps({
-            'STATE_FILE': self._state_file,
-        }))
+        charm_config = base64.b64encode(pickle.dumps({"STATE_FILE": self._state_file,}))
 
         # Simulate a scenario where there is a symlink for an event that
         # a charm does not know how to handle.
-        hook_path = JUJU_CHARM_DIR / 'hooks/not-implemented-event'
+        hook_path = JUJU_CHARM_DIR / "hooks/not-implemented-event"
         # This will be cleared up in tearDown.
-        hook_path.symlink_to('install')
+        hook_path.symlink_to("install")
 
         try:
-            self._simulate_event('not-implemented-event', charm_config)
+            self._simulate_event("not-implemented-event", charm_config)
         except subprocess.CalledProcessError:
-            self.fail('Event simulation for an unsupported event'
-                      ' results in a non-zero exit code returned')
+            self.fail(
+                "Event simulation for an unsupported event"
+                " results in a non-zero exit code returned"
+            )
 
     def test_setup_hooks(self):
         """Test auto-creation of symlinks for supported events.
         """
-        event_hooks = [f'hooks/{e.replace("_", "-")}'
-                       for e in charm.Charm.on.events().keys()
-                       if e != 'install']
+        event_hooks = [
+            f'hooks/{e.replace("_", "-")}'
+            for e in charm.Charm.on.events().keys()
+            if e != "install"
+        ]
 
-        install_link_path = JUJU_CHARM_DIR / 'hooks/install'
+        install_link_path = JUJU_CHARM_DIR / "hooks/install"
 
         # The symlink is expected to be present in the source tree.
         self.assertTrue(install_link_path.exists())
@@ -219,29 +238,34 @@ class TestMain(unittest.TestCase):
         self.assertEqual(os.readlink(install_link_path), self.MAIN_PY_RELPATH)
 
         def _assess_setup_hooks(event_name):
-            event_hook = JUJU_CHARM_DIR / f'hooks/{event_name}'
+            event_hook = JUJU_CHARM_DIR / f"hooks/{event_name}"
 
-            charm_config = base64.b64encode(pickle.dumps({
-                'STATE_FILE': self._state_file,
-            }))
+            charm_config = base64.b64encode(
+                pickle.dumps({"STATE_FILE": self._state_file,})
+            )
 
             # Simulate a fork + exec of a hook from a unit agent.
             self._simulate_event(event_name, charm_config)
 
-            r, _, files = next(os.walk(JUJU_CHARM_DIR / 'hooks'))
+            r, _, files = next(os.walk(JUJU_CHARM_DIR / "hooks"))
 
             self.assertTrue(event_name in files)
 
             for event_hook in event_hooks:
                 self.assertTrue(os.path.exists(event_hook))
-                self.assertEqual(os.readlink(event_hook), 'install')
-                self.assertEqual(os.readlink('hooks/install'),
-                                 self.MAIN_PY_RELPATH)
+                self.assertEqual(os.readlink(event_hook), "install")
+                self.assertEqual(os.readlink("hooks/install"), self.MAIN_PY_RELPATH)
 
         # Assess 'install' first because upgrade-charm or other
         # events cannot be handled before install creates symlinks for them.
-        events_to_assess = ['install', 'start', 'config-changed',
-                            'leader-elected', 'upgrade-charm', 'update-status']
+        events_to_assess = [
+            "install",
+            "start",
+            "config-changed",
+            "leader-elected",
+            "upgrade-charm",
+            "update-status",
+        ]
 
         for event_name in events_to_assess:
             _assess_setup_hooks(event_name)
@@ -249,8 +273,15 @@ class TestMain(unittest.TestCase):
         self._clear_symlinks()
 
         # Storage hooks run before "install" so this case needs to be checked as well.
-        events_to_assess = ['disks-storage-attached', 'install', 'start', 'config-changed',
-                            'leader-elected', 'upgrade-charm', 'update-status']
+        events_to_assess = [
+            "disks-storage-attached",
+            "install",
+            "start",
+            "config-changed",
+            "leader-elected",
+            "upgrade-charm",
+            "update-status",
+        ]
 
         for event_name in events_to_assess:
             _assess_setup_hooks(event_name)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -31,9 +31,7 @@ from op.charm import (
 # a path to the charm under test.
 JUJU_CHARM_DIR = Path(f"{__file__}/../charms/test_main").resolve()
 
-charm_spec = importlib.util.spec_from_file_location(
-    "charm", str(JUJU_CHARM_DIR / "lib/charm.py")
-)
+charm_spec = importlib.util.spec_from_file_location("charm", str(JUJU_CHARM_DIR / "lib/charm.py"))
 charm = importlib.util.module_from_spec(charm_spec)
 charm_spec.loader.exec_module(charm)
 
@@ -88,17 +86,10 @@ class TestMain(unittest.TestCase):
             absolute_path = Path(r) / f
             if absolute_path.name == "install" and absolute_path.is_symlink():
                 if os.readlink(absolute_path) != cls.MAIN_PY_RELPATH:
-                    raise SymlinkTargetError(
-                        f'"{absolute_path.name}" link does not point to {cls.MAIN_PY_RELPATH}'
-                    )
-            elif (
-                absolute_path.name.endswith("-storage-attached")
-                and absolute_path.is_symlink()
-            ):
+                    raise SymlinkTargetError(f'"{absolute_path.name}" link does not point to {cls.MAIN_PY_RELPATH}')
+            elif absolute_path.name.endswith("-storage-attached") and absolute_path.is_symlink():
                 if os.readlink(absolute_path) != "install":
-                    raise SymlinkTargetError(
-                        f'"{absolute_path.name}" link does not point to "install"'
-                    )
+                    raise SymlinkTargetError(f'"{absolute_path.name}" link does not point to "install"')
             else:
                 absolute_path.unlink()
 
@@ -146,9 +137,7 @@ class TestMain(unittest.TestCase):
 
         # Re-emit should pick the deferred config-changed.
         state = self._simulate_event("update-status", charm_config)
-        self.assertEqual(
-            state["observed_event_types"], [ConfigChangedEvent, UpdateStatusEvent]
-        )
+        self.assertEqual(state["observed_event_types"], [ConfigChangedEvent, UpdateStatusEvent])
 
     def test_multiple_events_handled(self):
 
@@ -164,16 +153,8 @@ class TestMain(unittest.TestCase):
         }
 
         expected_event_data = {
-            "db_relation_joined": {
-                "relation_name": "db",
-                "relation_id": 1,
-                "unit_name": "remote/0",
-            },
-            "mon_relation_changed": {
-                "relation_name": "mon",
-                "relation_id": 2,
-                "unit_name": "remote/0",
-            },
+            "db_relation_joined": {"relation_name": "db", "relation_id": 1, "unit_name": "remote/0",},
+            "mon_relation_changed": {"relation_name": "mon", "relation_id": 2, "unit_name": "remote/0",},
             "ha_relation_broken": {"relation_name": "ha", "relation_id": 3},
         }
 
@@ -198,9 +179,7 @@ class TestMain(unittest.TestCase):
             self.assertEqual(state["observed_event_types"], [event])
 
             if event_kind in expected_event_data:
-                self.assertEqual(
-                    state[f"{event_kind}_data"], expected_event_data[event_kind]
-                )
+                self.assertEqual(state[f"{event_kind}_data"], expected_event_data[event_kind])
 
     def test_event_not_implemented(self):
         """Make sure events without implementation do not cause non-zero exit.
@@ -216,19 +195,12 @@ class TestMain(unittest.TestCase):
         try:
             self._simulate_event("not-implemented-event", charm_config)
         except subprocess.CalledProcessError:
-            self.fail(
-                "Event simulation for an unsupported event"
-                " results in a non-zero exit code returned"
-            )
+            self.fail("Event simulation for an unsupported event" " results in a non-zero exit code returned")
 
     def test_setup_hooks(self):
         """Test auto-creation of symlinks for supported events.
         """
-        event_hooks = [
-            f'hooks/{e.replace("_", "-")}'
-            for e in charm.Charm.on.events().keys()
-            if e != "install"
-        ]
+        event_hooks = [f'hooks/{e.replace("_", "-")}' for e in charm.Charm.on.events().keys() if e != "install"]
 
         install_link_path = JUJU_CHARM_DIR / "hooks/install"
 
@@ -240,9 +212,7 @@ class TestMain(unittest.TestCase):
         def _assess_setup_hooks(event_name):
             event_hook = JUJU_CHARM_DIR / f"hooks/{event_name}"
 
-            charm_config = base64.b64encode(
-                pickle.dumps({"STATE_FILE": self._state_file,})
-            )
+            charm_config = base64.b64encode(pickle.dumps({"STATE_FILE": self._state_file,}))
 
             # Simulate a fork + exec of a hook from a unit agent.
             self._simulate_event(event_name, charm_config)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -24,27 +24,16 @@ class TestModelBackend:
 
     def relation_list(self, relation_id):
         try:
-            return {4: ["remoteapp1/0"], 5: ["remoteapp1/0"], 6: ["remoteapp2/0"],}[
-                relation_id
-            ]
+            return {4: ["remoteapp1/0"], 5: ["remoteapp1/0"], 6: ["remoteapp2/0"],}[relation_id]
         except KeyError:
             raise op.model.RelationNotFound()
 
     def relation_get(self, relation_id, member_name):
         try:
             return {
-                4: {
-                    "myapp/0": {"host": "myapp-0"},
-                    "remoteapp1/0": {"host": "remoteapp1-0"},
-                },
-                5: {
-                    "myapp/0": {"host": "myapp-0"},
-                    "remoteapp1/0": {"host": "remoteapp1-0"},
-                },
-                6: {
-                    "myapp/0": {"host": "myapp-0"},
-                    "remoteapp2/0": {"host": "remoteapp2-0"},
-                },
+                4: {"myapp/0": {"host": "myapp-0"}, "remoteapp1/0": {"host": "remoteapp1-0"},},
+                5: {"myapp/0": {"host": "myapp-0"}, "remoteapp1/0": {"host": "remoteapp1-0"},},
+                6: {"myapp/0": {"host": "myapp-0"}, "remoteapp2/0": {"host": "remoteapp2-0"},},
             }[relation_id][member_name]
         except KeyError:
             raise op.model.RelationNotFound()
@@ -73,9 +62,7 @@ class TestModel(unittest.TestCase):
     def test_relations_keys(self):
         for relation in self.model.relations["db2"]:
             self.assertIn(self.model.unit, relation.data)
-            unit_from_rel = next(
-                filter(lambda u: u.name == "myapp/0", relation.data.keys())
-            )
+            unit_from_rel = next(filter(lambda u: u.name == "myapp/0", relation.data.keys()))
             self.assertIs(self.model.unit, unit_from_rel)
 
     def test_get_relation(self):
@@ -105,22 +92,12 @@ class TestModel(unittest.TestCase):
         random_unit = self.model._cache.get(op.model.Unit, "randomunit/0")
         with self.assertRaises(KeyError):
             self.model.get_relation("db1").data[random_unit]
-        remoteapp1_0 = next(
-            filter(
-                lambda u: u.name == "remoteapp1/0", self.model.get_relation("db1").units
-            )
-        )
-        self.assertEqual(
-            self.model.get_relation("db1").data[remoteapp1_0], {"host": "remoteapp1-0"}
-        )
+        remoteapp1_0 = next(filter(lambda u: u.name == "remoteapp1/0", self.model.get_relation("db1").units))
+        self.assertEqual(self.model.get_relation("db1").data[remoteapp1_0], {"host": "remoteapp1-0"})
 
     def test_relation_data_modify_remote(self):
         rel_db1 = self.model.get_relation("db1")
-        remoteapp1_0 = next(
-            filter(
-                lambda u: u.name == "remoteapp1/0", self.model.get_relation("db1").units
-            )
-        )
+        remoteapp1_0 = next(filter(lambda u: u.name == "remoteapp1/0", self.model.get_relation("db1").units))
         # Force memory cache to be loaded.
         self.assertIn("host", rel_db1.data[remoteapp1_0])
         with self.assertRaises(op.model.RelationDataError):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -13,26 +13,20 @@ class TestModelBackend:
     def __init__(self):
         self.relation_set_calls = []
 
-        self.local_unit_name = 'myapp/0'
-        self.local_app_name = 'myapp'
+        self.local_unit_name = "myapp/0"
+        self.local_app_name = "myapp"
 
     def local_app_name(self):
-        return 'myapp'
+        return "myapp"
 
     def relation_ids(self, relation_name):
-        return {
-            'db0': [],
-            'db1': [4],
-            'db2': [5, 6],
-        }[relation_name]
+        return {"db0": [], "db1": [4], "db2": [5, 6],}[relation_name]
 
     def relation_list(self, relation_id):
         try:
-            return {
-                4: ['remoteapp1/0'],
-                5: ['remoteapp1/0'],
-                6: ['remoteapp2/0'],
-            }[relation_id]
+            return {4: ["remoteapp1/0"], 5: ["remoteapp1/0"], 6: ["remoteapp2/0"],}[
+                relation_id
+            ]
         except KeyError:
             raise op.model.RelationNotFound()
 
@@ -40,16 +34,16 @@ class TestModelBackend:
         try:
             return {
                 4: {
-                    'myapp/0': {'host': 'myapp-0'},
-                    'remoteapp1/0': {'host': 'remoteapp1-0'},
+                    "myapp/0": {"host": "myapp-0"},
+                    "remoteapp1/0": {"host": "remoteapp1-0"},
                 },
                 5: {
-                    'myapp/0': {'host': 'myapp-0'},
-                    'remoteapp1/0': {'host': 'remoteapp1-0'},
+                    "myapp/0": {"host": "myapp-0"},
+                    "remoteapp1/0": {"host": "remoteapp1-0"},
                 },
                 6: {
-                    'myapp/0': {'host': 'myapp-0'},
-                    'remoteapp2/0': {'host': 'remoteapp2-0'},
+                    "myapp/0": {"host": "myapp-0"},
+                    "remoteapp2/0": {"host": "remoteapp2-0"},
                 },
             }[relation_id][member_name]
         except KeyError:
@@ -62,41 +56,44 @@ class TestModelBackend:
 
     def config_get(self):
         return {
-            'foo': 'foo',
-            'bar': 1,
-            'qux': True,
+            "foo": "foo",
+            "bar": 1,
+            "qux": True,
         }
+
 
 class TestModel(unittest.TestCase):
     def setUp(self):
         self.backend = TestModelBackend()
-        self.model = op.model.Model('myapp/0', ['db0', 'db1', 'db2'], self.backend)
+        self.model = op.model.Model("myapp/0", ["db0", "db1", "db2"], self.backend)
 
     def test_model(self):
         self.assertIs(self.model.app, self.model.unit.app)
 
     def test_relations_keys(self):
-        for relation in self.model.relations['db2']:
+        for relation in self.model.relations["db2"]:
             self.assertIn(self.model.unit, relation.data)
-            unit_from_rel = next(filter(lambda u: u.name == 'myapp/0', relation.data.keys()))
+            unit_from_rel = next(
+                filter(lambda u: u.name == "myapp/0", relation.data.keys())
+            )
             self.assertIs(self.model.unit, unit_from_rel)
 
     def test_get_relation(self):
         with self.assertRaises(op.model.ModelError):
-            self.model.get_relation('db1', 'db1:4')
-        db1_4 = self.model.get_relation('db1', 4)
+            self.model.get_relation("db1", "db1:4")
+        db1_4 = self.model.get_relation("db1", 4)
         self.assertIsInstance(db1_4, op.model.Relation)
-        dead_rel = self.model.get_relation('db1', 7)
+        dead_rel = self.model.get_relation("db1", 7)
         self.assertIsInstance(dead_rel, op.model.Relation)
         self.assertEqual(list(dead_rel.data.keys()), [self.model.unit])
         self.assertEqual(dead_rel.data[self.model.unit], {})
-        self.assertIsNone(self.model.get_relation('db0'))
-        self.assertIs(self.model.get_relation('db1'), db1_4)
+        self.assertIsNone(self.model.get_relation("db0"))
+        self.assertIs(self.model.get_relation("db1"), db1_4)
         with self.assertRaises(op.model.TooManyRelatedApps):
-            self.model.get_relation('db2')
+            self.model.get_relation("db2")
 
     def test_remote_units_is_local(self):
-        for u in self.model.get_relation('db1').units:
+        for u in self.model.get_relation("db1").units:
             self.assertFalse(u.is_local)
             self.assertFalse(u.app.is_local)
 
@@ -105,65 +102,71 @@ class TestModel(unittest.TestCase):
         self.assertTrue(self.model.unit.app.is_local)
 
     def test_relation_data(self):
-        random_unit = self.model._cache.get(op.model.Unit, 'randomunit/0')
+        random_unit = self.model._cache.get(op.model.Unit, "randomunit/0")
         with self.assertRaises(KeyError):
-            self.model.get_relation('db1').data[random_unit]
-        remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0', self.model.get_relation('db1').units))
-        self.assertEqual(self.model.get_relation('db1').data[remoteapp1_0], {'host': 'remoteapp1-0'})
+            self.model.get_relation("db1").data[random_unit]
+        remoteapp1_0 = next(
+            filter(
+                lambda u: u.name == "remoteapp1/0", self.model.get_relation("db1").units
+            )
+        )
+        self.assertEqual(
+            self.model.get_relation("db1").data[remoteapp1_0], {"host": "remoteapp1-0"}
+        )
 
     def test_relation_data_modify_remote(self):
-        rel_db1 = self.model.get_relation('db1')
-        remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0', self.model.get_relation('db1').units))
+        rel_db1 = self.model.get_relation("db1")
+        remoteapp1_0 = next(
+            filter(
+                lambda u: u.name == "remoteapp1/0", self.model.get_relation("db1").units
+            )
+        )
         # Force memory cache to be loaded.
-        self.assertIn('host', rel_db1.data[remoteapp1_0])
+        self.assertIn("host", rel_db1.data[remoteapp1_0])
         with self.assertRaises(op.model.RelationDataError):
-            rel_db1.data[remoteapp1_0]['foo'] = 'bar'
+            rel_db1.data[remoteapp1_0]["foo"] = "bar"
         self.assertEqual(self.backend.relation_set_calls, [])
-        self.assertNotIn('foo', rel_db1.data[remoteapp1_0])
+        self.assertNotIn("foo", rel_db1.data[remoteapp1_0])
 
     def test_relation_data_modify_local(self):
-        rel_db1 = self.model.get_relation('db1')
+        rel_db1 = self.model.get_relation("db1")
         # Force memory cache to be loaded.
-        self.assertIn('host', rel_db1.data[self.model.unit])
-        rel_db1.data[self.model.unit]['host'] = 'bar'
-        self.assertEqual(self.backend.relation_set_calls, [(4, 'host', 'bar')])
-        self.assertEqual(rel_db1.data[self.model.unit]['host'], 'bar')
+        self.assertIn("host", rel_db1.data[self.model.unit])
+        rel_db1.data[self.model.unit]["host"] = "bar"
+        self.assertEqual(self.backend.relation_set_calls, [(4, "host", "bar")])
+        self.assertEqual(rel_db1.data[self.model.unit]["host"], "bar")
 
     def test_relation_data_del_key(self):
-        rel_db1 = self.model.get_relation('db1')
+        rel_db1 = self.model.get_relation("db1")
         # Force memory cache to be loaded.
-        self.assertIn('host', rel_db1.data[self.model.unit])
-        del rel_db1.data[self.model.unit]['host']
-        self.assertEqual(self.backend.relation_set_calls, [(4, 'host', '')])
-        self.assertNotIn('host', rel_db1.data[self.model.unit])
+        self.assertIn("host", rel_db1.data[self.model.unit])
+        del rel_db1.data[self.model.unit]["host"]
+        self.assertEqual(self.backend.relation_set_calls, [(4, "host", "")])
+        self.assertNotIn("host", rel_db1.data[self.model.unit])
 
     def test_relation_set_fail(self):
-        rel_db2 = self.model.relations['db2'][0]
+        rel_db2 = self.model.relations["db2"][0]
         # Force memory cache to be loaded.
-        self.assertIn('host', rel_db2.data[self.model.unit])
+        self.assertIn("host", rel_db2.data[self.model.unit])
         with self.assertRaises(ValueError):
-            rel_db2.data[self.model.unit]['host'] = 'bar'
-        self.assertEqual(rel_db2.data[self.model.unit]['host'], 'myapp-0')
+            rel_db2.data[self.model.unit]["host"] = "bar"
+        self.assertEqual(rel_db2.data[self.model.unit]["host"], "myapp-0")
         with self.assertRaises(ValueError):
-            del rel_db2.data[self.model.unit]['host']
-        self.assertIn('host', rel_db2.data[self.model.unit])
+            del rel_db2.data[self.model.unit]["host"]
+        self.assertIn("host", rel_db2.data[self.model.unit])
 
     def test_relation_data_type_check(self):
-        rel_db1 = self.model.get_relation('db1')
+        rel_db1 = self.model.get_relation("db1")
         with self.assertRaises(op.model.RelationDataError):
-            rel_db1.data[self.model.unit]['foo'] = 1
+            rel_db1.data[self.model.unit]["foo"] = 1
         with self.assertRaises(op.model.RelationDataError):
-            rel_db1.data[self.model.unit]['foo'] = {'foo': 'bar'}
+            rel_db1.data[self.model.unit]["foo"] = {"foo": "bar"}
         with self.assertRaises(op.model.RelationDataError):
-            rel_db1.data[self.model.unit]['foo'] = None
+            rel_db1.data[self.model.unit]["foo"] = None
         self.assertEqual(self.backend.relation_set_calls, [])
 
     def test_config(self):
-        self.assertEqual(self.model.config, {
-            'foo': 'foo',
-            'bar': 1,
-            'qux': True,
-        })
+        self.assertEqual(self.model.config, {"foo": "foo", "bar": 1, "qux": True,})
         with self.assertRaises(TypeError):
             # Confirm that we cannot modify config values.
-            self.model.config['foo'] = 'bar'
+            self.model.config["foo"] = "bar"


### PR DESCRIPTION
Mostly this just wraps long lines and changes '' strings into ""
strings. The big reason to do this is that we can commit to it like
people do for "go fmt". It is the "One True Formatting" that means we
don't have to worry about it, and don't have to end up fixing flake8
warnings. You can configure an editor to automatically run black on your
source file, and that will allow you to not have to worry about
formatting again.

See https://black.readthedocs.io/en/stable/

This is mostly because I wanted to use black, but I didn't want a small
change of mine to get drowned in lots of automatic changes. If we
decide that we don't want black, I can revert this and reconfigure my editor.
