### PR TITLE
Add support for storing floats

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -757,8 +757,8 @@ class BoundStoredState:
 
         value = _unwrap_stored(self._data, value)
 
-        if not isinstance(value, (type(None), int, str, bytes, list, dict, set)):
-            raise AttributeError("attribute '{}' cannot be set to {}: must be int/dict/list/etc".format(key, type(value).__name__))
+        if not isinstance(value, (type(None), int, float, str, bytes, list, dict, set)):
+            raise AttributeError("attribute '{}' cannot be set to {}: must be int/float/dict/list/etc".format(key, type(value).__name__))
 
         self._data[key] = _unwrap_stored(self._data, value)
         self.on.changed.emit()

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -787,6 +787,7 @@ class TestStoredState(unittest.TestCase):
         obj.state.foo = 42
         obj.state.bar = "s"
         obj.state.baz = 4.2
+        obj.state.bing = True
 
         self.assertEqual(obj.state.foo, 42)
 
@@ -803,6 +804,7 @@ class TestStoredState(unittest.TestCase):
         self.assertEqual(obj_copy.state.foo, 42)
         self.assertEqual(obj_copy.state.bar, "s")
         self.assertEqual(obj_copy.state.baz, 4.2)
+        self.assertEqual(obj_copy.state.bing, True)
 
     def test_mutable_types_invalid(self):
         framework = self.create_framework()

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -786,6 +786,7 @@ class TestStoredState(unittest.TestCase):
         obj.state.foo = 41
         obj.state.foo = 42
         obj.state.bar = "s"
+        obj.state.baz = 4.2
 
         self.assertEqual(obj.state.foo, 42)
 
@@ -801,6 +802,7 @@ class TestStoredState(unittest.TestCase):
         obj_copy = SomeObject(framework_copy, "1")
         self.assertEqual(obj_copy.state.foo, 42)
         self.assertEqual(obj_copy.state.bar, "s")
+        self.assertEqual(obj_copy.state.baz, 4.2)
 
     def test_mutable_types_invalid(self):
         framework = self.create_framework()
@@ -814,7 +816,7 @@ class TestStoredState(unittest.TestCase):
                 pass
             obj.state.foo = CustomObject()
         except AttributeError as e:
-            self.assertEqual(str(e), "attribute 'foo' cannot be set to CustomObject: must be int/dict/list/etc")
+            self.assertEqual(str(e), "attribute 'foo' cannot be set to CustomObject: must be int/float/dict/list/etc")
         else:
             self.fail('AttributeError not raised')
 


### PR DESCRIPTION
Storing floats was not supported although we claimed to support basic types.