### PR TITLE
Include set_default as a method on BoundStoredState.

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -704,6 +704,12 @@ class BoundStoredState:
         self._data[key] = _unwrap_stored(self._data, value)
         self.on.changed.emit()
 
+    def set_default(self, **kwargs):
+        """"Set the value of any given key if it has not already been set"""
+        for k, v in kwargs.items():
+            if k not in self._data:
+                self._data[k] = v
+
 
 class StoredState:
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -1139,6 +1139,29 @@ class TestStoredState(unittest.TestCase):
                 self.assertEqual(a, old_a)
                 self.assertEqual(b, old_b)
 
+    def test_set_default(self):
+        framework = self.create_framework()
+
+        class StatefulObject(Object):
+            state = StoredState()
+        parent = StatefulObject(framework, 'key')
+        parent.state.set_default(foo=1)
+        self.assertEqual(parent.state.foo, 1)
+        parent.state.set_default(foo=2)
+        # foo was already set, so it doesn't get replaced
+        self.assertEqual(parent.state.foo, 1)
+        parent.state.set_default(foo=3, bar=4)
+        self.assertEqual(parent.state.foo, 1)
+        self.assertEqual(parent.state.bar, 4)
+        # reloading the state still leaves things at the default values
+        framework.commit()
+        del parent
+        parent = StatefulObject(framework, 'key')
+        parent.state.set_default(foo=5, bar=6)
+        self.assertEqual(parent.state.foo, 1)
+        self.assertEqual(parent.state.bar, 4)
+        # TODO(jam) 2020-01-30: is there a clean way to tell that parent.state._data.dirty is False?
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This solves one of the big "how do I initialize my State" questions. The
implementation is fairly lean, and it avoids problems where things end
up dirty because you wanted to have a default value.