### PR TITLE
Object singularity

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -200,6 +200,7 @@ class Object:
             self.framework = parent.framework
             self.handle = Handle(parent, kind, key)
         if parent is not self:
+            # Framework is the only case where parent is self, don't track yourself.
             if self.handle.path in self.framework._objects:
                 raise RuntimeError(f"two objects claiming to be {self.handle.path} have been created")
             self.framework._objects[self.handle.path] = self

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -473,9 +473,7 @@ class Framework(Object):
         obj.framework = self
         obj.handle = handle
         obj.restore(data)
-        if handle.path in self._objects:
-            raise RuntimeError(f"two objects claiming to be {handle.path} have been created")
-        self._objects[handle.path] = obj
+        self._track(obj)
         return obj
 
     def drop_snapshot(self, handle):

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -202,6 +202,7 @@ class Object:
         if parent is not self:
             if self.handle.path in self.framework._objects:
                 raise RuntimeError(f"two objects claiming to be {self.handle.path} have been created")
+            self.framework._objects[self.handle.path] = self
 
         # TODO This can probably be dropped, because the event type is only
         # really relevant if someone is either emitting the event or observing
@@ -398,6 +399,7 @@ class Framework(Object):
         # We can't use the higher-level StoredState because it relies on events.
         self.register_type(StoredStateData, None, StoredStateData.handle_kind)
         self._stored = StoredStateData(self, '_stored')
+        self._forget(self._stored)  # we will replace this with the loaded value
         try:
             self._stored = self.load_snapshot(self._stored.handle)
         except NoSnapshotError:

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -405,7 +405,7 @@ class Framework(Object):
     def close(self):
         self._storage.close()
 
-    def _track(self, obj: Object) -> None:
+    def _track(self, obj):
         """Track object and ensure it is the only object created using its handle path."""
         if obj is self:
             # Framework objects don't track themselves

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -398,11 +398,11 @@ class Framework(Object):
 
         # We can't use the higher-level StoredState because it relies on events.
         self.register_type(StoredStateData, None, StoredStateData.handle_kind)
-        self._stored = StoredStateData(self, '_stored')
-        self._forget(self._stored)  # we will replace this with the loaded value
+        stored_handle = Handle(None, StoredStateData.handle_kind, '_stored')
         try:
-            self._stored = self.load_snapshot(self._stored.handle)
+            self._stored = self.load_snapshot(stored_handle)
         except NoSnapshotError:
+            self._stored = StoredStateData(self, '_stored')
             self._stored['event_count'] = 0
 
     def close(self):

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -200,7 +200,7 @@ class Object:
             self.framework = parent.framework
             self.handle = Handle(parent, kind, key)
         if parent is not self:
-            # Framework is the only case where parent is self, don't track yourself.
+            # Framework.__init__ passes parent=self, and we don't want to track ourself (also framework._objects may not be initialized yet)
             if self.handle.path in self.framework._objects:
                 raise RuntimeError(f"two objects claiming to be {self.handle.path} have been created")
             self.framework._objects[self.handle.path] = self

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -396,6 +396,7 @@ class TestFramework(unittest.TestCase):
         # Or using a second framework
         framework_copy = self.create_framework()
         o_copy = MyObject(framework_copy, "path")
+        self.assertEqual(o1.handle.path, o_copy.handle.path)
 
     def test_multiple_objects_with_load_snapshot(self):
         framework = self.create_framework()
@@ -421,20 +422,22 @@ class TestFramework(unittest.TestCase):
         o2 = framework.load_snapshot(o_handle)
         # Trying to load_snapshot a second object at the same path should fail with RuntimeError
         with self.assertRaises(RuntimeError):
-            o3 = framework.load_snapshot(o_handle)
+            framework.load_snapshot(o_handle)
         # Unless we _forget the object first
         framework._forget(o2)
         o3 = framework.load_snapshot(o_handle)
         self.assertEqual(o2.value, o3.value)
         # A loaded object also prevents direct creation of an object
         with self.assertRaises(RuntimeError):
-            o4 = MyObject(framework, "path")
+            MyObject(framework, "path")
         # But we can create an object, or load a snapshot in a copy of the framework
         framework_copy1 = self.create_framework()
         o_copy1 = MyObject(framework_copy1, "path")
+        self.assertEqual(o_copy1.value, "path")
         framework_copy2 = self.create_framework()
         framework_copy2.register_type(MyObject, None, MyObject.handle_kind)
         o_copy2 = framework_copy2.load_snapshot(o_handle)
+        self.assertEqual(o_copy2.value, "path")
 
     def test_events_base(self):
         framework = self.create_framework()

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -90,6 +90,7 @@ class TestFramework(unittest.TestCase):
         self.assertEqual(event2.my_n, 2)
 
         framework2.save_snapshot(event2)
+        framework2._forget(event)
         event3 = framework2.load_snapshot(handle)
         self.assertEqual(event3.my_n, 3)
 
@@ -264,9 +265,14 @@ class TestFramework(unittest.TestCase):
         pub2.c.emit()
 
         # Events remain stored because they were deferred.
+        # We are creating a local copy so we can do comparisons, but
+        # we don't want the framework to track them
         ev_a = framework.load_snapshot(Handle(pub1, "a", "1"))
+        framework._forget(ev_a)
         ev_b = framework.load_snapshot(Handle(pub1, "b", "2"))
+        framework._forget(ev_b)
         ev_c = framework.load_snapshot(Handle(pub2, "c", "3"))
+        framework._forget(ev_c)
 
         framework.reemit()
         obs1.done["a"] = True
@@ -871,6 +877,7 @@ class TestStoredState(unittest.TestCase):
             framework.commit()
 
             framework._forget(obj)
+            framework._forget(obj.state._data)
             obj_copy1 = SomeObject(framework, '1')
             self.assertEqual(obj_copy1.state.a, get_a())
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -892,7 +892,7 @@ class TestStoredState(unittest.TestCase):
             # created StoredStateData does not observe the on_commit event.
             # This is the one place where we intentionally create a second object for the framework.
             # User code should never be doing this, and we need it to test the side effect that 'commit()' is a no-op
-            framework_copy._objects.pop(obj_copy2.handle.path + "/StoredStateData[state]")
+            framework_copy._objects.pop(obj_copy2.state._data.handle.path)  # "SomeObject[1]/StoredStateData[state]"
             framework_copy.save_snapshot(StoredStateData(obj_copy2, 'state'))
             framework_copy.commit()
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -899,7 +899,7 @@ class TestStoredState(unittest.TestCase):
             # created StoredStateData does not observe the on_commit event.
             # This is the one place where we intentionally create a second object for the framework.
             # User code should never be doing this, and we need it to test the side effect that 'commit()' is a no-op
-            framework_copy._objects.pop(obj_copy2.state._data.handle.path)  # "SomeObject[1]/StoredStateData[state]"
+            framework_copy._forget(obj_copy2.state._data)
             framework_copy.save_snapshot(StoredStateData(obj_copy2, 'state'))
             framework_copy.commit()
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -955,7 +955,6 @@ class TestStoredState(unittest.TestCase):
             obj_copy2 = SomeObject(framework_copy, '1')
 
             validate_op(obj_copy2.state.a, expected_res)
-            framework_copy.commit()
 
             # Validate the dirty state functionality.
             # obj_copy2 state is not dirty because it was not modified in any supported way since the last commit so

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -870,6 +870,7 @@ class TestStoredState(unittest.TestCase):
             obj.state.a = get_a()
             framework.commit()
 
+            framework._forget(obj)
             obj_copy1 = SomeObject(framework, '1')
             self.assertEqual(obj_copy1.state.a, get_a())
 
@@ -892,6 +893,7 @@ class TestStoredState(unittest.TestCase):
             framework_copy.save_snapshot(StoredStateData(obj_copy2, 'state'))
             framework_copy.commit()
 
+            framework_copy._forget(obj_copy2)
             obj_copy3 = SomeObject(framework_copy, '1')
 
             # Now make sure that the modification was not saved as the state holding it was not dirty.
@@ -985,8 +987,8 @@ class TestStoredState(unittest.TestCase):
 
         framework = self.create_framework()
 
-        for a, b, op, op_ab, op_ba in test_operations:
-            obj = SomeObject(framework, "1")
+        for i, (a, b, op, op_ab, op_ba) in enumerate(test_operations):
+            obj = SomeObject(framework, str(i))
             obj.state.a = a
             self.assertEqual(op(obj.state.a, b), op_ab)
             self.assertEqual(op(b, obj.state.a), op_ba)
@@ -1026,8 +1028,8 @@ class TestStoredState(unittest.TestCase):
 
         # Validate that operations between StoredSet and built-in sets only result in built-in sets being returned.
         # Make sure that commutativity is preserved and that the original sets are not changed or used as a result.
-        for variable_operand, operation, ab_res, ba_res in test_operations:
-            obj = SomeObject(framework, "2")
+        for i, (variable_operand, operation, ab_res, ba_res) in enumerate(test_operations):
+            obj = SomeObject(framework, str(i))
             obj.state.set = {"a", "b"}
 
             for a, b, expected in [(obj.state.set, variable_operand, ab_res), (variable_operand, obj.state.set, ba_res)]:

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -890,6 +890,9 @@ class TestStoredState(unittest.TestCase):
             # it still contains the old value at this point. State is overridden here via save_snapshot to validate that
             # the modification will not be saved when StoredStateData is not dirty. This check assumes that the artificially
             # created StoredStateData does not observe the on_commit event.
+            # This is the one place where we intentionally create a second object for the framework.
+            # User code should never be doing this, and we need it to test the side effect that 'commit()' is a no-op
+            framework_copy._objects.pop(obj_copy2.handle.path + "/StoredStateData[state]")
             framework_copy.save_snapshot(StoredStateData(obj_copy2, 'state'))
             framework_copy.commit()
 


### PR DESCRIPTION
Ensure that `Object.__init__` doesn't ever create 2 objects that have the same handle path.
This will raise a RuntimeError if 2 objects are created that have the same path. It also won't let you create an Object that matches one that has been created by load_snapshot(), and load_snapshot will also fail if the same object gets loaded 2 times.
The test suite has been updated to use _forget where appropriate. And the Event _reemit also uses _forget. But that seems to be the only cases where we need to use it.