### PR TITLE
Add network-get support to ModelBackend

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -622,3 +622,14 @@ class ModelBackend:
         if not isinstance(count, int) or isinstance(count, bool):
             raise TypeError(f'storage count must be integer, got: {count} ({type(count)})')
         self._run('storage-add', f'{name}={count}')
+
+    def network_get(self, endpoint_name, relation_id=None):
+        """Return network info provided by network-get for a given endpoint.
+
+        endpoint_name -- A name of an endpoint (relation name or extra-binding name).
+        relation_id -- An optional relation id to get network info for.
+        """
+        cmd = ['network-get', endpoint_name]
+        if relation_id is not None:
+            cmd.extend(['-r', str(relation_id)])
+        return self._run(*cmd, return_output=True, use_json=True)

--- a/ops/model.py
+++ b/ops/model.py
@@ -632,4 +632,9 @@ class ModelBackend:
         cmd = ['network-get', endpoint_name]
         if relation_id is not None:
             cmd.extend(['-r', str(relation_id)])
-        return self._run(*cmd, return_output=True, use_json=True)
+        try:
+            return self._run(*cmd, return_output=True, use_json=True)
+        except ModelError as e:
+            if 'relation not found' in str(e):
+                raise RelationNotFoundError() from e
+            raise

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -769,9 +769,27 @@ class TestModelBackend(unittest.TestCase):
             self.assertEqual(fake_script_calls(self, clear=True), calls)
 
     def test_network_get(self):
-        network_get_out = ('{"bind-addresses":[{"mac-address":"","interface-name":"",'
-                           '"addresses":[{"hostname":"","value":"192.0.2.2","cidr":""}]}]'
-                           ',"egress-subnets":["192.0.2.2/32"],"ingress-addresses":["192.0.2.2"]}')
+        network_get_out = '''{
+  "bind-addresses": [
+    {
+      "mac-address": "",
+      "interface-name": "",
+      "addresses": [
+        {
+          "hostname": "",
+          "value": "192.0.2.2",
+          "cidr": ""
+        }
+      ]
+    }
+  ],
+  "egress-subnets": [
+    "192.0.2.2/32"
+  ],
+  "ingress-addresses": [
+    "192.0.2.2"
+  ]
+}'''
         fake_script(self, 'network-get', f'''[ "$1" = deadbeef ] && echo '{network_get_out}' || exit 1''')
         network_info = self.backend.network_get('deadbeef')
         self.assertEqual(network_info, json.loads(network_get_out))
@@ -782,8 +800,8 @@ class TestModelBackend(unittest.TestCase):
         self.assertEqual(fake_script_calls(self, clear=True), [['network-get', 'deadbeef', '-r', '1', '--format=json']])
 
     def test_network_get_errors(self):
-        err_no_endpoint = "ERROR no network config found for binding \"$2\""
-        err_no_rel = "ERROR invalid value \"$3\" for option -r: relation not found"
+        err_no_endpoint = 'ERROR no network config found for binding "$2"'
+        err_no_rel = 'ERROR invalid value "$3" for option -r: relation not found'
 
         test_cases = [(
             lambda: fake_script(self, 'network-get', f'echo {err_no_endpoint} >&2 ; exit 1'),

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -784,7 +784,7 @@ class TestModelBackend(unittest.TestCase):
         ), (
             lambda: fake_script(self, 'network-get', f'echo {err_no_rel} >&2 ; exit 2'),
             lambda: self.backend.network_get("deadbeef", 3),
-            ops.model.ModelError,
+            ops.model.RelationNotFoundError,
             [['network-get', 'deadbeef', '-r', '3', '--format=json']],
         )]
         for do_fake, run, exception, calls in test_cases:


### PR DESCRIPTION
Hook tool handling for network-get which may be a base for further
endpoint modeling in the model.