### PR TITLE
Makefile, test: avoid using backslash to protect quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,18 @@
 test: lint
 	@python3 -m unittest
 
-lint:
+lint: quotelint
 	@autopep8 -r --aggressive --diff --exit-code .
 	@flake8 --config=.flake8
+
+quotelint:
+	@x=$$(grep -rnH --include \*.py "\\\\[\"']");                  \
+	if [ "$$x" ]; then                                             \
+		echo "Please reconsider your choice of quoting for:";  \
+		echo "$$x";                                            \
+		exit 1;                                                \
+	fi >&2
+
+
 
 .PHONY: lint test

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ lint: quotelint
 	@flake8 --config=.flake8
 
 quotelint:
-	@x=$$(grep -rnH --include \*.py "\\\\[\"']");                  \
-	if [ "$$x" ]; then                                             \
-		echo "Please reconsider your choice of quoting for:";  \
-		echo "$$x";                                            \
-		exit 1;                                                \
+	@x=$$(grep -rnH --include \*.py "\\\\[\"']");                         \
+	if [ "$$x" ]; then                                                    \
+		echo "Please fix the quoting to avoid spurious backslashes:"; \
+		echo "$$x";                                                   \
+		exit 1;                                                       \
 	fi >&2
 
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -783,7 +783,7 @@ class TestStoredState(unittest.TestCase):
                 pass
             obj.state.foo = CustomObject()
         except AttributeError as e:
-            self.assertEqual(str(e), 'attribute \'foo\' cannot be set to CustomObject: must be int/dict/list/etc')
+            self.assertEqual(str(e), "attribute 'foo' cannot be set to CustomObject: must be int/dict/list/etc")
         else:
             self.fail('AttributeError not raised')
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -54,7 +54,7 @@ class TestModel(unittest.TestCase):
         ])
 
     def test_get_relation(self):
-        err_msg = "ERROR invalid value \"$2\" for option -r: relation not found"
+        err_msg = 'ERROR invalid value "$2" for option -r: relation not found'
 
         fake_script(self, 'relation-ids',
                     """([ "$1" = db1 ] && echo '["db1:4"]') || ([ "$1" = db2 ] && echo '["db2:5", "db2:6"]') || echo '[]'""")
@@ -92,7 +92,7 @@ class TestModel(unittest.TestCase):
         meta.relations = {'dbpeer': RelationMeta('peers', 'dbpeer', {'interface': 'dbpeer', 'scope': 'global'})}
         self.model = ops.model.Model('myapp/0', meta, self.backend)
 
-        err_msg = "ERROR invalid value \"$2\" for option -r: relation not found"
+        err_msg = 'ERROR invalid value "$2" for option -r: relation not found'
         fake_script(self, 'relation-ids',
                     '''([ "$1" = dbpeer ] && echo '["dbpeer:0"]') || echo "[]"''')
         fake_script(self, 'relation-list',
@@ -662,7 +662,7 @@ class TestModelBackend(unittest.TestCase):
         return self._backend
 
     def test_relation_tool_errors(self):
-        err_msg = "ERROR invalid value \"$2\" for option -r: relation not found"
+        err_msg = 'ERROR invalid value "$2" for option -r: relation not found'
 
         test_cases = [(
             lambda: fake_script(self, 'relation-list', f'echo fooerror >&2 ; exit 1'),


### PR DESCRIPTION
Python has a rich enough variety of quotes that you should never need
to use a backslash to protect a single quote in a string; it a silly
little thing but it hurts readability. So this fixes that, and adds a
linter to make sure it stays fixed.

Modulo bugs in the linter of course.