### PR TITLE
Fix .app population for single-unit peer relations

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -236,6 +236,10 @@ class Relation:
         except RelationNotFoundError:
             # If the relation is dead, just treat it as if it has no remote units.
             pass
+        # If an application has not been determined based on a remote unit, the only remaining
+        # case is a single unit and its peer relation where the application is our unit's application.
+        if self.app is None:
+            self.app = our_unit.app
         self.data = RelationData(self, our_unit, backend)
 
     def __repr__(self):

--- a/ops/model.py
+++ b/ops/model.py
@@ -209,9 +209,9 @@ class RelationMapping(Mapping):
         return relation_list
 
     def _get_unique(self, relation_name, relation_id=None):
-        if not isinstance(relation_id, (int, type(None))):
-            raise ModelError(f'relation name {relation_id} must be int or None not {type(relation_id).__name__}')
         if relation_id is not None:
+            if not isinstance(relation_id, int):
+                raise ModelError(f'relation name {relation_id} must be int or None not {type(relation_id).__name__}')
             for relation in self[relation_name]:
                 if relation.id == relation_id:
                     return relation
@@ -219,16 +219,15 @@ class RelationMapping(Mapping):
                 # The relation may be dead, but it is not forgotten.
                 is_peer = relation_name in self._peers
                 return Relation(relation_name, relation_id, is_peer, self._our_unit, self._backend, self._cache)
+        num_related = len(self[relation_name])
+        if num_related == 0:
+            return None
+        elif num_related == 1:
+            return self[relation_name][0]
         else:
-            num_related = len(self[relation_name])
-            if num_related == 0:
-                return None
-            elif num_related == 1:
-                return self[relation_name][0]
-            else:
-                # TODO: We need something in the framework to catch and gracefully handle
-                # errors, ideally integrating the error catching with Juju's mechanisms.
-                raise TooManyRelatedAppsError(relation_name, num_related, 1)
+            # TODO: We need something in the framework to catch and gracefully handle
+            # errors, ideally integrating the error catching with Juju's mechanisms.
+            raise TooManyRelatedAppsError(relation_name, num_related, 1)
 
 
 class Relation:

--- a/ops/model.py
+++ b/ops/model.py
@@ -15,7 +15,6 @@ from subprocess import run, PIPE, CalledProcessError
 class Model:
 
     def __init__(self, unit_name, meta, backend):
-        self._meta = meta
         self._cache = ModelCache(backend)
         self._backend = backend
         self.unit = self.get_unit(unit_name)

--- a/ops/model.py
+++ b/ops/model.py
@@ -218,8 +218,8 @@ class RelationMapping(Mapping):
         relation_list = self._data[relation_name]
         if relation_list is None:
             relation_list = self._data[relation_name] = []
+            relation_role = self._relations_meta[relation_name].role
             for relation_id in self._backend.relation_ids(relation_name):
-                relation_role = self._relations_meta[relation_name].role
                 relation_list.append(Relation(relation_name, relation_id, relation_role, self._our_unit, self._backend, self._cache))
         return relation_list
 
@@ -232,8 +232,7 @@ class Relation:
         self.app = None
         self.units = set()
 
-        # For peer relations an app of a remote unit is a local app so the remote app becomes a local app. When there
-        # is only one unit present, there are no remote units to draw a remote app from so it can be done from our unit instead.
+        # For peer relations, both the remote and the local app are the same.
         if self.role == 'peers':
             self.app = our_unit.app
         try:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -10,7 +10,7 @@ import ops.model
 import ops.charm
 from ops.charm import RelationMeta
 
-from .test_helpers import fake_script, fake_script_calls
+from test.test_helpers import fake_script, fake_script_calls
 
 
 class TestModel(unittest.TestCase):
@@ -457,11 +457,6 @@ class TestModel(unittest.TestCase):
             ops.model.ActiveStatus('test')
 
     def test_local_set_valid_unit_status(self):
-        self.backend = ops.model.ModelBackend()
-        meta = ops.charm.CharmMeta()
-        meta.relations = {'db0': None, 'db1': None, 'db2': None}
-        self.model = ops.model.Model('myapp/0', meta, self.backend)
-
         test_cases = [(
             ops.model.ActiveStatus(),
             lambda: fake_script(self, 'status-set', 'exit 0'),
@@ -490,13 +485,7 @@ class TestModel(unittest.TestCase):
             check_tool_calls()
 
     def test_local_set_valid_app_status(self):
-        self.backend = ops.model.ModelBackend()
-        meta = ops.charm.CharmMeta()
-        meta.relations = {'db0': None, 'db1': None, 'db2': None}
-        self.model = ops.model.Model('myapp/0', meta, self.backend)
-
         fake_script(self, 'is-leader', 'echo true')
-
         test_cases = [(
             ops.model.ActiveStatus(),
             lambda: fake_script(self, 'status-set', 'exit 0'),
@@ -525,11 +514,6 @@ class TestModel(unittest.TestCase):
             check_tool_calls()
 
     def test_set_app_status_non_leader_raises(self):
-        self.backend = ops.model.ModelBackend()
-        meta = ops.charm.CharmMeta()
-        meta.relations = {'db0': None, 'db1': None, 'db2': None}
-        self.model = ops.model.Model('myapp/0', meta, self.backend)
-
         fake_script(self, 'is-leader', 'echo false')
 
         with self.assertRaises(RuntimeError):
@@ -539,11 +523,6 @@ class TestModel(unittest.TestCase):
             self.model.app.status = ops.model.ActiveStatus()
 
     def test_local_set_invalid_status(self):
-        self.backend = ops.model.ModelBackend()
-        meta = ops.charm.CharmMeta()
-        meta.relations = {'db0': None, 'db1': None, 'db2': None}
-        self.model = ops.model.Model('myapp/0', meta, self.backend)
-
         fake_script(self, 'status-set', 'exit 1')
         fake_script(self, 'is-leader', 'echo true')
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -8,6 +8,7 @@ import re
 
 import ops.model
 import ops.charm
+from ops.charm import RelationMeta
 
 from .test_helpers import fake_script, fake_script_calls
 
@@ -24,7 +25,11 @@ class TestModel(unittest.TestCase):
 
         self.backend = ops.model.ModelBackend()
         meta = ops.charm.CharmMeta()
-        meta.relations = {'db0': None, 'db1': None, 'db2': None}
+        meta.relations = {
+            'db0': RelationMeta('provides', 'db0', {'interface': 'db0', 'scope': 'global'}),
+            'db1': RelationMeta('requires', 'db1', {'interface': 'db1', 'scope': 'global'}),
+            'db2': RelationMeta('peers', 'db2', {'interface': 'db2', 'scope': 'global'}),
+        }
         self.model = ops.model.Model('myapp/0', meta, self.backend)
 
     def test_model(self):
@@ -83,7 +88,7 @@ class TestModel(unittest.TestCase):
 
     def test_peer_relation_app(self):
         meta = ops.charm.CharmMeta()
-        meta.relations = {'dbpeer': None}
+        meta.relations = {'dbpeer': RelationMeta('peers', 'dbpeer', {'interface': 'dbpeer', 'scope': 'global'})}
         self.model = ops.model.Model('myapp/0', meta, self.backend)
 
         err_msg = "ERROR invalid value \"$2\" for option -r: relation not found"
@@ -132,11 +137,6 @@ class TestModel(unittest.TestCase):
         ])
 
     def test_remote_app_relation_data(self):
-        self.backend = ops.model.ModelBackend()
-        meta = ops.charm.CharmMeta()
-        meta.relations = {'db0': None, 'db1': None, 'db2': None}
-        self.model = ops.model.Model('myapp/0', meta, self.backend)
-
         fake_script(self, 'relation-ids', """[ "$1" = db1 ] && echo '["db1:4"]' || echo '[]'""")
         fake_script(self, 'relation-list', """[ "$2" = 4 ] && echo '["remoteapp1/0", "remoteapp1/1"]' || exit 2""")
         fake_script(self, 'relation-get', """[ "$2" = 4 ] && [ "$4" = remoteapp1 ] && echo '{"secret": "cafedeadbeef"}' || exit 2""")
@@ -194,11 +194,6 @@ class TestModel(unittest.TestCase):
         ])
 
     def test_app_relation_data_modify_local_as_leader(self):
-        self.backend = ops.model.ModelBackend()
-        meta = ops.charm.CharmMeta()
-        meta.relations = {'db0': None, 'db1': None, 'db2': None}
-        self.model = ops.model.Model('myapp/0', meta, self.backend)
-
         fake_script(self, 'relation-ids', """[ "$1" = db1 ] && echo '["db1:4"]' || echo '[]'""")
         fake_script(self, 'relation-list', """[ "$2" = 4 ] && echo '["remoteapp1/0", "remoteapp1/1"]' || exit 2""")
         fake_script(self, 'relation-get', """[ "$2" = 4 ] && [ "$4" = myapp ] && echo '{"password": "deadbeefcafe"}' || exit 2""")
@@ -223,11 +218,6 @@ class TestModel(unittest.TestCase):
         ])
 
     def test_app_relation_data_modify_local_as_minion(self):
-        self.backend = ops.model.ModelBackend()
-        meta = ops.charm.CharmMeta()
-        meta.relations = {'db0': None, 'db1': None, 'db2': None}
-        self.model = ops.model.Model('myapp/0', meta, self.backend)
-
         fake_script(self, 'relation-ids', """[ "$1" = db1 ] && echo '["db1:4"]' || echo '[]'""")
         fake_script(self, 'relation-list', """[ "$2" = 4 ] && echo '["remoteapp1/0", "remoteapp1/1"]' || exit 2""")
         fake_script(self, 'relation-get', """[ "$2" = 4 ] && [ "$4" = myapp ] && echo '{"password": "deadbeefcafe"}' || exit 2""")
@@ -364,7 +354,11 @@ class TestModel(unittest.TestCase):
         # Create a new model and backend to drop a cached is-leader output.
         self.backend = ops.model.ModelBackend()
         meta = ops.charm.CharmMeta()
-        meta.relations = {'db0': None, 'db1': None, 'db2': None}
+        meta.relations = {
+            'db0': RelationMeta('provides', 'db0', {'interface': 'db0', 'scope': 'global'}),
+            'db1': RelationMeta('requires', 'db1', {'interface': 'db1', 'scope': 'global'}),
+            'db2': RelationMeta('peers', 'db2', {'interface': 'db2', 'scope': 'global'}),
+        }
         self.model = ops.model.Model('myapp/0', meta, self.backend)
 
         fake_script(self, 'is-leader', 'echo false')
@@ -577,11 +571,6 @@ class TestModel(unittest.TestCase):
                 self.backend.status_set(ops.model.ActiveStatus, is_app=is_app_v)
 
     def test_remote_unit_status(self):
-        self.backend = ops.model.ModelBackend()
-        meta = ops.charm.CharmMeta()
-        meta.relations = {'db0': None, 'db1': None, 'db2': None}
-        self.model = ops.model.Model('myapp/0', meta, self.backend)
-
         fake_script(self, 'relation-ids', """[ "$1" = db1 ] && echo '["db1:4"]' || echo '[]'""")
         fake_script(self, 'relation-list', """[ "$2" = 4 ] && echo '["remoteapp1/0", "remoteapp1/1"]' || exit 2""")
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -46,12 +46,6 @@ class TestModel(unittest.TestCase):
             unit_from_rel = next(filter(lambda u: u.name == 'myapp/0', relation.data.keys()))
             self.assertIs(self.model.unit, unit_from_rel)
 
-        for relation_key in [('db2', 5), ('db2', 6)]:
-            relation = self.model.relations[relation_key]
-            self.assertIn(self.model.unit, relation.data)
-            unit_from_rel = next(filter(lambda u: u.name == 'myapp/0', relation.data.keys()))
-            self.assertIs(self.model.unit, unit_from_rel)
-
         self.assertEqual(fake_script_calls(self), [
             ['relation-ids', 'db2', '--format=json'],
             ['relation-list', '-r', '5', '--format=json'],

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -46,6 +46,12 @@ class TestModel(unittest.TestCase):
             unit_from_rel = next(filter(lambda u: u.name == 'myapp/0', relation.data.keys()))
             self.assertIs(self.model.unit, unit_from_rel)
 
+        for relation_key in [('db2', 5), ('db2', 6)]:
+            relation = self.model.relations[relation_key]
+            self.assertIn(self.model.unit, relation.data)
+            unit_from_rel = next(filter(lambda u: u.name == 'myapp/0', relation.data.keys()))
+            self.assertIs(self.model.unit, unit_from_rel)
+
         self.assertEqual(fake_script_calls(self), [
             ['relation-ids', 'db2', '--format=json'],
             ['relation-list', '-r', '5', '--format=json'],

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -98,7 +98,7 @@ class TestModel(unittest.TestCase):
                     f"""([ "$2" = 0 ] && echo '[]') || (echo {err_msg} >&2 ; exit 2)""")
 
         db1_4 = self.model.get_relation('dbpeer')
-        self.assertEqual(db1_4.app, self.model.app)
+        self.assertIs(db1_4.app, self.model.app)
 
     def test_remote_units_is_our(self):
         fake_script(self, 'relation-ids',

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -81,6 +81,20 @@ class TestModel(unittest.TestCase):
             ['relation-list', '-r', '6', '--format=json']
         ])
 
+    def test_peer_relation_app(self):
+        meta = ops.charm.CharmMeta()
+        meta.relations = {'dbpeer': None}
+        self.model = ops.model.Model('myapp/0', meta, self.backend)
+
+        err_msg = "ERROR invalid value \"$2\" for option -r: relation not found"
+        fake_script(self, 'relation-ids',
+                    """([ "$1" = dbpeer ] && echo '["dbpeer:0"]') || echo '[]'""")
+        fake_script(self, 'relation-list',
+                    f"""([ "$2" = 0 ] && echo '[]') || (echo {err_msg} >&2 ; exit 2)""")
+
+        db1_4 = self.model.get_relation('dbpeer')
+        self.assertEqual(db1_4.app, self.model.app)
+
     def test_remote_units_is_our(self):
         fake_script(self, 'relation-ids',
                     """[ "$1" = db1 ] && echo '["db1:4"]' || echo '[]'""")

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -93,9 +93,9 @@ class TestModel(unittest.TestCase):
 
         err_msg = "ERROR invalid value \"$2\" for option -r: relation not found"
         fake_script(self, 'relation-ids',
-                    """([ "$1" = dbpeer ] && echo '["dbpeer:0"]') || echo '[]'""")
+                    '''([ "$1" = dbpeer ] && echo '["dbpeer:0"]') || echo "[]"''')
         fake_script(self, 'relation-list',
-                    f"""([ "$2" = 0 ] && echo '[]') || (echo {err_msg} >&2 ; exit 2)""")
+                    f'''([ "$2" = 0 ] && echo "[]") || (echo {err_msg} >&2 ; exit 2)''')
 
         db1_4 = self.model.get_relation('dbpeer')
         self.assertIs(db1_4.app, self.model.app)


### PR DESCRIPTION
Currently .app property is None when a peer relation contains only one
unit (relation-list returns an empty list). This change addresses the
issue.