### PR TITLE
Harness: do not emit extra relation changed events

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -139,17 +139,25 @@ class Harness:
         self._relation_id_counter += 1
         return rel_id
 
-    def add_relation(self, relation_name, remote_app, remote_app_data=None):
+    def add_relation(self, relation_name, remote_app, remote_app_data=None, *,
+                     initial_unit_data=None, initial_app_data=None):
         """Declare that there is a new relation between this app and `remote_app`.
 
         TODO: Once relation_created exists as a Juju hook, it should be triggered by this code.
 
         :param relation_name: The relation on Charm that is being related to
+        :type relation_data: str
         :param remote_app: The name of the application that is being related to
+        :type remote_app: str
         :param remote_app_data: Optional data bag that the remote application is sending
           If remote_app_data is not empty, this should trigger
           ``charm.on[relation_name].relation_changed(app)``
           For peer relations, use initial_app_data instead.
+        :type remote_app_data: dict(str, str)
+        :param initial_unit_data: Optional data bag that holds our unit's initial data.
+        :type initial_unit_data: dict(str, str)
+        :param initial_app_data: Optional data bag that holds our app's initial data.
+        :type initial_app_data: dict(str, str)
         :return: The relation_id created by this add_relation.
         :rtype: int
         """
@@ -164,10 +172,14 @@ class Harness:
         self._backend._relation_list_map[rel_id] = []
         if remote_app_data is None:
             remote_app_data = {}
+        if initial_app_data is None:
+            initial_app_data = {}
+        if initial_unit_data is None:
+            initial_unit_data = {}
         self._backend._relation_data[rel_id] = {
             remote_app: remote_app_data,
-            self._backend.unit_name: {},
-            self._backend.app_name: {},
+            self._backend.unit_name: initial_unit_data,
+            self._backend.app_name: initial_app_data,
         }
         # Reload the relation_ids list
         if self._model is not None:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -139,7 +139,7 @@ class Harness:
         self._relation_id_counter += 1
         return rel_id
 
-    def add_relation(self, relation_name, remote_app, remote_app_data=None, *,
+    def add_relation(self, relation_name, remote_app, *, remote_app_data=None,
                      initial_unit_data=None, initial_app_data=None):
         """Declare that there is a new relation between this app and `remote_app`.
 
@@ -164,7 +164,7 @@ class Harness:
         is_peer = self._meta.relations[relation_name].role == 'peers'
         if is_peer and remote_app_data is not None:
             raise RuntimeError('unable to update remote app data as there is no remote app on'
-                               ' a peer relation')
+                               ' a peer relation - use initial app data instead')
 
         rel_id = self._next_relation_id()
         self._backend._relation_ids_map.setdefault(relation_name, []).append(rel_id)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -277,8 +277,9 @@ class Harness:
                 new_values[k] = v
         self._backend._relation_data[relation_id][app_or_unit] = new_values
 
-        # Updates to our app data are do not trigger change events for units of our app.
         if not is_peer and is_our_app_updated:
+            # The leader is updating app data next to us, we only see that change if this
+            # is a peer relation.
             return
         self._emit_relation_changed(relation_id, app_or_unit)
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -260,7 +260,20 @@ class Harness:
             if rel_data is not None:
                 # If we have read and cached this data, make sure we invalidate it
                 rel_data._invalidate()
-        # TODO: we only need to trigger relation_changed if it is a remote app or unit
+
+        is_peer = self._charm.meta.relations[relation_name].role == 'peers'
+        if self._model.unit == entity:
+            # Updates to our own unit do not trigger relation-changed events.
+            return
+        if not is_peer and self._model.app == entity:
+            # Updates to our own application on non-peer relations
+            # do not trigger relation-changed events.
+            return
+        elif isinstance(entity, model.Application):
+            # Updates to peer app relation data are not triggered for leaders.
+            if self._model.unit.is_leader():
+                return
+        # Remote app, unit or peer app relation data updates trigger an event.
         self._emit_relation_changed(relation_id, app_or_unit)
 
     def _emit_relation_changed(self, relation_id, app_or_unit):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -48,6 +48,24 @@ class TestHarness(unittest.TestCase):
         backend = harness._backend
         self.assertEqual([rel_id], backend.relation_ids('db'))
         self.assertEqual([], backend.relation_list(rel_id))
+        # Make sure the initial data bags for our app and unit are empty.
+        self.assertEqual({}, backend.relation_get(rel_id, 'test-app', is_app=True))
+        self.assertEqual({}, backend.relation_get(rel_id, 'test-app/0', is_app=False))
+
+    def test_add_relation_with_initial_data(self):
+        # language=YAML
+        harness = Harness(CharmBase, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            ''')
+        rel_id = harness.add_relation('db', 'postgresql', initial_app_data={'k', 'v'},
+                                      initial_unit_data={'ingress-address': '192.0.2.1'})
+        backend = harness._backend
+        self.assertEqual({'k', 'v'}, backend.relation_get(rel_id, 'test-app', is_app=True))
+        self.assertEqual({'ingress-address': '192.0.2.1'},
+                         backend.relation_get(rel_id, 'test-app/0', is_app=False))
 
     def test_add_relation_and_unit(self):
         # language=YAML


### PR DESCRIPTION
Do not emit relation-changed events on:

* current unit data bag updates;
* current application data bag updates for non-peer relations;
* peer app relation data bag updates for leader units.

https://github.com/canonical/operator/issues/211