### PR TITLE
Fix spacing in different files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,3 @@
 [flake8]
-ignore = E302
 max-line-length = 160
 exclude = sandbox

--- a/op/charm.py
+++ b/op/charm.py
@@ -8,29 +8,38 @@ class HookEvent(EventBase):
 class InstallEvent(HookEvent):
     pass
 
+
 class StartEvent(HookEvent):
     pass
+
 
 class StopEvent(HookEvent):
     pass
 
+
 class ConfigChangedEvent(HookEvent):
     pass
+
 
 class UpdateStatusEvent(HookEvent):
     pass
 
+
 class UpgradeCharmEvent(HookEvent):
     pass
+
 
 class PreSeriesUpgradeEvent(HookEvent):
     pass
 
+
 class PostSeriesUpgradeEvent(HookEvent):
     pass
 
+
 class LeaderElectedEvent(HookEvent):
     pass
+
 
 class LeaderSettingsChangedEvent(HookEvent):
     pass
@@ -73,14 +82,18 @@ class RelationEvent(HookEvent):
         else:
             self.unit = None
 
+
 class RelationJoinedEvent(RelationEvent):
     pass
+
 
 class RelationChangedEvent(RelationEvent):
     pass
 
+
 class RelationDepartedEvent(RelationEvent):
     pass
+
 
 class RelationBrokenEvent(RelationEvent):
     pass
@@ -89,8 +102,10 @@ class RelationBrokenEvent(RelationEvent):
 class StorageEvent(HookEvent):
     pass
 
+
 class StorageAttachedEvent(StorageEvent):
     pass
+
 
 class StorageDetachingEvent(StorageEvent):
     pass

--- a/op/framework.py
+++ b/op/framework.py
@@ -261,6 +261,7 @@ class EventsBase(Object):
 
 
 class PrefixedEvents:
+
     def __init__(self, emitter, key):
         self._emitter = emitter
         self._prefix = key.replace("-", "_") + '_'
@@ -272,8 +273,10 @@ class PrefixedEvents:
 class PreCommitEvent(EventBase):
     pass
 
+
 class CommitEvent(EventBase):
     pass
+
 
 class FrameworkEvents(EventsBase):
     pre_commit = Event(PreCommitEvent)
@@ -555,8 +558,10 @@ class Framework(Object):
 class StoredStateChanged(EventBase):
     pass
 
+
 class StoredStateEvents(EventsBase):
     changed = Event(StoredStateChanged)
+
 
 class StoredStateData(Object):
 
@@ -588,6 +593,7 @@ class StoredStateData(Object):
         if self.dirty:
             self.framework.save_snapshot(self)
             self.dirty = False
+
 
 class BoundStoredState:
 
@@ -668,6 +674,7 @@ def _wrap_stored(parent_data, value):
     if t is set:
         return StoredSet(parent_data, value)
     return value
+
 
 def _unwrap_stored(parent_data, value):
     t = type(value)

--- a/op/main.py
+++ b/op/main.py
@@ -135,6 +135,7 @@ def _get_event_args(charm, bound_event):
         return [relation], {}
     return [], {}
 
+
 def main(charm_class):
     """Setup the charm and dispatch the observed event.
 

--- a/op/model.py
+++ b/op/model.py
@@ -6,7 +6,6 @@ import tempfile
 import time
 import datetime
 
-
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, MutableMapping
 from pathlib import Path
@@ -14,6 +13,7 @@ from subprocess import run, PIPE, CalledProcessError
 
 
 class Model:
+
     def __init__(self, unit_name, meta, backend):
         self._cache = ModelCache(backend)
         self._backend = backend
@@ -59,6 +59,7 @@ class Model:
     def get_app(self, app_name):
         return self._cache.get(Application, app_name)
 
+
 class ModelCache:
 
     def __init__(self, backend):
@@ -75,6 +76,7 @@ class ModelCache:
 
 
 class Application:
+
     def __init__(self, name, backend, cache):
         self.name = name
         self._backend = backend
@@ -116,6 +118,7 @@ class Application:
 
 
 class Unit:
+
     def __init__(self, name, backend, cache):
         self.name = name
 
@@ -161,7 +164,9 @@ class Unit:
         else:
             raise RuntimeError(f"cannot determine leadership status for remote applications: {self}")
 
+
 class LazyMapping(Mapping, ABC):
+
     _lazy_data = None
 
     @abstractmethod
@@ -262,6 +267,7 @@ class RelationData(Mapping):
 # We mix in MutableMapping here to get some convenience implementations, but whether it's actually
 # mutable or not is controlled by the flag.
 class RelationDataContent(LazyMapping, MutableMapping):
+
     def __init__(self, relation, entity, backend):
         self.relation = relation
         self._entity = entity
@@ -313,11 +319,13 @@ class RelationDataContent(LazyMapping, MutableMapping):
 
 
 class ConfigData(LazyMapping):
+
     def __init__(self, backend):
         self._backend = backend
 
     def _load(self):
         return self._backend.config_get()
+
 
 class StatusBase:
     """Status values specific to applications and units."""
@@ -337,6 +345,7 @@ class StatusBase:
     def from_name(cls, name, message):
         return cls._statuses[name](message)
 
+
 class ActiveStatus(StatusBase):
     """The unit is ready.
 
@@ -347,12 +356,14 @@ class ActiveStatus(StatusBase):
     def __init__(self):
         super().__init__('')
 
+
 class BlockedStatus(StatusBase):
     """The unit requires manual intervention.
 
     An operator has to manually intervene to unblock the unit and let it proceed.
     """
     name = 'blocked'
+
 
 class MaintenanceStatus(StatusBase):
     """The unit is performing maintenance tasks.
@@ -361,6 +372,7 @@ class MaintenanceStatus(StatusBase):
     This is a "spinning" state, not an error state. It reflects activity on the unit itself, not on peers or related units.
     """
     name = 'maintenance'
+
 
 class UnknownStatus(StatusBase):
     """The unit status is unknown.
@@ -372,6 +384,7 @@ class UnknownStatus(StatusBase):
     def __init__(self):
         # Unknown status cannot be set and does not have a message associated with it.
         super().__init__('')
+
 
 class WaitingStatus(StatusBase):
     """A unit is unable to progress.
@@ -412,6 +425,7 @@ class Pod:
 
 class ModelError(Exception):
     pass
+
 
 class TooManyRelatedAppsError(ModelError):
     def __init__(self, relation_name, num_related, max_supported):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -679,6 +679,7 @@ def fake_script(test_case, name, content):
         f.write('#!/bin/bash\n{ echo -n $(basename $0); for s in "$@"; do echo -n \\;$s; done; echo; } >> $(dirname $0)/calls.txt\n' + content)
     os.chmod(test_case.fake_script_path / name, 0o755)
 
+
 def fake_script_calls(test_case, clear=False):
     with open(test_case.fake_script_path / 'calls.txt', 'r+') as f:
         calls = [line.split(';') for line in f.read().splitlines()]


### PR DESCRIPTION
* 1 line between groups of 'import' and 'from ... import' statements;
* 2 lines between types;
* 1 line between `__init__` and the class declaration.