### PR TITLE
Make Handle attributes read-only

### DIFF
--- a/op/framework.py
+++ b/op/framework.py
@@ -26,9 +26,19 @@ class Handle:
     def __init__(self, parent, kind, key):
         if parent and not isinstance(parent, Handle):
             parent = parent.handle
-        self.parent = parent
-        self.kind = kind
-        self.key = key
+        self._parent = parent
+        self._kind = kind
+        self._key = key
+        if parent:
+            if key:
+                self._path = f"{parent}/{kind}[{key}]"
+            else:
+                self._path = f"{parent}/{kind}"
+        else:
+            if key:
+                self._path = f"{kind}[{key}]"
+            else:
+                self._path = f"{kind}"
 
     def nest(self, kind, key):
         return Handle(self, kind, key)
@@ -43,18 +53,20 @@ class Handle:
         return self.path
 
     @property
+    def parent(self):
+        return self._parent
+
+    @property
+    def kind(self):
+        return self._kind
+
+    @property
+    def key(self):
+        return self._key
+
+    @property
     def path(self):
-        # TODO Cache result and either clear cache when attributes change, or make it read-only.
-        if self.parent:
-            if self.key:
-                return f"{self.parent}/{self.kind}[{self.key}]"
-            else:
-                return f"{self.parent}/{self.kind}"
-        else:
-            if self.key:
-                return f"{self.kind}[{self.key}]"
-            else:
-                return f"{self.kind}"
+        return self._path
 
     @classmethod
     def from_path(cls, path):

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -35,6 +35,17 @@ class TestFramework(unittest.TestCase):
             self.assertEqual(str(handle), path)
             self.assertEqual(Handle.from_path(path), handle)
 
+    def test_handle_attrs_readonly(self):
+        handle = Handle(None, 'kind', 'key')
+        with self.assertRaises(AttributeError):
+            handle.parent = 'foo'
+        with self.assertRaises(AttributeError):
+            handle.kind = 'foo'
+        with self.assertRaises(AttributeError):
+            handle.key = 'foo'
+        with self.assertRaises(AttributeError):
+            handle.path = 'foo'
+
     def test_restore_unknown(self):
         framework = self.create_framework()
 


### PR DESCRIPTION
Fixup for code TODO: Handle attributes really should not be changing at runtime, so this makes them read-only and pre-computes the path rather than doing it on demand.