### PR TITLE
Allow binding lookup without relation ids

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -63,8 +63,11 @@ class Model:
     def get_binding(self, binding_key):
         """Get a network space binding.
 
-        binding_key -- a name of a relation or a Relation object. Providing a Relation object will return
-                       a Binding object specific to a relation.
+        binding_key -- The relation name or instance to obtain bindings for.
+
+        If binding_key is a relation name, the method returns the default binding for that relation.
+        If a relation instance is provided, the method first looks up a more specific binding for that specific relation ID,
+        and if none is found falls back to the default binding for the relation name.
         """
         return self._bindings.get(binding_key)
 
@@ -270,7 +273,7 @@ class BindingMapping:
             binding_name = binding_key
             relation_id = None
         else:
-            raise ModelError('a binding key must be a str or Relation, not {}'.format(type(binding_key).__name__))
+            raise ModelError('binding key must be str or relation instance, not {}'.format(type(binding_key).__name__))
         binding = self._data.get(binding_key)
         if binding is None:
             binding = Binding(binding_name, relation_id, self._backend)

--- a/ops/model.py
+++ b/ops/model.py
@@ -65,9 +65,10 @@ class Model:
 
         binding_key -- The relation name or instance to obtain bindings for.
 
-        If binding_key is a relation name, the method returns the default binding for that relation.
-        If a relation instance is provided, the method first looks up a more specific binding for that specific relation ID,
-        and if none is found falls back to the default binding for the relation name.
+        If binding_key is a relation name, the method returns the default binding for that
+        relation. If a relation instance is provided, the method first looks up a more specific
+        binding for that specific relation ID, and if none is found falls back to the default
+        binding for the relation name.
         """
         return self._bindings.get(binding_key)
 
@@ -283,7 +284,8 @@ class BindingMapping:
             binding_name = binding_key
             relation_id = None
         else:
-            raise ModelError('binding key must be str or relation instance, not {}'.format(type(binding_key).__name__))
+            raise ModelError('binding key must be str or relation instance, not {}'
+                             ''.format(type(binding_key).__name__))
         binding = self._data.get(binding_key)
         if binding is None:
             binding = Binding(binding_name, relation_id, self._backend)
@@ -308,7 +310,8 @@ class Binding:
             except RelationNotFoundError:
                 if self._relation_id is None:
                     raise
-                # If a relation is dead, we can still get network info associated with an endpoint itself
+                # If a relation is dead, we can still get network info associated with an
+                # endpoint itself
                 self._network = Network(self._backend.network_get(self.name))
         return self._network
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -290,14 +290,12 @@ class Binding:
     @property
     def network(self):
         if self._network is None:
-            if self._relation_id is not None:
-                try:
-                    self._network = Network(self._backend.network_get(self.name, self._relation_id))
-                except RelationNotFoundError:
-                    # If a relation is dead, we can still get network info associated with an endpoint itself
-                    # not associated with a particular relation id.
-                    self._network = Network(self._backend.network_get(self.name))
-            else:
+            try:
+                self._network = Network(self._backend.network_get(self.name, self._relation_id))
+            except RelationNotFoundError:
+                if self._relation_id is None:
+                    raise
+                # If a relation is dead, we can still get network info associated with an endpoint itself
                 self._network = Network(self._backend.network_get(self.name))
         return self._network
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -290,11 +290,14 @@ class Binding:
     @property
     def network(self):
         if self._network is None:
-            try:
-                self._network = Network(self._backend.network_get(self.name, self._relation_id))
-            except RelationNotFoundError:
-                # If a relation is dead, we can still get network info associated with an endpoint itself
-                # not associated with a particular relation id.
+            if self._relation_id is not None:
+                try:
+                    self._network = Network(self._backend.network_get(self.name, self._relation_id))
+                except RelationNotFoundError:
+                    # If a relation is dead, we can still get network info associated with an endpoint itself
+                    # not associated with a particular relation id.
+                    self._network = Network(self._backend.network_get(self.name))
+            else:
                 self._network = Network(self._backend.network_get(self.name))
         return self._network
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -270,7 +270,7 @@ class BindingMapping:
             binding_name = binding_key
             relation_id = None
         else:
-            raise ModelError(f'a binding key must be a str or Relation, not {type(binding_key).__name__}')
+            raise ModelError('a binding key must be a str or Relation, not {}'.format(type(binding_key).__name__))
         binding = self._data.get(binding_key)
         if binding is None:
             binding = Binding(binding_name, relation_id, self._backend)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -656,18 +656,30 @@ class TestModel(unittest.TestCase):
             with self.assertRaises(TypeError):
                 self.model.storages.request('data', count_v)
 
-    def test_relation_endpoint_bindings(self):
+
+class TestModelBindings(unittest.TestCase):
+
+    def setUp(self):
+        def restore_env(env):
+            os.environ.clear()
+            os.environ.update(env)
+        self.addCleanup(restore_env, os.environ.copy())
+
+        os.environ['JUJU_UNIT_NAME'] = 'myapp/0'
+
         meta = ops.charm.CharmMeta()
         meta.relations = {
             'db0': RelationMeta('provides', 'db0', {'interface': 'db0', 'scope': 'global'}),
             'db1': RelationMeta('requires', 'db1', {'interface': 'db1', 'scope': 'global'}),
             'db2': RelationMeta('peers', 'db2', {'interface': 'db2', 'scope': 'global'}),
         }
+        self.backend = ops.model.ModelBackend()
+        self.model = ops.model.Model('myapp/0', meta, self.backend)
 
         fake_script(self, 'relation-ids',
                     """([ "$1" = db0 ] && echo '["db0:4"]') || echo '[]'""")
         fake_script(self, 'relation-list', """[ "$2" = 4 ] && echo '["remoteapp1/0"]' || exit 2""")
-        network_get_out = '''{
+        self.network_get_out = '''{
   "bind-addresses": [
     {
       "mac-address": "de:ad:be:ef:ca:fe",
@@ -721,12 +733,39 @@ class TestModel(unittest.TestCase):
   ]
 }'''
 
+    def _check_binding_data(self, binding_name, binding):
+        self.assertEqual(binding.name, binding_name)
+        self.assertEqual(binding.network.bind_address, ipaddress.ip_address('192.0.2.2'))
+        self.assertEqual(binding.network.ingress_address, ipaddress.ip_address('192.0.2.2'))
+        # /32 and /128 CIDRs are valid one-address networks for IPv{4,6}Network types respectively.
+        self.assertEqual(binding.network.egress_subnets, [ipaddress.ip_network('192.0.2.2/32'),
+                                                          ipaddress.ip_network('192.0.3.0/24'),
+                                                          ipaddress.ip_network('dead:beef::/64'),
+                                                          ipaddress.ip_network('2001:db8::3/128')])
+        self.assertEqual(binding.network.interfaces[0].name, 'lo')
+        self.assertEqual(binding.network.interfaces[0].address, ipaddress.ip_address('192.0.2.2'))
+        self.assertEqual(binding.network.interfaces[0].subnet, ipaddress.ip_network('192.0.2.0/24'))
+        self.assertEqual(binding.network.interfaces[1].name, 'lo')
+        self.assertEqual(binding.network.interfaces[1].address, ipaddress.ip_address('dead:beef::1'))
+        self.assertEqual(binding.network.interfaces[1].subnet, ipaddress.ip_network('dead:beef::/64'))
+        self.assertEqual(binding.network.interfaces[2].name, 'tun')
+        self.assertEqual(binding.network.interfaces[2].address, ipaddress.ip_address('192.0.3.3'))
+        self.assertEqual(binding.network.interfaces[2].subnet, ipaddress.ip_network('192.0.3.3/32'))
+        self.assertEqual(binding.network.interfaces[3].name, 'tun')
+        self.assertEqual(binding.network.interfaces[3].address, ipaddress.ip_address('2001:db8::3'))
+        self.assertEqual(binding.network.interfaces[3].subnet, ipaddress.ip_network('2001:db8::3/128'))
+        self.assertEqual(binding.network.interfaces[4].name, 'tun')
+        self.assertEqual(binding.network.interfaces[4].address, ipaddress.ip_address('fe80::1:1'))
+        self.assertEqual(binding.network.interfaces[4].subnet, ipaddress.ip_network('fe80::/64'))
+
+    def test_invalid_keys(self):
         # Basic validation for passing invalid keys.
         for name in (object, 0):
             with self.assertRaises(ops.model.ModelError):
                 self.model.get_binding(name)
 
-        fake_script(self, 'network-get', '''[ "$1" = db0 -a "$2" = --format=json ] && echo '{}' || '''.format(network_get_out) +
+    def test_dead_relations(self):
+        fake_script(self, 'network-get', '''[ "$1" = db0 -a "$2" = --format=json ] && echo '{}' || '''.format(self.network_get_out) +
                                          '''{ echo ERROR invalid value "$2" for option -r: relation not found >&2 ; exit 2; }'''),
         # Validate the behavior for dead relations.
         binding = ops.model.Binding('db0', 42, self.model._backend)
@@ -736,55 +775,27 @@ class TestModel(unittest.TestCase):
             ['network-get', 'db0', '--format=json'],
         ])
 
-        def check_binding_data(binding_name, binding):
-            self.assertEqual(binding.name, binding_name)
-            self.assertEqual(binding.network.bind_address, ipaddress.ip_address('192.0.2.2'))
-            self.assertEqual(binding.network.ingress_address, ipaddress.ip_address('192.0.2.2'))
-            # /32 and /128 CIDRs are valid one-address networks for IPv{4,6}Network types respectively.
-            self.assertEqual(binding.network.egress_subnets, [ipaddress.ip_network('192.0.2.2/32'),
-                                                              ipaddress.ip_network('192.0.3.0/24'),
-                                                              ipaddress.ip_network('dead:beef::/64'),
-                                                              ipaddress.ip_network('2001:db8::3/128')])
-            self.assertEqual(binding.network.interfaces[0].name, 'lo')
-            self.assertEqual(binding.network.interfaces[0].address, ipaddress.ip_address('192.0.2.2'))
-            self.assertEqual(binding.network.interfaces[0].subnet, ipaddress.ip_network('192.0.2.0/24'))
-            self.assertEqual(binding.network.interfaces[1].name, 'lo')
-            self.assertEqual(binding.network.interfaces[1].address, ipaddress.ip_address('dead:beef::1'))
-            self.assertEqual(binding.network.interfaces[1].subnet, ipaddress.ip_network('dead:beef::/64'))
-            self.assertEqual(binding.network.interfaces[2].name, 'tun')
-            self.assertEqual(binding.network.interfaces[2].address, ipaddress.ip_address('192.0.3.3'))
-            self.assertEqual(binding.network.interfaces[2].subnet, ipaddress.ip_network('192.0.3.3/32'))
-            self.assertEqual(binding.network.interfaces[3].name, 'tun')
-            self.assertEqual(binding.network.interfaces[3].address, ipaddress.ip_address('2001:db8::3'))
-            self.assertEqual(binding.network.interfaces[3].subnet, ipaddress.ip_network('2001:db8::3/128'))
-            self.assertEqual(binding.network.interfaces[4].name, 'tun')
-            self.assertEqual(binding.network.interfaces[4].address, ipaddress.ip_address('fe80::1:1'))
-            self.assertEqual(binding.network.interfaces[4].subnet, ipaddress.ip_network('fe80::/64'))
+    def test_binding_by_relation_name(self):
+        fake_script(self, 'network-get', '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(self.network_get_out))
+        binding_name = 'db0'
+        expected_calls = [['network-get', 'db0', '--format=json']]
 
-        single_binding_test_cases = [(
-            lambda: fake_script(self, 'network-get', '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(network_get_out)),
-            'db0',
-            lambda binding_name: self.model.get_binding(binding_name),
-            [['network-get', 'db0', '--format=json']],
-        ), (
-            lambda: fake_script(self, 'network-get', '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(network_get_out)),
-            'db0',
-            lambda binding_name: self.model.get_binding(self.model.get_relation(binding_name)),
-            [
-                ['relation-ids', 'db0', '--format=json'],
-                # The two invocations below are due to the get_relation call.
-                ['relation-list', '-r', '4', '--format=json'],
-                ['network-get', 'db0', '-r', '4', '--format=json'],
-            ],
-        )]
+        binding = self.model.get_binding(binding_name)
+        self._check_binding_data(binding_name, binding)
+        self.assertEqual(fake_script_calls(self, clear=True), expected_calls)
 
-        for do_fake, binding_name, get_binding, expected_calls in single_binding_test_cases:
-            self.backend = ops.model.ModelBackend()
-            self.model = ops.model.Model('myapp/0', meta, self.backend)
-            do_fake()
-            binding = get_binding(binding_name)
-            check_binding_data(binding_name, binding)
-            self.assertEqual(fake_script_calls(self, clear=True), expected_calls)
+    def test_binding_by_relation(self):
+        fake_script(self, 'network-get', '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(self.network_get_out))
+        binding_name = 'db0'
+        expected_calls = [
+            ['relation-ids', 'db0', '--format=json'],
+            # The two invocations below are due to the get_relation call.
+            ['relation-list', '-r', '4', '--format=json'],
+            ['network-get', 'db0', '-r', '4', '--format=json'],
+        ]
+        binding = self.model.get_binding(self.model.get_relation(binding_name))
+        self._check_binding_data(binding_name, binding)
+        self.assertEqual(fake_script_calls(self, clear=True), expected_calls)
 
 
 class TestModelBackend(unittest.TestCase):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -901,8 +901,11 @@ class TestModelBindings(unittest.TestCase):
                 self.model.get_binding(name)
 
     def test_dead_relations(self):
-        fake_script(self, 'network-get', '''[ "$1" = db0 -a "$2" = --format=json ] && echo '{}' || '''.format(self.network_get_out) +
-                                         '''{ echo ERROR invalid value "$2" for option -r: relation not found >&2 ; exit 2; }'''),
+        fake_script(self, 'network-get',
+                    '''[ "$1" = db0 -a "$2" = --format=json ]'''
+                    ''' && echo '{}' || '''.format(self.network_get_out) +
+                    '''{ echo ERROR invalid value "$2" for option -r: '''
+                    '''relation not found >&2 ; exit 2; }'''),
         # Validate the behavior for dead relations.
         binding = ops.model.Binding('db0', 42, self.model._backend)
         self.assertEqual(binding.network.bind_address, ipaddress.ip_address('192.0.2.2'))
@@ -912,7 +915,8 @@ class TestModelBindings(unittest.TestCase):
         ])
 
     def test_binding_by_relation_name(self):
-        fake_script(self, 'network-get', '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(self.network_get_out))
+        fake_script(self, 'network-get',
+                    '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(self.network_get_out))
         binding_name = 'db0'
         expected_calls = [['network-get', 'db0', '--format=json']]
 
@@ -921,7 +925,8 @@ class TestModelBindings(unittest.TestCase):
         self.assertEqual(fake_script_calls(self, clear=True), expected_calls)
 
     def test_binding_by_relation(self):
-        fake_script(self, 'network-get', '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(self.network_get_out))
+        fake_script(self, 'network-get',
+                    '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(self.network_get_out))
         binding_name = 'db0'
         expected_calls = [
             ['relation-ids', 'db0', '--format=json'],


### PR DESCRIPTION
* Networking information associated with a relation endpoint can be
  useful before the relations themselves exist;
* It is not possible to retrieve networking info for dead relations so
  for those cases networking info is looked up as if a relation ID was
  not specified.