### PR TITLE
many: make flake8 rules stricter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 127
+max-line-length = 100
 max-complexity = 10

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 160
+max-line-length = 127
 exclude = sandbox

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 100
+max-line-length = 99
 max-complexity = 10

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 127
-exclude = sandbox
+max-complexity = 10

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,2 @@
 [flake8]
 max-line-length = 99
-max-complexity = 10

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -34,7 +34,8 @@ class ActionEvent(EventBase):
         if event_action_name != env_action_name:
             # This could only happen if the dev manually emits the action, or from a bug.
             raise RuntimeError('action event kind does not match current action')
-        # Params are loaded at restore rather than __init__ because the model is not available in __init__.
+        # Params are loaded at restore rather than __init__ because
+        # the model is not available in __init__.
         self.params = self.framework.model._backend.action_get()
 
     def set_results(self, results):
@@ -97,8 +98,9 @@ class RelationEvent(HookEvent):
     def __init__(self, handle, relation, app=None, unit=None):
         super().__init__(handle)
 
-        if unit and unit.app != app:
-            raise RuntimeError('cannot create RelationEvent with application {} and unit {}'.format(app, unit))
+        if unit is not None and unit.app != app:
+            raise RuntimeError(
+                'cannot create RelationEvent with application {} and unit {}'.format(app, unit))
 
         self.relation = relation
         self.app = app
@@ -116,7 +118,8 @@ class RelationEvent(HookEvent):
         return snapshot
 
     def restore(self, snapshot):
-        self.relation = self.framework.model.get_relation(snapshot['relation_name'], snapshot['relation_id'])
+        self.relation = self.framework.model.get_relation(
+            snapshot['relation_name'], snapshot['relation_id'])
 
         app_name = snapshot.get('app_name')
         if app_name:

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -403,11 +403,13 @@ class SQLiteStorage:
             # Keep in mind what might happen if the process dies somewhere below.
             # The system must not be rendered permanently broken by that.
             self._db.execute("CREATE TABLE snapshot (handle TEXT PRIMARY KEY, data BLOB)")
-            self._db.execute("CREATE TABLE notice ("
-                             " sequence INTEGER PRIMARY KEY AUTOINCREMENT,"
-                             " event_path TEXT,"
-                             " observer_path TEXT,"
-                             " method_name TEXT)")
+            self._db.execute('''
+                CREATE TABLE notice (
+                  sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                  event_path TEXT,
+                  observer_path TEXT,
+                  method_name TEXT)
+                ''')
             self._db.commit()
 
     def close(self):
@@ -455,13 +457,13 @@ class SQLiteStorage:
                   FROM notice
                  WHERE event_path=?
                  ORDER BY sequence
-            ''', (event_path,))
+                ''', (event_path,))
         else:
             c = self._db.execute('''
                 SELECT event_path, observer_path, method_name
                   FROM notice
                  ORDER BY sequence
-            ''')
+                ''')
         while True:
             rows = c.fetchmany()
             if not rows:

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -627,8 +627,9 @@ class Framework(Object):
             method_name = "on_" + event_kind
             if not hasattr(observer, method_name):
                 raise RuntimeError(
-                    'Observer method not provided explicitly and {} type has no "{}" method'.format(
-                        type(observer).__name__, method_name))
+                    'Observer method not provided explicitly'
+                    ' and {} type has no {!r} method'.format(type(observer).__name__,
+                                                             method_name))
 
         # Validate that the method has an acceptable call signature.
         sig = inspect.signature(getattr(observer, method_name))

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -628,7 +628,7 @@ class Framework(Object):
             if not hasattr(observer, method_name):
                 raise RuntimeError(
                     'Observer method not provided explicitly'
-                    ' and {} type has no {!r} method'.format(type(observer).__name__,
+                    ' and {} type has no "{}" method'.format(type(observer).__name__,
                                                              method_name))
 
         # Validate that the method has an acceptable call signature.

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -144,7 +144,8 @@ class EventSource:
 
     def __init__(self, event_type):
         if not isinstance(event_type, type) or not issubclass(event_type, EventBase):
-            raise RuntimeError("Event requires a subclass of EventBase as an argument, got {}".format(event_type))
+            raise RuntimeError(
+                'Event requires a subclass of EventBase as an argument, got {}'.format(event_type))
         self.event_type = event_type
         self.event_kind = None
         self.emitter_type = None
@@ -165,8 +166,9 @@ class EventSource:
     def __get__(self, emitter, emitter_type=None):
         if emitter is None:
             return self
-        # Framework might not be available if accessed as CharmClass.on.event rather than charm_instance.on.event,
-        # but in that case it couldn't be emitted anyway, so there's no point to registering it.
+        # Framework might not be available if accessed as CharmClass.on.event
+        # rather than charm_instance.on.event, but in that case it couldn't be
+        # emitted anyway, so there's no point to registering it.
         framework = getattr(emitter, 'framework', None)
         if framework is not None:
             framework.register_type(self.event_type, emitter, self.event_kind)
@@ -303,14 +305,15 @@ class EventsBase(Object):
         event_type: a type of the event to define.
 
         """
-        pfx = 'unable to define an event with event_kind that '
+        prefix = 'unable to define an event with event_kind that '
         if not event_kind.isidentifier():
-            raise RuntimeError(pfx + 'is not a valid python identifier: ' + event_kind)
+            raise RuntimeError(prefix + 'is not a valid python identifier: ' + event_kind)
         elif keyword.iskeyword(event_kind):
-            raise RuntimeError(pfx + 'is a python keyword: ' + event_kind)
+            raise RuntimeError(prefix + 'is a python keyword: ' + event_kind)
         try:
             getattr(cls, event_kind)
-            raise RuntimeError(pfx + 'overlaps with an existing type {} attribute: {}'.format(cls, event_kind))
+            raise RuntimeError(
+                prefix + 'overlaps with an existing type {} attribute: {}'.format(cls, event_kind))
         except AttributeError:
             pass
 
@@ -385,11 +388,14 @@ class SQLiteStorage:
     def __init__(self, filename):
         # The isolation_level argument is set to None such that the implicit
         # transaction management behavior of the sqlite3 module is disabled.
-        self._db = sqlite3.connect(str(filename), isolation_level=None, timeout=self.DB_LOCK_TIMEOUT.total_seconds())
+        self._db = sqlite3.connect(str(filename),
+                                   isolation_level=None,
+                                   timeout=self.DB_LOCK_TIMEOUT.total_seconds())
         self._setup()
 
     def _setup(self):
-        # Make sure that the database is locked until the connection is closed, not until the transaction ends.
+        # Make sure that the database is locked until the connection is closed,
+        # not until the transaction ends.
         self._db.execute("PRAGMA locking_mode=EXCLUSIVE")
         c = self._db.execute("BEGIN")
         c.execute("SELECT count(name) FROM sqlite_master WHERE type='table' AND name='snapshot'")
@@ -431,18 +437,31 @@ class SQLiteStorage:
         self._db.execute("DELETE FROM snapshot WHERE handle=?", (handle_path,))
 
     def save_notice(self, event_path, observer_path, method_name):
-        self._db.execute("INSERT INTO notice VALUES (NULL, ?, ?, ?)", (event_path, observer_path, method_name))
-
-    def drop_notice(self, event_path, observer_path, method_name):
-        self._db.execute("DELETE FROM notice WHERE event_path=? AND observer_path=? AND method_name=?",
+        self._db.execute('INSERT INTO notice VALUES (NULL, ?, ?, ?)',
                          (event_path, observer_path, method_name))
 
+    def drop_notice(self, event_path, observer_path, method_name):
+        self._db.execute('''
+            DELETE FROM notice
+             WHERE event_path=?
+               AND observer_path=?
+               AND method_name=?
+            ''', (event_path, observer_path, method_name))
+
     def notices(self, event_path):
-        pfx = "SELECT event_path, observer_path, method_name FROM notice "
         if event_path:
-            c = self._db.execute(pfx + "WHERE event_path=? ORDER BY sequence", (event_path,))
+            c = self._db.execute('''
+                SELECT event_path, observer_path, method_name
+                  FROM notice
+                 WHERE event_path=?
+                 ORDER BY sequence
+            ''', (event_path,))
         else:
-            c = self._db.execute(pfx + "ORDER BY sequence")
+            c = self._db.execute('''
+                SELECT event_path, observer_path, method_name
+                  FROM notice
+                 ORDER BY sequence
+            ''')
         while True:
             rows = c.fetchmany()
             if not rows:
@@ -494,7 +513,8 @@ class Framework(Object):
             # Framework objects don't track themselves
             return
         if obj.handle.path in self.framework._objects:
-            raise RuntimeError("two objects claiming to be {} have been created".format(obj.handle.path))
+            raise RuntimeError(
+                'two objects claiming to be {} have been created'.format(obj.handle.path))
         self._objects[obj.handle.path] = obj
 
     def _forget(self, obj):
@@ -533,7 +553,8 @@ class Framework(Object):
         value.restore(snapshot)    # Restore custom state from prior snapshot.
         """
         if type(value) not in self._type_known:
-            raise RuntimeError("cannot save {} values before registering that type".format(type(value).__name__))
+            raise RuntimeError(
+                'cannot save {} values before registering that type'.format(type(value).__name__))
         data = value.snapshot()
         # Use marshal as a validator, enforcing the use of simple types.
         marshal.dumps(data)
@@ -582,7 +603,9 @@ class Framework(Object):
 
         """
         if not isinstance(bound_event, BoundEvent):
-            raise RuntimeError('Framework.observe requires a BoundEvent as second parameter, got {}'.format(bound_event))
+            raise RuntimeError(
+                'Framework.observe requires a BoundEvent as second parameter, got {}'.format(
+                    bound_event))
 
         event_type = bound_event.event_type
         event_kind = bound_event.event_kind
@@ -593,7 +616,8 @@ class Framework(Object):
         if hasattr(emitter, "handle"):
             emitter_path = emitter.handle.path
         else:
-            raise RuntimeError('event emitter {} must have a "handle" attribute'.format(type(emitter).__name__))
+            raise RuntimeError(
+                'event emitter {} must have a "handle" attribute'.format(type(emitter).__name__))
 
         method_name = None
         if isinstance(observer, types.MethodType):
@@ -602,19 +626,22 @@ class Framework(Object):
         else:
             method_name = "on_" + event_kind
             if not hasattr(observer, method_name):
-                raise RuntimeError('Observer method not provided explicitly and {} type has no "{}" method'.format(
-                    type(observer).__name__, method_name))
+                raise RuntimeError(
+                    'Observer method not provided explicitly and {} type has no "{}" method'.format(
+                        type(observer).__name__, method_name))
 
         # Validate that the method has an acceptable call signature.
         sig = inspect.signature(getattr(observer, method_name))
         # Self isn't included in the params list, so the first arg will be the event.
         extra_params = list(sig.parameters.values())[1:]
         if not sig.parameters:
-            raise TypeError('{}.{} must accept event parameter'.format(type(observer).__name__, method_name))
+            raise TypeError(
+                '{}.{} must accept event parameter'.format(type(observer).__name__, method_name))
         elif any(param.default is inspect.Parameter.empty for param in extra_params):
             # Allow for additional optional params, since there's no reason to exclude them, but
             # required params will break.
-            raise TypeError('{}.{} has extra required parameter'.format(type(observer).__name__, method_name))
+            raise TypeError(
+                '{}.{} has extra required parameter'.format(type(observer).__name__, method_name))
 
         # TODO Prevent the exact same parameters from being registered more than once.
 
@@ -623,7 +650,8 @@ class Framework(Object):
 
     def _next_event_key(self):
         """Return the next event key that should be used, incrementing the internal counter."""
-        # Increment the count first; this means the keys will start at 1, and 0 means no events have been emitted.
+        # Increment the count first; this means the keys will start at 1, and 0
+        # means no events have been emitted.
         self._stored['event_count'] += 1
         return str(self._stored['event_count'])
 
@@ -686,7 +714,8 @@ class Framework(Object):
                 deferred = True
             else:
                 self._storage.drop_notice(event_path, observer_path, method_name)
-            # We intentionally consider this event to be dead and reload it from scratch in the next path.
+            # We intentionally consider this event to be dead and reload it from
+            # scratch in the next path.
             self.framework._forget(event)
 
         if not deferred:
@@ -765,8 +794,9 @@ class BoundStoredState:
         value = _unwrap_stored(self._data, value)
 
         if not isinstance(value, (type(None), int, float, str, bytes, list, dict, set)):
-            raise AttributeError("attribute '{}' cannot be set to {}: must be int/float/dict/list/etc".format(
-                key, type(value).__name__))
+            raise AttributeError(
+                'attribute {!r} cannot be a {}: must be int/float/dict/list/etc'.format(
+                    key, type(value).__name__))
 
         self._data[key] = _unwrap_stored(self._data, value)
         self.on.changed.emit()
@@ -788,7 +818,9 @@ class StoredState:
         if self.parent_type is None:
             self.parent_type = parent_type
         elif self.parent_type is not parent_type:
-            raise RuntimeError("StoredState shared by {} and {}".format(self.parent_type.__name__, parent_type.__name__))
+            raise RuntimeError(
+                'StoredState shared by {} and {}'.format(
+                    self.parent_type.__name__, parent_type.__name__))
 
         if parent is None:
             return self
@@ -806,7 +838,8 @@ class StoredState:
                     parent.__dict__[attr_name] = bound
                     break
             else:
-                raise RuntimeError("cannot find StoredVariable attribute in type {}".format(parent_type.__name__))
+                raise RuntimeError(
+                    'cannot find StoredVariable attribute in type {}'.format(parent_type.__name__))
 
         return bound
 

--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -17,18 +17,61 @@ from functools import total_ordering
 
 
 @total_ordering
-class JujuVersion:
+class _Tag:
+    """_Tag is an internal class used to encapsulate how tags sort.
 
-    PATTERN = r'^(?P<major>\d{1,9})\.(?P<minor>\d{1,9})((?:\.|-(?P<tag>[a-z]+))(?P<patch>\d{1,9}))?(\.(?P<build>\d{1,9}))?$'
+    tags are special because an empty tag sorts after a non-empty tag,
+    which is backwards from string.
+    """
+
+    def __init__(self, tag):
+        self.tag = tag
+
+    def __eq__(self, other):
+        return self.tag == other.tag
+
+    def __lt__(self, other):
+        if self.tag == other.tag:
+            return False
+        if not self.tag:
+            return False
+        if not other.tag:
+            return True
+        return self.tag < other.tag
+
+
+@total_ordering
+class JujuVersion:
+    """JujuVersion can be used to compare different Juju versions.
+
+    Juju uses some convetions for its versions which make comparing them
+    slightly simpler than the generic version compare function you might find
+    elsewhere (e.g. apt_pkg.version_compare). This class encapsulates the needed
+    logic.
+
+    """
+
+    _matcher = re.compile(
+        r'''^
+            (?P<major>\d{1,9})\.(?P<minor>\d{1,9})       # <major> and <minor> numbers are always there
+            ((?:\.|-(?P<tag>[a-z]+))(?P<patch>\d{1,9}))? # sometimes with .<patch> or -<tag><patch>
+            (\.(?P<build>\d{1,9}))?$                     # and sometimes with a <build> number.
+        ''',
+        re.VERBOSE).match
 
     def __init__(self, version):
-        m = re.match(self.PATTERN, version)
+        # we could inherit from tuple (or namedtuple) but then again we'd have to
+        # implement all the comparison funcs instead of using total_ordering.
+        # end result would be faster and lighter so if performance is an issue start there
+
+        m = self._matcher(version)
         if not m:
             raise RuntimeError('"{}" is not a valid Juju version string'.format(version))
 
         d = m.groupdict()
-        self.major = int(m.group('major'))
-        self.minor = int(m.group('minor'))
+
+        self.major = int(d['major'])
+        self.minor = int(d['minor'])
         self.tag = d['tag'] or ''
         self.patch = int(d['patch'] or 0)
         self.build = int(d['build'] or 0)
@@ -42,36 +85,23 @@ class JujuVersion:
             s += '.{}'.format(self.build)
         return s
 
+    def _tuple(self):
+        return (self.major, self.minor, _Tag(self.tag), self.patch, self.build)
+
+    def _adapt(self, other):
+        cls = type(self)
+        if isinstance(other, cls):
+            return other
+        if isinstance(other, str):
+            return cls(other)
+        raise RuntimeError('cannot compare Juju version "{}" with "{}"'.format(self, other))
+
     def __eq__(self, other):
         if self is other:
             return True
-        if isinstance(other, str):
-            other = type(self)(other)
-        elif not isinstance(other, JujuVersion):
-            raise RuntimeError('cannot compare Juju version "{}" with "{}"'.format(self, other))
-        return self.major == other.major and self.minor == other.minor\
-            and self.tag == other.tag and self.build == other.build and self.patch == other.patch
+        return self._tuple() == self._adapt(other)._tuple()
 
     def __lt__(self, other):
         if self is other:
             return False
-        if isinstance(other, str):
-            other = type(self)(other)
-        elif not isinstance(other, JujuVersion):
-            raise RuntimeError('cannot compare Juju version "{}" with "{}"'.format(self, other))
-
-        if self.major != other.major:
-            return self.major < other.major
-        elif self.minor != other.minor:
-            return self.minor < other.minor
-        elif self.tag != other.tag:
-            if not self.tag:
-                return False
-            elif not other.tag:
-                return True
-            return self.tag < other.tag
-        elif self.patch != other.patch:
-            return self.patch < other.patch
-        elif self.build != other.build:
-            return self.build < other.build
-        return False
+        return self._tuple() < self._adapt(other)._tuple()

--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -25,6 +25,9 @@ class _Tag:
     """
 
     def __init__(self, tag):
+        # we could inherit from str but then we'd have to implement
+        # all the rich comparison operations instead of relying on
+        # total_ordering
         self.tag = tag
 
     def __eq__(self, other):
@@ -44,7 +47,7 @@ class _Tag:
 class JujuVersion:
     """JujuVersion can be used to compare different Juju versions.
 
-    Juju uses some convetions for its versions which make comparing them
+    Juju uses some conventions for its versions which make comparing them
     slightly simpler than the generic version compare function you might find
     elsewhere (e.g. apt_pkg.version_compare). This class encapsulates the needed
     logic.

--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -51,13 +51,12 @@ class JujuVersion:
 
     """
 
-    _matcher = re.compile(
-        r'''^
-            (?P<major>\d{1,9})\.(?P<minor>\d{1,9})       # <major> and <minor> numbers are always there
-            ((?:\.|-(?P<tag>[a-z]+))(?P<patch>\d{1,9}))? # sometimes with .<patch> or -<tag><patch>
-            (\.(?P<build>\d{1,9}))?$                     # and sometimes with a <build> number.
-        ''',
-        re.VERBOSE).match
+    _matcher = re.compile(r'''^
+    (?P<major>\d{1,9})\.(?P<minor>\d{1,9})       # <major> and <minor> numbers are always there
+    ((?:\.|-(?P<tag>[a-z]+))(?P<patch>\d{1,9}))? # sometimes with .<patch> or -<tag><patch>
+    (\.(?P<build>\d{1,9}))?$                     # and sometimes with a <build> number.
+                          ''',
+                          re.VERBOSE).match
 
     def __init__(self, version):
         # we could inherit from tuple (or namedtuple) but then again we'd have to

--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -53,8 +53,12 @@ class JujuVersion:
             other = type(self)(other)
         elif not isinstance(other, JujuVersion):
             raise RuntimeError('cannot compare Juju version "{}" with "{}"'.format(self, other))
-        return self.major == other.major and self.minor == other.minor\
-            and self.tag == other.tag and self.build == other.build and self.patch == other.patch
+        return (
+            self.major == other.major
+            and self.minor == other.minor
+            and self.tag == other.tag
+            and self.build == other.build
+            and self.patch == other.patch)
 
     def __lt__(self, other):
         if self is other:

--- a/ops/main.py
+++ b/ops/main.py
@@ -195,8 +195,8 @@ def main(charm_class):
         #
         # 'start' event is included as Juju does not fire the install event for
         # K8s charms (see LP: #1854635).
-        if juju_event_name in ('install', 'start', 'upgrade_charm') \
-                or juju_event_name.endswith('_storage_attached'):
+        if (juju_event_name in ('install', 'start', 'upgrade_charm')
+                or juju_event_name.endswith('_storage_attached')):
             _setup_event_links(charm_dir, charm)
 
         # TODO: Remove the collect_metrics check below as soon as the relevant

--- a/ops/model.py
+++ b/ops/model.py
@@ -653,7 +653,11 @@ class ModelBackend:
             raise TypeError('is_app parameter to relation_get must be a boolean')
 
         try:
-            return self._run('relation-get', '-r', str(relation_id), '-', member_name, '--app={}'.format(is_app), return_output=True, use_json=True)
+            return self._run('relation-get',
+                             '-r', str(relation_id),
+                             '-', member_name,
+                             '--app={}'.format(is_app),
+                             return_output=True, use_json=True)
         except ModelError as e:
             if 'relation not found' in str(e):
                 raise RelationNotFoundError() from e

--- a/ops/model.py
+++ b/ops/model.py
@@ -851,12 +851,12 @@ class _ModelBackendValidator:
         try:
             decimal_value = decimal.Decimal.from_float(value)
         except TypeError as e:
-            e2 = ModelError(
-                'invalid metric value {!r} provided: must be a positive finite float'.format(value))
+            e2 = ModelError('invalid metric value {!r} provided:'
+                            ' must be a positive finite float'.format(value))
             raise e2 from e
         if decimal_value.is_nan() or decimal_value.is_infinite() or decimal_value < 0:
-            raise ModelError(
-                'invalid metric value {!r} provided: must be a positive finite float'.format(value))
+            raise ModelError('invalid metric value {!r} provided:'
+                             ' must be a positive finite float'.format(value))
         return str(decimal_value)
 
     @classmethod

--- a/ops/model.py
+++ b/ops/model.py
@@ -107,7 +107,9 @@ class Application:
     @status.setter
     def status(self, value):
         if not isinstance(value, StatusBase):
-            raise InvalidStatusError('invalid value provided for application {} status: {}'.format(self, value))
+            raise InvalidStatusError(
+                'invalid value provided for application {} status: {}'.format(self, value)
+            )
 
         if not self._is_our_app:
             raise RuntimeError('cannot to set status for a remote application {}'.format(self))
@@ -150,7 +152,9 @@ class Unit:
     @status.setter
     def status(self, value):
         if not isinstance(value, StatusBase):
-            raise InvalidStatusError('invalid value provided for unit {} status: {}'.format(self, value))
+            raise InvalidStatusError(
+                'invalid value provided for unit {} status: {}'.format(self, value)
+            )
 
         if not self._is_our_unit:
             raise RuntimeError('cannot set status for a remote unit {}'.format(self))
@@ -167,7 +171,9 @@ class Unit:
             # of a hook execution.
             return self._backend.is_leader()
         else:
-            raise RuntimeError("cannot determine leadership status for remote applications: {}".format(self))
+            raise RuntimeError(
+                'cannot determine leadership status for remote applications: {}'.format(self)
+            )
 
 
 class LazyMapping(Mapping, ABC):
@@ -226,21 +232,25 @@ class RelationMapping(Mapping):
         if relation_list is None:
             relation_list = self._data[relation_name] = []
             for rid in self._backend.relation_ids(relation_name):
-                relation = Relation(relation_name, rid, is_peer, self._our_unit, self._backend, self._cache)
+                relation = Relation(relation_name, rid, is_peer,
+                                    self._our_unit, self._backend, self._cache)
                 relation_list.append(relation)
         return relation_list
 
     def _get_unique(self, relation_name, relation_id=None):
         if relation_id is not None:
             if not isinstance(relation_id, int):
-                raise ModelError('relation id {} must be int or None not {}'.format(relation_id, type(relation_id).__name__))
+                raise ModelError('relation id {} must be int or None not {}'.format(
+                    relation_id,
+                    type(relation_id).__name__))
             for relation in self[relation_name]:
                 if relation.id == relation_id:
                     return relation
             else:
                 # The relation may be dead, but it is not forgotten.
                 is_peer = relation_name in self._peers
-                return Relation(relation_name, relation_id, is_peer, self._our_unit, self._backend, self._cache)
+                return Relation(relation_name, relation_id, is_peer,
+                                self._our_unit, self._backend, self._cache)
         num_related = len(self[relation_name])
         if num_related == 0:
             return None
@@ -288,7 +298,8 @@ class Network:
 
     def __init__(self, network_info):
         self.interfaces = []
-        # Treat multiple addresses on an interface as multiple logical interfaces with the same name.
+        # Treat multiple addresses on an interface as multiple logical
+        # interfaces with the same name.
         for interface_info in network_info['bind-addresses']:
             interface_name = interface_info['interface-name']
             for address_info in interface_info['addresses']:
@@ -317,7 +328,8 @@ class NetworkInterface:
         self.address = ipaddress.ip_address(address_info['value'])
         cidr = address_info['cidr']
         if not cidr:
-            # The cidr field may be empty, see LP: #1864102. In this case, make it a /32 or /128 IP network.
+            # The cidr field may be empty, see LP: #1864102.
+            # In this case, make it a /32 or /128 IP network.
             self.subnet = ipaddress.ip_network(address_info['value'])
         else:
             self.subnet = ipaddress.ip_network(cidr)
@@ -346,18 +358,27 @@ class Relation:
         self.data = RelationData(self, our_unit, backend)
 
     def __repr__(self):
-        return '<{}.{} {}:{}>'.format(type(self).__module__, type(self).__name__, self.name, self.id)
+        return '<{}.{} {}:{}>'.format(type(self).__module__,
+                                      type(self).__name__,
+                                      self.name,
+                                      self.id)
 
 
 class RelationData(Mapping):
     def __init__(self, relation, our_unit, backend):
         self.relation = weakref.proxy(relation)
-        self._data = {our_unit: RelationDataContent(self.relation, our_unit, backend)}
-        self._data.update({our_unit.app: RelationDataContent(self.relation, our_unit.app, backend)})
-        self._data.update({unit: RelationDataContent(self.relation, unit, backend) for unit in self.relation.units})
+        self._data = {
+            our_unit: RelationDataContent(self.relation, our_unit, backend),
+            our_unit.app: RelationDataContent(self.relation, our_unit.app, backend),
+        }
+        self._data.update({
+            unit: RelationDataContent(self.relation, unit, backend)
+            for unit in self.relation.units})
         # The relation might be dead so avoid a None key here.
-        if self.relation.app:
-            self._data.update({self.relation.app: RelationDataContent(self.relation, self.relation.app, backend)})
+        if self.relation.app is not None:
+            self._data.update({
+                self.relation.app: RelationDataContent(self.relation, self.relation.app, backend),
+            })
 
     def __contains__(self, key):
         return key in self._data
@@ -394,8 +415,9 @@ class RelationDataContent(LazyMapping, MutableMapping):
             is_our_app = self._backend.app_name == self._entity.name
             if not is_our_app:
                 return False
-            # Whether the application data bag is mutable or not depends on whether this unit is a leader or not,
-            # but this is not guaranteed to be always true during the same hook execution.
+            # Whether the application data bag is mutable or not depends on
+            # whether this unit is a leader or not, but this is not guaranteed
+            # to be always true during the same hook execution.
             return self._backend.is_leader()
         else:
             is_our_unit = self._backend.unit_name == self._entity.name
@@ -414,15 +436,15 @@ class RelationDataContent(LazyMapping, MutableMapping):
         # Don't load data unnecessarily if we're only updating.
         if self._lazy_data is not None:
             if value == '':
-                # Match the behavior of Juju, which is that setting the value to an empty string will
-                # remove the key entirely from the relation data.
+                # Match the behavior of Juju, which is that setting the value to an
+                # empty string will remove the key entirely from the relation data.
                 del self._data[key]
             else:
                 self._data[key] = value
 
     def __delitem__(self, key):
-        # Match the behavior of Juju, which is that setting the value to an empty string will
-        # remove the key entirely from the relation data.
+        # Match the behavior of Juju, which is that setting the value to an empty
+        # string will remove the key entirely from the relation data.
         self.__setitem__(key, '')
 
 
@@ -476,8 +498,10 @@ class BlockedStatus(StatusBase):
 class MaintenanceStatus(StatusBase):
     """The unit is performing maintenance tasks.
 
-    The unit is not yet providing services, but is actively doing work in preparation for providing those services.
-    This is a "spinning" state, not an error state. It reflects activity on the unit itself, not on peers or related units.
+    The unit is not yet providing services, but is actively doing work in preparation
+    for providing those services.  This is a "spinning" state, not an error state. It
+    reflects activity on the unit itself, not on peers or related units.
+
     """
     name = 'maintenance'
 
@@ -485,7 +509,9 @@ class MaintenanceStatus(StatusBase):
 class UnknownStatus(StatusBase):
     """The unit status is unknown.
 
-    A unit-agent has finished calling install, config-changed and start, but the charm has not called status-set yet.
+    A unit-agent has finished calling install, config-changed and start, but the
+    charm has not called status-set yet.
+
     """
     name = 'unknown'
 
@@ -497,7 +523,9 @@ class UnknownStatus(StatusBase):
 class WaitingStatus(StatusBase):
     """A unit is unable to progress.
 
-    The unit is unable to progress to an active state because an application to which it is related is not running.
+    The unit is unable to progress to an active state because an application to which
+    it is related is not running.
+
     """
     name = 'waiting'
 
@@ -564,7 +592,8 @@ class StorageMapping(Mapping):
         via <storage-name>-storage-attached events when it becomes available.
         """
         if storage_name not in self._storage_map:
-            raise ModelError('cannot add storage with {} as it is not present in the charm metadata'.format(storage_name))
+            raise ModelError(('cannot add storage {!r}:'
+                              ' it is not present in the charm metadata').format(storage_name))
         self._backend.storage_add(storage_name, count)
 
 
@@ -579,7 +608,8 @@ class Storage:
     @property
     def location(self):
         if self._location is None:
-            self._location = Path(self._backend.storage_get('{}/{}'.format(self.name, self.id), "location"))
+            raw = self._backend.storage_get('{}/{}'.format(self.name, self.id), "location")
+            self._location = Path(raw)
         return self._location
 
 
@@ -589,7 +619,8 @@ class ModelError(Exception):
 
 class TooManyRelatedAppsError(ModelError):
     def __init__(self, relation_name, num_related, max_supported):
-        super().__init__('Too many remote applications on {} ({} > {})'.format(relation_name, num_related, max_supported))
+        super().__init__('Too many remote applications on {} ({} > {})'.format(
+            relation_name, num_related, max_supported))
         self.relation_name = relation_name
         self.num_related = num_related
         self.max_supported = max_supported
@@ -642,7 +673,8 @@ class ModelBackend:
 
     def relation_list(self, relation_id):
         try:
-            return self._run('relation-list', '-r', str(relation_id), return_output=True, use_json=True)
+            return self._run('relation-list', '-r', str(relation_id),
+                             return_output=True, use_json=True)
         except ModelError as e:
             if 'relation not found' in str(e):
                 raise RelationNotFoundError() from e
@@ -653,10 +685,8 @@ class ModelBackend:
             raise TypeError('is_app parameter to relation_get must be a boolean')
 
         try:
-            return self._run('relation-get',
-                             '-r', str(relation_id),
-                             '-', member_name,
-                             '--app={}'.format(is_app),
+            return self._run('relation-get', '-r', str(relation_id),
+                             '-', member_name, '--app={}'.format(is_app),
                              return_output=True, use_json=True)
         except ModelError as e:
             if 'relation not found' in str(e):
@@ -668,7 +698,8 @@ class ModelBackend:
             raise TypeError('is_app parameter to relation_set must be a boolean')
 
         try:
-            return self._run('relation-set', '-r', str(relation_id), '{}={}'.format(key, value), '--app={}'.format(is_app))
+            return self._run('relation-set', '-r', str(relation_id),
+                             '{}={}'.format(key, value), '--app={}'.format(is_app))
         except ModelError as e:
             if 'relation not found' in str(e):
                 raise RelationNotFoundError() from e
@@ -715,27 +746,34 @@ class ModelBackend:
 
     def status_get(self, *, is_app=False):
         """Get a status of a unit or an application.
-        app -- A boolean indicating whether the status should be retrieved for a unit or an application.
+
+        app -- A boolean indicating whether the status should be retrieved for a unit
+               or an application.
         """
         return self._run('status-get', '--include-data', '--application={}'.format(is_app))
 
     def status_set(self, status, message='', *, is_app=False):
         """Set a status of a unit or an application.
-        app -- A boolean indicating whether the status should be set for a unit or an application.
+
+        app -- A boolean indicating whether the status should be set for a unit or an
+               application.
         """
         if not isinstance(is_app, bool):
             raise TypeError('is_app parameter must be boolean')
         return self._run('status-set', '--application={}'.format(is_app), status, message)
 
     def storage_list(self, name):
-        return [int(s.split('/')[1]) for s in self._run('storage-list', name, return_output=True, use_json=True)]
+        return [int(s.split('/')[1]) for s in self._run('storage-list', name,
+                                                        return_output=True, use_json=True)]
 
     def storage_get(self, storage_name_id, attribute):
-        return self._run('storage-get', '-s', storage_name_id, attribute, return_output=True, use_json=True)
+        return self._run('storage-get', '-s', storage_name_id, attribute,
+                         return_output=True, use_json=True)
 
     def storage_add(self, name, count=1):
         if not isinstance(count, int) or isinstance(count, bool):
-            raise TypeError('storage count must be integer, got: {} ({})'.format(count, type(count)))
+            raise TypeError('storage count must be integer, got: {} ({})'.format(count,
+                                                                                 type(count)))
         self._run('storage-add', '{}={}'.format(name, count))
 
     def action_get(self):
@@ -797,28 +835,38 @@ class _ModelBackendValidator:
     @classmethod
     def validate_metric_key(cls, key):
         if cls.METRIC_KEY_REGEX.match(key) is None:
-            raise ModelError('invalid metric key {!r}: must match {}'.format(key, cls.METRIC_KEY_REGEX.pattern))
+            raise ModelError(
+                'invalid metric key {!r}: must match {}'.format(
+                    key, cls.METRIC_KEY_REGEX.pattern))
 
     @classmethod
     def validate_metric_label(cls, label_name):
         if cls.METRIC_KEY_REGEX.match(label_name) is None:
-            raise ModelError('invalid metric label name {!r}: must match {}'.format(label_name, cls.METRIC_KEY_REGEX.pattern))
+            raise ModelError(
+                'invalid metric label name {!r}: must match {}'.format(
+                    label_name, cls.METRIC_KEY_REGEX.pattern))
 
     @classmethod
     def format_metric_value(cls, value):
         try:
             decimal_value = decimal.Decimal.from_float(value)
         except TypeError as e:
-            raise ModelError('invalid metric value {!r} provided: must be a positive finite float'.format(value)) from e
+            e2 = ModelError(
+                'invalid metric value {!r} provided: must be a positive finite float'.format(value))
+            raise e2 from e
         if decimal_value.is_nan() or decimal_value.is_infinite() or decimal_value < 0:
-            raise ModelError('invalid metric value {!r} provided: must be a positive finite float'.format(value))
+            raise ModelError(
+                'invalid metric value {!r} provided: must be a positive finite float'.format(value))
         return str(decimal_value)
 
     @classmethod
     def validate_label_value(cls, label, value):
-        # Label values cannot be empty, contain commas or equal signs as those are used by add-metric as separators.
+        # Label values cannot be empty, contain commas or equal signs as those are
+        # used by add-metric as separators.
         if not value:
-            raise ModelError('metric label {} has an empty value, which is not allowed'.format(label))
+            raise ModelError(
+                'metric label {} has an empty value, which is not allowed'.format(label))
         v = str(value)
         if re.search('[,=]', v) is not None:
-            raise ModelError('metric label values must not contain "," or "=": {}={!r}'.format(label, value))
+            raise ModelError(
+                'metric label values must not contain "," or "=": {}={!r}'.format(label, value))

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -133,45 +133,45 @@ class Charm(CharmBase):
         self._write_state()
 
     def on_mon_relation_changed(self, event):
-        assert event.app is not None, \
-            'application name cannot be None for a relation-changed event'
+        assert event.app is not None, (
+            'application name cannot be None for a relation-changed event')
         if os.environ.get('JUJU_REMOTE_UNIT'):
-            assert event.unit is not None, \
-                'a unit name cannot be None for a relation-changed event' \
-                ' associated with a remote unit'
+            assert event.unit is not None, (
+                'a unit name cannot be None for a relation-changed event'
+                ' associated with a remote unit')
         self._state['on_mon_relation_changed'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._state['mon_relation_changed_data'] = event.snapshot()
         self._write_state()
 
     def on_mon_relation_departed(self, event):
-        assert event.app is not None, \
-            'application name cannot be None for a relation-departed event'
+        assert event.app is not None, (
+            'application name cannot be None for a relation-departed event')
         self._state['on_mon_relation_departed'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._state['mon_relation_departed_data'] = event.snapshot()
         self._write_state()
 
     def on_ha_relation_broken(self, event):
-        assert event.app is None, \
-            'relation-broken events cannot have a reference to a remote application'
-        assert event.unit is None, \
-            'relation broken events cannot have a reference to a remote unit'
+        assert event.app is None, (
+            'relation-broken events cannot have a reference to a remote application')
+        assert event.unit is None, (
+            'relation broken events cannot have a reference to a remote unit')
         self._state['on_ha_relation_broken'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._state['ha_relation_broken_data'] = event.snapshot()
         self._write_state()
 
     def on_start_action(self, event):
-        assert event.handle.kind == 'start_action', \
-            'event action name cannot be different from the one being handled'
+        assert event.handle.kind == 'start_action', (
+            'event action name cannot be different from the one being handled')
         self._state['on_start_action'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()
 
     def on_foo_bar_action(self, event):
-        assert event.handle.kind == 'foo_bar_action', \
-            'event action name cannot be different from the one being handled'
+        assert event.handle.kind == 'foo_bar_action', (
+            'event action name cannot be different from the one being handled')
         self._state['on_foo_bar_action'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -136,35 +136,41 @@ class Charm(CharmBase):
         assert event.app is not None, 'application name cannot be None for a relation-changed event'
         if os.environ.get('JUJU_REMOTE_UNIT'):
             assert event.unit is not None, \
-                'a unit name cannot be None for a relation-changed event associated with a remote unit'
+                'a unit name cannot be None for a relation-changed event' \
+                ' associated with a remote unit'
         self._state['on_mon_relation_changed'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._state['mon_relation_changed_data'] = event.snapshot()
         self._write_state()
 
     def on_mon_relation_departed(self, event):
-        assert event.app is not None, 'application name cannot be None for a relation-departed event'
+        assert event.app is not None, \
+            'application name cannot be None for a relation-departed event'
         self._state['on_mon_relation_departed'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._state['mon_relation_departed_data'] = event.snapshot()
         self._write_state()
 
     def on_ha_relation_broken(self, event):
-        assert event.app is None, 'relation-broken events cannot have a reference to a remote application'
-        assert event.unit is None, 'relation broken events cannot have a reference to a remote unit'
+        assert event.app is None, \
+            'relation-broken events cannot have a reference to a remote application'
+        assert event.unit is None, \
+            'relation broken events cannot have a reference to a remote unit'
         self._state['on_ha_relation_broken'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._state['ha_relation_broken_data'] = event.snapshot()
         self._write_state()
 
     def on_start_action(self, event):
-        assert event.handle.kind == 'start_action', 'event action name cannot be different from the one being handled'
+        assert event.handle.kind == 'start_action', \
+            'event action name cannot be different from the one being handled'
         self._state['on_start_action'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()
 
     def on_foo_bar_action(self, event):
-        assert event.handle.kind == 'foo_bar_action', 'event action name cannot be different from the one being handled'
+        assert event.handle.kind == 'foo_bar_action', \
+            'event action name cannot be different from the one being handled'
         self._state['on_foo_bar_action'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -133,7 +133,8 @@ class Charm(CharmBase):
         self._write_state()
 
     def on_mon_relation_changed(self, event):
-        assert event.app is not None, 'application name cannot be None for a relation-changed event'
+        assert event.app is not None, \
+            'application name cannot be None for a relation-changed event'
         if os.environ.get('JUJU_REMOTE_UNIT'):
             assert event.unit is not None, \
                 'a unit name cannot be None for a relation-changed event' \

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -61,7 +61,8 @@ class Charm(CharmBase):
         self._state['on_log_info_action'] = []
         self._state['on_log_debug_action'] = []
 
-        # Observed event types per invocation. A list is used to preserve the order in which charm handlers have observed the events.
+        # Observed event types per invocation. A list is used to preserve the
+        # order in which charm handlers have observed the events.
         self._state['observed_event_types'] = []
 
         self.framework.observe(self.on.install, self)
@@ -134,7 +135,8 @@ class Charm(CharmBase):
     def on_mon_relation_changed(self, event):
         assert event.app is not None, 'application name cannot be None for a relation-changed event'
         if os.environ.get('JUJU_REMOTE_UNIT'):
-            assert event.unit is not None, 'a unit name cannot be None for a relation-changed event associated with a remote unit'
+            assert event.unit is not None, \
+                'a unit name cannot be None for a relation-changed event associated with a remote unit'
         self._state['on_mon_relation_changed'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._state['mon_relation_changed_data'] = event.snapshot()

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -1024,7 +1024,8 @@ class TestStoredState(unittest.TestCase):
 
             validate_op(obj_copy2.state.a, expected_res)
 
-            # Commit saves the pre-commit and commit events, and the framework event counter, but shouldn't update the stored state of my object
+            # Commit saves the pre-commit and commit events, and the framework
+            # event counter, but shouldn't update the stored state of my object
             framework.snapshots.clear()
             framework_copy.commit()
             self.assertEqual(framework_copy.snapshots, [])

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -157,7 +157,9 @@ class TestFramework(unittest.TestCase):
         try:
             framework.observe(pub.baz, obs)
         except RuntimeError as e:
-            self.assertEqual(str(e), 'Observer method not provided explicitly and MyObserver type has no "on_baz" method')
+            self.assertEqual(str(e),
+                             'Observer method not provided explicitly'
+                             ' and MyObserver type has no "on_baz" method')
         else:
             self.fail("RuntimeError not raised")
 
@@ -816,7 +818,9 @@ class TestStoredState(unittest.TestCase):
                 pass
             obj.state.foo = CustomObject()
         except AttributeError as e:
-            self.assertEqual(str(e), "attribute 'foo' cannot be set to CustomObject: must be int/float/dict/list/etc")
+            self.assertEqual(
+                str(e),
+                "attribute 'foo' cannot be a CustomObject: must be int/float/dict/list/etc")
         else:
             self.fail('AttributeError not raised')
 
@@ -824,7 +828,8 @@ class TestStoredState(unittest.TestCase):
 
     def test_mutable_types(self):
         # Test and validation functions in a list of 2-tuples.
-        # Assignment and keywords like del are not supported in lambdas so functions are used instead.
+        # Assignment and keywords like del are not supported in lambdas
+        #  so functions are used instead.
         test_operations = [(
             lambda: {},         # Operand A.
             None,               # Operand B.
@@ -1155,13 +1160,17 @@ class TestStoredState(unittest.TestCase):
 
         framework = self.create_framework()
 
-        # Validate that operations between StoredSet and built-in sets only result in built-in sets being returned.
-        # Make sure that commutativity is preserved and that the original sets are not changed or used as a result.
+        # Validate that operations between StoredSet and built-in sets
+        # only result in built-in sets being returned.
+        # Make sure that commutativity is preserved and that the
+        # original sets are not changed or used as a result.
         for i, (variable_operand, operation, ab_res, ba_res) in enumerate(test_operations):
             obj = SomeObject(framework, str(i))
             obj.state.set = {"a", "b"}
 
-            for a, b, expected in [(obj.state.set, variable_operand, ab_res), (variable_operand, obj.state.set, ba_res)]:
+            for a, b, expected in [
+                    (obj.state.set, variable_operand, ab_res),
+                    (variable_operand, obj.state.set, ba_res)]:
                 old_a = set(a)
                 old_b = set(b)
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -1205,8 +1205,8 @@ class TestStoredState(unittest.TestCase):
         parent.state.set_default(foo=5, bar=6)
         self.assertEqual(parent.state.foo, 1)
         self.assertEqual(parent.state.bar, 4)
-        # TODO(jam) 2020-01-30: is there a clean way to tell that
-        #                       parent.state._data.dirty is False?
+        # TODO: jam 2020-01-30 is there a clean way to tell that
+        #       parent.state._data.dirty is False?
 
 
 if __name__ == "__main__":

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -1205,7 +1205,8 @@ class TestStoredState(unittest.TestCase):
         parent.state.set_default(foo=5, bar=6)
         self.assertEqual(parent.state.foo, 1)
         self.assertEqual(parent.state.bar, 4)
-        # TODO(jam) 2020-01-30: is there a clean way to tell that parent.state._data.dirty is False?
+        # TODO(jam) 2020-01-30: is there a clean way to tell that
+        #                       parent.state._data.dirty is False?
 
 
 if __name__ == "__main__":

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -157,9 +157,10 @@ class TestFramework(unittest.TestCase):
         try:
             framework.observe(pub.baz, obs)
         except RuntimeError as e:
-            self.assertEqual(str(e),
-                             'Observer method not provided explicitly'
-                             ' and MyObserver type has no "on_baz" method')
+            self.assertEqual(
+                str(e),
+                'Observer method not provided explicitly'
+                ' and MyObserver type has no "on_baz" method')
         else:
             self.fail("RuntimeError not raised")
 

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -34,7 +34,7 @@ def fake_script(test_case, name, content):
 
     with open(str(test_case.fake_script_path / name), "w") as f:
         # Before executing the provided script, dump the provided arguments in calls.txt.
-        f.write('#!/bin/bash\n{ echo -n $(basename $0); for s in "$@"; do echo -n \\;"$s"; done; echo; } >> $(dirname $0)/calls.txt\n' + content)
+        f.write('#!/bin/bash\n{ echo -n $(basename $0); printf ";%s" "$@"; echo; } >> $(dirname $0)/calls.txt\n' + content)
     os.chmod(str(test_case.fake_script_path / name), 0o755)
 
 

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -34,7 +34,9 @@ def fake_script(test_case, name, content):
 
     with open(str(test_case.fake_script_path / name), "w") as f:
         # Before executing the provided script, dump the provided arguments in calls.txt.
-        f.write('#!/bin/bash\n{ echo -n $(basename $0); printf ";%s" "$@"; echo; } >> $(dirname $0)/calls.txt\n' + content)
+        f.write('''#!/bin/bash
+{ echo -n $(basename $0); printf ";%s" "$@"; echo; } >> $(dirname $0)/calls.txt
+''' + content)
     os.chmod(str(test_case.fake_script_path / name), 0o755)
 
 

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -88,6 +88,7 @@ class TestJujuVersion(unittest.TestCase):
         for a, b, expected in test_cases:
             self.assertEqual(JujuVersion(a) == JujuVersion(b), expected)
             self.assertEqual(JujuVersion(a) == b, expected)
+            self.assertEqual(a == JujuVersion(b), expected)
 
     def test_comparison(self):
         test_cases = [
@@ -124,6 +125,8 @@ class TestJujuVersion(unittest.TestCase):
             self.assertEqual(JujuVersion(a) <= b, expected_weak)
             self.assertEqual(b > JujuVersion(a), expected_strict)
             self.assertEqual(b >= JujuVersion(a), expected_weak)
+            self.assertEqual(JujuVersion(a) >= b, not expected_strict)
+            self.assertEqual(JujuVersion(a) > b, not expected_weak)
 
 
 if __name__ == "__main__":

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -88,7 +88,6 @@ class TestJujuVersion(unittest.TestCase):
         for a, b, expected in test_cases:
             self.assertEqual(JujuVersion(a) == JujuVersion(b), expected)
             self.assertEqual(JujuVersion(a) == b, expected)
-            self.assertEqual(a == JujuVersion(b), expected)
 
     def test_comparison(self):
         test_cases = [
@@ -125,8 +124,6 @@ class TestJujuVersion(unittest.TestCase):
             self.assertEqual(JujuVersion(a) <= b, expected_weak)
             self.assertEqual(b > JujuVersion(a), expected_strict)
             self.assertEqual(b >= JujuVersion(a), expected_weak)
-            self.assertEqual(JujuVersion(a) >= b, not expected_strict)
-            self.assertEqual(JujuVersion(a) > b, not expected_weak)
 
 
 if __name__ == "__main__":

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -49,7 +49,8 @@ from ops.charm import (
 
 from .test_helpers import fake_script, fake_script_calls
 
-# This relies on the expected repository structure to find a path to source of the charm under test.
+# This relies on the expected repository structure to find a path to
+# source of the charm under test.
 TEST_CHARM_DIR = Path(__file__ + '/../charms/test_main').resolve()
 
 logger = logging.getLogger(__name__)
@@ -447,7 +448,8 @@ start:
         self._simulate_event(EventSpec(InstallEvent, 'install', charm_config=charm_config))
         self._simulate_event(EventSpec(CollectMetricsEvent, 'collect_metrics',
                                        charm_config=charm_config))
-        self.assertEqual(fake_script_calls(self), [['add-metric', '--labels', 'bar=4.2', 'foo=42']])
+        self.assertEqual(fake_script_calls(self),
+                         [['add-metric', '--labels', 'bar=4.2', 'foo=42']])
 
     def test_logger(self):
         charm_config = base64.b64encode(pickle.dumps({

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -60,7 +60,8 @@ class SymlinkTargetError(Exception):
 
 
 class EventSpec:
-    def __init__(self, event_type, event_name, env_var=None, relation_id=None, remote_app=None, remote_unit=None,
+    def __init__(self, event_type, event_name, env_var=None,
+                 relation_id=None, remote_app=None, remote_unit=None,
                  charm_config=None):
         self.event_type = event_type
         self.event_name = event_name
@@ -96,10 +97,12 @@ class TestMain(unittest.TestCase):
     def _setup_charm_dir(self):
         self.JUJU_CHARM_DIR = Path(tempfile.mkdtemp()) / 'test_main'
         self.hooks_dir = self.JUJU_CHARM_DIR / 'hooks'
-        self.charm_exec_path = os.path.relpath(str(self.JUJU_CHARM_DIR / 'src/charm.py'), str(self.hooks_dir))
+        charm_path = str(self.JUJU_CHARM_DIR / 'src/charm.py')
+        self.charm_exec_path = os.path.relpath(charm_path,
+                                               str(self.hooks_dir))
         shutil.copytree(str(TEST_CHARM_DIR), str(self.JUJU_CHARM_DIR))
 
-        charm_spec = importlib.util.spec_from_file_location("charm", str(self.JUJU_CHARM_DIR / 'src/charm.py'))
+        charm_spec = importlib.util.spec_from_file_location("charm", charm_path)
         self.charm_module = importlib.util.module_from_spec(charm_spec)
         charm_spec.loader.exec_module(self.charm_module)
 
@@ -191,7 +194,8 @@ start:
         event_file = self.JUJU_CHARM_DIR / event_dir / event_filename
         # Note that sys.executable is used to make sure we are using the same
         # interpreter for the child process to support virtual environments.
-        subprocess.check_call([sys.executable, str(event_file)], env=env, cwd=str(self.JUJU_CHARM_DIR))
+        subprocess.check_call([sys.executable, str(event_file)],
+                              env=env, cwd=str(self.JUJU_CHARM_DIR))
         return self._read_and_clear_state()
 
     def test_event_reemitted(self):
@@ -204,11 +208,13 @@ start:
         state = self._simulate_event(EventSpec(InstallEvent, 'install', charm_config=charm_config))
         self.assertEqual(state['observed_event_types'], [InstallEvent])
 
-        state = self._simulate_event(EventSpec(ConfigChangedEvent, 'config-changed', charm_config=charm_config))
+        state = self._simulate_event(EventSpec(ConfigChangedEvent, 'config-changed',
+                                               charm_config=charm_config))
         self.assertEqual(state['observed_event_types'], [ConfigChangedEvent])
 
         # Re-emit should pick the deferred config-changed.
-        state = self._simulate_event(EventSpec(UpdateStatusEvent, 'update-status', charm_config=charm_config))
+        state = self._simulate_event(EventSpec(UpdateStatusEvent, 'update-status',
+                                               charm_config=charm_config))
         self.assertEqual(state['observed_event_types'], [ConfigChangedEvent, UpdateStatusEvent])
 
     def test_no_reemission_on_collect_metrics(self):
@@ -222,11 +228,14 @@ start:
         state = self._simulate_event(EventSpec(InstallEvent, 'install', charm_config=charm_config))
         self.assertEqual(state['observed_event_types'], [InstallEvent])
 
-        state = self._simulate_event(EventSpec(ConfigChangedEvent, 'config-changed', charm_config=charm_config))
+        state = self._simulate_event(EventSpec(ConfigChangedEvent, 'config-changed',
+                                               charm_config=charm_config))
         self.assertEqual(state['observed_event_types'], [ConfigChangedEvent])
 
-        # Re-emit should not pick the deferred config-changed because collect-metrics runs in a restricted context.
-        state = self._simulate_event(EventSpec(CollectMetricsEvent, 'collect-metrics', charm_config=charm_config))
+        # Re-emit should not pick the deferred config-changed because
+        # collect-metrics runs in a restricted context.
+        state = self._simulate_event(EventSpec(CollectMetricsEvent, 'collect-metrics',
+                                               charm_config=charm_config))
         self.assertEqual(state['observed_event_types'], [CollectMetricsEvent])
 
     def test_multiple_events_handled(self):
@@ -245,55 +254,100 @@ start:
         # Sample events with a different amount of dashes used
         # and with endpoints from different sections of metadata.yaml
         events_under_test = [(
-            EventSpec(InstallEvent, 'install', charm_config=charm_config),
-            {},
-        ), (
-            EventSpec(StartEvent, 'start', charm_config=charm_config),
-            {},
-        ), (
-            EventSpec(UpdateStatusEvent, 'update_status', charm_config=charm_config),
-            {},
-        ), (
-            EventSpec(LeaderSettingsChangedEvent, 'leader_settings_changed', charm_config=charm_config),
-            {},
-        ), (
-            EventSpec(RelationJoinedEvent, 'db_relation_joined', relation_id=1,
-                      remote_app='remote', remote_unit='remote/0', charm_config=charm_config),
-            {'relation_name': 'db', 'relation_id': 1, 'app_name': 'remote', 'unit_name': 'remote/0'},
-        ), (
-            EventSpec(RelationChangedEvent, 'mon_relation_changed', relation_id=2,
-                      remote_app='remote', remote_unit='remote/0', charm_config=charm_config),
-            {'relation_name': 'mon', 'relation_id': 2, 'app_name': 'remote', 'unit_name': 'remote/0'},
-        ), (
-            EventSpec(RelationChangedEvent, 'mon_relation_changed', relation_id=2,
-                      remote_app='remote', remote_unit=None, charm_config=charm_config),
-            {'relation_name': 'mon', 'relation_id': 2, 'app_name': 'remote', 'unit_name': None},
-        ), (
-            EventSpec(RelationDepartedEvent, 'mon_relation_departed', relation_id=2,
-                      remote_app='remote', remote_unit='remote/0', charm_config=charm_config),
-            {'relation_name': 'mon', 'relation_id': 2, 'app_name': 'remote', 'unit_name': 'remote/0'},
-        ), (
-            EventSpec(RelationBrokenEvent, 'ha_relation_broken', relation_id=3,
+            EventSpec(InstallEvent, 'install',
                       charm_config=charm_config),
-            {'relation_name': 'ha', 'relation_id': 3},
+            {},
+        ), (
+            EventSpec(StartEvent, 'start',
+                      charm_config=charm_config),
+            {},
+        ), (
+            EventSpec(UpdateStatusEvent, 'update_status',
+                      charm_config=charm_config),
+            {},
+        ), (
+            EventSpec(LeaderSettingsChangedEvent, 'leader_settings_changed',
+                      charm_config=charm_config),
+            {},
+        ), (
+            EventSpec(RelationJoinedEvent, 'db_relation_joined',
+                      relation_id=1,
+                      remote_app='remote', remote_unit='remote/0',
+                      charm_config=charm_config),
+            {'relation_name': 'db',
+             'relation_id': 1,
+             'app_name': 'remote',
+             'unit_name': 'remote/0'},
+        ), (
+            EventSpec(RelationChangedEvent, 'mon_relation_changed',
+                      relation_id=2,
+                      remote_app='remote', remote_unit='remote/0',
+                      charm_config=charm_config),
+            {'relation_name': 'mon',
+             'relation_id': 2,
+             'app_name': 'remote',
+             'unit_name': 'remote/0'},
+        ), (
+            EventSpec(RelationChangedEvent, 'mon_relation_changed',
+                      relation_id=2,
+                      remote_app='remote', remote_unit=None,
+                      charm_config=charm_config),
+            {'relation_name': 'mon',
+             'relation_id': 2,
+             'app_name': 'remote',
+             'unit_name': None},
+        ), (
+            EventSpec(RelationDepartedEvent, 'mon_relation_departed',
+                      relation_id=2,
+                      remote_app='remote', remote_unit='remote/0',
+                      charm_config=charm_config),
+            {'relation_name': 'mon',
+             'relation_id': 2,
+             'app_name': 'remote',
+             'unit_name': 'remote/0'},
+        ), (
+            EventSpec(RelationBrokenEvent, 'ha_relation_broken',
+                      relation_id=3,
+                      charm_config=charm_config),
+            {'relation_name': 'ha',
+             'relation_id': 3},
         ), (
             # Events without a remote app specified (for Juju < 2.7).
-            EventSpec(RelationJoinedEvent, 'db_relation_joined', relation_id=1,
-                      remote_unit='remote/0', charm_config=charm_config),
-            {'relation_name': 'db', 'relation_id': 1, 'app_name': 'remote', 'unit_name': 'remote/0'},
+            EventSpec(RelationJoinedEvent, 'db_relation_joined',
+                      relation_id=1,
+                      remote_unit='remote/0',
+                      charm_config=charm_config),
+            {'relation_name': 'db',
+             'relation_id': 1,
+             'app_name': 'remote',
+             'unit_name': 'remote/0'},
         ), (
-            EventSpec(RelationChangedEvent, 'mon_relation_changed', relation_id=2,
-                      remote_unit='remote/0', charm_config=charm_config),
-            {'relation_name': 'mon', 'relation_id': 2, 'app_name': 'remote', 'unit_name': 'remote/0'},
+            EventSpec(RelationChangedEvent, 'mon_relation_changed',
+                      relation_id=2,
+                      remote_unit='remote/0',
+                      charm_config=charm_config),
+            {'relation_name': 'mon',
+             'relation_id': 2,
+             'app_name': 'remote',
+             'unit_name': 'remote/0'},
         ), (
-            EventSpec(RelationDepartedEvent, 'mon_relation_departed', relation_id=2,
-                      remote_unit='remote/0', charm_config=charm_config),
-            {'relation_name': 'mon', 'relation_id': 2, 'app_name': 'remote', 'unit_name': 'remote/0'},
+            EventSpec(RelationDepartedEvent, 'mon_relation_departed',
+                      relation_id=2,
+                      remote_unit='remote/0',
+                      charm_config=charm_config),
+            {'relation_name': 'mon',
+             'relation_id': 2,
+             'app_name': 'remote',
+             'unit_name': 'remote/0'},
         ), (
-            EventSpec(ActionEvent, 'start_action', env_var='JUJU_ACTION_NAME', charm_config=actions_charm_config),
+            EventSpec(ActionEvent, 'start_action',
+                      env_var='JUJU_ACTION_NAME',
+                      charm_config=actions_charm_config),
             {},
         ), (
-            EventSpec(ActionEvent, 'foo_bar_action', env_var='JUJU_ACTION_NAME', charm_config=actions_charm_config),
+            EventSpec(ActionEvent, 'foo_bar_action',
+                      env_var='JUJU_ACTION_NAME',
+                      charm_config=actions_charm_config),
             {},
         )]
 
@@ -318,7 +372,8 @@ start:
             self.assertEqual(state['observed_event_types'], [event_spec.event_type])
 
             if event_spec.event_name in expected_event_data:
-                self.assertEqual(state[event_spec.event_name + '_data'], expected_event_data[event_spec.event_name])
+                self.assertEqual(state[event_spec.event_name + '_data'],
+                                 expected_event_data[event_spec.event_name])
 
     def test_event_not_implemented(self):
         """Make sure events without implementation do not cause non-zero exit.
@@ -334,7 +389,8 @@ start:
         hook_path.symlink_to('install')
 
         try:
-            self._simulate_event(EventSpec(HookEvent, 'not-implemented-event', charm_config=charm_config))
+            self._simulate_event(EventSpec(HookEvent, 'not-implemented-event',
+                                           charm_config=charm_config))
         except subprocess.CalledProcessError:
             self.fail('Event simulation for an unsupported event'
                       ' results in a non-zero exit code returned')
@@ -342,7 +398,8 @@ start:
     def test_setup_event_links(self):
         """Test auto-creation of symlinks caused by initial events.
         """
-        all_event_hooks = ['hooks/' + e.replace("_", "-") for e in self.charm_module.Charm.on.events().keys()]
+        all_event_hooks = ['hooks/' + e.replace("_", "-")
+                           for e in self.charm_module.Charm.on.events().keys()]
         charm_config = base64.b64encode(pickle.dumps({
             'STATE_FILE': self._state_file,
         }))
@@ -356,8 +413,10 @@ start:
         def _assess_event_links(event_spec):
             self.assertTrue(self.hooks_dir / event_spec.event_name in self.hooks_dir.iterdir())
             for event_hook in all_event_hooks:
-                self.assertTrue((self.JUJU_CHARM_DIR / event_hook).exists(), 'Missing hook: ' + event_hook)
-                self.assertEqual(os.readlink(str(self.JUJU_CHARM_DIR / event_hook)), self.charm_exec_path)
+                self.assertTrue((self.JUJU_CHARM_DIR / event_hook).exists(),
+                                'Missing hook: ' + event_hook)
+                self.assertEqual(os.readlink(str(self.JUJU_CHARM_DIR / event_hook)),
+                                 self.charm_exec_path)
 
         for initial_event in initial_events:
             self._setup_charm_dir()
@@ -386,7 +445,8 @@ start:
         }))
         fake_script(self, 'add-metric', 'exit 0')
         self._simulate_event(EventSpec(InstallEvent, 'install', charm_config=charm_config))
-        self._simulate_event(EventSpec(CollectMetricsEvent, 'collect_metrics', charm_config=charm_config))
+        self._simulate_event(EventSpec(CollectMetricsEvent, 'collect_metrics',
+                                       charm_config=charm_config))
         self.assertEqual(fake_script_calls(self), [['add-metric', '--labels', 'bar=4.2', 'foo=42']])
 
     def test_logger(self):
@@ -406,21 +466,29 @@ log_debug: {}
             ''')
 
         test_cases = [(
-            EventSpec(ActionEvent, 'log_critical_action', env_var='JUJU_ACTION_NAME', charm_config=charm_config),
+            EventSpec(ActionEvent, 'log_critical_action', env_var='JUJU_ACTION_NAME',
+                      charm_config=charm_config),
             ['juju-log', '--log-level', 'CRITICAL', 'super critical'],
         ), (
-            EventSpec(ActionEvent, 'log_error_action', env_var='JUJU_ACTION_NAME', charm_config=charm_config),
+            EventSpec(ActionEvent, 'log_error_action',
+                      env_var='JUJU_ACTION_NAME',
+                      charm_config=charm_config),
             ['juju-log', '--log-level', 'ERROR', 'grave error'],
         ), (
-            EventSpec(ActionEvent, 'log_warning_action', env_var='JUJU_ACTION_NAME', charm_config=charm_config),
+            EventSpec(ActionEvent, 'log_warning_action',
+                      env_var='JUJU_ACTION_NAME',
+                      charm_config=charm_config),
             ['juju-log', '--log-level', 'WARNING', 'wise warning'],
         ), (
-            EventSpec(ActionEvent, 'log_info_action', env_var='JUJU_ACTION_NAME', charm_config=charm_config),
+            EventSpec(ActionEvent, 'log_info_action',
+                      env_var='JUJU_ACTION_NAME',
+                      charm_config=charm_config),
             ['juju-log', '--log-level', 'INFO', 'useful info'],
         )]
 
         # Set up action symlinks.
-        self._simulate_event(EventSpec(InstallEvent, 'install', charm_config=charm_config))
+        self._simulate_event(EventSpec(InstallEvent, 'install',
+                                       charm_config=charm_config))
 
         for event_spec, calls in test_cases:
             self._simulate_event(event_spec)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1131,7 +1131,8 @@ class TestModelBackend(unittest.TestCase):
         test_cases = [(
             OrderedDict([('foo', 42), ('b-ar', 4.5), ('ba_-z', 4.5), ('a', 1)]),
             OrderedDict([('de', 'ad'), ('be', 'ef_ -')]),
-            [['add-metric', '--labels', 'de=ad,be=ef_ -', 'foo=42', 'b-ar=4.5', 'ba_-z=4.5', 'a=1']]
+            [['add-metric', '--labels', 'de=ad,be=ef_ -',
+              'foo=42', 'b-ar=4.5', 'ba_-z=4.5', 'a=1']]
         ), (
             OrderedDict([('foo1', 0), ('b2r', 4.5)]),
             OrderedDict([('d3', 'aд'), ('b33f', '3_ -')]),

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -82,10 +82,27 @@ esac
     def test_get_relation(self):
         err_msg = 'ERROR invalid value "$2" for option -r: relation not found'
 
-        fake_script(self, 'relation-ids',
-                    """([ "$1" = db1 ] && echo '["db1:4"]') || ([ "$1" = db2 ] && echo '["db2:5", "db2:6"]') || echo '[]'""")
-        fake_script(self, 'relation-list',
-                    """([ "$2" = 4 ] && echo '["remoteapp1/0"]') || (echo {} >&2 ; exit 2)""".format(err_msg))
+        fake_script(self, 'relation-ids', '''
+            case "$1" in
+            db1)
+                echo '["db1:4"]'
+                ;;
+            db2)
+                echo '["db2:5", "db2:6"]'
+                ;;
+            *)
+                echo '[]'
+                ;;
+            esac
+        ''')
+        fake_script(self, 'relation-list', '''
+            if [ "$2" = 4 ]; then
+                echo '["remoteapp1/0"]'
+            else
+                echo {} >&2
+                exit 2
+            fi
+        '''.format(err_msg))
         fake_script(self, 'relation-get',
                     """echo {} >&2 ; exit 2""".format(err_msg))
 
@@ -115,7 +132,8 @@ esac
 
     def test_peer_relation_app(self):
         meta = ops.charm.CharmMeta()
-        meta.relations = {'dbpeer': RelationMeta('peers', 'dbpeer', {'interface': 'dbpeer', 'scope': 'global'})}
+        meta.relations = {'dbpeer': RelationMeta('peers', 'dbpeer',
+                                                 {'interface': 'dbpeer', 'scope': 'global'})}
         self.model = ops.model.Model('myapp/0', meta, self.backend)
 
         err_msg = 'ERROR invalid value "$2" for option -r: relation not found'
@@ -160,8 +178,10 @@ fi
         random_unit = self.model._cache.get(ops.model.Unit, 'randomunit/0')
         with self.assertRaises(KeyError):
             self.model.get_relation('db1').data[random_unit]
-        remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0', self.model.get_relation('db1').units))
-        self.assertEqual(self.model.get_relation('db1').data[remoteapp1_0], {'host': 'remoteapp1-0'})
+        remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0',
+                                   self.model.get_relation('db1').units))
+        self.assertEqual(self.model.get_relation('db1').data[remoteapp1_0],
+                         {'host': 'remoteapp1-0'})
 
         self.assertEqual(fake_script_calls(self), [
             ['relation-ids', 'db1', '--format=json'],
@@ -171,14 +191,20 @@ fi
 
     def test_remote_app_relation_data(self):
         fake_script(self, 'relation-ids', """[ "$1" = db1 ] && echo '["db1:4"]' || echo '[]'""")
-        fake_script(self, 'relation-list', """[ "$2" = 4 ] && echo '["remoteapp1/0", "remoteapp1/1"]' || exit 2""")
-        fake_script(self, 'relation-get', """
-if [ "$2" = 4 ] && [ "$4" = remoteapp1 ]; then
-    echo '{"secret": "cafedeadbeef"}'
-else
-    exit 2
-fi
-""")
+        fake_script(self, 'relation-list', '''
+            if [ "$2" = 4 ]; then
+                echo '["remoteapp1/0", "remoteapp1/1"]'
+            else
+                exit 2
+            fi
+        ''')
+        fake_script(self, 'relation-get', '''
+            if [ "$2" = 4 ] && [ "$4" = remoteapp1 ]; then
+                echo '{"secret": "cafedeadbeef"}'
+            else
+                exit 2
+            fi
+        ''')
 
         # Try to get relation data for an invalid remote application.
         random_app = self.model._cache.get(ops.model.Application, 'randomapp')
@@ -186,7 +212,8 @@ fi
             self.model.get_relation('db1').data[random_app]
 
         remoteapp1 = self.model.get_relation('db1').app
-        self.assertEqual(self.model.get_relation('db1').data[remoteapp1], {'secret': 'cafedeadbeef'})
+        self.assertEqual(self.model.get_relation('db1').data[remoteapp1],
+                         {'secret': 'cafedeadbeef'})
 
         self.assertEqual(fake_script_calls(self), [
             ['relation-ids', 'db1', '--format=json'],
@@ -206,7 +233,8 @@ fi
 """)
 
         rel_db1 = self.model.get_relation('db1')
-        remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0', self.model.get_relation('db1').units))
+        remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0',
+                                   self.model.get_relation('db1').units))
         # Force memory cache to be loaded.
         self.assertIn('host', rel_db1.data[remoteapp1_0])
         with self.assertRaises(ops.model.RelationDataError):
@@ -223,7 +251,13 @@ fi
         fake_script(self, 'relation-ids', """[ "$1" = db1 ] && echo '["db1:4"]' || echo '[]'""")
         fake_script(self, 'relation-list', """[ "$2" = 4 ] && echo '["remoteapp1/0"]' || exit 2""")
         fake_script(self, 'relation-set', '''[ "$2" = 4 ] && exit 0 || exit 2''')
-        fake_script(self, 'relation-get', """([ "$2" = 4 ] && [ "$4" = "myapp/0" ]) && echo '{"host": "bar"}' || exit 2""")
+        fake_script(self, 'relation-get', '''
+            if [ "$2" = 4 ] && [ "$4" = "myapp/0" ]; then
+                echo '{"host": "bar"}'
+            else
+                exit 2
+            fi
+        ''')
 
         rel_db1 = self.model.get_relation('db1')
         # Force memory cache to be loaded.
@@ -240,14 +274,20 @@ fi
 
     def test_app_relation_data_modify_local_as_leader(self):
         fake_script(self, 'relation-ids', """[ "$1" = db1 ] && echo '["db1:4"]' || echo '[]'""")
-        fake_script(self, 'relation-list', """[ "$2" = 4 ] && echo '["remoteapp1/0", "remoteapp1/1"]' || exit 2""")
-        fake_script(self, 'relation-get', """
-if [ "$2" = 4 ] && [ "$4" = myapp ]; then
-    echo '{"password": "deadbeefcafe"}'
-else
-    exit 2
-fi
-""")
+        fake_script(self, 'relation-list', '''
+            if [ "$2" = 4 ]; then
+                echo '["remoteapp1/0", "remoteapp1/1"]'
+            else
+                exit 2
+            fi
+        ''')
+        fake_script(self, 'relation-get', '''
+            if [ "$2" = 4 ] && [ "$4" = myapp ]; then
+                echo '{"password": "deadbeefcafe"}'
+            else
+                exit 2
+            fi
+        ''')
         fake_script(self, 'relation-set', """[ "$2" = 4 ] && exit 0 || exit 2""")
         fake_script(self, 'is-leader', 'echo true')
 
@@ -270,14 +310,20 @@ fi
 
     def test_app_relation_data_modify_local_as_minion(self):
         fake_script(self, 'relation-ids', """[ "$1" = db1 ] && echo '["db1:4"]' || echo '[]'""")
-        fake_script(self, 'relation-list', """[ "$2" = 4 ] && echo '["remoteapp1/0", "remoteapp1/1"]' || exit 2""")
-        fake_script(self, 'relation-get', """
-if [ "$2" = 4 ] && [ "$4" = myapp ]; then
-    echo '{"password": "deadbeefcafe"}'
-else
-    exit 2
-fi
-""")
+        fake_script(self, 'relation-list', '''
+            if [ "$2" = 4 ]; then
+                echo '["remoteapp1/0", "remoteapp1/1"]'
+            else
+                exit 2
+            fi
+        ''')
+        fake_script(self, 'relation-get', '''
+            if [ "$2" = 4 ] && [ "$4" = myapp ]; then
+                echo '{"password": "deadbeefcafe"}'
+            else
+                exit 2
+            fi
+        ''')
         fake_script(self, 'is-leader', 'echo false')
 
         local_app = self.model.unit.app
@@ -299,13 +345,25 @@ fi
         fake_script(self, 'relation-ids', """[ "$1" = db1 ] && echo '["db1:4"]' || echo '[]'""")
         fake_script(self, 'relation-list', """[ "$2" = 4 ] && echo '["remoteapp1/0"]' || exit 2""")
         fake_script(self, 'relation-set', '''[ "$2" = 4 ] && exit 0 || exit 2''')
-        fake_script(self, 'relation-get', """([ "$2" = 4 ] && [ "$4" = "myapp/0" ]) && echo '{"host": "bar"}' || exit 2""")
+        fake_script(self, 'relation-get', '''
+            if [ "$2" = 4 ] && [ "$4" = "myapp/0" ]; then
+                echo '{"host": "bar"}'
+            else
+                exit 2
+            fi
+        ''')
 
         rel_db1 = self.model.get_relation('db1')
         # Force memory cache to be loaded.
         self.assertIn('host', rel_db1.data[self.model.unit])
         del rel_db1.data[self.model.unit]['host']
-        fake_script(self, 'relation-get', """([ "$2" = 4 ] && [ "$4" = "myapp/0" ]) && echo '{}' || exit 2""")
+        fake_script(self, 'relation-get', '''
+            if [ "$2" = 4 ] && [ "$4" = "myapp/0" ]; then
+                echo '{}'
+            else
+                exit 2
+            fi
+        ''')
         self.assertNotIn('host', rel_db1.data[self.model.unit])
 
         self.assertEqual(fake_script_calls(self), [
@@ -319,7 +377,13 @@ fi
         fake_script(self, 'relation-ids', """[ "$1" = db2 ] && echo '["db2:5"]' || echo '[]'""")
         fake_script(self, 'relation-list',
                     """[ "$2" = 5 ] && echo '["remoteapp1/0"]' || exit 2""")
-        fake_script(self, 'relation-get', """([ "$2" = 5 ] && [ "$4" = "myapp/0" ]) && echo '{"host": "myapp-0"}' || exit 2""")
+        fake_script(self, 'relation-get', '''
+            if [ "$2" = 5 ] && [ "$4" = "myapp/0" ]; then
+                echo '{"host": "myapp-0"}'
+            else
+                exit 2
+            fi
+        ''')
         fake_script(self, 'relation-set', 'exit 2')
 
         rel_db2 = self.model.relations['db2'][0]
@@ -362,7 +426,13 @@ fi
         fake_script(self, 'relation-ids', """[ "$1" = db1 ] && echo '["db1:4"]' || echo '[]'""")
         fake_script(self, 'relation-list',
                     """[ "$2" = 4 ] && echo '["remoteapp1/0"]' || exit 2""")
-        fake_script(self, 'relation-get', """([ "$2" = 4 ] && [ "$4" = "myapp/0" ]) && echo '{"host": "myapp-0"}' || exit 2""")
+        fake_script(self, 'relation-get', '''
+            if [ "$2" = 4 ] && [ "$4" = "myapp/0" ]; then
+                echo '{"host": "myapp-0"}'
+            else
+                exit 2
+            fi
+        ''')
 
         rel_db1 = self.model.get_relation('db1')
         with self.assertRaises(ops.model.RelationDataError):
@@ -458,7 +528,8 @@ fi
         with self.assertRaises(ops.model.ModelError):
             model.resources.fetch('foo')
 
-        fake_script(self, 'resource-get', 'echo /var/lib/juju/agents/unit-test-0/resources/$1/$1.tgz')
+        fake_script(self, 'resource-get',
+                    'echo /var/lib/juju/agents/unit-test-0/resources/$1/$1.tgz')
         self.assertEqual(model.resources.fetch('foo').name, 'foo.tgz')
         self.assertEqual(model.resources.fetch('bar').name, 'bar.tgz')
 
@@ -477,7 +548,8 @@ fi
             pod_spec_call = next(filter(lambda c: c[0] == 'pod-spec-set', calls))
             self.assertEqual(pod_spec_call[:2], ['pod-spec-set', '--file'])
             # 8 bytes are used as of python 3.4.0, see Python bug #12015.
-            # Other characters are from POSIX 3.282 (Portable Filename Character Set) a subset of which Python's mkdtemp uses.
+            # Other characters are from POSIX 3.282 (Portable Filename
+            # Character Set) a subset of which Python's mkdtemp uses.
             self.assertRegex(pod_spec_call[2], '.*/tmp[A-Za-z0-9._-]{8}-pod-spec-set')
 
         self.model.pod.set_spec({'foo': 'bar'})
@@ -518,8 +590,9 @@ fi
         ), (
             ops.model.MaintenanceStatus('Yellow'),
             lambda: fake_script(self, 'status-set', 'exit 0'),
-            lambda: self.assertEqual(fake_script_calls(self, True),
-                                     [['status-set', '--application=False', 'maintenance', 'Yellow']]),
+            lambda: self.assertEqual(
+                fake_script_calls(self, True),
+                [['status-set', '--application=False', 'maintenance', 'Yellow']]),
         ), (
             ops.model.BlockedStatus('Red'),
             lambda: fake_script(self, 'status-set', 'exit 0'),
@@ -546,7 +619,8 @@ fi
         test_cases = [(
             ops.model.ActiveStatus('Green'),
             lambda: fake_script(self, 'status-set', 'exit 0'),
-            lambda: self.assertIn(['status-set', '--application=True', 'active', 'Green'], fake_script_calls(self, True)),
+            lambda: self.assertIn(['status-set', '--application=True', 'active', 'Green'],
+                                  fake_script_calls(self, True)),
         ), (
             ops.model.MaintenanceStatus('Yellow'),
             lambda: fake_script(self, 'status-set', 'exit 0'),
@@ -555,11 +629,13 @@ fi
         ), (
             ops.model.BlockedStatus('Red'),
             lambda: fake_script(self, 'status-set', 'exit 0'),
-            lambda: self.assertIn(['status-set', '--application=True', 'blocked', 'Red'], fake_script_calls(self, True)),
+            lambda: self.assertIn(['status-set', '--application=True', 'blocked', 'Red'],
+                                  fake_script_calls(self, True)),
         ), (
             ops.model.WaitingStatus('White'),
             lambda: fake_script(self, 'status-set', 'exit 0'),
-            lambda: self.assertIn(['status-set', '--application=True', 'waiting', 'White'], fake_script_calls(self, True)),
+            lambda: self.assertIn(['status-set', '--application=True', 'waiting', 'White'],
+                                  fake_script_calls(self, True)),
         )]
 
         for target_status, setup_tools, check_tool_calls in test_cases:
@@ -609,9 +685,16 @@ fi
 
     def test_remote_unit_status(self):
         fake_script(self, 'relation-ids', """[ "$1" = db1 ] && echo '["db1:4"]' || echo '[]'""")
-        fake_script(self, 'relation-list', """[ "$2" = 4 ] && echo '["remoteapp1/0", "remoteapp1/1"]' || exit 2""")
+        fake_script(self, 'relation-list', '''
+            if [ "$2" = 4 ]; then
+                echo '["remoteapp1/0", "remoteapp1/1"]'
+            else
+                exit 2
+            fi
+        ''')
 
-        remote_unit = next(filter(lambda u: u.name == 'remoteapp1/0', self.model.get_relation('db1').units))
+        remote_unit = next(filter(lambda u: u.name == 'remoteapp1/0',
+                                  self.model.get_relation('db1').units))
 
         test_statuses = (
             ops.model.UnknownStatus(),
@@ -627,7 +710,13 @@ fi
 
     def test_remote_app_status(self):
         fake_script(self, 'relation-ids', """[ "$1" = db1 ] && echo '["db1:4"]' || echo '[]'""")
-        fake_script(self, 'relation-list', """[ "$2" = 4 ] && echo '["remoteapp1/0", "remoteapp1/1"]' || exit 2""")
+        fake_script(self, 'relation-list', '''
+            if [ "$2" = 4 ]; then
+                echo '["remoteapp1/0", "remoteapp1/1"]'
+            else
+                exit 2
+            fi
+        ''')
 
         remoteapp1 = self.model.get_relation('db1').app
 
@@ -655,17 +744,22 @@ fi
         meta.storages = {'disks': None, 'data': None}
         self.model = ops.model.Model('myapp/0', meta, self.backend)
 
-        fake_script(self, 'storage-list', """[ "$1" = disks ] && echo '["disks/0", "disks/1"]' || echo '[]'""")
-        fake_script(self, 'storage-get',
-                    """
-                    if [ "$2" = disks/0 ]; then
-                      echo '"/var/srv/disks/0"'
-                    elif [ "$2" = disks/1 ]; then
-                      echo '"/var/srv/disks/1"'
-                    else
-                      exit 2
-                    fi
-                    """)
+        fake_script(self, 'storage-list', '''
+            if [ "$1" = disks ]; then
+                echo '["disks/0", "disks/1"]'
+            else
+                echo '[]'
+            fi
+        ''')
+        fake_script(self, 'storage-get', '''
+            if [ "$2" = disks/0 ]; then
+                echo '"/var/srv/disks/0"'
+            elif [ "$2" = disks/1 ]; then
+                echo '"/var/srv/disks/1"'
+            else
+                exit 2
+            fi
+        ''')
         fake_script(self, 'storage-add', '')
 
         self.assertEqual(len(self.model.storages), 2)
@@ -766,12 +860,19 @@ fi
             with self.assertRaises(ops.model.ModelError):
                 self.model.get_binding(name)
 
-        fake_script(self, 'network-get', '''[ "$1" = db0 -a "$3" = 4 ] && echo '{}' || exit 1'''.format(network_get_out)),
+        fake_script(self, 'network-get', '''
+            if [ "$1" = db0 ] && [ "$3" = 4 ]; then
+                echo '{}'
+            else
+                exit 1
+            fi
+        '''.format(network_get_out)),
         # Bindings for dead relations are not supported.
         with self.assertRaises(ops.model.ModelError):
             binding = ops.model.Binding('db0', 42, self.model._backend)
             binding.network
-        self.assertEqual(fake_script_calls(self, clear=True), [['network-get', 'db0', '-r', '42', '--format=json']])
+        self.assertEqual(fake_script_calls(self, clear=True),
+                         [['network-get', 'db0', '-r', '42', '--format=json']])
 
         expected_calls = [
             ['relation-ids', 'db0', '--format=json'],
@@ -788,21 +889,16 @@ fi
                                                           ipaddress.ip_network('192.0.3.0/24'),
                                                           ipaddress.ip_network('dead:beef::/64'),
                                                           ipaddress.ip_network('2001:db8::3/128')])
-        self.assertEqual(binding.network.interfaces[0].name, 'lo')
-        self.assertEqual(binding.network.interfaces[0].address, ipaddress.ip_address('192.0.2.2'))
-        self.assertEqual(binding.network.interfaces[0].subnet, ipaddress.ip_network('192.0.2.0/24'))
-        self.assertEqual(binding.network.interfaces[1].name, 'lo')
-        self.assertEqual(binding.network.interfaces[1].address, ipaddress.ip_address('dead:beef::1'))
-        self.assertEqual(binding.network.interfaces[1].subnet, ipaddress.ip_network('dead:beef::/64'))
-        self.assertEqual(binding.network.interfaces[2].name, 'tun')
-        self.assertEqual(binding.network.interfaces[2].address, ipaddress.ip_address('192.0.3.3'))
-        self.assertEqual(binding.network.interfaces[2].subnet, ipaddress.ip_network('192.0.3.3/32'))
-        self.assertEqual(binding.network.interfaces[3].name, 'tun')
-        self.assertEqual(binding.network.interfaces[3].address, ipaddress.ip_address('2001:db8::3'))
-        self.assertEqual(binding.network.interfaces[3].subnet, ipaddress.ip_network('2001:db8::3/128'))
-        self.assertEqual(binding.network.interfaces[4].name, 'tun')
-        self.assertEqual(binding.network.interfaces[4].address, ipaddress.ip_address('fe80::1:1'))
-        self.assertEqual(binding.network.interfaces[4].subnet, ipaddress.ip_network('fe80::/64'))
+
+        for (i, (name, address, subnet)) in enumerate([
+                ('lo', '192.0.2.2', '192.0.2.0/24'),
+                ('lo', 'dead:beef::1', 'dead:beef::/64'),
+                ('tun', '192.0.3.3', '192.0.3.3/32'),
+                ('tun', '2001:db8::3', '2001:db8::3/128'),
+                ('tun', 'fe80::1:1', 'fe80::/64')]):
+            self.assertEqual(binding.network.interfaces[i].name, name)
+            self.assertEqual(binding.network.interfaces[i].address, ipaddress.ip_address(address))
+            self.assertEqual(binding.network.interfaces[i].subnet, ipaddress.ip_network(subnet))
         self.assertEqual(fake_script_calls(self, clear=True), expected_calls)
 
 
@@ -931,21 +1027,25 @@ class TestModelBackend(unittest.TestCase):
     "192.0.2.2"
   ]
 }'''
-        fake_script(self, 'network-get', '''[ "$1" = deadbeef ] && echo '{}' || exit 1'''.format(network_get_out))
+        fake_script(self, 'network-get',
+                    '''[ "$1" = deadbeef ] && echo '{}' || exit 1'''.format(network_get_out))
         network_info = self.backend.network_get('deadbeef')
         self.assertEqual(network_info, json.loads(network_get_out))
-        self.assertEqual(fake_script_calls(self, clear=True), [['network-get', 'deadbeef', '--format=json']])
+        self.assertEqual(fake_script_calls(self, clear=True),
+                         [['network-get', 'deadbeef', '--format=json']])
 
         network_info = self.backend.network_get('deadbeef', 1)
         self.assertEqual(network_info, json.loads(network_get_out))
-        self.assertEqual(fake_script_calls(self, clear=True), [['network-get', 'deadbeef', '-r', '1', '--format=json']])
+        self.assertEqual(fake_script_calls(self, clear=True),
+                         [['network-get', 'deadbeef', '-r', '1', '--format=json']])
 
     def test_network_get_errors(self):
         err_no_endpoint = 'ERROR no network config found for binding "$2"'
         err_no_rel = 'ERROR invalid value "$3" for option -r: relation not found'
 
         test_cases = [(
-            lambda: fake_script(self, 'network-get', 'echo {} >&2 ; exit 1'.format(err_no_endpoint)),
+            lambda: fake_script(self, 'network-get',
+                                'echo {} >&2 ; exit 1'.format(err_no_endpoint)),
             lambda: self.backend.network_get("deadbeef"),
             ops.model.ModelError,
             [['network-get', 'deadbeef', '--format=json']],
@@ -1013,7 +1113,8 @@ class TestModelBackend(unittest.TestCase):
     def test_juju_log(self):
         fake_script(self, 'juju-log', 'exit 0')
         self.backend.juju_log('WARNING', 'foo')
-        self.assertEqual(fake_script_calls(self, clear=True), [['juju-log', '--log-level', 'WARNING', 'foo']])
+        self.assertEqual(fake_script_calls(self, clear=True),
+                         [['juju-log', '--log-level', 'WARNING', 'foo']])
 
         with self.assertRaises(TypeError):
             self.backend.juju_log('DEBUG')
@@ -1022,7 +1123,8 @@ class TestModelBackend(unittest.TestCase):
         fake_script(self, 'juju-log', 'exit 1')
         with self.assertRaises(ops.model.ModelError):
             self.backend.juju_log('BAR', 'foo')
-        self.assertEqual(fake_script_calls(self, clear=True), [['juju-log', '--log-level', 'BAR', 'foo']])
+        self.assertEqual(fake_script_calls(self, clear=True),
+                         [['juju-log', '--log-level', 'BAR', 'foo']])
 
     def test_valid_metrics(self):
         fake_script(self, 'add-metric', 'exit 0')


### PR DESCRIPTION
This changes the flake8 config in two ways:
* shrink max-line-width to 99
   this is done in the first commit. 127 is the maximum width github can show without scrolling sideways
   Also, considering
   ![plot of lines to fix vs max line width](https://r.chipaca.com/silly_plot_for_operator_framework_pr_162.png)
   99 doesn't seem like a completely unreasonable target
* set the maximum [cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) to 10. This only results in having to refactor jujuversion, today.
