### PR TITLE
Change Framework._observer to be a WeakValueDictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+/sandbox

--- a/op/framework.py
+++ b/op/framework.py
@@ -372,7 +372,7 @@ class Framework(Object):
         self.meta = meta
         self.model = model
         self._event_count = 0
-        self._observers = []      # [(observer, method_name, parent_path, event_key)]
+        self._observers = []      # [(observer_path, method_name, parent_path, event_key)]
         self._observer = weakref.WeakValueDictionary()       # {observer_path: observer}
         self._type_registry = {}  # {(parent_path, kind): cls}
         self._type_known = set()  # {cls}

--- a/op/framework.py
+++ b/op/framework.py
@@ -599,9 +599,6 @@ class BoundStoredState:
         self.__dict__["_data"] = data
         self.__dict__["_attr_name"] = attr_name
 
-        # TODO: Use weak references to make sure observers are garbage collected as a new observer will
-        # be created every time an instance of BoundStoredState is created.
-
         parent.framework.observe(parent.framework.on.commit, self._data)
 
     def __getattr__(self, key):

--- a/op/framework.py
+++ b/op/framework.py
@@ -6,6 +6,7 @@ import sqlite3
 import collections
 import collections.abc
 import keyword
+import weakref
 
 
 class Handle:
@@ -372,7 +373,7 @@ class Framework(Object):
         self.model = model
         self._event_count = 0
         self._observers = []      # [(observer, method_name, parent_path, event_key)]
-        self._observer = {}       # {observer_path: observer}
+        self._observer = weakref.WeakValueDictionary()       # {observer_path: observer}
         self._type_registry = {}  # {(parent_path, kind): cls}
         self._type_known = set()  # {cls}
 
@@ -497,6 +498,7 @@ class Framework(Object):
         event_path = event.handle.path
         event_kind = event.handle.kind
         parent_path = event.handle.parent.path
+        # TODO Track observers by (parent_path, event_kind) rather than as a list of all observers. Avoiding linear search through all observers for every event
         for observer_path, method_name, _parent_path, _event_kind in self._observers:
             if _parent_path != parent_path:
                 continue

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -3,6 +3,7 @@
 import unittest
 import tempfile
 import shutil
+import gc
 
 from pathlib import Path
 
@@ -311,10 +312,10 @@ class TestFramework(unittest.TestCase):
         framework.observe(pub.on.foo, obs)
         pub.on.foo.emit()
         self.assertEqual(observed_events, ["foo"])
-        # Now delete the observer, and note that
-        # when we emit the event, it doesn't update
-        # the local slice again
+        # Now delete the observer, and note that when we emit the event, it
+        # doesn't update the local slice again
         del obs
+        gc.collect()
         pub.on.foo.emit()
         self.assertEqual(observed_events, ["foo"])
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -287,6 +287,37 @@ class TestFramework(unittest.TestCase):
         #
         self.assertEqual(obs.seen, ["on_foo:foo=2", "on_foo:foo=2"])
 
+    def test_weak_observer(self):
+        framework = self.create_framework()
+
+        observed_events = []
+
+        class MyEvent(EventBase):
+            pass
+
+        class MyEvents(EventsBase):
+            foo = Event(MyEvent)
+
+        class MyNotifier(Object):
+            on = MyEvents()
+
+        class MyObserver(Object):
+            def on_foo(self, event):
+                observed_events.append("foo")
+
+        pub = MyNotifier(framework, "1")
+        obs = MyObserver(framework, "2")
+
+        framework.observe(pub.on.foo, obs)
+        pub.on.foo.emit()
+        self.assertEqual(observed_events, ["foo"])
+        # Now delete the observer, and note that
+        # when we emit the event, it doesn't update
+        # the local slice again
+        del obs
+        pub.on.foo.emit()
+        self.assertEqual(observed_events, ["foo"])
+
     def test_events_base(self):
         framework = self.create_framework()
 


### PR DESCRIPTION
This means that setting up an observe() won't keep your object alive
indefinitely. This is safe, because we don't ever iterate the _observer
slice, and we already handled the case where we have a registered
observer_path but no matching observer.