### PR TITLE
Weakref finalizers

### DIFF
--- a/op/framework.py
+++ b/op/framework.py
@@ -489,7 +489,6 @@ class Framework(Object):
         # TODO Validate that the method has the right signature here.
 
         # TODO Prevent the exact same parameters from being registered more than once.
-        # If there was an object going away at 'path' this is a new object at 'path' and should be considered as such
         if self._stale_observer_paths:
             # Make sure we've processed any objects that have been removed before we add a new object.
             self._cleanup_observer_paths()

--- a/op/framework.py
+++ b/op/framework.py
@@ -489,6 +489,10 @@ class Framework(Object):
         # TODO Validate that the method has the right signature here.
 
         # TODO Prevent the exact same parameters from being registered more than once.
+        # If there was an object going away at 'path' this is a new object at 'path' and should be considered as such
+        if self._stale_observer_paths:
+            # Make sure we've processed any objects that have been removed before we add a new object.
+            self._cleanup_observer_paths()
         self._observer[observer.handle.path] = observer
         weakref.finalize(observer, self._stale_observer_paths.add, observer.handle.path)
         self._observers.append((observer.handle.path, method_name, emitter_path, event_kind))

--- a/op/framework.py
+++ b/op/framework.py
@@ -375,6 +375,7 @@ class Framework(Object):
         self.meta = meta
         self.model = model
         self._event_count = 0
+        self._stale_observer_paths = []
         self._observers = []      # [(observer_path, method_name, parent_path, event_key)]
         self._observer = weakref.WeakValueDictionary()       # {observer_path: observer}
         self._type_registry = {}  # {(parent_path, kind): cls}
@@ -488,16 +489,21 @@ class Framework(Object):
         # TODO Validate that the method has the right signature here.
 
         # TODO Prevent the exact same parameters from being registered more than once.
-
         self._observer[observer.handle.path] = observer
+        weakref.finalize(observer, self._stale_observer_paths.append, observer.handle.path)
         self._observers.append((observer.handle.path, method_name, emitter_path, event_kind))
 
-    def _cleanup_observer_paths(self, stale):
+    def _cleanup_observer_paths(self):
+        if len(self._stale_observer_paths) == 0:
+            return
+        stale = set(self._stale_observer_paths)
         new_observers = []
         for observer_path, method_name, _parent_path, _event_kind in self._observers:
             if observer_path in stale:
                 continue
-            new_observers.append(observer_path, method_name, _parent_path, _event_kind)
+            new_observers.append((observer_path, method_name, _parent_path, _event_kind))
+        # Don't change the list, as the original list.append() is being used.
+        self._stale_observer_paths.clear()
         self._observers = new_observers
 
     def _emit(self, event):
@@ -509,21 +515,17 @@ class Framework(Object):
         event_path = event.handle.path
         event_kind = event.handle.kind
         parent_path = event.handle.parent.path
-        stale_observer_paths = set()
+        if self._stale_observer_paths:
+            self._cleanup_observer_paths()
         # TODO Track observers by (parent_path, event_kind) rather than as a list of all observers.
         #  Avoiding linear search through all observers for every event
         for observer_path, method_name, _parent_path, _event_kind in self._observers:
-            if observer_path not in self._observer:
-                stale_observer_paths.add(observer_path)
-                continue
             if _parent_path != parent_path:
                 continue
             if _event_kind and _event_kind != event_kind:
                 continue
             # Again, only commit this after all notices are saved.
             self._storage.save_notice(event_path, observer_path, method_name)
-        if stale_observer_paths:
-            self._cleanup_observer_paths(stale_observer_paths)
         self._reemit(event_path)
 
     def reemit(self):

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -356,11 +356,18 @@ class TestFramework(unittest.TestCase):
         self.assertEqual(len(framework._observer), 8)
         pub.on.foo.emit()
         self.assertEqual(observed_events, ["foo-2", "foo-3", "foo-4", "foo-5", "foo-6", "foo-7", "foo-8", "foo-9"])
+        # Remove some, but not all, observers, see the remaining ones are still triggering
+        observers = observers[:2]
+        gc.collect()
+        pub.on.foo.emit()
+        self.assertEqual(observed_events, ["foo-2", "foo-3", "foo-4", "foo-5", "foo-6", "foo-7", "foo-8", "foo-9", "foo-2", "foo-3"])
+        self.assertEqual(len(framework._observer), 2)
+        self.assertEqual(len(framework._observers), 2)
+        # Delete the rest, and see that there are no new triggers
         del observers
         gc.collect()
         pub.on.foo.emit()
-        # No new notices, and the number of _observers has been trimmed
-        self.assertEqual(observed_events, ["foo-2", "foo-3", "foo-4", "foo-5", "foo-6", "foo-7", "foo-8", "foo-9"])
+        self.assertEqual(observed_events, ["foo-2", "foo-3", "foo-4", "foo-5", "foo-6", "foo-7", "foo-8", "foo-9", "foo-2", "foo-3"])
         self.assertEqual(len(framework._observer), 0)
         self.assertEqual(len(framework._observers), 0)
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -400,6 +400,7 @@ class TestFramework(unittest.TestCase):
         # Now, we delete the existing obs, which would cause it to be removed from observers,
         # and then immediately register a new obs at the same path using a new object
         del obs
+        gc.collect()
         new_obs = MyObserver(framework, "2")
         framework.observe(pub.on.foo, new_obs)
         pub.on.foo.emit()


### PR DESCRIPTION
This adds a list that keeps track of when observers are removed (by their path). It does assume that an objects path never changes (which I think is safe), as it traps the objects path during observe() rather than during teardown.
In the happy path, it has a single check during emit() to see if there have been any recent cleanups, and then processes all of them in a single pass over the observer list. Which is also done before we track notices that need to be sent (so we don't create and delete notices for observers which are gone).
I haven't tested this at scale, but we do avoid adding extra loops and extra overhead when things aren't changing.