### PR TITLE
Add support for storage to model

### DIFF
--- a/op/model.py
+++ b/op/model.py
@@ -414,6 +414,7 @@ class Pod:
 class Storage(Sequence):
     """Sequence of paths where each instance of a given storage name can be found.
     """
+
     def __init__(self, name, backend):
         self._name = name
         self._backend = backend


### PR DESCRIPTION
Allow charms to iterate over storage instances and dynamically request new instances for a given storage.