### PR TITLE
Add storage support into Model

### DIFF
--- a/op/charm.py
+++ b/op/charm.py
@@ -139,7 +139,7 @@ class CharmBase(Object):
             self.on.define_event(f'{relation_name}_relation_departed', RelationDepartedEvent)
             self.on.define_event(f'{relation_name}_relation_broken', RelationBrokenEvent)
 
-        for storage_name in self.framework.meta.storage:
+        for storage_name in self.framework.meta.storages:
             storage_name = storage_name.replace('-', '_')
             self.on.define_event(f'{storage_name}_storage_attached', StorageAttachedEvent)
             self.on.define_event(f'{storage_name}_storage_detaching', StorageDetachingEvent)
@@ -183,8 +183,8 @@ class CharmMeta:
         self.relations.update(self.requires)
         self.relations.update(self.provides)
         self.relations.update(self.peers)
-        self.storage = {name: StorageMeta(name, store)
-                        for name, store in raw.get('storage', {}).items()}
+        self.storages = {name: StorageMeta(name, storage)
+                         for name, storage in raw.get('storage', {}).items()}
         self.resources = {name: ResourceMeta(name, res)
                           for name, res in raw.get('resources', {}).items()}
         self.payloads = {name: PayloadMeta(name, payload)

--- a/op/model.py
+++ b/op/model.py
@@ -455,8 +455,6 @@ class StorageMapping(Mapping):
         """
         if storage_name not in self._storage_map:
             raise ModelError(f'cannot add storage with {storage_name} as it is not present in the charm metadata')
-        elif not isinstance(count, int) or isinstance(count, bool):
-            raise ModelError(f'storage count must be integer, got: {count} ({type(count)})')
         self._backend.storage_add(storage_name, count)
 
 
@@ -618,5 +616,7 @@ class ModelBackend:
     def storage_get(self, storage_id, attribute):
         return self._run('storage-get', '-s', storage_id, attribute, return_output=True, use_json=True)
 
-    def storage_add(self, name, count):
+    def storage_add(self, name, count=1):
+        if not isinstance(count, int) or isinstance(count, bool):
+            raise RuntimeError(f'storage count must be integer, got: {count} ({type(count)})')
         self._run('storage-add', f'{name}={count}')

--- a/op/model.py
+++ b/op/model.py
@@ -470,7 +470,7 @@ class Storage:
     @property
     def location(self):
         if self._location is None:
-            self._location = Path(self._backend.storage_get(self.id, "location"))
+            self._location = Path(self._backend.storage_get(f'{self.name}/{self.id}', "location"))
         return self._location
 
 
@@ -611,10 +611,10 @@ class ModelBackend:
         return self._run('status-set', f'--application={is_app}', status, message)
 
     def storage_list(self, name):
-        return self._run('storage-list', name, return_output=True, use_json=True)
+        return [int(s.split('/')[1]) for s in self._run('storage-list', name, return_output=True, use_json=True)]
 
-    def storage_get(self, storage_id, attribute):
-        return self._run('storage-get', '-s', storage_id, attribute, return_output=True, use_json=True)
+    def storage_get(self, storage_name_id, attribute):
+        return self._run('storage-get', '-s', storage_name_id, attribute, return_output=True, use_json=True)
 
     def storage_add(self, name, count=1):
         if not isinstance(count, int) or isinstance(count, bool):

--- a/op/model.py
+++ b/op/model.py
@@ -460,7 +460,6 @@ class StorageMapping(Mapping):
 
 
 class Storage:
-    """A storage unit."""
 
     def __init__(self, storage_name, storage_id, backend):
         self.name = storage_name

--- a/op/model.py
+++ b/op/model.py
@@ -448,10 +448,11 @@ class StorageMapping(Mapping):
                 storage_list.append(Storage(storage_name, storage_id, self._backend))
         return storage_list
 
-    def add(self, storage_name, count=1):
-        """Adds new storage instances of a given name.
+    def request(self, storage_name, count=1):
+        """Requests new storage instances of a given name.
 
-        Juju will notify the unit via <storage-name>-storage-attached events when it becomes available.
+        Uses storage-add tool to request additional storage. Juju will notify the unit
+        via <storage-name>-storage-attached events when it becomes available.
         """
         if storage_name not in self._storage_map:
             raise ModelError(f'cannot add storage with {storage_name} as it is not present in the charm metadata')

--- a/op/model.py
+++ b/op/model.py
@@ -618,5 +618,5 @@ class ModelBackend:
 
     def storage_add(self, name, count=1):
         if not isinstance(count, int) or isinstance(count, bool):
-            raise RuntimeError(f'storage count must be integer, got: {count} ({type(count)})')
+            raise TypeError(f'storage count must be integer, got: {count} ({type(count)})')
         self._run('storage-add', f'{name}={count}')

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -174,10 +174,10 @@ class TestCharm(unittest.TestCase):
             },
         })
 
-        self.assertIsNone(self.meta.storage['stor1'].multiple_range)
-        self.assertEqual(self.meta.storage['stor2'].multiple_range, (2, 2))
-        self.assertEqual(self.meta.storage['stor3'].multiple_range, (2, None))
-        self.assertEqual(self.meta.storage['stor-4'].multiple_range, (2, 4))
+        self.assertIsNone(self.meta.storages['stor1'].multiple_range)
+        self.assertEqual(self.meta.storages['stor2'].multiple_range, (2, 2))
+        self.assertEqual(self.meta.storages['stor3'].multiple_range, (2, None))
+        self.assertEqual(self.meta.storages['stor-4'].multiple_range, (2, 4))
 
         charm = MyCharm(self.create_framework(), None)
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -601,16 +601,12 @@ class TestModel(unittest.TestCase):
         meta.storages = {'disks': None, 'data': None}
         self.model = op.model.Model('myapp/0', meta, self.backend)
 
-        self.assertEqual(len(self.model.storages), 2)
-        self.assertEqual(self.model.storages.keys(), meta.storages.keys())
-        self.assertTrue('disks' in self.model.storages)
-
         fake_script(self, 'storage-list', """[ "$1" = disks ] && echo '["disks/0", "disks/1"]' || echo '[]'""")
         fake_script(self, 'storage-get',
                     """
                     if [ "$2" = disks/0 ]; then
                       echo '"/var/srv/disks/0"'
-                    elif [ "$2" == disks/1 ]; then
+                    elif [ "$2" = disks/1 ]; then
                       echo '"/var/srv/disks/1"'
                     else
                       exit 2
@@ -618,6 +614,9 @@ class TestModel(unittest.TestCase):
                     """)
         fake_script(self, 'storage-add', '')
 
+        self.assertEqual(len(self.model.storages), 2)
+        self.assertEqual(self.model.storages.keys(), meta.storages.keys())
+        self.assertIn('disks', self.model.storages)
         test_cases = {
             0: {'name': 'disks', 'location': pathlib.Path('/var/srv/disks/0')},
             1: {'name': 'disks', 'location': pathlib.Path('/var/srv/disks/1')},

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -645,7 +645,7 @@ class TestModel(unittest.TestCase):
 
         # Invalid count parameter types.
         for count_v in [None, False, 2.0, 'a', b'beef', object]:
-            with self.assertRaises(RuntimeError):
+            with self.assertRaises(TypeError):
                 self.model.storages.add('data', count_v)
 
 
@@ -732,12 +732,12 @@ class TestModelBackend(unittest.TestCase):
         ), (
             lambda: fake_script(self, 'storage-add', f'echo fooerror >&2 ; exit 1'),
             lambda: self.backend.storage_add('foobar', count=object),
-            RuntimeError,
+            TypeError,
             [['storage-get', '-s', 'foobar', 'someattr', '--format=json']],
         ), (
             lambda: fake_script(self, 'storage-add', f'echo fooerror >&2 ; exit 1'),
             lambda: self.backend.storage_add('foobar', count=True),
-            RuntimeError,
+            TypeError,
             [['storage-get', '-s', 'foobar', 'someattr', '--format=json']],
         )]
         for do_fake, run, exception, calls in test_cases:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -648,6 +648,7 @@ class TestModel(unittest.TestCase):
             with self.assertRaises(op.model.ModelError):
                 self.model.storages.add('data', count_v)
 
+
 class TestModelBackend(unittest.TestCase):
 
     def setUp(self):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -635,7 +635,7 @@ class TestModel(unittest.TestCase):
         ])
 
         self.assertSequenceEqual(self.model.storages['data'], [])
-        self.model.storages.add('data', count=3)
+        self.model.storages.request('data', count=3)
         self.assertEqual(fake_script_calls(self), [
             ['storage-list', 'data', '--format=json'],
             ['storage-add', 'data=3'],
@@ -643,12 +643,12 @@ class TestModel(unittest.TestCase):
 
         # Try to add storage not present in charm metadata.
         with self.assertRaises(op.model.ModelError):
-            self.model.storages.add('deadbeef')
+            self.model.storages.request('deadbeef')
 
         # Invalid count parameter types.
         for count_v in [None, False, 2.0, 'a', b'beef', object]:
             with self.assertRaises(TypeError):
-                self.model.storages.add('data', count_v)
+                self.model.storages.request('data', count_v)
 
 
 class TestModelBackend(unittest.TestCase):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -619,12 +619,14 @@ class TestModel(unittest.TestCase):
         fake_script(self, 'storage-add', '')
 
         test_cases = {
-            'disks/0': pathlib.Path('/var/srv/disks/0'),
-            'disks/1': pathlib.Path('/var/srv/disks/1'),
+            0: {'name': 'disks', 'location': pathlib.Path('/var/srv/disks/0')},
+            1: {'name': 'disks', 'location': pathlib.Path('/var/srv/disks/1')},
         }
         for storage in self.model.storages['disks']:
             self.assertEqual(storage.name, 'disks')
-            self.assertEqual(storage.location, test_cases[storage.id])
+            self.assertIn(storage.id, test_cases)
+            self.assertEqual(storage.name, test_cases[storage.id]['name'])
+            self.assertEqual(storage.location, test_cases[storage.id]['location'])
 
         self.assertEqual(fake_script_calls(self, clear=True), [
             ['storage-list', 'disks', '--format=json'],


### PR DESCRIPTION
* Storage support modeled closely relation support and types;
* Storage can be requested dynamically via a hook tool (count is the
  only constraint supported by the hook tool) in addition to Juju client
  commands that can be issued by an operator to do the same;
* storage ids are in the form of <storage-name>/<id> compared to
  relation ids;
* The plural wording of storage ("storages") is intentional. Although it
  is marked as uncountable in several dictionaries, it looks like it has
  become a norm in the IT world.
  * https://en.wiktionary.org/wiki/storage#Usage_notes;
  * https://en.wiktionary.org/wiki/storages#English;
  * https://www.merriam-webster.com/thesaurus/storages
* storage-get at the time of writing only exposes 2 attributes:
  * kind (storage endpoint name which we already have from metadata);
  * location (a path to a block device or mount point).