### PR TITLE
Persist event count to avoid reused event handles

### DIFF
--- a/op/framework.py
+++ b/op/framework.py
@@ -156,8 +156,7 @@ class BoundEvent:
         The current storage state is committed before and after each observer is notified.
         """
         framework = self.emitter.framework
-        framework._stored['event_count'] += 1
-        key = str(framework._stored['event_count'])
+        key = str(framework.event_count)
         event = self.event_type(Handle(self.emitter, self.event_kind, key), *args, **kwargs)
         framework._emit(event)
 
@@ -388,6 +387,10 @@ class Framework(Object):
         except NoSnapshotError:
             self._stored['event_count'] = 0
 
+    @property
+    def event_count(self):
+        return self._stored['event_count']
+
     def close(self):
         self._storage.close()
 
@@ -502,6 +505,9 @@ class Framework(Object):
 
     def _emit(self, event):
         """See BoundEvent.emit for the public way to call this."""
+
+        # Count another event having been emitted.
+        self._stored['event_count'] += 1
 
         # Save the event for all known observers before the first notification
         # takes place, so that either everyone interested sees it, or nobody does.

--- a/op/framework.py
+++ b/op/framework.py
@@ -156,7 +156,7 @@ class BoundEvent:
         The current storage state is committed before and after each observer is notified.
         """
         framework = self.emitter.framework
-        key = str(framework.event_count)
+        key = str(framework._stored['event_count'])
         event = self.event_type(Handle(self.emitter, self.event_kind, key), *args, **kwargs)
         framework._emit(event)
 
@@ -379,17 +379,13 @@ class Framework(Object):
 
         self._storage = SQLiteStorage(data_path)
 
-        # Note: we can't use the higher-level StoredData because it relies on events.
+        # We can't use the higher-level StoredState because it relies on events.
         self.register_type(StoredStateData, None, StoredStateData.handle_kind)
         self._stored = StoredStateData(self, '_stored')
         try:
             self._stored = self.load_snapshot(self._stored.handle)
         except NoSnapshotError:
             self._stored['event_count'] = 0
-
-    @property
-    def event_count(self):
-        return self._stored['event_count']
 
     def close(self):
         self._storage.close()

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -217,9 +217,9 @@ class TestFramework(unittest.TestCase):
         pub2.c.emit()
 
         # Events remain stored because they were deferred.
-        ev_a = framework.load_snapshot(Handle(pub1, "a", "1"))
-        ev_b = framework.load_snapshot(Handle(pub1, "b", "2"))
-        ev_c = framework.load_snapshot(Handle(pub2, "c", "3"))
+        ev_a = framework.load_snapshot(Handle(pub1, "a", "0"))
+        ev_b = framework.load_snapshot(Handle(pub1, "b", "1"))
+        ev_c = framework.load_snapshot(Handle(pub2, "c", "2"))
 
         framework.reemit()
         obs1.done["a"] = True

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -217,9 +217,9 @@ class TestFramework(unittest.TestCase):
         pub2.c.emit()
 
         # Events remain stored because they were deferred.
-        ev_a = framework.load_snapshot(Handle(pub1, "a", "0"))
-        ev_b = framework.load_snapshot(Handle(pub1, "b", "1"))
-        ev_c = framework.load_snapshot(Handle(pub2, "c", "2"))
+        ev_a = framework.load_snapshot(Handle(pub1, "a", "1"))
+        ev_b = framework.load_snapshot(Handle(pub1, "b", "2"))
+        ev_c = framework.load_snapshot(Handle(pub2, "c", "3"))
 
         framework.reemit()
         obs1.done["a"] = True

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -562,7 +562,7 @@ class TestFramework(unittest.TestCase):
         obs1 = MyObserver(framework1, "obs")
         framework1.observe(pub1.foo, obs1)
         pub1.foo.emit('first')
-        self.assertEqual(obs1.seen, [('0', 'first')])
+        self.assertEqual(obs1.seen, [('1', 'first')])
 
         framework1.commit()
         framework1.close()
@@ -576,10 +576,10 @@ class TestFramework(unittest.TestCase):
         framework2.reemit()
 
         # First observer didn't get updated, since framework it was bound to is gone.
-        self.assertEqual(obs1.seen, [('0', 'first')])
+        self.assertEqual(obs1.seen, [('1', 'first')])
         # Second observer saw the new event plus the reemit of the first event.
         # (The event key goes up by 2 due to the pre-commit and commit events.)
-        self.assertEqual(obs2.seen, [('3', 'second'), ('0', 'first')])
+        self.assertEqual(obs2.seen, [('4', 'second'), ('1', 'first')])
 
 
 class TestStoredState(unittest.TestCase):


### PR DESCRIPTION
Fixup for TODO: Not persisting the event count means that on subsequent hooks, new events of the same type will overwrite previous events, potentially leading to a loss of data.