### PR TITLE
Remove the need for explicit event decoration

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1,4 +1,4 @@
-from ops.framework import Object, Event, EventBase, EventsBase
+from ops.framework import Object, EventBase, EventsBase
 
 
 class HookEvent(EventBase):
@@ -113,16 +113,16 @@ class StorageDetachingEvent(StorageEvent):
 
 class CharmEvents(EventsBase):
 
-    install = Event(InstallEvent)
-    start = Event(StartEvent)
-    stop = Event(StopEvent)
-    update_status = Event(UpdateStatusEvent)
-    config_changed = Event(ConfigChangedEvent)
-    upgrade_charm = Event(UpgradeCharmEvent)
-    pre_series_upgrade = Event(PreSeriesUpgradeEvent)
-    post_series_upgrade = Event(PostSeriesUpgradeEvent)
-    leader_elected = Event(LeaderElectedEvent)
-    leader_settings_changed = Event(LeaderSettingsChangedEvent)
+    install = InstallEvent
+    start = StartEvent
+    stop = StopEvent
+    update_status = UpdateStatusEvent
+    config_changed = ConfigChangedEvent
+    upgrade_charm = UpgradeCharmEvent
+    pre_series_upgrade = PreSeriesUpgradeEvent
+    post_series_upgrade = PostSeriesUpgradeEvent
+    leader_elected = LeaderElectedEvent
+    leader_settings_changed = LeaderSettingsChangedEvent
 
 
 class CharmBase(Object):

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -201,7 +201,7 @@ class Object:
 
         # TODO This can probably be dropped, because the event type is only
         # really relevant if someone is either emitting the event or observing
-        # it. Specifically, this could be done in Event.__get__ instead.
+        # it.
         for attr_name, attr_value in inspect.getmembers(type(self)):
             if isinstance(attr_value, Event):
                 event_type = attr_value.event_type

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from ops.charm import CharmBase, CharmMeta
 from ops.charm import CharmEvents
-from ops.framework import Framework, Event, EventBase
+from ops.framework import Framework, EventBase
 from ops.model import Model, ModelBackend
 
 
@@ -29,7 +29,7 @@ class TestCharm(unittest.TestCase):
             pass
 
         class TestCharmEvents(CharmEvents):
-            custom = Event(CustomEvent)
+            custom = CustomEvent
 
         # Relations events are defined dynamically and modify the class attributes.
         # We use a subclass temporarily to prevent these side effects from leaking.

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -408,22 +408,22 @@ class TestFramework(unittest.TestCase):
             foo = event
 
         class SubEvents(MyEvents):
-            qux = MyEvent
+            bar = MyEvent
 
         class OtherEvents(EventsBase):
-            foo = event
+            qux = event
 
         class MyCharm(Object):
             on = SubEvents()
             other = OtherEvents()
-            bar = event
+            ham = event
 
             def __init__(self, parent, key):
                 super().__init__(parent, key)
                 self.framework.observe(self.on.foo, self.on_any)
-                self.framework.observe(self.on.qux, self.on_any)
-                self.framework.observe(self.other.foo, self.on_any)
-                self.framework.observe(self.bar, self.on_any)
+                self.framework.observe(self.on.bar, self.on_any)
+                self.framework.observe(self.other.qux, self.on_any)
+                self.framework.observe(self.ham, self.on_any)
                 self.seen = []
 
             def on_any(self, event):
@@ -432,10 +432,10 @@ class TestFramework(unittest.TestCase):
         framework = self.create_framework()
         charm = MyCharm(framework, None)
         charm.on.foo.emit()
-        charm.on.qux.emit()
-        charm.other.foo.emit()
-        charm.bar.emit()
-        self.assertEqual(charm.seen, ['MyCharm/on/foo[1]', 'MyCharm/on/qux[2]', 'MyCharm/other/foo[3]', 'MyCharm/bar[4]'])
+        charm.on.bar.emit()
+        charm.other.qux.emit()
+        charm.ham.emit()
+        self.assertEqual(charm.seen, ['MyCharm/on/foo[1]', 'MyCharm/on/bar[2]', 'MyCharm/on/qux[3]', 'MyCharm/ham[4]'])
 
     def test_reemit_ignores_unknown_event_type(self):
         # The event type may have been gone for good, and nobody cares,


### PR DESCRIPTION
By splitting `Event` into the more explicit `UnassignedEvent` and `AssignedEvent` to go along with `BoundEvent`, and by using a metaclass for the unassigned state to allow the descriptor pattern to work at the class level, it's possible to use the event type directly and avoid the need for the charm author to explicitly decorate the event every time it is used, while reducing the potential for conflicts and keeping the distinction between the event type, bound state, and event instances well separated.

The only change in usage is that instead of:

```python
class CharmEvents(EventsBase):
    install = Event(InstallEvent)
```

it is defined as:

```python
class CharmEvents(EventsBase):
    install = InstallEvent
```

The event is still emitted in the same way:

```python
    # self.on.install is still a BoundEvent
    self.on.install.emit()
```