### PR TITLE
Clarify how Juju events map to operator framework functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,7 @@ if __name__ == "__main__":
 This charm does nothing, because the `MyCharm` class passed to the operator
 framework's `main` function is empty. Functionality can be added to the charm
 by instructing it to observe particular Juju events when the `MyCharm` object
-is initialized. In the example below we're observing the `start` event; the
-known event sources are all attributes of `<emitter>.on`, so in this case
-`self.on.start` is passed to `self.framework.observe`. This will look for a
-method named `on_start` when that Juju event is triggered.
+is initialized. For example,
 
 ```python
 class MyCharm(CharmBase):
@@ -90,13 +87,13 @@ class MyCharm(CharmBase):
         # Handle the start event here.
 ```
 
+Every standard event in Juju may be observed that way, and you can also easily
+define your own events in your custom types.
+
 > The second argument to `observe` can be either the handler as a bound
 > method, or the observer itself if the handler is a method of the observer
 > that follows the conventional naming pattern. That is, in this case, we
 > could have called just `self.framework.obseve(self.on.start, self)`.
-
-Every standard event in Juju may be observed that way, and you can also easily
-define your own events in your custom types.
 
 The `hooks/` directory must contain a symlink to your `src/charm.py` entry
 point so that Juju can call it. You only need to set up the `hooks/install` link

--- a/README.md
+++ b/README.md
@@ -84,11 +84,16 @@ method named `on_start` when that Juju event is triggered.
 class MyCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-        self.framework.observe(self.on.start, self)
+        self.framework.observe(self.on.start, self.on_start)
 
      def on_start(self, event):
         # Handle the start event here.
 ```
+
+> The second argument to `observe` can be either the handler as a bound
+> method, or the observer itself if the handler is a method of the observer
+> that follows the conventional naming pattern. That is, in this case, we
+> could have called just `self.framework.obseve(self.on.start, self)`.
 
 Every standard event in Juju may be observed that way, and you can also easily
 define your own events in your custom types.

--- a/README.md
+++ b/README.md
@@ -53,9 +53,8 @@ git submodule update --init
 ```
 
 Your `src/charm.py` is the entry point for your charm logic. It should be set
-to executable and use Python 3.6 or greater (as such, operator charms can only
-support Ubuntu 18.04 or later). At a minimum, it needs to define a subclass of
-`CharmBase` and pass that into the framework's `main` function:
+to executable and use Python 3.6 or greater. At a minimum, it needs to define
+a subclass of `CharmBase` and pass that into the framework's `main` function:
 
 ```python
 import sys
@@ -76,10 +75,10 @@ if __name__ == "__main__":
 This charm does nothing, because the `MyCharm` class passed to the operator
 framework's `main` function is empty. Functionality can be added to the charm
 by instructing it to observe particular Juju events when the `MyCharm` object
-is initialized. In the example below we're observing the `start` event. The
-name of the event is a function of `self.on`, so in this case `self.on.start`
-is passed to `self.framework.observe`. This will look for method named
-`on_start` when that Juju event is triggered.
+is initialized. In the example below we're observing the `start` event; the
+known event sources are all attributes of `<emitter>.on`, so in this case
+`self.on.start` is passed to `self.framework.observe`. This will look for a
+method named `on_start` when that Juju event is triggered.
 
 ```python
 class MyCharm(CharmBase):
@@ -92,22 +91,7 @@ class MyCharm(CharmBase):
 ```
 
 Every standard event in Juju may be observed that way, and you can also easily
-define your own events in your custom types. For example, to observe the
-`config-changed` Juju event:
-
-```python
-class MyCharm(CharmBase):
-    def __init__(self, *args):
-        super().__init__(*args)
-        self.framework.observe(self.on.start, self)
-        self.framework.observe(self.on.config_changed, self)
-
-     def on_start(self, event):
-        # Handle the start event here.
-
-     def on_config_changed(self, event):
-        # Handle the config-changed event here.
-```
+define your own events in your custom types.
 
 The `hooks/` directory must contain a symlink to your `src/charm.py` entry
 point so that Juju can call it. You only need to set up the `hooks/install` link

--- a/README.md
+++ b/README.md
@@ -28,13 +28,6 @@ submodule:
 git submodule add https://github.com/canonical/operator mod/operator
 ```
 
-You can sync subsequent changes from the framework and other submodule
-dependencies by running:
-
-```
-git submodule update
-```
-
 Then symlink from the git submodule for the operator framework into the `lib/`
 directory of your charm so it can be imported at run time:
 
@@ -45,6 +38,20 @@ ln -s ../mod/operator/ops lib/ops
 Other dependencies included as git submodules can be added in the `mod/`
 directory and symlinked into `lib/` as well.
 
+You can sync subsequent changes from the framework and other submodule
+dependencies by running:
+
+```
+git submodule update
+```
+
+Those cloning and checking out the source for your charm for the first time
+will need to run:
+
+```
+git submodule update --init
+```
+
 Your `src/charm.py` is the entry point for your charm logic. It should be set
 to executable and use Python 3.6 or greater (as such, operator charms can only
 support Ubuntu 18.04 or later). At a minimum, it needs to define a subclass of
@@ -52,9 +59,10 @@ support Ubuntu 18.04 or later). At a minimum, it needs to define a subclass of
 
 ```python
 import sys
+sys.path.append('lib')  # noqa: E402
 
-from lib.ops.charm import CharmBase
-from lib.ops.main import main
+from ops.charm import CharmBase
+from ops.main import main
 
 
 class MyCharm(CharmBase):


### PR DESCRIPTION
There are some potentially controversial changes here, so happy to discuss here or in another forum if appropriate: 

- Switching the import path to avoid needing to add to sys.path before imports (avoids violating E402).
- Shows how to publish to the charmstore as well as local deploy.
- Clarifies that because the operator framework requires python 3.6 or greater it only supports charms for bionic or later.