### PR TITLE
Allow ActiveStatus constructor to take optional message argument

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -367,8 +367,8 @@ class ActiveStatus(StatusBase):
     """
     name = 'active'
 
-    def __init__(self):
-        super().__init__('')
+    def __init__(self, message=None):
+        super().__init__(message or '')
 
 
 class BlockedStatus(StatusBase):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -453,15 +453,14 @@ class TestModel(unittest.TestCase):
         with self.assertRaises(TypeError):
             ops.model.StatusBase('test')
 
-    def test_active_message_raises(self):
-        with self.assertRaises(TypeError):
-            ops.model.ActiveStatus('test')
+    def test_active_message_default(self):
+        self.assertEqual(ops.model.ActiveStatus().message, '')
 
     def test_local_set_valid_unit_status(self):
         test_cases = [(
-            ops.model.ActiveStatus(),
+            ops.model.ActiveStatus('Green'),
             lambda: fake_script(self, 'status-set', 'exit 0'),
-            lambda: self.assertEqual(fake_script_calls(self, True), [['status-set', '--application=False', 'active', '']]),
+            lambda: self.assertEqual(fake_script_calls(self, True), [['status-set', '--application=False', 'active', 'Green']]),
         ), (
             ops.model.MaintenanceStatus('Yellow'),
             lambda: fake_script(self, 'status-set', 'exit 0'),
@@ -488,9 +487,9 @@ class TestModel(unittest.TestCase):
     def test_local_set_valid_app_status(self):
         fake_script(self, 'is-leader', 'echo true')
         test_cases = [(
-            ops.model.ActiveStatus(),
+            ops.model.ActiveStatus('Green'),
             lambda: fake_script(self, 'status-set', 'exit 0'),
-            lambda: self.assertIn(['status-set', '--application=True', 'active', ''], fake_script_calls(self, True)),
+            lambda: self.assertIn(['status-set', '--application=True', 'active', 'Green'], fake_script_calls(self, True)),
         ), (
             ops.model.MaintenanceStatus('Yellow'),
             lambda: fake_script(self, 'status-set', 'exit 0'),
@@ -558,7 +557,7 @@ class TestModel(unittest.TestCase):
 
         test_statuses = (
             ops.model.UnknownStatus(),
-            ops.model.ActiveStatus(),
+            ops.model.ActiveStatus('Green'),
             ops.model.MaintenanceStatus('Yellow'),
             ops.model.BlockedStatus('Red'),
             ops.model.WaitingStatus('White'),


### PR DESCRIPTION
Hi there,

Here's a small ergonomics change that allows the `ActiveStatus` subclass of `StatusBase` accept a message. Currently all other subclasses do *except* for `ActiveStatus` (and `UnknownStatus`, but see note below), which is surprising and may catch people out when refactoring. This change also makes it easier to construct a status object conditionally, e.g. when the logic for determining the message and status are confined to methods (contrived example):

``` python
def self.on_some_event(self, event):
  # ... stuff ...
  message = self.build_status_message()
  # ... more stuff ...
  self.model.app.status = self.current_status()(message)
```

The current behaviour is preserved when no argument is given. Thoughts?

Note the same could be done for `UnknownStatus` without issue, but that one doesn't seem to be meant for charm authors to use, and we haven't found a time we would intentionally set a status to it either, so have left it out.