### PR TITLE
Reformat the code using autopep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 install:
     - sudo apt update
-    - sudo apt install flake8 autopep8
+    - sudo apt install flake8 python-autopep8
     - pip3 install pyyaml
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ install:
 
 script:
     - python3 -m unittest
-    - flake8
     - autopep8 -r --aggressive --diff --exit-code .
+    - flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ python:
 
 install:
     - sudo apt update
-    - sudo apt install flake8
+    - sudo apt install flake8 autopep8
     - pip3 install pyyaml
 
 script:
     - python3 -m unittest
     - flake8
+    - autopep8 -r --aggressive --diff --exit-code .

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ python:
 
 install:
     - sudo apt update
-    - sudo apt install flake8 python-autopep8
-    - pip3 install pyyaml
+    - sudo apt install flake8
+    - pip3 install pyyaml autopep8
 
 script:
     - python3 -m unittest

--- a/op/charm.py
+++ b/op/charm.py
@@ -133,6 +133,7 @@ class CharmMeta:
     requires, provides, and peers RelationMeta items.  If needed, the role of
     the relation definition can be obtained from its role attribute.
     """
+
     def __init__(self, raw=None):
         raw = raw or {}
         self.name = raw.get('name', '')
@@ -169,6 +170,7 @@ class CharmMeta:
 
 class RelationMeta:
     """Object containing metadata about a relation definition."""
+
     def __init__(self, role, relation_name, raw):
         self.role = role
         self.relation_name = relation_name
@@ -178,6 +180,7 @@ class RelationMeta:
 
 class StorageMeta:
     """Object containing metadata about a storage definition."""
+
     def __init__(self, name, raw):
         self.storage_name = name
         self.type = raw['type']
@@ -198,6 +201,7 @@ class StorageMeta:
 
 class ResourceMeta:
     """Object containing metadata about a resource definition."""
+
     def __init__(self, name, raw):
         self.resource_name = name
         self.type = raw['type']
@@ -207,6 +211,7 @@ class ResourceMeta:
 
 class PayloadMeta:
     """Object containing metadata about a payload definition."""
+
     def __init__(self, name, raw):
         self.payload_name = name
         self.type = raw['type']

--- a/op/model.py
+++ b/op/model.py
@@ -128,6 +128,7 @@ class LazyMapping(Mapping, ABC):
 
 class RelationMapping(Mapping):
     """Map of relation names to lists of Relation instances."""
+
     def __init__(self, relation_names, our_unit, backend, cache):
         self._our_unit = our_unit
         self._backend = backend


### PR DESCRIPTION
This is a much lighter touch than python-black. It seems to respect the
existing line lengths, even with --aggressive.

There are only some small tweaks of adding whitespace after class doc
strings before the __init__ function, which seems reasonable, and much
lighter than the python-black changes.

I ran
```
pip install autopep8
~/.local/bin/autopep8 --aggressive --in-place -r .
```

and it resulted in these changes. I also configured my editor to run "autopep8 --aggressive --in-place $file", which seems to be fine and doesn't disturb the project like python-black did.

I don't know where we'll run into interesting reformatting, but this looks better than nothing without being a strong rewrite.