### PR TITLE
Implement CharmMeta.from_yaml.

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -204,11 +204,11 @@ class CharmMeta:
         self.series = raw.get('series', [])
         self.subordinate = raw.get('subordinate', False)
         self.min_juju_version = raw.get('min-juju-version')
-        self.requires = {name: RelationMeta('requirer', name, rel)
+        self.requires = {name: RelationMeta('requires', name, rel)
                          for name, rel in raw.get('requires', {}).items()}
-        self.provides = {name: RelationMeta('provider', name, rel)
+        self.provides = {name: RelationMeta('provides', name, rel)
                          for name, rel in raw.get('provides', {}).items()}
-        self.peers = {name: RelationMeta('peer', name, rel)
+        self.peers = {name: RelationMeta('peers', name, rel)
                       for name, rel in raw.get('peers', {}).items()}
         self.relations = {}
         self.relations.update(self.requires)

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1,5 +1,7 @@
 import os
 
+import yaml
+
 from ops.framework import Object, EventSource, EventBase, EventsBase
 
 
@@ -202,11 +204,11 @@ class CharmMeta:
         self.series = raw.get('series', [])
         self.subordinate = raw.get('subordinate', False)
         self.min_juju_version = raw.get('min-juju-version')
-        self.requires = {name: RelationMeta('requires', name, rel)
+        self.requires = {name: RelationMeta('requirer', name, rel)
                          for name, rel in raw.get('requires', {}).items()}
-        self.provides = {name: RelationMeta('provides', name, rel)
+        self.provides = {name: RelationMeta('provider', name, rel)
                          for name, rel in raw.get('provides', {}).items()}
-        self.peers = {name: RelationMeta('peers', name, rel)
+        self.peers = {name: RelationMeta('peer', name, rel)
                       for name, rel in raw.get('peers', {}).items()}
         self.relations = {}
         self.relations.update(self.requires)
@@ -220,6 +222,14 @@ class CharmMeta:
                          for name, payload in raw.get('payloads', {}).items()}
         self.extra_bindings = raw.get('extra-bindings', [])
         self.functions = {name: FunctionMeta(name, function) for name, function in functions_raw.items()}
+
+    @classmethod
+    def from_yaml(cls, metadata, actions=None):
+        meta = yaml.safe_load(metadata)
+        raw_actions = {}
+        if actions is not None:
+            raw_actions = yaml.safe_load(actions)
+        return cls(meta, raw_actions)
 
 
 class RelationMeta:

--- a/ops/main.py
+++ b/ops/main.py
@@ -28,7 +28,7 @@ def _get_charm_dir():
 
 
 def _load_metadata(charm_dir):
-    metadata = yaml.load((charm_dir / 'metadata.yaml').read_text(), Loader=yaml.SafeLoader)
+    metadata = yaml.safe_load((charm_dir / 'metadata.yaml').read_text())
 
     functions_meta = charm_dir / 'functions.yaml'
     actions_meta = charm_dir / 'actions.yaml'

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -94,21 +94,25 @@ class TestCharm(unittest.TestCase):
                 assert event.relation.app.name == 'remote'
                 self.seen.append(type(event).__name__)
 
-        self.meta = CharmMeta({
-            'name': 'my-charm',
-            'requires': {
-                'req1': {'interface': 'req1'},
-                'req-2': {'interface': 'req2'},
-            },
-            'provides': {
-                'pro1': {'interface': 'pro1'},
-                'pro-2': {'interface': 'pro2'},
-            },
-            'peers': {
-                'peer1': {'interface': 'peer1'},
-                'peer-2': {'interface': 'peer2'},
-            },
-        })
+        # language=YAML
+        self.meta = CharmMeta.from_yaml(metadata='''
+name: my-charm
+requires:
+ req1:
+   interface: req1
+ req-2:
+   interface: req2
+provides:
+ pro1:
+   interface: pro1
+ pro-2:
+   interface: pro2
+peers:
+ peer1:
+   interface: peer1
+ peer-2:
+   interface: peer2
+''')
 
         charm = MyCharm(self.create_framework(), None)
 
@@ -155,30 +159,25 @@ class TestCharm(unittest.TestCase):
             def on_stor_4_storage_attached(self, event):
                 self.seen.append(f'{type(event).__name__}')
 
-        self.meta = CharmMeta({
-            'name': 'my-charm',
-            'storage': {
-                'stor1': {'type': 'filesystem'},
-                'stor2': {
-                    'type': 'filesystem',
-                    'multiple': {
-                        'range': '2',
-                    },
-                },
-                'stor3': {
-                    'type': 'filesystem',
-                    'multiple': {
-                        'range': '2-',
-                    },
-                },
-                'stor-4': {
-                    'type': 'filesystem',
-                    'multiple': {
-                        'range': '2-4',
-                    },
-                },
-            },
-        })
+        # language=YAML
+        self.meta = CharmMeta.from_yaml('''
+name: my-charm
+storage:
+  stor-4:
+    multiple:
+      range: 2-4
+    type: filesystem
+  stor1:
+    type: filesystem
+  stor2:
+    multiple:
+      range: "2"
+    type: filesystem
+  stor3:
+    multiple:
+      range: 2-
+    type: filesystem
+''')
 
         self.assertIsNone(self.meta.storages['stor1'].multiple_range)
         self.assertEqual(self.meta.storages['stor2'].multiple_range, (2, 2))
@@ -201,30 +200,25 @@ class TestCharm(unittest.TestCase):
 
     @classmethod
     def _get_function_test_meta(cls):
-        return CharmMeta(
-            {'name': 'my-charm'},
-            {
-                'foo-bar': {
-                    'description': 'Foos the bar.',
-                    'title': 'foo-bar',
-                    'required': 'foo-bar',
-                    'params': {
-                        'foo-name': {
-                            'type': 'string',
-                            'description': 'A foo name to bar',
-                        },
-                        'silent': {
-                            'type': 'boolean',
-                            'description': '',
-                            'default': False,
-                        },
-                    },
-                },
-                'start': {
-                    'description': 'Start the unit.'
-                }
-            }
-        )
+        # language=YAML
+        return CharmMeta.from_yaml(metadata='''
+name: my-charm
+''', actions='''
+foo-bar:
+  description: "Foos the bar."
+  params:
+    foo-name:
+      description: "A foo name to bar"
+      type: string
+    silent:
+      default: false
+      description: ""
+      type: boolean
+  required: foo-bar
+  title: foo-bar
+start:
+  description: "Start the unit."
+''')
 
     def _test_function_events(self, cmd_type):
 


### PR DESCRIPTION
We had CharmMeta taking dicts that you could pass in, which made it
easier to set up in tests, etc. However, Python dicts still have a lot
of meta characters vs the YAML representation.
Also, by using YAML you more accurately understand the content that
would be put into metadata.yaml or actions.yaml.

Further, PyCharm has support for comments of the form "language=XXX"
which give you syntax highlighting for a string which follows. I added
them here, though we can discuss if we want comment artifacts for a
particular editor.

If we prefer, it wouldn't be hard to have a standalone function for tests, rather than having 'charm.py' depending on PyYAML. Though I don't think there is a real problem, since we depend on PyYAML already.
