### PR TITLE
Move charm.py to src in test_main

### DIFF
--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -4,7 +4,7 @@ import os
 import base64
 import pickle
 import sys
-sys.path.append('lib') # noqa
+sys.path.append('lib')  # noqa
 
 from ops.charm import CharmBase
 from ops.main import main

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -3,6 +3,8 @@
 import os
 import base64
 import pickle
+import sys
+sys.path.append('lib') # noqa
 
 from ops.charm import CharmBase
 from ops.main import main

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -80,10 +80,10 @@ class TestMain(unittest.TestCase):
     def _setup_charm_dir(self):
         self.JUJU_CHARM_DIR = Path(tempfile.mkdtemp()) / 'test_main'
         self.hooks_dir = self.JUJU_CHARM_DIR / 'hooks'
-        self.charm_exec_path = os.path.relpath(self.JUJU_CHARM_DIR / 'lib/charm.py', self.hooks_dir)
+        self.charm_exec_path = os.path.relpath(self.JUJU_CHARM_DIR / 'src/charm.py', self.hooks_dir)
         shutil.copytree(TEST_CHARM_DIR, self.JUJU_CHARM_DIR)
 
-        charm_spec = importlib.util.spec_from_file_location("charm", str(self.JUJU_CHARM_DIR / 'lib/charm.py'))
+        charm_spec = importlib.util.spec_from_file_location("charm", str(self.JUJU_CHARM_DIR / 'src/charm.py'))
         self.charm_module = importlib.util.module_from_spec(charm_spec)
         charm_spec.loader.exec_module(self.charm_module)
 


### PR DESCRIPTION
Readme was updated to account for the new recommended directory structure but not the test_main charm.