### PR TITLE
Return an empty list if not relation-ids exist yet

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -342,7 +342,7 @@ class _TestingModelBackend:
         self._unit_status = None
 
     def relation_ids(self, relation_name):
-        return self._relation_ids_map[relation_name]
+        return self._relation_ids_map.get(relation_name, [])
 
     def relation_list(self, relation_id):
         return self._relation_list_map[relation_id]

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -258,6 +258,19 @@ class TestHarness(unittest.TestCase):
         # The charm_dir also gets set
         self.assertEqual(harness.framework.charm_dir, tmp)
 
+    def test_no_relation_ids(self):
+        # language=YAML
+        harness = Harness(CharmBase, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            ''')
+        harness.begin()
+
+        self.assertIsNone(harness.charm.model.get_relation('db'))
+        self.assertEqual(harness.charm.model.relations['db'], [])
+
 
 class DBRelationChangedHelper(Object):
     def __init__(self, parent, key):


### PR DESCRIPTION
If 'myendpoint' is present in metadata.yaml but there are no relations
for it yet, the relation-ids hook tool returns an empty list.

juju run --unit mycharm/0 'relation-ids --format=yaml myendpoint'
[]

The test backend behavior is currently different which leads to the
issue described here https://github.com/canonical/operator/issues/202.