### PR TITLE
Cache EventsBase and BoundEvent instances to prevent error

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -235,12 +235,12 @@ class EventsBase(Object):
             self._cache = weakref.WeakKeyDictionary()
 
     def __get__(self, emitter, emitter_type):
-        # Same type, different instance, more data. Doing this unusual construct
-        # means people can subclass just this one class to have their own 'on'.
         if emitter is None:
             return self
         instance = self._cache.get(emitter)
         if instance is None:
+            # Same type, different instance, more data. Doing this unusual construct
+            # means people can subclass just this one class to have their own 'on'.
             instance = self._cache[emitter] = type(self)(emitter)
         return instance
 

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -232,11 +232,12 @@ class EventsBase(Object):
     """Convenience type to allow defining .on attributes at class level."""
 
     handle_kind = "on"
-    _cache = weakref.WeakKeyDictionary()
 
     def __init__(self, parent=None, key=None):
         if parent is not None:
             super().__init__(parent, key)
+        else:
+            self._cache = weakref.WeakKeyDictionary()
 
     def __get__(self, emitter, emitter_type):
         # Same type, different instance, more data. Doing this unusual construct

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -133,7 +133,6 @@ class EventSource:
         self.event_type = event_type
         self.event_kind = None
         self.emitter_type = None
-        self._bound_event = None
 
     def __set_name__(self, emitter_type, event_kind):
         if self.event_kind is not None:
@@ -147,9 +146,7 @@ class EventSource:
     def __get__(self, emitter, emitter_type=None):
         if emitter is None:
             return self
-        if self._bound_event is None:
-            self._bound_event = BoundEvent(emitter, self.event_type, self.event_kind)
-        return self._bound_event
+        return BoundEvent(emitter, self.event_type, self.event_kind)
 
 
 class BoundEvent:
@@ -160,7 +157,7 @@ class BoundEvent:
                 f'at {hex(id(self))}>')
 
     def __init__(self, emitter, event_type, event_kind):
-        self.emitter = weakref.proxy(emitter)
+        self.emitter = emitter
         self.event_type = event_type
         self.event_kind = event_kind
 
@@ -235,13 +232,11 @@ class EventsBase(Object):
     """Convenience type to allow defining .on attributes at class level."""
 
     handle_kind = "on"
+    _cache = weakref.WeakKeyDictionary()
 
     def __init__(self, parent=None, key=None):
         if parent is not None:
             super().__init__(parent, key)
-            self._cache = None
-        else:
-            self._cache = weakref.WeakKeyDictionary()
 
     def __get__(self, emitter, emitter_type):
         # Same type, different instance, more data. Doing this unusual construct

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -448,6 +448,7 @@ class TestFramework(unittest.TestCase):
 
         class MyEvents(EventsBase):
             foo = EventSource(MyEvent)
+            bar = EventSource(MyEvent)
 
         class MyNotifier(Object):
             on = MyEvents()
@@ -461,11 +462,18 @@ class TestFramework(unittest.TestCase):
                 self.seen.append(f"on_foo:{event.handle.kind}")
                 event.defer()
 
+            def on_bar(self, event):
+                self.seen.append(f"on_bar:{event.handle.kind}")
+
         pub = MyNotifier(framework, "1")
         obs = MyObserver(framework, "1")
 
-        framework.observe(pub.on.foo, obs)
+        # Confirm that temporary persistence of BoundEvents doesn't cause errors,
+        # and that events can be observed.
+        for bound_event in [pub.on.foo, pub.on.bar]:
+            framework.observe(bound_event, obs)
 
+        # Confirm that events can be emitted and seen.
         pub.on.foo.emit()
 
         self.assertEqual(obs.seen, ["on_foo:foo"])

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -591,16 +591,14 @@ class TestFramework(unittest.TestCase):
         framework = self.create_framework()
 
         class MyEventsA(EventsBase):
-            pass
+            handle_kind = 'on_a'
 
         class MyEventsB(EventsBase):
-            pass
+            handle_kind = 'on_b'
 
-        class MyNotifierA(Object):
-            on = MyEventsA()
-
-        class MyNotifierB(Object):
-            on = MyEventsB()
+        class MyNotifier(Object):
+            on_a = MyEventsA()
+            on_b = MyEventsB()
 
         class MyObserver(Object):
             def __init__(self, parent, key):
@@ -615,9 +613,8 @@ class TestFramework(unittest.TestCase):
                 self.seen.append(f"on_bar:{type(event).__name__}:{event.handle.kind}")
                 event.defer()
 
-        pub_a = MyNotifierA(framework, "pub_a")
-        pub_b = MyNotifierB(framework, "pub_b")
-        obs = MyObserver(framework, "obs")
+        pub = MyNotifier(framework, "1")
+        obs = MyObserver(framework, "1")
 
         class MyFoo(EventBase):
             pass
@@ -631,32 +628,32 @@ class TestFramework(unittest.TestCase):
         class NoneEvent(EventBase):
             pass
 
-        pub_a.on.define_event("foo", MyFoo)
-        pub_b.on.define_event("bar", MyBar)
+        pub.on_a.define_event("foo", MyFoo)
+        pub.on_b.define_event("bar", MyBar)
 
-        framework.observe(pub_a.on.foo, obs)
-        framework.observe(pub_b.on.bar, obs)
+        framework.observe(pub.on_a.foo, obs)
+        framework.observe(pub.on_b.bar, obs)
 
-        pub_a.on.foo.emit()
-        pub_b.on.bar.emit()
+        pub.on_a.foo.emit()
+        pub.on_b.bar.emit()
 
         self.assertEqual(obs.seen, ["on_foo:MyFoo:foo", "on_bar:MyBar:bar"])
 
         # Definitions remained local to the specific type.
-        self.assertRaises(AttributeError, lambda: pub_a.on.bar)
-        self.assertRaises(AttributeError, lambda: pub_b.on.foo)
+        self.assertRaises(AttributeError, lambda: pub.on_a.bar)
+        self.assertRaises(AttributeError, lambda: pub.on_b.foo)
 
         # Try to use an event name which is not a valid python identifier.
         with self.assertRaises(RuntimeError):
-            pub_a.on.define_event("dead-beef", DeadBeefEvent)
+            pub.on_a.define_event("dead-beef", DeadBeefEvent)
 
         # Try to use a python keyword for an event name.
         with self.assertRaises(RuntimeError):
-            pub_a.on.define_event("None", NoneEvent)
+            pub.on_a.define_event("None", NoneEvent)
 
         # Try to override an existing attribute.
         with self.assertRaises(RuntimeError):
-            pub_a.on.define_event("foo", MyFoo)
+            pub.on_a.define_event("foo", MyFoo)
 
     def test_event_key_roundtrip(self):
         class MyEvent(EventBase):


### PR DESCRIPTION
Keeping a reference to a bound event, even for a short period such as when [looping over a set of events][1], will lead to an "two objects claiming to be GitLabK8sCharm/on have been created" error due to new `EventsBase` instances being created each time, while the `BoundEvent` instance keeps a reference to the instance it was bound to.

Fixes #103

[1]: https://github.com/johnsca/charm-gitlab-k8s/blob/fe834fbe42a1ee478c3522663c063afdf7e5a869/src/charm.py#L29-L33