### PR TITLE
Rename functions back to actions

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -7,28 +7,28 @@ class HookEvent(EventBase):
     pass
 
 
-class FunctionEvent(EventBase):
+class ActionEvent(EventBase):
 
     def defer(self):
-        raise RuntimeError('cannot defer function events')
+        raise RuntimeError('cannot defer action events')
 
     def restore(self, snapshot):
-        env_function_name = os.environ.get('JUJU_FUNCTION_NAME', os.environ.get('JUJU_ACTION_NAME'))
-        event_function_name = self.handle.kind[:-len('_function')].replace('_', '-')
-        if event_function_name != env_function_name:
-            # This could only happen if the dev manually emits the function, or from a bug.
-            raise RuntimeError('function event kind does not match current function')
+        env_action_name = os.environ.get('JUJU_ACTION_NAME')
+        event_action_name = self.handle.kind[:-len('_action')].replace('_', '-')
+        if event_action_name != env_action_name:
+            # This could only happen if the dev manually emits the action, or from a bug.
+            raise RuntimeError('action event kind does not match current action')
         # Params are loaded at restore rather than __init__ because the model is not available in __init__.
-        self.params = self.framework.model._backend.function_get()
+        self.params = self.framework.model._backend.action_get()
 
     def set_results(self, results):
-        self.framework.model._backend.function_set(results)
+        self.framework.model._backend.action_set(results)
 
     def log(self, message):
-        self.framework.model._backend.function_log(message)
+        self.framework.model._backend.action_log(message)
 
     def fail(self, message=''):
-        self.framework.model._backend.function_fail(message)
+        self.framework.model._backend.action_fail(message)
 
 
 class InstallEvent(HookEvent):
@@ -170,9 +170,9 @@ class CharmBase(Object):
             self.on.define_event(f'{storage_name}_storage_attached', StorageAttachedEvent)
             self.on.define_event(f'{storage_name}_storage_detaching', StorageDetachingEvent)
 
-        for function_name in self.framework.meta.functions:
-            function_name = function_name.replace('-', '_')
-            self.on.define_event(f'{function_name}_function', FunctionEvent)
+        for action_name in self.framework.meta.actions:
+            action_name = action_name.replace('-', '_')
+            self.on.define_event(f'{action_name}_action', ActionEvent)
 
 
 class CharmMeta:
@@ -188,7 +188,7 @@ class CharmMeta:
     the relation definition can be obtained from its role attribute.
     """
 
-    def __init__(self, raw={}, functions_raw={}):
+    def __init__(self, raw={}, actions_raw={}):
         self.name = raw.get('name', '')
         self.summary = raw.get('summary', '')
         self.description = raw.get('description', '')
@@ -219,7 +219,7 @@ class CharmMeta:
         self.payloads = {name: PayloadMeta(name, payload)
                          for name, payload in raw.get('payloads', {}).items()}
         self.extra_bindings = raw.get('extra-bindings', [])
-        self.functions = {name: FunctionMeta(name, function) for name, function in functions_raw.items()}
+        self.actions = {name: ActionMeta(name, action) for name, action in actions_raw.items()}
 
 
 class RelationMeta:
@@ -271,7 +271,7 @@ class PayloadMeta:
         self.type = raw['type']
 
 
-class FunctionMeta:
+class ActionMeta:
 
     def __init__(self, name, raw=None):
         raw = raw or {}

--- a/ops/model.py
+++ b/ops/model.py
@@ -508,10 +508,6 @@ class ModelBackend:
         self.unit_name = os.environ['JUJU_UNIT_NAME']
         self.app_name = self.unit_name.split('/')[0]
 
-        if shutil.which('function-get'):
-            self._function_cmd_prefix = 'function'
-        else:
-            self._function_cmd_prefix = 'action'
         self._is_leader = None
         self._leader_check_time = 0
 
@@ -627,14 +623,14 @@ class ModelBackend:
             raise TypeError(f'storage count must be integer, got: {count} ({type(count)})')
         self._run('storage-add', f'{name}={count}')
 
-    def function_get(self):
-        return self._run(f'{self._function_cmd_prefix}-get', return_output=True, use_json=True)
+    def action_get(self):
+        return self._run(f'action-get', return_output=True, use_json=True)
 
-    def function_set(self, results):
-        self._run(f'{self._function_cmd_prefix}-set', *[f"{k}={v}" for k, v in results.items()])
+    def action_set(self, results):
+        self._run(f'action-set', *[f"{k}={v}" for k, v in results.items()])
 
-    def function_log(self, message):
-        self._run(f'{self._function_cmd_prefix}-log', f"{message}")
+    def action_log(self, message):
+        self._run(f'action-log', f"{message}")
 
-    def function_fail(self, message=''):
-        self._run(f'{self._function_cmd_prefix}-fail', f"{message}")
+    def action_fail(self, message=''):
+        self._run(f'action-fail', f"{message}")

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -38,8 +38,8 @@ class Charm(CharmBase):
         self._state['on_mon_relation_changed'] = []
         self._state['on_mon_relation_departed'] = []
         self._state['on_ha_relation_broken'] = []
-        self._state['on_foo_bar_function'] = []
-        self._state['on_start_function'] = []
+        self._state['on_foo_bar_action'] = []
+        self._state['on_start_action'] = []
 
         # Observed event types per invocation. A list is used to preserve the order in which charm handlers have observed the events.
         self._state['observed_event_types'] = []
@@ -56,9 +56,9 @@ class Charm(CharmBase):
         self.framework.observe(self.on.mon_relation_departed, self)
         self.framework.observe(self.on.ha_relation_broken, self)
 
-        if self._charm_config.get('USE_FUNCTIONS'):
-            self.framework.observe(self.on.start_function, self)
-            self.framework.observe(self.on.foo_bar_function, self)
+        if self._charm_config.get('USE_ACTIONS'):
+            self.framework.observe(self.on.start_action, self)
+            self.framework.observe(self.on.foo_bar_action, self)
 
     def _write_state(self):
         """Write state variables so that the parent process can read them.
@@ -126,15 +126,15 @@ class Charm(CharmBase):
         self._state['ha_relation_broken_data'] = event.snapshot()
         self._write_state()
 
-    def on_start_function(self, event):
-        assert event.handle.kind == 'start_function', 'event function name cannot be different from the one being handled'
-        self._state['on_start_function'].append(type(event))
+    def on_start_action(self, event):
+        assert event.handle.kind == 'start_action', 'event action name cannot be different from the one being handled'
+        self._state['on_start_action'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()
 
-    def on_foo_bar_function(self, event):
-        assert event.handle.kind == 'foo_bar_function', 'event function name cannot be different from the one being handled'
-        self._state['on_foo_bar_function'].append(type(event))
+    def on_foo_bar_action(self, event):
+        assert event.handle.kind == 'foo_bar_action', 'event action name cannot be different from the one being handled'
+        self._state['on_foo_bar_action'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()
 

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -200,7 +200,7 @@ class TestCharm(unittest.TestCase):
         ])
 
     @classmethod
-    def _get_function_test_meta(cls):
+    def _get_action_test_meta(cls):
         return CharmMeta(
             {'name': 'my-charm'},
             {
@@ -226,40 +226,40 @@ class TestCharm(unittest.TestCase):
             }
         )
 
-    def _test_function_events(self, cmd_type):
+    def _test_action_events(self, cmd_type):
 
         class MyCharm(CharmBase):
 
             def __init__(self, *args):
                 super().__init__(*args)
-                framework.observe(self.on.foo_bar_function, self)
-                framework.observe(self.on.start_function, self)
+                framework.observe(self.on.foo_bar_action, self)
+                framework.observe(self.on.start_action, self)
 
-            def on_foo_bar_function(self, event):
-                self.seen_function_params = event.params
+            def on_foo_bar_action(self, event):
+                self.seen_action_params = event.params
                 event.log('test-log')
                 event.set_results({'res': 'val with spaces'})
                 event.fail('test-fail')
 
-            def on_start_function(self, event):
+            def on_start_action(self, event):
                 pass
 
         fake_script(self, f'{cmd_type}-get', """echo '{"foo-name": "name", "silent": true}'""")
         fake_script(self, f'{cmd_type}-set', "")
         fake_script(self, f'{cmd_type}-log', "")
         fake_script(self, f'{cmd_type}-fail', "")
-        self.meta = self._get_function_test_meta()
+        self.meta = self._get_action_test_meta()
 
         os.environ[f'JUJU_{cmd_type.upper()}_NAME'] = 'foo-bar'
         framework = self.create_framework()
         charm = MyCharm(framework, None)
 
         events = list(MyCharm.on.events())
-        self.assertIn('foo_bar_function', events)
-        self.assertIn('start_function', events)
+        self.assertIn('foo_bar_action', events)
+        self.assertIn('start_action', events)
 
-        charm.on.foo_bar_function.emit()
-        self.assertEqual(charm.seen_function_params, {"foo-name": "name", "silent": True})
+        charm.on.foo_bar_action.emit()
+        self.assertEqual(charm.seen_action_params, {"foo-name": "name", "silent": True})
         self.assertEqual(fake_script_calls(self), [
             [f'{cmd_type}-get', '--format=json'],
             [f'{cmd_type}-log', "test-log"],
@@ -267,43 +267,37 @@ class TestCharm(unittest.TestCase):
             [f'{cmd_type}-fail', "test-fail"],
         ])
 
-        # Make sure that function events that do not match the current context are
+        # Make sure that action events that do not match the current context are
         # not possible to emit by hand.
         with self.assertRaises(RuntimeError):
-            charm.on.start_function.emit()
+            charm.on.start_action.emit()
 
-    def test_function_events(self):
-        self._test_function_events('function')
+    def test_action_events(self):
+        self._test_action_events('action')
 
-    def test_function_events_legacy(self):
-        self._test_function_events('action')
-
-    def _test_function_event_defer_fails(self, cmd_type):
+    def _test_action_event_defer_fails(self, cmd_type):
 
         class MyCharm(CharmBase):
 
             def __init__(self, *args):
                 super().__init__(*args)
-                framework.observe(self.on.start_function, self)
+                framework.observe(self.on.start_action, self)
 
-            def on_start_function(self, event):
+            def on_start_action(self, event):
                 event.defer()
 
         fake_script(self, f'{cmd_type}-get', """echo '{"foo-name": "name", "silent": true}'""")
-        self.meta = self._get_function_test_meta()
+        self.meta = self._get_action_test_meta()
 
         os.environ[f'JUJU_{cmd_type.upper()}_NAME'] = 'start'
         framework = self.create_framework()
         charm = MyCharm(framework, None)
 
         with self.assertRaises(RuntimeError):
-            charm.on.start_function.emit()
+            charm.on.start_action.emit()
 
-    def test_function_event_defer_fails(self):
-        self._test_function_event_defer_fails('function')
-
-    def test_function_event_defer_legacy(self):
-        self._test_function_event_defer_fails('action')
+    def test_action_event_defer_fails(self):
+        self._test_action_event_defer_fails('action')
 
 
 if __name__ == "__main__":

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -30,7 +30,7 @@ from ops.charm import (
     RelationBrokenEvent,
     RelationEvent,
     StorageAttachedEvent,
-    FunctionEvent,
+    ActionEvent,
 )
 
 from .test_helpers import fake_script
@@ -96,8 +96,8 @@ class TestMain(unittest.TestCase):
             hook_path = self.hooks_dir / hook
             hook_path.symlink_to(self.charm_exec_path)
 
-    def _prepare_functions(self, legacy=False):
-        functions_meta = '''
+    def _prepare_actions(self):
+        actions_meta = '''
 foo-bar:
   description: Foos the bar.
   title: foo-bar
@@ -113,20 +113,16 @@ foo-bar:
     - foo-name
 start:
     description: Start the unit.'''
-        if legacy:
-            functions_dir_name = 'actions'
-            functions_meta_file = 'actions.yaml'
-        else:
-            functions_dir_name = 'functions'
-            functions_meta_file = 'functions.yaml'
+        actions_dir_name = 'actions'
+        actions_meta_file = 'actions.yaml'
 
-        with open(self.JUJU_CHARM_DIR / functions_meta_file, 'w+') as f:
-            f.write(functions_meta)
-        functions_dir = self.JUJU_CHARM_DIR / functions_dir_name
-        functions_dir.mkdir()
-        for function_name in ('start', 'foo-bar'):
-            function_path = functions_dir / function_name
-            function_path.symlink_to(self.charm_exec_path)
+        with open(self.JUJU_CHARM_DIR / actions_meta_file, 'w+') as f:
+            f.write(actions_meta)
+        actions_dir = self.JUJU_CHARM_DIR / actions_dir_name
+        actions_dir.mkdir()
+        for action_name in ('start', 'foo-bar'):
+            action_path = actions_dir / action_name
+            action_path.symlink_to(self.charm_exec_path)
 
     def _read_and_clear_state(self):
         state = None
@@ -164,24 +160,22 @@ start:
                 'JUJU_REMOTE_UNIT': '',
                 'JUJU_REMOTE_APP': '',
             })
-        if issubclass(event_spec.event_type, FunctionEvent):
-            event_filename = event_spec.event_name[:-len('_function')].replace('_', '-')
+        if issubclass(event_spec.event_type, ActionEvent):
+            event_filename = event_spec.event_name[:-len('_action')].replace('_', '-')
             env.update({
                 event_spec.env_var: event_filename,
             })
-            if event_spec.env_var == 'JUJU_FUNCTION_NAME':
-                event_dir = 'functions'
-            elif event_spec.env_var == 'JUJU_ACTION_NAME':
+            if event_spec.env_var == 'JUJU_ACTION_NAME':
                 event_dir = 'actions'
             else:
-                raise RuntimeError('invalid envar name specified for a function event')
+                raise RuntimeError('invalid envar name specified for a action event')
         else:
             event_filename = event_spec.event_name.replace('_', '-')
             event_dir = 'hooks'
         event_file = self.JUJU_CHARM_DIR / event_dir / event_filename
         # Note that sys.executable is used to make sure we are using the same
         # interpreter for the child process to support virtual environments.
-        subprocess.check_call([sys.executable, event_file], env=env, cwd=self.JUJU_CHARM_DIR, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.check_call([sys.executable, event_file], env=env, cwd=self.JUJU_CHARM_DIR)
         return self._read_and_clear_state()
 
     def test_event_reemitted(self):
@@ -202,17 +196,17 @@ start:
         self.assertEqual(state['observed_event_types'], [ConfigChangedEvent, UpdateStatusEvent])
 
     def test_multiple_events_handled(self):
-        self._prepare_functions()
+        self._prepare_actions()
 
         charm_config = base64.b64encode(pickle.dumps({
             'STATE_FILE': self._state_file,
         }))
-        functions_charm_config = base64.b64encode(pickle.dumps({
+        actions_charm_config = base64.b64encode(pickle.dumps({
             'STATE_FILE': self._state_file,
-            'USE_FUNCTIONS': True,
+            'USE_ACTIONS': True,
         }))
 
-        fake_script(self, 'function-get', "echo '{}'")
+        fake_script(self, 'action-get', "echo '{}'")
 
         # Sample events with a different amount of dashes used
         # and with endpoints from different sections of metadata.yaml
@@ -262,10 +256,10 @@ start:
                       remote_unit='remote/0', charm_config=charm_config),
             {'relation_name': 'mon', 'relation_id': 2, 'app_name': 'remote', 'unit_name': 'remote/0'},
         ), (
-            EventSpec(FunctionEvent, 'start_function', env_var='JUJU_FUNCTION_NAME', charm_config=functions_charm_config),
+            EventSpec(ActionEvent, 'start_action', env_var='JUJU_ACTION_NAME', charm_config=actions_charm_config),
             {},
         ), (
-            EventSpec(FunctionEvent, 'foo_bar_function', env_var='JUJU_FUNCTION_NAME', charm_config=functions_charm_config),
+            EventSpec(ActionEvent, 'foo_bar_action', env_var='JUJU_ACTION_NAME', charm_config=actions_charm_config),
             {},
         )]
 
@@ -291,25 +285,6 @@ start:
 
             if event_spec.event_name in expected_event_data:
                 self.assertEqual(state[f'{event_spec.event_name}_data'], expected_event_data[event_spec.event_name])
-
-    def test_legacy_function(self):
-        self._prepare_functions(legacy=True)
-        charm_config = base64.b64encode(pickle.dumps({
-            'STATE_FILE': self._state_file,
-            'USE_FUNCTIONS': True,
-        }))
-
-        fake_script(self, 'action-get', "echo '{}'")
-
-        # First run "install" to make sure all hooks are set up.
-        state = self._simulate_event(EventSpec(InstallEvent, 'install', charm_config=charm_config))
-        event_spec = EventSpec(FunctionEvent, 'foo_bar_function', env_var='JUJU_ACTION_NAME', charm_config=charm_config)
-        state = self._simulate_event(event_spec)
-        handled_events = state.get(f'on_{event_spec.event_name}', [])
-        self.assertEqual(len(handled_events), 1)
-        handled_event_type = handled_events[0]
-        self.assertEqual(handled_event_type, event_spec.event_type)
-        self.assertEqual(state['observed_event_types'], [event_spec.event_type])
 
     def test_event_not_implemented(self):
         """Make sure events without implementation do not cause non-zero exit.
@@ -359,25 +334,15 @@ start:
             self._simulate_event(initial_event)
             _assess_event_links(initial_event)
 
-    def test_setup_function_links(self):
+    def test_setup_action_links(self):
         charm_config = base64.b64encode(pickle.dumps({
             'STATE_FILE': self._state_file,
         }))
-        functions_yaml = self.JUJU_CHARM_DIR / 'functions.yaml'
-        functions_yaml.write_text('test: {}')
+        actions_yaml = self.JUJU_CHARM_DIR / 'actions.yaml'
+        actions_yaml.write_text('test: {}')
         self._simulate_event(EventSpec(InstallEvent, 'install', charm_config=charm_config))
-        function_hook = self.JUJU_CHARM_DIR / 'functions' / 'test'
-        self.assertTrue(function_hook.exists())
-
-    def test_functions_actions_mutually_exclusive(self):
-        self._prepare_functions()
-        self._prepare_functions(legacy=True)
-        charm_config = base64.b64encode(pickle.dumps({
-            'STATE_FILE': self._state_file,
-            'USE_FUNCTIONS': True,
-        }))
-        with self.assertRaises(subprocess.CalledProcessError):
-            self._simulate_event(EventSpec(InstallEvent, 'install', charm_config=charm_config))
+        action_hook = self.JUJU_CHARM_DIR / 'actions' / 'test'
+        self.assertTrue(action_hook.exists())
 
 
 if __name__ == "__main__":

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -767,104 +767,53 @@ class TestModelBackend(unittest.TestCase):
                 run()
             self.assertEqual(fake_script_calls(self, clear=True), calls)
 
-    def test_function_get_error(self):
-        fake_script(self, 'function-get', '')
-        fake_script(self, 'function-get', f'echo fooerror >&2 ; exit 1')
-        with self.assertRaises(ops.model.ModelError):
-            self.backend.function_get()
-        calls = [['function-get', '--format=json']]
-        self.assertEqual(fake_script_calls(self, clear=True), calls)
-
-    def test_function_set_error(self):
-        fake_script(self, 'function-get', '')
-        fake_script(self, 'function-set', f'echo fooerror >&2 ; exit 1')
-        with self.assertRaises(ops.model.ModelError):
-            self.backend.function_set({'foo': 'bar', 'dead': 'beef cafe'})
-        calls = [["function-set", "foo=bar", "dead=beef cafe"]]
-        self.assertEqual(fake_script_calls(self, clear=True), calls)
-
-    def test_function_log_error(self):
-        fake_script(self, 'function-get', '')
-        fake_script(self, 'function-log', f'echo fooerror >&2 ; exit 1')
-        with self.assertRaises(ops.model.ModelError):
-            self.backend.function_log('log-message')
-        calls = [["function-log", "log-message"]]
-        self.assertEqual(fake_script_calls(self, clear=True), calls)
-
-    def test_function_fail_error(self):
-        fake_script(self, 'function-get', '')
-        fake_script(self, 'function-fail', f'echo fooerror >&2 ; exit 1')
-        with self.assertRaises(ops.model.ModelError):
-            self.backend.function_fail('fail-message')
-        calls = [["function-fail", "fail-message"]]
-        self.assertEqual(fake_script_calls(self, clear=True), calls)
-
-    def test_function_get_error_legacy(self):
+    def test_action_get_error(self):
+        fake_script(self, 'action-get', '')
         fake_script(self, 'action-get', f'echo fooerror >&2 ; exit 1')
         with self.assertRaises(ops.model.ModelError):
-            self.backend.function_get()
+            self.backend.action_get()
         calls = [['action-get', '--format=json']]
         self.assertEqual(fake_script_calls(self, clear=True), calls)
 
-    def test_function_set_error_legacy(self):
+    def test_action_set_error(self):
+        fake_script(self, 'action-get', '')
         fake_script(self, 'action-set', f'echo fooerror >&2 ; exit 1')
         with self.assertRaises(ops.model.ModelError):
-            self.backend.function_set({'foo': 'bar', 'dead': 'beef cafe'})
+            self.backend.action_set({'foo': 'bar', 'dead': 'beef cafe'})
         calls = [["action-set", "foo=bar", "dead=beef cafe"]]
         self.assertEqual(fake_script_calls(self, clear=True), calls)
 
-    def test_function_fail_error_legacy(self):
-        fake_script(self, 'action-fail', f'echo fooerror >&2 ; exit 1')
+    def test_action_log_error(self):
+        fake_script(self, 'action-get', '')
+        fake_script(self, 'action-log', f'echo fooerror >&2 ; exit 1')
         with self.assertRaises(ops.model.ModelError):
-            self.backend.function_fail('fail-message')
-        calls = [["action-fail", "fail-message"]]
+            self.backend.action_log('log-message')
+        calls = [["action-log", "log-message"]]
         self.assertEqual(fake_script_calls(self, clear=True), calls)
 
-    def test_function_get(self):
-        fake_script(self, 'function-get', """echo '{"foo-name": "bar", "silent": false}'""")
-        params = self.backend.function_get()
-        self.assertEqual(params['foo-name'], 'bar')
-        self.assertEqual(params['silent'], False)
-        self.assertEqual(fake_script_calls(self), [['function-get', '--format=json']])
-
-    def test_function_get_legacy(self):
+    def test_action_get(self):
         fake_script(self, 'action-get', """echo '{"foo-name": "bar", "silent": false}'""")
-        params = self.backend.function_get()
+        params = self.backend.action_get()
         self.assertEqual(params['foo-name'], 'bar')
         self.assertEqual(params['silent'], False)
         self.assertEqual(fake_script_calls(self), [['action-get', '--format=json']])
 
-    def test_function_set(self):
-        fake_script(self, 'function-get', 'exit 1')
-        fake_script(self, 'function-set', 'exit 0')
-        self.backend.function_set({'x': 'dead beef', 'y': 1})
-        self.assertEqual(fake_script_calls(self), [['function-set', 'x=dead beef', 'y=1']])
-
-    def test_function_set_legacy(self):
+    def test_action_set(self):
+        fake_script(self, 'action-get', 'exit 1')
         fake_script(self, 'action-set', 'exit 0')
-        self.backend.function_set({'x': 'dead beef', 'y': 1})
+        self.backend.action_set({'x': 'dead beef', 'y': 1})
         self.assertEqual(fake_script_calls(self), [['action-set', 'x=dead beef', 'y=1']])
 
-    def test_function_fail(self):
-        fake_script(self, 'function-get', 'exit 1')
-        fake_script(self, 'function-fail', 'exit 0')
-        self.backend.function_fail('error 42')
-        self.assertEqual(fake_script_calls(self), [['function-fail', 'error 42']])
-
-    def test_function_fail_legacy(self):
+    def test_action_fail(self):
+        fake_script(self, 'action-get', 'exit 1')
         fake_script(self, 'action-fail', 'exit 0')
-        self.backend.function_fail('error 42')
+        self.backend.action_fail('error 42')
         self.assertEqual(fake_script_calls(self), [['action-fail', 'error 42']])
 
-    def test_function_log(self):
-        fake_script(self, 'function-get', 'exit 1')
-        fake_script(self, 'function-log', 'exit 0')
-        self.backend.function_log('progress: 42%')
-        self.assertEqual(fake_script_calls(self), [['function-log', 'progress: 42%']])
-
-    def test_function_log_legacy(self):
+    def test_action_log(self):
+        fake_script(self, 'action-get', 'exit 1')
         fake_script(self, 'action-log', 'exit 0')
-        self.backend.function_log('progress: 42%')
+        self.backend.action_log('progress: 42%')
         self.assertEqual(fake_script_calls(self), [['action-log', 'progress: 42%']])
 
 


### PR DESCRIPTION
Per sprint discussions it was decided to avoid the renaming of actions
to functions although this was included into 2.7.x.

Relevant Juju PR: https://github.com/juju/juju/pull/11148

This change removes the previous logic of preferring functions and
multiplexing for older versions and simply uses actions.