### PR TITLE
Lazy-load action parameters

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -26,9 +26,12 @@ class ActionEvent(EventBase):
 
     @property
     def params(self):
-        # NoneType will be returned if an action has no parameters defined but in that case this property is unlikely to be used.
+        # None will be returned if an action has no parameters defined but in that case this property is unlikely to be used.
         if self._params is None:
             self._params = self.framework.model._backend.action_get()
+            if self._params is None:
+                # No parameters defined for an action but avoid calling action-get again due to LP: #1862026.
+                self._params = {}
         return self._params
 
     def set_results(self, results):

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -9,23 +9,21 @@ class HookEvent(EventBase):
 
 class ActionEvent(EventBase):
 
-    def __init__(self, *args):
-        super().__init__(*args)
+    def __init__(self, handle):
+        super().__init__(handle)
         self._params = None
 
     def defer(self):
         raise RuntimeError('cannot defer action events')
 
-    def snapshot(self):
-        return {'params': self._params}
-
     def restore(self, snapshot):
+        self._params = None
+        # Make sure that an ActionEvent object only exists during an execution of its associated action.
         env_action_name = os.environ.get('JUJU_ACTION_NAME')
         event_action_name = self.handle.kind[:-len('_action')].replace('_', '-')
         if event_action_name != env_action_name:
             # This could only happen if the dev manually emits the action, or from a bug.
             raise RuntimeError('action event kind does not match current action')
-        self._params = snapshot['params']
 
     @property
     def params(self):

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -18,8 +18,12 @@ class ActionEvent(EventBase):
         if event_action_name != env_action_name:
             # This could only happen if the dev manually emits the action, or from a bug.
             raise RuntimeError('action event kind does not match current action')
-        # Params are loaded at restore rather than __init__ because the model is not available in __init__.
-        self.params = self.framework.model._backend.action_get()
+
+    @property
+    def params(self):
+        # NoneType will be returned if an action has no parameters defined so getattr is used instead of a check for NoneType.
+        self._params = getattr(self, '_params', self.framework.model._backend.action_get())
+        return self._params
 
     def set_results(self, results):
         self.framework.model._backend.action_set(results)

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -16,13 +16,16 @@ class ActionEvent(EventBase):
     def defer(self):
         raise RuntimeError('cannot defer action events')
 
+    def snapshot(self):
+        return {'params': self._params}
+
     def restore(self, snapshot):
-        self._params = None
         env_action_name = os.environ.get('JUJU_ACTION_NAME')
         event_action_name = self.handle.kind[:-len('_action')].replace('_', '-')
         if event_action_name != env_action_name:
             # This could only happen if the dev manually emits the action, or from a bug.
             raise RuntimeError('action event kind does not match current action')
+        self._params = snapshot['params']
 
     @property
     def params(self):

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -40,6 +40,7 @@ class Charm(CharmBase):
         self._state['on_ha_relation_broken'] = []
         self._state['on_foo_bar_action'] = []
         self._state['on_start_action'] = []
+        self._state['on_test_event_action'] = []
 
         # Observed event types per invocation. A list is used to preserve the order in which charm handlers have observed the events.
         self._state['observed_event_types'] = []
@@ -59,6 +60,7 @@ class Charm(CharmBase):
         if self._charm_config.get('USE_ACTIONS'):
             self.framework.observe(self.on.start_action, self)
             self.framework.observe(self.on.foo_bar_action, self)
+            self.framework.observe(self.on.test_event_action, self)
 
     def _write_state(self):
         """Write state variables so that the parent process can read them.
@@ -128,20 +130,24 @@ class Charm(CharmBase):
 
     def on_start_action(self, event):
         assert event.handle.kind == 'start_action', 'event action name cannot be different from the one being handled'
-
-        assert event.params == {}
-
         self._state['on_start_action'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()
 
     def on_foo_bar_action(self, event):
         assert event.handle.kind == 'foo_bar_action', 'event action name cannot be different from the one being handled'
-
-        assert event.params['foo-name'] == 'bar'
-        assert event.params['silent'] is False
-
         self._state['on_foo_bar_action'].append(type(event))
+        self._state['observed_event_types'].append(type(event))
+        self._write_state()
+
+    def on_test_event_action(self, event):
+        assert event.params['string-param'] == 'foo'
+        assert event.params['bool-param'] is False
+        assert event.params['int-param'] == 0
+        event.set_results({'out': 'something'})
+        event.log('progress-message')
+        event.fail('failure-message')
+        self._state['on_test_event_action'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()
 

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -128,12 +128,19 @@ class Charm(CharmBase):
 
     def on_start_action(self, event):
         assert event.handle.kind == 'start_action', 'event action name cannot be different from the one being handled'
+
+        assert event.params == {}
+
         self._state['on_start_action'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()
 
     def on_foo_bar_action(self, event):
         assert event.handle.kind == 'foo_bar_action', 'event action name cannot be different from the one being handled'
+
+        assert event.params['foo-name'] == 'bar'
+        assert event.params['silent'] is False
+
         self._state['on_foo_bar_action'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -33,8 +33,6 @@ from ops.charm import (
     ActionEvent,
 )
 
-from .test_helpers import fake_script
-
 # This relies on the expected repository structure to find a path to source of the charm under test.
 TEST_CHARM_DIR = Path(f'{__file__}/../charms/test_main').resolve()
 
@@ -205,8 +203,6 @@ start:
             'STATE_FILE': self._state_file,
             'USE_ACTIONS': True,
         }))
-
-        fake_script(self, 'action-get', "echo '{}'")
 
         # Sample events with a different amount of dashes used
         # and with endpoints from different sections of metadata.yaml


### PR DESCRIPTION
In order to avoid an extra action-get call, this change introduces a
"params" property. "action-get" will return None if there are no
parameters defined for an action, however, in that case `.params` is unlikely to be used so an extra call will not matter.

Closes-Bug: #131