### PR TITLE
Rework DB lock handling

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -332,7 +332,7 @@ class SQLiteStorage:
     DB_LOCK_TIMEOUT = timedelta(hours=1)
 
     def __init__(self, filename):
-        # The isolation_level argument is set to None such that autocommit behavior of the sqlite3 module is disabled.
+        # The isolation_level argument is set to None such that the implicit transaction management behavior of the sqlite3 module is disabled.
         self._db = sqlite3.connect(str(filename), isolation_level=None, timeout=self.DB_LOCK_TIMEOUT.total_seconds())
         self._setup()
 

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -333,7 +333,7 @@ class SQLiteStorage:
         self._setup()
 
     def _setup(self):
-        c = self._db.execute("BEGIN")
+        c = self._db.cursor()
         c.execute("SELECT count(name) FROM sqlite_master WHERE type='table' AND name='snapshot'")
         if c.fetchone()[0] == 0:
             # Keep in mind what might happen if the process dies somewhere below.

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -332,10 +332,12 @@ class SQLiteStorage:
     DB_LOCK_TIMEOUT = timedelta(hours=1).total_seconds()
 
     def __init__(self, filename):
+        # The isolation_level argument is set to None such that autocommit behavior of the sqlite3 module is disabled.
         self._db = sqlite3.connect(str(filename), isolation_level=None, timeout=self.DB_LOCK_TIMEOUT)
         self._setup()
 
     def _setup(self):
+        # Make sure that the database is locked until the connection is closed, not until the transaction ends.
         c = self._db.execute("PRAGMA locking_mode=EXCLUSIVE")
         c = self._db.execute("BEGIN EXCLUSIVE")
         c.execute("SELECT count(name) FROM sqlite_master WHERE type='table' AND name='snapshot'")

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -338,7 +338,7 @@ class SQLiteStorage:
 
     def _setup(self):
         # Make sure that the database is locked until the connection is closed, not until the transaction ends.
-        c = self._db.execute("PRAGMA locking_mode=EXCLUSIVE")
+        self._db.execute("PRAGMA locking_mode=EXCLUSIVE")
         c = self._db.execute("BEGIN")
         c.execute("SELECT count(name) FROM sqlite_master WHERE type='table' AND name='snapshot'")
         if c.fetchone()[0] == 0:

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -7,6 +7,7 @@ import collections
 import collections.abc
 import keyword
 import weakref
+from datetime import timedelta
 
 
 class Handle:
@@ -328,8 +329,10 @@ class NoTypeError(Exception):
 
 class SQLiteStorage:
 
+    DB_LOCK_TIMEOUT = timedelta(hours=1).total_seconds()
+
     def __init__(self, filename):
-        self._db = sqlite3.connect(str(filename), isolation_level=None, timeout=0)
+        self._db = sqlite3.connect(str(filename), isolation_level=None, timeout=self.DB_LOCK_TIMEOUT)
         self._setup()
 
     def _setup(self):

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -730,11 +730,10 @@ class TestFramework(unittest.TestCase):
         self.assertEqual(my_obj.charm_dir, framework.charm_dir)
 
     def test_ban_concurrent_frameworks(self):
-        framework = self.create_framework()
+        _ = self.create_framework()
         with self.assertRaises(Exception) as cm:
-            framework_copy = self.create_framework()
-            self.fail(f'frameworks {framework} and {framework_copy} got instantiated successfully')
-        self.assertTrue('database is locked' in str(cm.exception))
+            self.create_framework()
+        self.assertIn('database is locked', str(cm.exception))
 
 
 class TestStoredState(unittest.TestCase):

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -730,7 +730,7 @@ class TestFramework(unittest.TestCase):
         self.assertEqual(my_obj.charm_dir, framework.charm_dir)
 
     def test_ban_concurrent_frameworks(self):
-        _ = self.create_framework()
+        _ = self.create_framework()  # noqa: E841
         with self.assertRaises(Exception) as cm:
             self.create_framework()
         self.assertIn('database is locked', str(cm.exception))

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -730,7 +730,7 @@ class TestFramework(unittest.TestCase):
         self.assertEqual(my_obj.charm_dir, framework.charm_dir)
 
     def test_ban_concurrent_frameworks(self):
-        _ = self.create_framework()  # noqa: E841
+        _ = self.create_framework()  # noqa: F841
         with self.assertRaises(Exception) as cm:
             self.create_framework()
         self.assertIn('database is locked', str(cm.exception))

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -730,10 +730,11 @@ class TestFramework(unittest.TestCase):
         self.assertEqual(my_obj.charm_dir, framework.charm_dir)
 
     def test_ban_concurrent_frameworks(self):
-        _ = self.create_framework()  # noqa: F841
+        f = self.create_framework()
         with self.assertRaises(Exception) as cm:
             self.create_framework()
         self.assertIn('database is locked', str(cm.exception))
+        f.close()
 
 
 class TestStoredState(unittest.TestCase):

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from ops.framework import (
     Framework, Handle, EventSource, EventsBase, EventBase, Object, PreCommitEvent, CommitEvent,
-    NoSnapshotError, StoredState, StoredList, BoundStoredState, StoredStateData
+    NoSnapshotError, StoredState, StoredList, BoundStoredState, StoredStateData, SQLiteStorage
 )
 
 from sqlite3 import OperationalError
@@ -20,6 +20,13 @@ class TestFramework(unittest.TestCase):
     def setUp(self):
         self.tmpdir = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, self.tmpdir)
+
+        default_timeout = SQLiteStorage.DB_LOCK_TIMEOUT
+
+        def timeout_cleanup():
+            SQLiteStorage.DB_LOCK_TIMEOUT = default_timeout
+        SQLiteStorage.DB_LOCK_TIMEOUT = 0
+        self.addCleanup(timeout_cleanup)
 
     def create_framework(self):
         framework = Framework(self.tmpdir / "framework.data", self.tmpdir, None, None)


### PR DESCRIPTION
Rework handling of exclusive db access

* sqlite3 Python module provides an implicit transaction management
  functionality when isolation_level argument is not None when passed to
  a connect method;
* sqlite3 itself by default operates in the autocommit mode which can
  be disabled by executing the "BEGIN" SQL command;
  https://www.sqlite.org/lockingv3.html#transaction_control
* BEGIN without EXCLUSIVE does not obtain an exclusive lock for the
  database and the default behavior is to run a transaction as DEFERRED;
  https://www.sqlite.org/lang_transaction.html#immediate

The desired behavior for the framework is holding an exclusive access to
the DB while a Framework object exists and is not closed which requires
maintaining exclusive access across transactions. This is possible to
achieve by using `PRAGMA locking_mode=EXCLUSIVE`.

With this change, it will not be possible to have two Framework objects
with exclusive access to the backend storage.


