### PR TITLE
Use TypeError for invalid argument type errors

### DIFF
--- a/op/model.py
+++ b/op/model.py
@@ -490,7 +490,7 @@ class ModelBackend:
 
     def relation_get(self, relation_id, member_name, is_app):
         if not isinstance(is_app, bool):
-            raise RuntimeError('is_app parameter to relation_get must be a boolean')
+            raise TypeError('is_app parameter to relation_get must be a boolean')
 
         try:
             return self._run('relation-get', '-r', str(relation_id), '-', member_name, f'--app={is_app}', return_output=True, use_json=True)
@@ -501,7 +501,7 @@ class ModelBackend:
 
     def relation_set(self, relation_id, key, value, is_app):
         if not isinstance(is_app, bool):
-            raise RuntimeError('is_app parameter to relation_set must be a boolean')
+            raise TypeError('is_app parameter to relation_set must be a boolean')
 
         try:
             return self._run('relation-set', '-r', str(relation_id), f'{key}={value}', f'--app={is_app}')
@@ -556,5 +556,5 @@ class ModelBackend:
         app -- A boolean indicating whether the status should be set for a unit or an application.
         """
         if not isinstance(is_app, bool):
-            raise RuntimeError('is_app parameter must be boolean')
+            raise TypeError('is_app parameter must be boolean')
         return self._run('status-set', f'--application={is_app}', status, message)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -288,10 +288,10 @@ class TestModel(unittest.TestCase):
 
         # Invalid types for is_app.
         for is_app_v in [None, 1, 2.0, 'a', b'beef']:
-            with self.assertRaises(RuntimeError):
+            with self.assertRaises(TypeError):
                 self.backend.relation_set(1, 'fookey', 'barval', is_app=is_app_v)
 
-            with self.assertRaises(RuntimeError):
+            with self.assertRaises(TypeError):
                 self.backend.relation_get(1, 'fooentity', is_app=is_app_v)
 
     def test_relation_data_type_check(self):
@@ -545,7 +545,7 @@ class TestModel(unittest.TestCase):
         self.backend = op.model.ModelBackend()
 
         for is_app_v in [None, 1, 2.0, 'a', b'beef', object]:
-            with self.assertRaises(RuntimeError):
+            with self.assertRaises(TypeError):
                 self.backend.status_set(op.model.ActiveStatus, is_app=is_app_v)
 
     def test_remote_unit_status(self):


### PR DESCRIPTION
RuntimeError is currently used instead of TypeError in multiple places
in ModelBackend where incorrect argument type is handled. There is a
more specific exception for that purpose:

https://docs.python.org/3/library/exceptions.html#TypeError
"Passing arguments of the wrong type (e.g. passing a list when an int is
expected) should result in a TypeError"