### PR TITLE
Add support for collect-metrics events

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -73,6 +73,12 @@ class LeaderSettingsChangedEvent(HookEvent):
     pass
 
 
+class CollectMetricsEvent(HookEvent):
+
+    def add_metrics(self, metrics, labels=None):
+        self.framework.model._backend.add_metric(metrics, labels)
+
+
 class RelationEvent(HookEvent):
     def __init__(self, handle, relation, app=None, unit=None):
         super().__init__(handle)
@@ -151,6 +157,7 @@ class CharmEvents(EventsBase):
     post_series_upgrade = EventSource(PostSeriesUpgradeEvent)
     leader_elected = EventSource(LeaderElectedEvent)
     leader_settings_changed = EventSource(LeaderSettingsChangedEvent)
+    collect_metrics = EventSource(CollectMetricsEvent)
 
 
 class CharmBase(Object):

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -76,7 +76,7 @@ class LeaderSettingsChangedEvent(HookEvent):
 class CollectMetricsEvent(HookEvent):
 
     def add_metrics(self, metrics, labels=None):
-        self.framework.model._backend.add_metric(metrics, labels)
+        self.framework.model._backend.add_metrics(metrics, labels)
 
 
 class RelationEvent(HookEvent):

--- a/ops/model.py
+++ b/ops/model.py
@@ -684,9 +684,9 @@ class ModelBackend:
             label_args = []
             for k, v in labels.items():
                 if not key_re.match(k):
-                    raise ModelError(f'invalid label key "{k}": must start from an ASCII letter and contain alphanumeric characters or underscores only')
+                    raise ModelError(f'invalid label key "{repr(k)}": must start with [a-zA-Z] and contain [a-zA-Z0-9_] only')
                 elif not is_valid_label_value(v):
-                    raise ModelError('metric label values must not contain "," or "=".')
+                    raise ModelError('metric label values must not contain "," or "="')
                 else:
                     label_args.append(f'{k}={v}')
             cmd.extend(['--labels', ','.join(label_args)])
@@ -694,9 +694,9 @@ class ModelBackend:
         metric_args = []
         for k, v in metrics.items():
             if not key_re.match(k):
-                raise ModelError(f'invalid metric key "{k}": must start from an ASCII letter and contain alphanumeric characters or underscores only')
+                raise ModelError(f'invalid metric key "{repr(k)}": must start with [a-zA-Z] and contain [a-zA-Z0-9_] only')
             elif not is_valid_metric_value(v):
-                raise ModelError(f'invalid value "{v}" provided for key "{k}": must be a real number')
+                raise ModelError(f'invalid value "{repr(v)}" provided for key "{k}": must be a float number')
             else:
                 metric_args.append(f'{k}={v}')
         cmd.extend(metric_args)

--- a/ops/model.py
+++ b/ops/model.py
@@ -667,7 +667,7 @@ class ModelBackend:
 
     def add_metrics(self, metrics, labels=None):
         cmd = ['add-metric']
-        key_re = re.compile(r'^[a-zA-Z][a-zA-Z0-9_]*$')
+        key_re = re.compile(r'^[a-zA-Z](?:[a-zA-Z0-9-_]*[a-zA-Z0-9])?$')
 
         def is_valid_metric_value(value):
             try:

--- a/ops/model.py
+++ b/ops/model.py
@@ -663,3 +663,10 @@ class ModelBackend:
             if 'relation not found' in str(e):
                 raise RelationNotFoundError() from e
             raise
+
+    def add_metric(self, metrics, labels=None):
+        cmd = ['add-metric']
+        if labels:
+            cmd.extend(['--labels', ','.join(f'{k}={v}' for k, v in labels.items())])
+        cmd.extend([*[f'{k}={v}' for k, v in metrics.items()]])
+        self._run(*cmd)

--- a/ops/model.py
+++ b/ops/model.py
@@ -677,7 +677,7 @@ class ModelBackend:
                 return False
 
         def is_valid_label_value(value):
-            # Label values cannot be empty, contain commas and equal signs those are used by add-metric as separators.
+            # Label values cannot be empty, contain commas or equal signs as those are used by add-metric as separators.
             return value and all(c not in str(value) for c in ',=')
 
         if labels:

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -4,8 +4,6 @@ import os
 import base64
 import pickle
 import sys
-import pathlib
-import fcntl
 sys.path.append('lib')  # noqa
 
 from ops.charm import CharmBase
@@ -64,7 +62,6 @@ class Charm(CharmBase):
             self.framework.observe(self.on.foo_bar_action, self)
 
         self.framework.observe(self.on.collect_metrics, self)
-        self.framework.observe(self.on.ha_relation_departed, self)
 
     def _write_state(self):
         """Write state variables so that the parent process can read them.
@@ -147,15 +144,8 @@ class Charm(CharmBase):
     def on_collect_metrics(self, event):
         self._state['on_collect_metrics'].append(type(event))
         self._state['observed_event_types'].append(type(event))
-        event.add_metrics({'foo': 'bar'}, {'dead': ' beef '})
+        event.add_metrics({'foo': 42}, {'bar': 4.2})
         self._write_state()
-
-    def on_ha_relation_departed(self, event):
-        indicator_file = pathlib.Path(self._charm_config['INDICATOR_FILE'])
-        indicator_file.touch()
-        with open(self._state_file, 'w+') as state_fd:
-            fcntl.flock(state_fd, fcntl.LOCK_EX)
-            fcntl.flock(state_fd, fcntl.LOCK_UN)
 
 
 if __name__ == '__main__':

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -20,7 +20,7 @@ def fake_script(test_case, name, content):
 
     with open(test_case.fake_script_path / name, "w") as f:
         # Before executing the provided script, dump the provided arguments in calls.txt.
-        f.write('#!/bin/bash\n{ echo -n $(basename $0); for s in "$@"; do echo -n \\;$s; done; echo; } >> $(dirname $0)/calls.txt\n' + content)
+        f.write('#!/bin/bash\n{ echo -n $(basename $0); for s in "$@"; do echo -n \\;"$s"; done; echo; } >> $(dirname $0)/calls.txt\n' + content)
     os.chmod(test_case.fake_script_path / name, 0o755)
 
 
@@ -37,10 +37,10 @@ class FakeScriptTest(unittest.TestCase):
     def test_fake_script_works(self):
         fake_script(self, 'foo', 'echo foo runs')
         fake_script(self, 'bar', 'echo bar runs')
-        output = subprocess.getoutput('foo a "b c"; bar "d e" f')
+        output = subprocess.getoutput('foo a "b c "; bar "d e" f')
         self.assertEqual(output, 'foo runs\nbar runs')
         self.assertEqual(fake_script_calls(self), [
-            ['foo', 'a', 'b c'],
+            ['foo', 'a', 'b c '],
             ['bar', 'd e', 'f'],
         ])
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -9,6 +9,9 @@ import pickle
 import base64
 import tempfile
 import shutil
+import fcntl
+import time
+import concurrent.futures
 
 import importlib.util
 
@@ -31,9 +34,10 @@ from ops.charm import (
     RelationEvent,
     StorageAttachedEvent,
     ActionEvent,
+    CollectMetricsEvent,
 )
 
-from .test_helpers import fake_script
+from .test_helpers import fake_script, fake_script_calls
 
 # This relies on the expected repository structure to find a path to source of the charm under test.
 TEST_CHARM_DIR = Path(f'{__file__}/../charms/test_main').resolve()
@@ -343,6 +347,32 @@ start:
         self._simulate_event(EventSpec(InstallEvent, 'install', charm_config=charm_config))
         action_hook = self.JUJU_CHARM_DIR / 'actions' / 'test'
         self.assertTrue(action_hook.exists())
+
+    def test_collect_metrics_concurrent(self):
+        indicator_file = self.JUJU_CHARM_DIR / 'indicator'
+        charm_config = base64.b64encode(pickle.dumps({
+            'STATE_FILE': self._state_file,
+            'INDICATOR_FILE': indicator_file
+        }))
+        fake_script(self, 'add-metric', 'exit 0')
+        self._simulate_event(EventSpec(InstallEvent, 'install', charm_config=charm_config))
+
+        with open(self._state_file, 'w+') as state_fd:
+            fcntl.flock(state_fd, fcntl.LOCK_EX)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(self._simulate_event, EventSpec(RelationDepartedEvent, 'ha_relation_departed',
+                                                                         relation_id=3, charm_config=charm_config))
+                # A simple spinlock to wait until the indicator file appears (avoids inotify as a dependency).
+                while not indicator_file.exists():
+                    time.sleep(0.01)
+                try:
+                    self._simulate_event(EventSpec(CollectMetricsEvent, 'collect_metrics', charm_config=charm_config))
+                except Exception:
+                    fcntl.flock(state_fd, fcntl.LOCK_UN)
+                    self.fail('simulating a concurrent collect-metrics hook resulted in an exception')
+                self.assertEqual(fake_script_calls(self), [['add-metric', '--labels', 'dead= beef ', 'foo=bar']])
+                fcntl.flock(state_fd, fcntl.LOCK_UN)
+                future.result()
 
 
 if __name__ == "__main__":

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -854,9 +854,9 @@ class TestModelBackend(unittest.TestCase):
     def test_metrics(self):
         fake_script(self, 'add-metric', 'exit 0')
         test_cases = [(
-            {'foo': 42, 'bar': 4.2},
+            {'foo': 42, 'b-ar': 4.2, 'ba_-z': 4.2, 'a': 1},
             {'de': 'ad', 'be': 'ef_ -'},
-            [['add-metric', '--labels', 'de=ad,be=ef_ -', 'foo=42', 'bar=4.2']]
+            [['add-metric', '--labels', 'de=ad,be=ef_ -', 'foo=42', 'b-ar=4.2', 'ba_-z=4.2', 'a=1']]
         ), (
             {'foo1': 0, 'b2r': -4.2},
             {'d3': 'aд', 'b33f': '3_ -'},
@@ -868,8 +868,15 @@ class TestModelBackend(unittest.TestCase):
 
         invalid_inputs = [
             ({'': 4.2}, {}),
+            ({'1': 4.2}, {}),
             ({'123': 4.2}, {}),
             ({'1foo': 4.2}, {}),
+            ({'-foo': 4.2}, {}),
+            ({'_foo': 4.2}, {}),
+            ({'foo-': 4.2}, {}),
+            ({'foo_': 4.2}, {}),
+            ({'a-': 4.2}, {}),
+            ({'a_': 4.2}, {}),
             ({'foo': 'bar'}, {}),
             ({'foo': '1O'}, {}),
             ({'BAЯ': 4.2}, {}),

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -851,6 +851,11 @@ class TestModelBackend(unittest.TestCase):
         self.backend.action_log('progress: 42%')
         self.assertEqual(fake_script_calls(self), [['action-log', 'progress: 42%']])
 
+    def test_metrics(self):
+        fake_script(self, 'add-metric', 'exit 0')
+        self.backend.add_metric({'foo': 1, 'bar': ' baz '}, {'de': 'ad', 'be ': 'ef '})
+        self.assertEqual(fake_script_calls(self), [['add-metric', '--labels', 'de=ad,be =ef ', 'foo=1', 'bar= baz ']])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -854,13 +854,13 @@ class TestModelBackend(unittest.TestCase):
     def test_metrics(self):
         fake_script(self, 'add-metric', 'exit 0')
         test_cases = [(
-            {'foo': 42, 'b-ar': 4.2, 'ba_-z': 4.2, 'a': 1},
+            {'foo': 42, 'b-ar': 4.5, 'ba_-z': 4.5, 'a': 1},
             {'de': 'ad', 'be': 'ef_ -'},
-            [['add-metric', '--labels', 'de=ad,be=ef_ -', 'foo=42', 'b-ar=4.2', 'ba_-z=4.2', 'a=1']]
+            [['add-metric', '--labels', 'de=ad,be=ef_ -', 'foo=42', 'b-ar=4.5', 'ba_-z=4.5', 'a=1']]
         ), (
-            {'foo1': 0, 'b2r': -4.2},
+            {'foo1': 0, 'b2r': 4.5},
             {'d3': 'aд', 'b33f': '3_ -'},
-            [['add-metric', '--labels', 'd3=aд,b33f=3_ -', 'foo1=0', 'b2r=-4.2']],
+            [['add-metric', '--labels', 'd3=aд,b33f=3_ -', 'foo1=0', 'b2r=4.5']],
         )]
         for metrics, labels, expected_calls in test_cases:
             self.backend.add_metrics(metrics, labels)
@@ -869,6 +869,10 @@ class TestModelBackend(unittest.TestCase):
         invalid_inputs = [
             ({'': 4.2}, {}),
             ({'1': 4.2}, {}),
+            ({'1': -4.2}, {}),
+            ({'a': float('+inf')}, {}),
+            ({'a': float('-inf')}, {}),
+            ({'a': float('nan')}, {}),
             ({'123': 4.2}, {}),
             ({'1foo': 4.2}, {}),
             ({'-foo': 4.2}, {}),


### PR DESCRIPTION
* add CollectMetricsEvent and a relevant API for supporting add-metric
  hook tool on that event;
* add CollectMetricsEvent to CharmEvents;
* At the time of writing, collect-metrics hooks can run concurrently to other hooks
  ignoring the usual semantics, however, this is serialized via DB locking with
  a long timeout;
* collect-metrics hooks run in a limited environment where regular hook
  tools are not available;
* Utility of deferring collect-metrics hooks is questionable but this is not prevented;
* metrics keys, metric values, label keys and label values are sanity-checked, although
   those restrictions are not yet in place at the time of writing.