### PR TITLE
Add a Juju version comparison module

### DIFF
--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -1,0 +1,75 @@
+import re
+from functools import total_ordering
+
+
+@total_ordering
+class JujuVersion:
+
+    PATTERN = r'^(\d{1,9})\.(\d{1,9})((?:\.|-([a-z]+))(\d{1,9}))?(\.(\d{1,9}))?$'
+
+    def __init__(self, version):
+        m = re.match(self.PATTERN, version)
+        if not m:
+            raise RuntimeError(f"{version} is not a valid Juju version string.")
+
+        self.major = int(m.group(1))
+        self.minor = int(m.group(2))
+        tag = m.group(4)
+        if tag is None:
+            tag = ''
+        self.tag = tag
+
+        patch = m.group(5)
+        if patch is None:
+            self.patch = 0
+        else:
+            self.patch = int(patch)
+
+        build = m.group(7)
+        if build is None:
+            self.build = 0
+        else:
+            self.build = int(build)
+
+    def __repr__(self):
+        if self.tag:
+            s = f'{self.major}.{self.minor}-{self.tag}{self.patch}'
+        else:
+            s = f'{self.major}.{self.minor}.{self.patch}'
+        if isinstance(self.build, int) and self.build > 0:
+            s += f'.{self.build}'
+        return s
+
+    def __eq__(self, other):
+        if id(self) == id(other):
+            return True
+        if not isinstance(other, JujuVersion) and isinstance(other, str):
+            other = type(self)(other)
+        elif not isinstance(other, JujuVersion):
+            raise RuntimeError(f"Cannot compare Juju version {self} with {other}")
+        return self.major == other.major and self.minor == other.minor\
+            and self.tag == other.tag and self.build == other.build and self.patch == other.patch
+
+    def __lt__(self, other):
+        if id(self) == id(other):
+            return False
+        if not isinstance(other, JujuVersion) and isinstance(other, str):
+            other = type(self)(other)
+        elif not isinstance(other, JujuVersion):
+            raise RuntimeError(f"Cannot compare Juju version {self} with {other}")
+
+        if self.major != other.major:
+            return self.major < other.major
+        elif self.minor != other.minor:
+            return self.minor < other.minor
+        elif self.tag != other.tag:
+            if not self.tag:
+                return False
+            elif not other.tag:
+                return True
+            return self.tag < other.tag
+        elif self.patch != other.patch:
+            return self.patch < other.patch
+        elif self.build != other.build:
+            return self.build < other.build
+        return False

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+import unittest
+from ops.jujuversion import JujuVersion
+
+
+class TestJujuVersion(unittest.TestCase):
+
+    def test_parsing(self):
+        test_cases = [(
+            "0.0.0", 0, 0, '', 0, 0,
+        ), (
+            "0.0.2", 0, 0, '', 2, 0,
+        ), (
+            "0.1.0", 0, 1, '', 0, 0,
+        ), (
+            "0.2.3", 0, 2, '', 3, 0,
+        ), (
+            "10.234.3456", 10, 234, '', 3456, 0,
+        ), (
+            "10.234.3456.1", 10, 234, '', 3456, 1,
+        ), (
+            "1.21-alpha12", 1, 21, 'alpha', 12, 0,
+        ), (
+            "1.21-alpha1.34", 1, 21, 'alpha', 1, 34,
+        ), (
+            "2.7", 2, 7, '', 0, 0,
+        )]
+
+        for vs, major, minor, tag, patch, build in test_cases:
+            v = JujuVersion(vs)
+            self.assertEqual(v.major, major)
+            self.assertEqual(v.minor, minor)
+            self.assertEqual(v.tag, tag)
+            self.assertEqual(v.patch, patch)
+            self.assertEqual(v.build, build)
+
+    def test_parsing_errors(self):
+        invalid_versions = [
+            "xyz",
+            "foo.bar",
+            "foo.bar.baz",
+            "dead.beef.ca.fe",
+            "1234567890.2.1",     # The major version is too long.
+            "0.2..1",             # Two periods next to each other.
+            "1.21.alpha1",        # Tag comes after period.
+            "1.21-alpha",         # No patch number but a tag is present.
+            "1.21-alpha1beta",    # Non-numeric string after the patch number.
+            "1.21-alpha-dev",     # Tag duplication.
+            "1.21-alpha_dev3",    # Underscore in a tag.
+            "1.21-alpha123dev3",  # Non-numeric string after the patch number.
+        ]
+        for v in invalid_versions:
+            with self.assertRaises(RuntimeError):
+                JujuVersion(v)
+
+    def test_equality(self):
+        test_cases = [
+            ("1.0.0", "1.0.0", True),
+            ("01.0.0", "1.0.0", True),
+            ("10.0.0", "9.0.0", False),
+            ("1.0.0", "1.0.1", False),
+            ("1.0.1", "1.0.0", False),
+            ("1.0.0", "1.1.0", False),
+            ("1.1.0", "1.0.0", False),
+            ("1.0.0", "2.0.0", False),
+            ("1.2-alpha1", "1.2.0", False),
+            ("1.2-alpha2", "1.2-alpha1", False),
+            ("1.2-alpha2.1", "1.2-alpha2", False),
+            ("1.2-alpha2.2", "1.2-alpha2.1", False),
+            ("1.2-beta1", "1.2-alpha1", False),
+            ("1.2-beta1", "1.2-alpha2.1", False),
+            ("1.2-beta1", "1.2.0", False),
+            ("1.2.1", "1.2.0", False),
+            ("2.0.0", "1.0.0", False),
+            ("2.0.0.0", "2.0.0", True),
+            ("2.0.0.0", "2.0.0.0", True),
+            ("2.0.0.1", "2.0.0.0", False),
+            ("2.0.1.10", "2.0.0.0", False),
+        ]
+
+        for a, b, expected in test_cases:
+            self.assertEqual(JujuVersion(a) == JujuVersion(b), expected)
+            self.assertEqual(JujuVersion(a) == b, expected)
+
+    def test_comparison(self):
+        test_cases = [
+            ("1.0.0", "1.0.0", False, True),
+            ("01.0.0", "1.0.0", False, True),
+            ("10.0.0", "9.0.0", False, False),
+            ("1.0.0", "1.0.1", True, True),
+            ("1.0.1", "1.0.0", False, False),
+            ("1.0.0", "1.1.0", True, True),
+            ("1.1.0", "1.0.0", False, False),
+            ("1.0.0", "2.0.0", True, True),
+            ("1.2-alpha1", "1.2.0", True, True),
+            ("1.2-alpha2", "1.2-alpha1", False, False),
+            ("1.2-alpha2.1", "1.2-alpha2", False, False),
+            ("1.2-alpha2.2", "1.2-alpha2.1", False, False),
+            ("1.2-beta1", "1.2-alpha1", False, False),
+            ("1.2-beta1", "1.2-alpha2.1", False, False),
+            ("1.2-beta1", "1.2.0", True, True),
+            ("1.2.1", "1.2.0", False, False),
+            ("2.0.0", "1.0.0", False, False),
+            ("2.0.0.0", "2.0.0", False, True),
+            ("2.0.0.0", "2.0.0.0", False, True),
+            ("2.0.0.1", "2.0.0.0", False, False),
+            ("2.0.1.10", "2.0.0.0", False, False),
+        ]
+
+        for a, b, expected_strict, expected_weak in test_cases:
+            self.assertEqual(JujuVersion(a) < JujuVersion(b), expected_strict)
+            self.assertEqual(JujuVersion(a) <= JujuVersion(b), expected_weak)
+            self.assertEqual(JujuVersion(b) > JujuVersion(a), expected_strict)
+            self.assertEqual(JujuVersion(b) >= JujuVersion(a), expected_weak)
+            # Implicit conversion.
+            self.assertEqual(JujuVersion(a) < b, expected_strict)
+            self.assertEqual(JujuVersion(a) <= b, expected_weak)
+            self.assertEqual(b > JujuVersion(a), expected_strict)
+            self.assertEqual(b >= JujuVersion(a), expected_weak)


### PR DESCRIPTION
Introduce support for Juju version comparison in order to allow for
version-specific checks and warnings in the framework.