### PR TITLE
ops.framework: enable inheritance of classes that use StoredState

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -870,12 +870,14 @@ class StoredState:
                     # attributes -> unclear what is expected of us -> bail out
                     raise RuntimeError("StoredState shared by {0}.{1} and {0}.{2}".format(
                         cls.__name__, self.attr_name, attr_name))
-                # we've found ourselves for the first time; save where, and bind & cache the object
+                # we've found ourselves for the first time; save where, and bind the object
                 self.attr_name = attr_name
                 self.parent_type = cls
                 bound = BoundStoredState(parent, attr_name)
 
         if bound is not None:
+            # cache the bound object to avoid the expensive lookup the next time
+            # (don't use setattr, to keep things symmetric with the fast-path lookup above)
             parent.__dict__[self.attr_name] = bound
             return bound
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -813,6 +813,21 @@ class TestStoredState(unittest.TestCase):
         self._stored_state_tests(SubA)
         self._stored_state_tests(SubB)
 
+    def test_the_crazy_thing(self):
+        class NoState(Object):
+            pass
+
+        class StatedObject(NoState):
+            state = StoredState()
+
+        class Sibling(NoState):
+            pass
+
+        class FinalChild(StatedObject, Sibling):
+            pass
+
+        self._stored_state_tests(FinalChild)
+
     def _stored_state_tests(self, cls):
         framework = self.create_framework()
         obj = cls(framework, "1")
@@ -903,6 +918,10 @@ class TestStoredState(unittest.TestCase):
             self.fail("exception RuntimeError not raised")
         finally:
             framework.close()
+
+        # make sure we're not changing the object on failure
+        self.assertNotIn("stored", obj.__dict__)
+        self.assertNotIn("state", obj.__dict__)
 
     def test_same_name_two_classes(self):
         class Base(Object):

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -910,14 +910,10 @@ class TestStoredState(unittest.TestCase):
         framework = self.create_framework()
         obj = Mine(framework, None)
 
-        try:
+        with self.assertRaises(RuntimeError):
             obj.state.foo = 42
-        except RuntimeError:
-            pass
-        else:
-            self.fail("exception RuntimeError not raised")
-        finally:
-            framework.close()
+
+        framework.close()
 
         # make sure we're not changing the object on failure
         self.assertNotIn("stored", obj.__dict__)
@@ -937,17 +933,17 @@ class TestStoredState(unittest.TestCase):
         a = A(framework, None)
         b = B(framework, None)
 
-        try:
-            # NOTE it's the second one that actually triggers the
-            # exception, but that's an implementation detail
-            a.stored.foo = 42
+        # NOTE it's the second one that actually triggers the
+        # exception, but that's an implementation detail
+        a.stored.foo = 42
+
+        with self.assertRaises(RuntimeError):
             b.stored.foo = "xyzzy"
-        except RuntimeError:
-            pass
-        else:
-            self.fail("exception RuntimeError not raised")
-        finally:
-            framework.close()
+
+        framework.close()
+
+        # make sure we're not changing the object on failure
+        self.assertNotIn("stored", b.__dict__)
 
     def test_mutable_types_invalid(self):
         framework = self.create_framework()


### PR DESCRIPTION
Before this change, if you create a class that uses StoredState, e.g.

    class MyClass(Object):
        stored = StoredState()

and then subclassed it,

    class Another(MyClass):
        pass

things broke. This fixes that, and closes #193.