### PR TITLE
Use git+https URL for pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Then install the framework into the `lib/` directory using:
 
 ```
 mkdir lib/
-pip install -t lib/ https://github.com/canonical/operator
+pip install -t lib/ git+https://github.com/canonical/operator
 ```
 
 Your `src/charm.py` is the entry point for your charm logic. At a minimum, it


### PR DESCRIPTION
This seems to be the supported syntax per [pip's documentation](https://pip.pypa.io/en/stable/reference/pip_install/#git). Without it, pip seems to incorrectly treat the GitHub URL as an archive:

```
Collecting https://github.com/canonical/operator
  Downloading https://github.com/canonical/operator
     | 112kB 549kB/s
  ERROR: Cannot unpack file /run/user/9000/pip-unpack-gfd5qem8/operator (downloaded from /run/user/9000/pip-req-build-n9xrwe8b, content-type: text/html; charset=utf-8); cannot detect archive format
ERROR: Cannot determine archive format of /run/user/9000/pip-req-build-n9xrwe8b
```