### PR TITLE
Add convience properties for accessing model, meta, and charm_dir

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -194,6 +194,9 @@ class Object:
         kind = self.handle_kind
         if isinstance(parent, Framework):
             self.framework = parent
+            # Avoid Framework instances having a circular reference to themselves.
+            if self.framework is self:
+                self.framework = weakref.proxy(self.framework)
             self.handle = Handle(None, kind, key)
         else:
             self.framework = parent.framework
@@ -211,6 +214,18 @@ class Object:
                 self.framework.register_type(event_type, emitter, event_kind)
 
         # TODO Detect conflicting handles here.
+
+    @property
+    def model(self):
+        return self.framework.model
+
+    @property
+    def meta(self):
+        return self.framework.meta
+
+    @property
+    def charm_dir(self):
+        return self.framework.charm_dir
 
 
 class EventsBase(Object):
@@ -375,6 +390,11 @@ class SQLiteStorage:
 class Framework(Object):
 
     on = FrameworkEvents()
+
+    # Override properties from Object so that we can set them in __init__.
+    model = None
+    meta = None
+    charm_dir = None
 
     def __init__(self, data_path, charm_dir, meta, model):
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -700,6 +700,16 @@ class TestFramework(unittest.TestCase):
         # (The event key goes up by 2 due to the pre-commit and commit events.)
         self.assertEqual(obs2.seen, [('4', 'second'), ('1', 'first')])
 
+    def test_helper_properties(self):
+        framework = self.create_framework()
+        framework.model = 'test-model'
+        framework.meta = 'test-meta'
+
+        my_obj = Object(framework, 'my_obj')
+        self.assertEqual(my_obj.model, framework.model)
+        self.assertEqual(my_obj.meta, framework.meta)
+        self.assertEqual(my_obj.charm_dir, framework.charm_dir)
+
 
 class TestStoredState(unittest.TestCase):
 


### PR DESCRIPTION
Always having to write `self.framework.model` gets repetitive and has to be done frequently enough that having a short-cut of `self.model` is worth doing.