### PR TITLE
Optimize is_leader checks by caching temporarily

### DIFF
--- a/op/model.py
+++ b/op/model.py
@@ -298,7 +298,7 @@ class RelationNotFound(ModelError):
 
 class ModelBackend:
 
-    LEASE_REFRESH_PERIOD = datetime.timedelta(seconds=30)
+    LEASE_RENEWAL_PERIOD = datetime.timedelta(seconds=30)
 
     def __init__(self):
         self.unit_name = os.environ['JUJU_UNIT_NAME']
@@ -367,10 +367,12 @@ class ModelBackend:
 
         The value is cached for the duration of a lease which is 30s in Juju.
         """
-        if datetime.timedelta(seconds=time.monotonic() - self._leader_check_time) > self.LEASE_REFRESH_PERIOD or self._is_leader is None:
+        now = time.monotonic()
+        time_since_check = datetime.timedelta(seconds=now - self._leader_check_time)
+        if time_since_check > self.LEASE_RENEWAL_PERIOD or self._is_leader is None:
             # Current time MUST be saved before running is-leader to ensure the cache
             # is only used inside the window that is-leader itself asserts.
-            self._leader_check_time = time.monotonic()
+            self._leader_check_time = now
             self._is_leader = self._run('is-leader')
 
         return self._is_leader

--- a/op/model.py
+++ b/op/model.py
@@ -368,7 +368,8 @@ class ModelBackend:
         The value is cached for the duration of a lease which is 30s in Juju.
         """
         if datetime.timedelta(seconds=time.monotonic() - self._leader_check_time) > self.LEASE_REFRESH_PERIOD or self._is_leader is None:
-            # Record the time before executing is-leader to account for the execution delay and so make the next check to happen earlier.
+            # Current time MUST be saved before running is-leader to ensure the cache
+            # is only used inside the window that is-leader itself asserts.
             self._leader_check_time = time.monotonic()
             self._is_leader = self._run('is-leader')
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -225,20 +225,20 @@ class TestModel(unittest.TestCase):
         self.model = op.model.Model('myapp/0', meta, self.backend)
 
         # A sanity check.
-        self.assertGreater(time.monotonic(), op.model.ModelBackend.LEASE_REFRESH_PERIOD.total_seconds())
+        self.assertGreater(time.monotonic(), op.model.ModelBackend.LEASE_RENEWAL_PERIOD.total_seconds())
 
+        fake_script(self, 'is-leader', 'echo false')
+        self.assertFalse(self.model.unit.is_leader())
+
+        # Change the leadership status and force a recheck.
         fake_script(self, 'is-leader', 'echo true')
+        self.backend._leader_check_time = 0
         self.assertTrue(self.model.unit.is_leader())
 
         # Force a recheck without changing the leadership status.
         fake_script(self, 'is-leader', 'echo true')
         self.backend._leader_check_time = 0
         self.assertTrue(self.model.unit.is_leader())
-
-        # Change the leadership status and force a recheck.
-        fake_script(self, 'is-leader', 'echo false')
-        self.backend._leader_check_time = 0
-        self.assertFalse(self.model.unit.is_leader())
 
     def test_resources(self):
         backend = op.model.ModelBackend()


### PR DESCRIPTION
In order to avoid is-leader hook tool executions on every write to
application relation data bags caching of is-leader return values is
introduced. It relies on the implementation detail in Juju where it
grants a lease for 30 seconds when either of the following happens:

1) a unit agent renews the lease;
2) is-leader is called;
3) leader-set is called.