### PR TITLE
ops/charm.py: Document all of the public attributes

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -61,7 +61,7 @@ class ActionEvent(EventBase):
 
         :param results: The result of the action as a Dict
         :type results: collections.abc.Mapping
-        :rtype: None
+        :return: None
         """
         self.framework.model._backend.action_set(results)
 
@@ -70,7 +70,7 @@ class ActionEvent(EventBase):
 
         :param message: The message for the user.
         :type message: str
-        :rtype: None
+        :return: None
         """
         self.framework.model._backend.action_log(message)
 
@@ -79,54 +79,60 @@ class ActionEvent(EventBase):
 
         :param message: Optional message to record why it has failed.
         :type message: str
-        :rtype: None
+        :return: None
         """
         self.framework.model._backend.action_fail(message)
 
 
 class InstallEvent(HookEvent):
-    """Represents the `install` hook from Juju,
-    triggered by `CharmBase.on.install`
+    """Represents the `install` hook from Juju.
+
+    It's riggered by `CharmBase.on.install`.
     """
 
     pass
 
 
 class StartEvent(HookEvent):
-    """Represents the `start` hook from Juju,
-    triggered by `CharmBase.on.start`
+    """Represents the `start` hook from Juju.
+
+    Its' triggered by `CharmBase.on.start`.
     """
 
     pass
 
 
 class StopEvent(HookEvent):
-    """Represents the `stop` hook from Juju,
-    triggered by `CharmBase.on.stop`
+    """Represents the `stop` hook from Juju.
+
+    It's triggered by `CharmBase.on.stop`.
     """
 
     pass
 
 
 class ConfigChangedEvent(HookEvent):
-    """Represents the `config-changed` hook from Juju,
-    triggered by `CharmBase.on.config_changed`
+    """Represents the `config-changed` hook from Juju.
+
+    It's triggered by `CharmBase.on.config_changed`.
     """
 
     pass
 
 
 class UpdateStatusEvent(HookEvent):
-    """Represents the `update-status` hook from Juju,
-    triggered by `CharmBase.on.update_status`
+    """Represents the `update-status` hook from Juju.
+
+    It's triggered by `CharmBase.on.update_status`
     """
 
     pass
 
 
 class UpgradeCharmEvent(HookEvent):
-    """Represents the `upgrade-charm` hook from Juju,
-    triggered by `CharmBase.on.upgrade_charm`.
+    """Represents the `upgrade-charm` hook from Juju.
+
+    It's triggered by `CharmBase.on.upgrade_charm`.
 
     This will be triggered when a user has run `juju upgrade-charm`. It is run after Juju
     has unpacked the upgraded charm code, and so this event will be handled with new code.
@@ -136,8 +142,9 @@ class UpgradeCharmEvent(HookEvent):
 
 
 class PreSeriesUpgradeEvent(HookEvent):
-    """Represents the `pre-series-upgrade` hook from Juju, triggered by
-    `CharmBase.on.pre_series_upgrade`.
+    """Represents the `pre-series-upgrade` hook from Juju.
+
+     It's triggered by `CharmBase.on.pre_series_upgrade`.
 
     This happens when a user has run `juju upgrade-series MACHINE prepare` and
     will fire for each unit that is running on the machine, telling them that
@@ -155,8 +162,9 @@ class PreSeriesUpgradeEvent(HookEvent):
 
 
 class PostSeriesUpgradeEvent(HookEvent):
-    """Represents the `post-series-upgrade` hook from Juju,
-    triggered by `CharmBase.on.post_series_upgrade`.
+    """Represents the `post-series-upgrade` hook from Juju.
+
+    It's triggered by `CharmBase.on.post_series_upgrade`.
 
     This is run after the user has done a distribution upgrade (or rolled back
     and kept the same series). It is called in response to
@@ -168,10 +176,11 @@ class PostSeriesUpgradeEvent(HookEvent):
 
 
 class LeaderElectedEvent(HookEvent):
-    """Represents the `leader-elected` hook from Juju,
-    triggered by `CharmBase.on.leader_elected`.
+    """Represents the `leader-elected` hook from Juju.
 
-    This is triggered by Juju when a new lead unit is chosen for a given application.
+    It's triggered by `CharmBase.on.leader_elected`.
+
+    Juju will trigger this when a new lead unit is chosen for a given application.
     This represents the leader of the charm information (not necessarily the primary
     of a running application). The main utility is that charm authors can know
     that only one unit will be a leader at any given time, so they can do
@@ -183,8 +192,9 @@ class LeaderElectedEvent(HookEvent):
 
 
 class LeaderSettingsChangedEvent(HookEvent):
-    """Represents the `leader-settings-changed` hook from Juju,
-    triggered by `CharmBase.on.leader_settings_changed`.
+    """Represents the `leader-settings-changed` hook from Juju.
+
+    It's triggered by `CharmBase.on.leader_settings_changed`.
 
     Deprecated. This represents when a lead unit would call `leader-set` to inform
     the other units of an application that they have new information to handle.
@@ -197,8 +207,9 @@ class LeaderSettingsChangedEvent(HookEvent):
 
 
 class CollectMetricsEvent(HookEvent):
-    """Represents the `collect-metrics` hook from Juju,
-    triggered by `CharmBase.on.collect_metrics`.
+    """Represents the `collect-metrics` hook from Juju.
+
+    It's triggered by `CharmBase.on.collect_metrics`.
 
     Note that events firing during a CollectMetricsEvent are currently
     sandboxed in how they can interact with Juju. To report metrics
@@ -212,7 +223,7 @@ class CollectMetricsEvent(HookEvent):
           metrics that have been gathered
         :param labels: Optional {key:value} strings that can be applied to the
             metrics that are being gathered
-        :rtype: None
+        :return: None
         """
         self.framework.model._backend.add_metrics(metrics, labels)
 
@@ -227,6 +238,10 @@ class RelationEvent(HookEvent):
     """
 
     def __init__(self, handle, relation, app=None, unit=None):
+        """Charm authors should not directly instantiate RelationEvent.
+
+        Instead use `Charm.on[relation_name].relation_event.emit()`
+        """
         super().__init__(handle)
 
         if unit is not None and unit.app != app:
@@ -274,8 +289,9 @@ class RelationEvent(HookEvent):
 
 
 class RelationJoinedEvent(RelationEvent):
-    """Represents the `relation-joined` hook from Juju,
-    triggered by `CharmBase.on[RELATION].relation_joined`.
+    """Represents the `relation-joined` hook from Juju.
+
+    It's triggered by `CharmBase.on[RELATION].relation_joined`.
 
     This is triggered whenever a new unit of a related application joins the relation.
     (eg, a unit was added to an existing related app, or a new relation was established
@@ -286,8 +302,9 @@ class RelationJoinedEvent(RelationEvent):
 
 
 class RelationChangedEvent(RelationEvent):
-    """Represents the `relation-changed` hook from Juju,
-    triggered by `CharmBase.on[RELATION].relation_changed`.
+    """Represents the `relation-changed` hook from Juju.
+
+    It's triggered by `CharmBase.on[RELATION].relation_changed`.
 
     This is triggered whenever there is a change to the data bucket for a related
     application or unit. Look at `event.relation.data[event.unit/app]` to see the
@@ -298,8 +315,9 @@ class RelationChangedEvent(RelationEvent):
 
 
 class RelationDepartedEvent(RelationEvent):
-    """Represents the `relation-departed` hook from Juju,
-    triggered by `CharmBase.on[RELATION].relation_departed`.
+    """Represents the `relation-departed` hook from Juju.
+
+    It's triggered by `CharmBase.on[RELATION].relation_departed`.
 
     This is the inverse of the RelationJoinedEvent, representing when a unit
     is leaving the relation (the unit is being removed, the app is being removed,
@@ -311,8 +329,9 @@ class RelationDepartedEvent(RelationEvent):
 
 
 class RelationBrokenEvent(RelationEvent):
-    """Represents the `relation-broken` hook from Juju,
-    triggered by `CharmBase.on[RELATION].relation_broken`.
+    """Represents the `relation-broken` hook from Juju.
+
+    It's triggered by `CharmBase.on[RELATION].relation_broken`.
 
     If a relation is being removed (`juju remove-relation` or `juju remove-application`),
     once all the units have been removed, RelationBrokenEvent will fire to signal
@@ -329,8 +348,9 @@ class StorageEvent(HookEvent):
 
 
 class StorageAttachedEvent(StorageEvent):
-    """Represents the `storage-attached` hook from Juju,
-    triggered by `CharmBase.on[STORAGE].storage_attached`.
+    """Represents the `storage-attached` hook from Juju.
+
+    It's triggered by `CharmBase.on[STORAGE].storage_attached`.
 
     Called when new storage is available for the charm to use.
     """
@@ -339,8 +359,9 @@ class StorageAttachedEvent(StorageEvent):
 
 
 class StorageDetachingEvent(StorageEvent):
-    """Represents the `storage-detaching` hook from Juju,
-    triggered by `CharmBase.on.storage_detaching`.
+    """Represents the `storage-detaching` hook from Juju.
+
+    It's triggered by `CharmBase.on.storage_detaching`.
 
     Called when storage a charm has been using is going away.
     """
@@ -373,7 +394,19 @@ class CharmBase(Object):
     on = CharmEvents()
 
     def __init__(self, framework, key):
-        super().__init__(framework, key)
+        """Initialize the Charm with its framework and application name.
+
+        Usually this initialization is done by ops.main.main() rather than Charm authors
+        directly instantiating a Charm.
+
+        :param framework: The framework responsible for managing the Model and events for this
+            Charm.
+        :type framework: ops.Framework
+        :param key: Arbitrary key to distinguish this instance of CharmBase from another.
+            Generally is None when initialized by the framework.
+        :type key: NoneType or str
+        """
+        super().__init__(framework, application_name)
 
         for relation_name in self.framework.meta.relations:
             relation_name = relation_name.replace('-', '_')
@@ -393,7 +426,7 @@ class CharmBase(Object):
 
     @property
     def app(self):
-        """The Application that this unit is part of.
+        """Application that this unit is part of.
 
         :rtype: ops.model.Application
         """
@@ -401,7 +434,7 @@ class CharmBase(Object):
 
     @property
     def unit(self):
-        """The Unit that this execution is responsible for.
+        """Unit that this execution is responsible for.
 
         :rtype: ops.model.Unit
         """
@@ -409,7 +442,7 @@ class CharmBase(Object):
 
     @property
     def meta(self):
-        """The CharmMeta of this charm.
+        """CharmMeta of this charm.
 
         :rtype: ops.charm.CharmMeta
         """
@@ -417,7 +450,7 @@ class CharmBase(Object):
 
     @property
     def charm_dir(self):
-        """The root directory of the Charm as it is running.
+        """Root directory of the Charm as it is running.
 
         :rtype: pathlib.Path
         """

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -406,7 +406,7 @@ class CharmBase(Object):
             Generally is None when initialized by the framework.
         :type key: NoneType or str
         """
-        super().__init__(framework, application_name)
+        super().__init__(framework, key)
 
         for relation_name in self.framework.meta.relations:
             relation_name = relation_name.replace('-', '_')

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -21,6 +21,7 @@ from ops.framework import Object, EventSource, EventBase, EventsBase
 
 class HookEvent(EventBase):
     """A base class for events that trigger because of a Juju hook firing."""
+
     pass
 
 
@@ -85,31 +86,41 @@ class ActionEvent(EventBase):
 
 class InstallEvent(HookEvent):
     """Represents the `install` hook from Juju,
-    triggered by `CharmBase.on.install`"""
+    triggered by `CharmBase.on.install`
+    """
+
     pass
 
 
 class StartEvent(HookEvent):
     """Represents the `start` hook from Juju,
-    triggered by `CharmBase.on.start`"""
+    triggered by `CharmBase.on.start`
+    """
+
     pass
 
 
 class StopEvent(HookEvent):
     """Represents the `stop` hook from Juju,
-    triggered by `CharmBase.on.stop`"""
+    triggered by `CharmBase.on.stop`
+    """
+
     pass
 
 
 class ConfigChangedEvent(HookEvent):
     """Represents the `config-changed` hook from Juju,
-    triggered by `CharmBase.on.config_changed`"""
+    triggered by `CharmBase.on.config_changed`
+    """
+
     pass
 
 
 class UpdateStatusEvent(HookEvent):
     """Represents the `update-status` hook from Juju,
-    triggered by `CharmBase.on.update_status`"""
+    triggered by `CharmBase.on.update_status`
+    """
+
     pass
 
 
@@ -120,6 +131,7 @@ class UpgradeCharmEvent(HookEvent):
     This will be triggered when a user has run `juju upgrade-charm`. It is run after Juju
     has unpacked the upgraded charm code, and so this event will be handled with new code.
     """
+
     pass
 
 
@@ -138,6 +150,7 @@ class PreSeriesUpgradeEvent(HookEvent):
     initiate the steps to actually upgrade the machine (eg `do-release-upgrade`).
     When the upgrade has been completed, the `PostSeriesUpgradeEvent`_ will fire.
     """
+
     pass
 
 
@@ -150,6 +163,7 @@ class PostSeriesUpgradeEvent(HookEvent):
     `juju upgrade-series MACHINE complete`. Charms are expected to do whatever
     steps are necessary to reconfigure their applications for the new series.
     """
+
     pass
 
 
@@ -164,6 +178,7 @@ class LeaderElectedEvent(HookEvent):
     configuration, etc, that would otherwise require coordination between units.
     (eg, selecting a password for a new relation)
     """
+
     pass
 
 
@@ -177,6 +192,7 @@ class LeaderSettingsChangedEvent(HookEvent):
     leader set a value in the Application data bag for that peer relation.
     (see `RelationChangedEvent`_).
     """
+
     pass
 
 
@@ -265,6 +281,7 @@ class RelationJoinedEvent(RelationEvent):
     (eg, a unit was added to an existing related app, or a new relation was established
     with an application that already had units.)
     """
+
     pass
 
 
@@ -276,6 +293,7 @@ class RelationChangedEvent(RelationEvent):
     application or unit. Look at `event.relation.data[event.unit/app]` to see the
     new information.
     """
+
     pass
 
 
@@ -288,6 +306,7 @@ class RelationDepartedEvent(RelationEvent):
     the relation is being removed). It is fired once for each unit that is
     going away.
     """
+
     pass
 
 
@@ -299,11 +318,13 @@ class RelationBrokenEvent(RelationEvent):
     once all the units have been removed, RelationBrokenEvent will fire to signal
     that the relationship has been fully terminated.
     """
+
     pass
 
 
 class StorageEvent(HookEvent):
     """Base class representing Storage related events."""
+
     pass
 
 
@@ -313,6 +334,7 @@ class StorageAttachedEvent(StorageEvent):
 
     Called when new storage is available for the charm to use.
     """
+
     pass
 
 
@@ -322,6 +344,7 @@ class StorageDetachingEvent(StorageEvent):
 
     Called when storage a charm has been using is going away.
     """
+
     pass
 
 
@@ -449,7 +472,7 @@ class CharmMeta:
 
     @classmethod
     def from_yaml(cls, metadata, actions=None):
-        """"Instantiate a CharmMeta from a YAML description of metadata.yaml.
+        """Instantiate a CharmMeta from a YAML description of metadata.yaml.
 
         :param metadata: A YAML description of charm metadata (name, relations, etc.)
             This can be a simple string, or a file-like object. (passed to `yaml.safe_load`).


### PR DESCRIPTION
This is an attempt to make sure we clearly identify what is the expected
interaction points for charm authors.

I started off wanting to flag things as private where appropriate, but I didn't end up marking anything private, I just ended up documenting all the public interfaces.
