### PR TITLE
Add python 3.8 testing, and also test on arm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,14 @@ dist: bionic
 
 language: python
 
+arch:
+    - amd64
+    - arm64
+
 python:
     - "3.6"
     - "3.7"
+    - "3.8"
 
 install:
     - sudo apt update

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,14 @@ python:
     - "3.7"
     - "3.8"
 
+addons:
+    apt:
+        update: true
+        packages:
+            - flake8
+            - make
+
 install:
-    - sudo apt update
-    - sudo apt install flake8 make
     - pip3 install pyyaml autopep8
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
 
         "License :: OSI Approved :: Apache Software License",
     ],


### PR DESCRIPTION
3.8 is the default python in Focal, so we should start testing on it.

And travis lets you test things on arm also, so why not?