### PR TITLE
Error messages should start lowercase.

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -738,7 +738,7 @@ class StoredState:
                     parent.__dict__[attr_name] = bound
                     break
             else:
-                raise RuntimeError("Cannot find StoredVariable attribute in type {}".format(parent_type.__name__))
+                raise RuntimeError("cannot find StoredVariable attribute in type {}".format(parent_type.__name__))
 
         return bound
 


### PR DESCRIPTION
The only capital letters for error messages are when we are referring to a named Type.
This provides consistency for our error strings.