### PR TITLE
Do not re-emit events in a metric event context

### DIFF
--- a/ops/main.py
+++ b/ops/main.py
@@ -186,7 +186,10 @@ def main(charm_class):
         if juju_event_name in ('install', 'start', 'upgrade_charm') or juju_event_name.endswith('_storage_attached'):
             _setup_event_links(charm_dir, charm)
 
-        framework.reemit()
+        # Skip reemission of deferred events for collect-metrics events because they do not have the full access
+        # to all hook tools.
+        if juju_event_name != 'collect_metrics':
+            framework.reemit()
 
         _emit_charm_event(charm, juju_event_name)
 

--- a/ops/main.py
+++ b/ops/main.py
@@ -186,6 +186,7 @@ def main(charm_class):
         if juju_event_name in ('install', 'start', 'upgrade_charm') or juju_event_name.endswith('_storage_attached'):
             _setup_event_links(charm_dir, charm)
 
+        # TODO: Remove the collect_metrics check below as soon as the relevant Juju changes are made.
         # Skip reemission of deferred events for collect-metrics events because they do not have the full access
         # to all hook tools.
         if juju_event_name != 'collect_metrics':


### PR DESCRIPTION
Juju doesn't run collect-metrics hooks with the same context as regular
hooks and so regular hook tools are not available in those. Re-emitting
regular deferred events makes them fail due to that.