### PR TITLE
Validate call signatures for event handlers

### DIFF
--- a/op/framework.py
+++ b/op/framework.py
@@ -497,7 +497,16 @@ class Framework(Object):
             if not hasattr(observer, method_name):
                 raise RuntimeError(f'Observer method not provided explicitly and {type(observer).__name__} type has no "{method_name}" method')
 
-        # TODO Validate that the method has the right signature here.
+        # Validate that the method has an acceptable call signature.
+        sig = inspect.signature(getattr(observer, method_name))
+        if len(sig.parameters) < 1:  # Note: self isn't included.
+            raise TypeError(f'{type(observer).__name__}.{method_name} must accept event parameter')
+        elif len(sig.parameters) > 1:
+            # Allow for additional optional params, since there's no reason to exclude them. Note: we only
+            # need to check the second, because once you start allowing optional params, you have to continue.
+            second_param = list(sig.parameters.values())[1]
+            if second_param.default is inspect.Parameter.empty:
+                raise TypeError(f'{type(observer).__name__}.{method_name} requires too many parameters')
 
         # TODO Prevent the exact same parameters from being registered more than once.
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -152,6 +152,7 @@ class TestFramework(unittest.TestCase):
         class MyNotifier(Object):
             foo = Event(MyEvent)
             bar = Event(MyEvent)
+            baz = Event(MyEvent)
             qux = Event(MyEvent)
 
         class MyObserver(Object):
@@ -159,6 +160,9 @@ class TestFramework(unittest.TestCase):
                 assert False, 'should not be reached'
 
             def on_bar(self, event, extra):
+                assert False, 'should not be reached'
+
+            def on_baz(self, event, extra=None, *, k):
                 assert False, 'should not be reached'
 
             def on_qux(self, event, extra=None):
@@ -172,6 +176,8 @@ class TestFramework(unittest.TestCase):
             framework.observe(pub.foo, obs)
         with self.assertRaises(TypeError):
             framework.observe(pub.bar, obs)
+        with self.assertRaises(TypeError):
+            framework.observe(pub.baz, obs)
         framework.observe(pub.qux, obs)
 
     def test_on_pre_commit_emitted(self):

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -144,6 +144,36 @@ class TestFramework(unittest.TestCase):
 
         self.assertEqual(obs.seen, ["on_any:foo", "on_foo:foo", "on_any:bar"])
 
+    def test_bad_sig_observer(self):
+
+        class MyEvent(EventBase):
+            pass
+
+        class MyNotifier(Object):
+            foo = Event(MyEvent)
+            bar = Event(MyEvent)
+            qux = Event(MyEvent)
+
+        class MyObserver(Object):
+            def on_foo(self):
+                assert False, 'should not be reached'
+
+            def on_bar(self, event, extra):
+                assert False, 'should not be reached'
+
+            def on_qux(self, event, extra=None):
+                assert False, 'should not be reached'
+
+        framework = self.create_framework()
+        pub = MyNotifier(framework, "pub")
+        obs = MyObserver(framework, "obs")
+
+        with self.assertRaises(TypeError):
+            framework.observe(pub.foo, obs)
+        with self.assertRaises(TypeError):
+            framework.observe(pub.bar, obs)
+        framework.observe(pub.qux, obs)
+
     def test_on_pre_commit_emitted(self):
         framework = self.create_framework()
 


### PR DESCRIPTION
Fixup for TODO: Make sure that registered observers won't blow up when called due to a mismatched method signature.