### PR TITLE
Fix an argument name passed to pod-spec-set

### DIFF
--- a/op/model.py
+++ b/op/model.py
@@ -378,7 +378,7 @@ class ModelBackend:
         try:
             spec_path = tmpdir / 'spec.json'
             spec_path.write_text(json.dumps(spec))
-            args = ['--spec', str(spec_path)]
+            args = ['--file', str(spec_path)]
             if k8s_resources:
                 k8s_res_path = tmpdir / 'k8s-resources.json'
                 k8s_res_path.write_text(json.dumps(k8s_resources))


### PR DESCRIPTION
* --file needs to be used instead of --spec;
* the current implementation of pod_spec_set function does not allow for
  easy testing of hook tool calls as temporary directories created for
  json files are hidden from the caller and contain a randomized 8-byte
  component. The current test is an attempt to do an immediate fix
  without reworking pod_spec_set to solve an immediate problem of it
  being broken.