### PR TITLE
Raise an error if a minion calls set_podspec

### DIFF
--- a/op/model.py
+++ b/op/model.py
@@ -421,6 +421,8 @@ class Pod:
         self._backend = backend
 
     def set_spec(self, spec, k8s_resources=None):
+        if not self._backend.is_leader():
+            raise ModelError('cannot set a pod spec as this unit is not a leader')
         self._backend.pod_spec_set(spec, k8s_resources)
 
 


### PR DESCRIPTION
While there is only one operator pod per application in CAAS models,
it periodically executes hooks for different units which may or may not
be leaders.

Charm developers should make sure that their unit is a leader before
trying to set a pod spec while the framework needs to check for
leadership early and raise an appropriate exception.