### PR TITLE
Enable stderr logging if JUJU_DEBUG is set.

### DIFF
--- a/ops/log.py
+++ b/ops/log.py
@@ -41,6 +41,6 @@ def setup_root_logging(model_backend, *, debug_stream=None):
     logger.addHandler(JujuLogHandler(model_backend))
     if debug_stream is not None:
         streamHandler = logging.StreamHandler(debug_stream)
-        formatter = logging.Formatter('%(levelname)8s %(message)s')
+        formatter = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
         streamHandler.setFormatter(formatter)
         logger.addHandler(streamHandler)

--- a/ops/log.py
+++ b/ops/log.py
@@ -26,22 +26,21 @@ class JujuLogHandler(logging.Handler):
         self.model_backend.juju_log(record.levelname, self.format(record))
 
 
-def setup_root_logging(model_backend, *, debug_stream=None):
+def setup_root_logging(model_backend, debug=False):
     """Setup python logging to forward messages to juju-log.
 
-    :param model_backend: a ModelBackend to use for juju_log.
-    :param debug_stream: A file stream where debug messages will be sent, in addition to juju-log.
-    :type debug_stream: File, optional
+    model_backend -- a ModelBackend to use for juju-log
+    debug -- if True, enable DEBUG level logging, and write logs to stderr as well as to juju-log.
     """
-    if debug_stream is not None:
-        logLevel = logging.DEBUG
+    if debug:
+        level = logging.DEBUG
     else:
-        logLevel = logging.INFO
+        level = logging.INFO
     logger = logging.getLogger()
-    logger.setLevel(logLevel)
+    logger.setLevel(level)
     logger.addHandler(JujuLogHandler(model_backend))
-    if debug_stream is not None:
-        streamHandler = logging.StreamHandler(debug_stream)
+    if debug:
+        handler = logging.StreamHandler()
         formatter = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
-        streamHandler.setFormatter(formatter)
-        logger.addHandler(streamHandler)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)

--- a/ops/log.py
+++ b/ops/log.py
@@ -26,7 +26,25 @@ class JujuLogHandler(logging.Handler):
         self.model_backend.juju_log(record.levelname, self.format(record))
 
 
-def setup_root_logging(model_backend):
+def setup_root_logging(model_backend, *, debug=False, debug_stream=None):
+    """Setup python logging to forward messages to juju-log.
+
+    :param model_backend: a ModelBackend to use for juju_log.
+    :param debug: (optional) If set to True, this will log messages at DEBUG level to
+        debug_stream as well as INFO to juju_log.
+    :type debug: bool
+    :param debug_stream: (optional) when debug is True, message will also be sent to this
+        stream. If not supplied, uses the default logging.StreamHandler (stderr)
+    """
+    if debug:
+        logLevel = logging.DEBUG
+    else:
+        logLevel = logging.INFO
     logger = logging.getLogger()
-    logger.setLevel(logging.INFO)
+    logger.setLevel(logLevel)
     logger.addHandler(JujuLogHandler(model_backend))
+    if debug:
+        streamHandler = logging.StreamHandler(debug_stream)
+        formatter = logging.Formatter('%(levelname)8s %(message)s')
+        streamHandler.setFormatter(formatter)
+        logger.addHandler(streamHandler)

--- a/ops/log.py
+++ b/ops/log.py
@@ -30,7 +30,8 @@ def setup_root_logging(model_backend, *, debug_stream=None):
     """Setup python logging to forward messages to juju-log.
 
     :param model_backend: a ModelBackend to use for juju_log.
-    :param debug_stream: (optional) If set, debug messages will also be sent to this stream.
+    :param debug_stream: A file stream where debug messages will be sent, in addition to juju-log.
+    :type debug_stream: File, optional
     """
     if debug_stream is not None:
         logLevel = logging.DEBUG

--- a/ops/log.py
+++ b/ops/log.py
@@ -26,24 +26,20 @@ class JujuLogHandler(logging.Handler):
         self.model_backend.juju_log(record.levelname, self.format(record))
 
 
-def setup_root_logging(model_backend, *, debug=False, debug_stream=None):
+def setup_root_logging(model_backend, *, debug_stream=None):
     """Setup python logging to forward messages to juju-log.
 
     :param model_backend: a ModelBackend to use for juju_log.
-    :param debug: (optional) If set to True, this will log messages at DEBUG level to
-        debug_stream as well as INFO to juju_log.
-    :type debug: bool
-    :param debug_stream: (optional) when debug is True, message will also be sent to this
-        stream. If not supplied, uses the default logging.StreamHandler (stderr)
+    :param debug_stream: (optional) If set, debug messages will also be sent to this stream.
     """
-    if debug:
+    if debug_stream is not None:
         logLevel = logging.DEBUG
     else:
         logLevel = logging.INFO
     logger = logging.getLogger()
     logger.setLevel(logLevel)
     logger.addHandler(JujuLogHandler(model_backend))
-    if debug:
+    if debug_stream is not None:
         streamHandler = logging.StreamHandler(debug_stream)
         formatter = logging.Formatter('%(levelname)8s %(message)s')
         streamHandler.setFormatter(formatter)

--- a/ops/main.py
+++ b/ops/main.py
@@ -174,10 +174,10 @@ def main(charm_class):
         juju_event_name = '{}_action'.format(juju_event_name)
 
     model_backend = ops.model.ModelBackend()
-    debug = False
+    debug_stream = None
     if os.getenv("JUJU_DEBUG"):
-        debug = True
-    setup_root_logging(model_backend, debug=debug)
+        debug_stream = sys.stderr
+    setup_root_logging(model_backend, debug_stream=debug_stream)
 
     metadata, actions_metadata = _load_metadata(charm_dir)
     meta = ops.charm.CharmMeta(metadata, actions_metadata)

--- a/ops/main.py
+++ b/ops/main.py
@@ -174,7 +174,10 @@ def main(charm_class):
         juju_event_name = '{}_action'.format(juju_event_name)
 
     model_backend = ops.model.ModelBackend()
-    setup_root_logging(model_backend)
+    debug = False
+    if os.getenv("JUJU_DEBUG"):
+        debug = True
+    setup_root_logging(model_backend, debug=debug)
 
     metadata, actions_metadata = _load_metadata(charm_dir)
     meta = ops.charm.CharmMeta(metadata, actions_metadata)

--- a/ops/main.py
+++ b/ops/main.py
@@ -175,7 +175,7 @@ def main(charm_class):
 
     model_backend = ops.model.ModelBackend()
     debug_stream = None
-    if os.getenv("JUJU_DEBUG"):
+    if 'JUJU_DEBUG' in os.environ:
         debug_stream = sys.stderr
     setup_root_logging(model_backend, debug_stream=debug_stream)
 

--- a/ops/main.py
+++ b/ops/main.py
@@ -174,10 +174,8 @@ def main(charm_class):
         juju_event_name = '{}_action'.format(juju_event_name)
 
     model_backend = ops.model.ModelBackend()
-    debug_stream = None
-    if 'JUJU_DEBUG' in os.environ:
-        debug_stream = sys.stderr
-    setup_root_logging(model_backend, debug_stream=debug_stream)
+    debug = ('JUJU_DEBUG' in os.environ)
+    setup_root_logging(model_backend, debug=debug)
 
     metadata, actions_metadata = _load_metadata(charm_dir)
     meta = ops.charm.CharmMeta(metadata, actions_metadata)

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -16,6 +16,7 @@
 
 import io
 import unittest
+from unittest.mock import patch
 import importlib
 
 import logging
@@ -88,16 +89,17 @@ class TestLogging(unittest.TestCase):
 
     def test_debug_logging(self):
         buffer = io.StringIO()
-        ops.log.setup_root_logging(self.backend, debug_stream=buffer)
-        logger = logging.getLogger()
-        logger.debug('debug message')
-        self.assertEqual(self.backend.calls(), [])
-        self.assertRegex(
-            buffer.getvalue(),
-            r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d DEBUG    debug message\n")
-        logger.info('info message')
-        logger.warning('warning message')
-        logger.critical('critical message')
+        with patch('sys.stderr', buffer):
+            ops.log.setup_root_logging(self.backend, debug=True)
+            logger = logging.getLogger()
+            logger.debug('debug message')
+            self.assertEqual(self.backend.calls(), [])
+            self.assertRegex(
+                buffer.getvalue(),
+                r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d DEBUG    debug message\n")
+            logger.info('info message')
+            logger.warning('warning message')
+            logger.critical('critical message')
         self.assertEqual(
             self.backend.calls(),
             [('INFO', 'info message'),

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -88,7 +88,7 @@ class TestLogging(unittest.TestCase):
 
     def test_debug_logging(self):
         buffer = io.StringIO()
-        ops.log.setup_root_logging(self.backend, debug=True, debug_stream=buffer)
+        ops.log.setup_root_logging(self.backend, debug_stream=buffer)
         logger = logging.getLogger()
         logger.debug('debug message')
         self.assertEqual(self.backend.calls(), [])

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -92,9 +92,9 @@ class TestLogging(unittest.TestCase):
         logger = logging.getLogger()
         logger.debug('debug message')
         self.assertEqual(self.backend.calls(), [])
-        self.assertEqual(
+        self.assertRegex(
             buffer.getvalue(),
-            "   DEBUG debug message\n")
+            r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d DEBUG    debug message\n")
         logger.info('info message')
         logger.warning('warning message')
         logger.critical('critical message')
@@ -104,12 +104,12 @@ class TestLogging(unittest.TestCase):
              ('WARNING', 'warning message'),
              ('CRITICAL', 'critical message'),
              ])
-        self.assertEqual(
+        self.assertRegex(
             buffer.getvalue(),
-            "   DEBUG debug message\n"
-            "    INFO info message\n"
-            " WARNING warning message\n"
-            "CRITICAL critical message\n"
+            r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d DEBUG    debug message\n"
+            r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d INFO     info message\n"
+            r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d WARNING  warning message\n"
+            r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d CRITICAL critical message\n"
         )
 
 

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -93,10 +93,6 @@ class TestLogging(unittest.TestCase):
             ops.log.setup_root_logging(self.backend, debug=True)
             logger = logging.getLogger()
             logger.debug('debug message')
-            self.assertEqual(self.backend.calls(), [])
-            self.assertRegex(
-                buffer.getvalue(),
-                r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d DEBUG    debug message\n")
             logger.info('info message')
             logger.warning('warning message')
             logger.critical('critical message')

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -13,15 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import base64
 import logging
 import os
-import sys
-import subprocess
 import pickle
-import base64
-import tempfile
 import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
 
 import importlib.util
 
@@ -195,8 +195,10 @@ start:
         event_file = self.JUJU_CHARM_DIR / event_dir / event_filename
         # Note that sys.executable is used to make sure we are using the same
         # interpreter for the child process to support virtual environments.
-        subprocess.check_call([sys.executable, str(event_file)],
-                              env=env, cwd=str(self.JUJU_CHARM_DIR))
+        cmd = [sys.executable, str(event_file)]
+        subprocess.run(
+            cmd, check=True, env=env, cwd=str(self.JUJU_CHARM_DIR),
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return self._read_and_clear_state()
 
     def test_event_reemitted(self):


### PR DESCRIPTION
When running under 'juju debug-hooks' JUJU_DEBUG is set, which we can
use to detect that we should also print to stderr, so that people
interactively running the charm can see what is going on. It also
changes the default log level to DEBUG (though juju-log is still at
INFO).

This should address #200.

I chose to include the log level, and went with right-aligned, and fixed width so the messages end up left aligned. I don't terribly care, if people prefer a different format, this is all stderr, so it didn't make sense to me to include timestamps, etc. I also considered including the logger name, and/or file/line. Since it is stderr, I didn't want to overwhelm the output, but I'm flexible.
