### PR TITLE
Fix ResourceMeta for oci-image type resources

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -229,7 +229,7 @@ class ResourceMeta:
     def __init__(self, name, raw):
         self.resource_name = name
         self.type = raw['type']
-        self.filename = raw['filename']
+        self.filename = raw.get('filename', None)
         self.description = raw.get('description', '')
 
 


### PR DESCRIPTION
Resources of the type `oci-image` do not actually define a filename, since they are actually just metadata about an image in a registry.