### PR TITLE
tcp-load-balancer interface (provides and requires sides, completely new interface)

### DIFF
--- a/ops/lib/tcp_load_balancer/tcp_lb.py
+++ b/ops/lib/tcp_load_balancer/tcp_lb.py
@@ -226,7 +226,7 @@ class TCPLoadBalancer(Object):
 
 
 class Listener(SimpleNamespace):
-    """Listeners specifies load-balancer frontend and backend configuration."""
+    """Listeners specify load-balancer frontend and backend configuration."""
 
     def __init__(self, name, port, balancing_algorithm, **kwargs):
         self.name = name

--- a/ops/lib/tcp_load_balancer/tcp_lb.py
+++ b/ops/lib/tcp_load_balancer/tcp_lb.py
@@ -143,7 +143,12 @@ class TCPBackendManager(Object):
                     continue
                 backend = Backend(**json.loads(backend_data))
                 members.append(backend)
-            pools.append(BackendPool(listener, members, health_monitor))
+            # Add a pool only if there are members in it.
+            if members:
+                pools.append(BackendPool(listener, members, health_monitor))
+            else:
+                logger.debug('No backend data for listener {} exposed yet by any backend unit -'
+                             ' no pool will be added.'.format(listener.name))
         return pools
 
 

--- a/ops/lib/tcp_load_balancer/tcp_lb.py
+++ b/ops/lib/tcp_load_balancer/tcp_lb.py
@@ -282,4 +282,4 @@ class InterfaceDataEncoder(json.JSONEncoder):
         if isinstance(obj, datetime.timedelta):
             return obj.total_seconds()
         else:
-            return json.JSONEncoder.default(self, obj)
+            return super().default(self, obj)

--- a/ops/lib/tcp_load_balancer/tcp_lb.py
+++ b/ops/lib/tcp_load_balancer/tcp_lb.py
@@ -53,9 +53,12 @@ load-balancer should provide load-balancing for::
         def _on_load_balancer_available(self, event):
             listener = Listener(name=self.app.name.replace('/', '_'), port=self.LISTENER_PORT)
             fqdn = socket.getfqdn()
-            backend = Backend(fqdn, self.MEMBER_PORT, monitor_port=self.MONITOR_PORT)
-            health_monitor = HTTPHealthMonitor(timeout=timedelta(seconds=10), http_method='GET',
-                                               url_path='/health?ready=1')
+            backend = Backend(fqdn, self.SERVICE_PORT, monitor_port=self.MONITOR_PORT)
+            health_monitor = HTTPHealthMonitor(
+                timeout=timedelta(seconds=10),
+                http_method='GET',
+                url_path='/health?ready=1'
+            )
             self.tcp_lb.expose_backend(listener, backend, health_monitor)
 """
 

--- a/ops/lib/tcp_load_balancer/tcp_lb.py
+++ b/ops/lib/tcp_load_balancer/tcp_lb.py
@@ -1,3 +1,17 @@
+# Copyright 2020 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Implements types for provides and requires sides of the 'tcp-load-balancer' relation.
 
 `TcpBackendManager`_ is the type that exposes the information about members that a TCP
@@ -42,20 +56,6 @@ load-balancer should provide load-balancing for.
             health_monitor = HTTPHealthMonitor(timeout=timedelta(seconds=10), http_method='GET',
                                                url_path='/health?ready=1')
             self.tcp_lb.expose_backend(listener, backend, health_monitor)
-
-Copyright 2020 Canonical Ltd.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 """
 
 import logging

--- a/ops/lib/tcp_load_balancer/tcp_lb.py
+++ b/ops/lib/tcp_load_balancer/tcp_lb.py
@@ -19,8 +19,8 @@ load-balancer should provide load-balancing for.
 
 class MyLBCharm(ops.charm.CharmBase):
 
-   def __init__(self, framework):
-      super().__init__(framework, None)
+   def __init__(self, *args):
+      super().__init__(*args)
       self.tcp_backend_manager = TcpBackendManagers(self, 'tcp-lb')
       self.framework.observe(self.tcp_backend_manager.on.pools_changed, self._on_tcp_pools_changed)
 
@@ -43,8 +43,8 @@ load-balancer should provide load-balancing for.
         SERVICE_PORT = 8080
         MONITOR_PORT = 8081
 
-        def __init__(self, framework):
-            super().__init__(framework, None)
+        def __init__(self, *args):
+            super().__init__(*args)
             self.tcp_lb = TcpLoadBalancer(self, 'tcp-lb', load_balancer_algorithm='round_robin')
             self.framework.observe(self.tcp_lb.on.load_balancer_available,
                                    self._on_load_balancer_available)

--- a/ops/lib/tcp_load_balancer/tcp_lb.py
+++ b/ops/lib/tcp_load_balancer/tcp_lb.py
@@ -31,7 +31,7 @@ class MyLBCharm(ops.charm.CharmBase):
            for member in pool.members:
                logger.debug(member.port)
                logger.debug(member.address)
-               # other fields...
+               # Access other fields...
 
 
 `TcpLoadBalancer`_ is the type that exposes the information about members that a TCP
@@ -56,7 +56,6 @@ load-balancer should provide load-balancing for.
             health_monitor = HTTPHealthMonitor(timeout=timedelta(seconds=10), http_method='GET',
                                                url_path='/health?ready=1')
             self.tcp_lb.expose_backend(listener, backend, health_monitor)
-            # ...
 """
 
 import logging

--- a/ops/lib/tcp_load_balancer/tcp_lb.py
+++ b/ops/lib/tcp_load_balancer/tcp_lb.py
@@ -188,9 +188,13 @@ class TCPLoadBalancer(Object):
     def expose_backend(self, backend, listener, health_monitor):
         """Expose a backend to the load-balancer.
 
-        backend -- a backend to expose to a TCP load-balancer.
-        listener -- a listener instance to provide frontend configuration parameters.
-        health_monitor -- a health monitor instance to configure health-checking for the backend.
+        :param backend: a backend to expose to a TCP load-balancer.
+        :type backend: :class: `.Backend`
+        :param listener: a listener instance to provide frontend configuration parameters.
+        :type listener: :class: `.Listener`
+        :param health_monitor: a health monitor instance to configure health-checking
+            for the backend.
+        :type health_monitor: :class: `.HealthMonitor`
         """
         rel = self.model.get_relation(self._relation_name)
         our_unit_data = rel.data[self.model.unit]

--- a/ops/lib/tcp_load_balancer/tcp_lb.py
+++ b/ops/lib/tcp_load_balancer/tcp_lb.py
@@ -1,0 +1,241 @@
+# Copyright 2020 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pickle
+
+from ops.framework import Object, StoredState, EventBase, EventSetBase, EventSource
+
+
+'''Implements types for provides and requires sides of the 'tcp-load-balancer' relation.
+
+`TcpMemberPools`_ is the type that exposes the information about members that a TCP
+load-balancer should provide load-balancing for.
+
+
+     class MyLBCharm(ops.charm.CharmBase):
+
+        def __init__(self, framework):
+           super().__init__(framework, None)
+           self.tcp_member_pools = TcpMemberPools(self, 'tcp-lb')
+           self.framework.observe(self.member_pools.on.pools_changed, self._on_tcp_pools_changed)
+        ...
+        def _on_tcp_pools_changed(self, event):
+            pools = self.tcp_member_pools.pools
+            for pool in self.tcp_member_pools.pools:
+                logger.debug(pools.listener.port)
+                logger.debug(pools.listener.name)
+                for member in pool.members:
+                    logger.debug(member.port)
+                    logger.debug(member.address)
+                    # other fields...
+
+
+`TcpLoadBalancer`_ is the type that exposes the information about members that a TCP
+load-balancer should provide load-balancing for.
+
+    class MyServiceCharm(ops.charm.CharmBase):
+
+        LISTENER_PORT = 80
+        SERVICE_PORT = 8080
+        MONITOR_PORT = 8081
+
+        def __init__(self, framework):
+            super().__init__(framework, None)
+            self.tcp_lb = TcpLoadBalancer(self, 'tcp-lb', lb_algorithm='round_robin')
+            self.framework.observe(self.tcp_lb.on.lb_available, self._on_lb_available)
+
+        def _on_lb_available(self, event):
+            listener = Listener(name=self.app.name.replace('/', '_'), port=self.LISTENER_PORT)
+            fqdn = socket.getfqdn()
+            member = Member(fqdn, self.MEMBER_PORT, monitor_port=self.MONITOR_PORT)
+            health_monitor = HTTPHealthMonitor(timeout=timedelta(seconds=10), http_method='GET',
+                                               url_path='/health?ready=1')
+            self.tcp_lb.expose_member(listener, member, health_monitor)
+            # ...
+'''
+
+
+class PoolsChanged(EventBase):
+
+    '''Event emitted by TcpMemberPools.on.pools_changed.
+
+    This event will be emitted if any of the existing or new members exposes new data over a
+    relation for the load-balancer to re-assess its current state.
+    '''
+    pass
+
+
+class TcpMemberPoolEvents(EventSetBase):
+
+    '''Events emitted by the TcpMemberPoolEvents class.'''
+    pools_changed = EventSource(PoolsChanged)
+
+
+class TcpMemberPools(Object):
+
+    '''Provides the information about pools of TCP load-balancer members.'''
+
+    on = TcpMemberPoolEvents()
+
+    _stored = StoredState()
+
+    def __init__(self, charm, relation_name):
+        super().__init__(charm, relation_name)
+        self._relation_name = relation_name
+        self._member_pools = None
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def _on_relation_changed(self, event):
+        self.on.pools_changed.emit()
+
+    @property
+    def pools(self):
+        if self._member_pools is None:
+            self._member_pools = []
+            for relation in self.model.relations[self._relation_name]:
+                if not relation.units:
+                    continue
+                app_data = relation.data[relation.app]
+
+                listener_data = app_data.get('listener')
+                if listener_data is None:
+                    continue
+                listener = pickle.loads(listener_data.encode('utf-8'))
+                health_monitor_data = app_data.get('health_monitor')
+                if health_monitor_data is None:
+                    continue
+                health_monitor = pickle.loads(health_monitor_data.encode('utf-8'))
+
+                members = []
+                for unit in relation.units:
+                    member_data = relation.data[unit].get('member')
+                    if member_data is None:
+                        continue
+                    members.append(pickle.loads(member_data.encode('utf-8')))
+                self._member_pools.append(MemberPool(listener, members, health_monitor))
+        return self._member_pools
+
+
+class MemberPool:
+
+    '''A class that aggregates the information about a pool of load-balancer members'''
+
+    def __init__(self, listener, members, health_monitor=None):
+        self.members = members
+        self.listener = listener
+        self.health_monitor = health_monitor
+
+
+class LBAvailable(EventBase):
+
+    '''Event emitted by TcpLoadBalancer.on.lb_available.
+
+    This event will be emitted when a new load-balancer instance appears on a relation for a member
+    to expose its data. If a load-balancer is highly-available, there will be multiple of those
+    events fired as instances of the load-balancer are observed by the member.
+    '''
+    pass
+
+
+class TcpLoadBalancerEvents(EventSetBase):
+
+    '''Events emitted by the TcpLoadBalancer class.'''
+    lb_available = EventSource(LBAvailable)
+
+
+class TcpLoadBalancer(Object):
+
+    on = TcpLoadBalancerEvents()
+    _stored = StoredState()
+
+    def __init__(self, charm, relation_name, lb_algorithm=None):
+        super().__init__(charm, relation_name)
+        self._relation_name = relation_name
+        self._lb_algorithm = lb_algorithm
+
+        self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_joined)
+
+    def _on_relation_joined(self, event):
+        self.on.lb_available.emit()
+
+    @property
+    def _relation(self):
+        # TODO: there could be multiple independent reverse proxies in theory, address that later.
+        return self.model.get_relation(self._relation_name)
+
+    def expose_member(self, member, listener, health_monitor):
+        our_unit_data = self._relation.data[self.model.unit]
+        if member.address is None:
+            addr = self.model.get_binding(self._relation).network.ingress_address
+            member.set_address(addr)
+
+        our_unit_data['member'] = pickle.dumps(member, 0).decode('utf-8')
+        if self.model.unit.is_leader():
+            our_app_data = self._relation.data[self.model.app]
+            our_app_data['listener'] = pickle.dumps(listener, 0).decode('utf-8')
+            # A monitor for a pool of members.
+            our_app_data['health_monitor'] = pickle.dumps(health_monitor, 0).decode('utf-8')
+            our_app_data['lb_algorithm'] = self._lb_algorithm
+
+
+class Listener:
+
+    '''Listeners determine how load-balancer front-ends are configured.
+    '''
+
+    def __init__(self, name, port):
+        self.name = name
+        self.port = port
+
+
+class Member:
+
+    '''Members describe the details about a particular backend service instance.
+    '''
+
+    def __init__(self, name, port, *, address=None, monitor_port=None, weight=None,
+                 data_timeout=None):
+        self.name = name
+        self.port = port
+        self.address = address
+        self.monitor_port = monitor_port
+        self.weight = weight
+        self.data_timeout = data_timeout
+
+    def set_address(self, address):
+        self.address = address
+
+
+class HealthMonitor:
+
+    '''Health-monitors provide parameters for regular health-checking operations.
+    '''
+
+    def __init__(self, *, delay=None, timeout=None, max_retries=None, max_retries_down=None):
+        self.delay = delay
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.max_retries_down = max_retries_down
+
+
+class HTTPHealthMonitor(HealthMonitor):
+
+    '''HTTP health monitors provide parameters to perform health-checks over HTTP.
+    '''
+
+    def __init__(self, http_method=None, url_path=None, expected_codes=None, *args):
+        super().__init__(*args)
+        self.http_method = http_method
+        self.url_path = url_path
+        self.expected_codes = expected_codes

--- a/ops/lib/tcp_load_balancer/tcp_lb.py
+++ b/ops/lib/tcp_load_balancer/tcp_lb.py
@@ -65,7 +65,6 @@ import datetime
 from collections.abc import Mapping
 
 from ops.framework import Object, StoredState, EventBase, EventSetBase, EventSource
-
 logger = logging.getLogger(__name__)
 
 

--- a/ops/lib/tcp_load_balancer/tcp_lb.py
+++ b/ops/lib/tcp_load_balancer/tcp_lb.py
@@ -1,17 +1,3 @@
-# Copyright 2020 Canonical Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 """Implements types for provides and requires sides of the 'tcp-load-balancer' relation.
 
 `TcpBackendManager`_ is the type that exposes the information about members that a TCP
@@ -56,6 +42,20 @@ load-balancer should provide load-balancing for.
             health_monitor = HTTPHealthMonitor(timeout=timedelta(seconds=10), http_method='GET',
                                                url_path='/health?ready=1')
             self.tcp_lb.expose_backend(listener, backend, health_monitor)
+
+Copyright 2020 Canonical Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 """
 
 import logging

--- a/ops/lib/tcp_load_balancer/tcp_lb.py
+++ b/ops/lib/tcp_load_balancer/tcp_lb.py
@@ -14,28 +14,29 @@
 
 """Implements types for provides and requires sides of the 'tcp-load-balancer' relation.
 
-`TcpBackendManager`_ is the type that exposes the information about members that a TCP
-load-balancer should provide load-balancing for.
+`TCPBackendManager`_ is the type that exposes the information about members that a TCP
+load-balancer should provide load-balancing for::
 
-class MyLBCharm(ops.charm.CharmBase):
+    class MyLBCharm(ops.charm.CharmBase):
 
-   def __init__(self, *args):
-      super().__init__(*args)
-      self.tcp_backend_manager = TcpBackendManagers(self, 'tcp-lb')
-      self.framework.observe(self.tcp_backend_manager.on.pools_changed, self._on_tcp_pools_changed)
+       def __init__(self, *args):
+          super().__init__(*args)
+          self.tcp_backend_manager = TCPBackendManagers(self, 'tcp-lb')
+          self.framework.observe(self.tcp_backend_manager.on.pools_changed,
+                                 self._on_tcp_pools_changed)
 
-   def _on_tcp_pools_changed(self, event):
-       for pool in self.tcp_backend_manager.pools:
-           logger.debug(pool.listener.port)
-           logger.debug(pool.listener.name)
-           for member in pool.members:
-               logger.debug(member.port)
-               logger.debug(member.address)
-               # Access other fields...
+       def _on_tcp_pools_changed(self, event):
+           for pool in self.tcp_backend_manager.pools:
+               logger.debug(pool.listener.port)
+               logger.debug(pool.listener.name)
+               for member in pool.members:
+                   logger.debug(member.port)
+                   logger.debug(member.address)
+                   # Access other fields...
 
 
-`TcpLoadBalancer`_ is the type that exposes the information about members that a TCP
-load-balancer should provide load-balancing for.
+`TCPLoadBalancer`_ is the type that exposes the information about members that a TCP
+load-balancer should provide load-balancing for::
 
     class MyServiceCharm(ops.charm.CharmBase):
 
@@ -45,7 +46,7 @@ load-balancer should provide load-balancing for.
 
         def __init__(self, *args):
             super().__init__(*args)
-            self.tcp_lb = TcpLoadBalancer(self, 'tcp-lb', load_balancer_algorithm='round_robin')
+            self.tcp_lb = TCPLoadBalancer(self, 'tcp-lb', load_balancer_algorithm='round_robin')
             self.framework.observe(self.tcp_lb.on.load_balancer_available,
                                    self._on_load_balancer_available)
 
@@ -75,23 +76,23 @@ JSON_ENCODE_OPTIONS = dict(
 
 
 class PoolsChanged(EventBase):
-    """Event emitted by TcpBackendManagers.on.pools_changed.
+    """Event emitted by TCPBackendManagers.on.pools_changed.
 
     This event will be emitted if any of the existing or new members exposes new data over a
     relation for the load-balancer to re-assess its current state.
     """
 
 
-class TcpBackendManagerEvents(EventSetBase):
-    """Events emitted by the TcpBackendManager class."""
+class TCPBackendManagerEvents(EventSetBase):
+    """Events emitted by the TCPBackendManager class."""
 
     pools_changed = EventSource(PoolsChanged)
 
 
-class TcpBackendManager(Object):
+class TCPBackendManager(Object):
     """Handles TCP backend events and exposes pools of TCP backends."""
 
-    on = TcpBackendManagerEvents()
+    on = TCPBackendManagerEvents()
 
     _stored = StoredState()
 
@@ -155,19 +156,19 @@ class LoadBalancerAvailable(EventBase):
     """
 
 
-class TcpLoadBalancerEvents(EventSetBase):
-    """Events emitted by the TcpLoadBalancer class."""
+class TCPLoadBalancerEvents(EventSetBase):
+    """Events emitted by the TCPLoadBalancer class."""
 
     load_balancer_available = EventSource(LoadBalancerAvailable)
 
 
-class TcpLoadBalancer(Object):
+class TCPLoadBalancer(Object):
     """Represents a TCP load-balancer that distributes traffic across backends exposed to it.
 
     Backends would use this type to expose themselves to a single TCP load-balancer.
     """
 
-    on = TcpLoadBalancerEvents()
+    on = TCPLoadBalancerEvents()
     _stored = StoredState()
 
     def __init__(self, charm, relation_name, load_balancer_algorithm=None):
@@ -267,7 +268,7 @@ class HealthMonitor(InterfaceDataType):
         self.max_retries_down = max_retries_down
 
 
-class HttpHealthMonitor(HealthMonitor):
+class HTTPHealthMonitor(HealthMonitor):
     """HTTP health monitors provide parameters to perform health-checks over HTTP."""
 
     def __init__(self, http_method=None, url_path=None, expected_codes=None, *kwargs):

--- a/test/lib/tcp_load_balancer/test_tcp_lb.py
+++ b/test/lib/tcp_load_balancer/test_tcp_lb.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
 
-# Copyright 2020 Canonical Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+"""Unit tests for the tcp-load-balancer interface
+
+Copyright 2020 Canonical Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
 
 import unittest
 import datetime

--- a/test/lib/tcp_load_balancer/test_tcp_lb.py
+++ b/test/lib/tcp_load_balancer/test_tcp_lb.py
@@ -28,6 +28,7 @@ from ops.lib.tcp_load_balancer.tcp_lb import (
     HealthMonitor,
     TCPLoadBalancer,
     JSON_ENCODE_OPTIONS,
+    BalancingAlgorithm,
 )
 
 
@@ -80,7 +81,8 @@ class TestTCPBackendManager(unittest.TestCase):
         test_pool = pools[0]
         self.assertEqual(test_pool.listener.port, 80)
         self.assertEqual(test_pool.listener.name, 'tcp-server')
-        self.assertEqual(test_pool.listener.balancing_algorithm, 'least_connections')
+        self.assertEqual(test_pool.listener.balancing_algorithm,
+                         BalancingAlgorithm.LEAST_CONNECTIONS)
         self.assertEqual(test_pool.health_monitor.timeout, datetime.timedelta(seconds=10))
 
     def test_empty_pool(self):
@@ -140,7 +142,7 @@ class TestLoadBalancer(unittest.TestCase):
         self.harness.update_relation_data(
             relation_id, 'tcp-server/0', {'ingress-address': '192.0.2.1'})
 
-        listener = Listener('tcp-server', 80, 'round_robin')
+        listener = Listener('tcp-server', 80, BalancingAlgorithm.ROUND_ROBIN)
         backend = Backend(name='tcp-server-0.example', port=80, address='192.0.2.1')
         health_monitor = HealthMonitor(timeout=datetime.timedelta(seconds=10))
 

--- a/test/lib/tcp_load_balancer/test_tcp_lb.py
+++ b/test/lib/tcp_load_balancer/test_tcp_lb.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import pickle
+import datetime
+
+from ops.charm import CharmBase
+from ops.testing import Harness
+
+from ops.lib.tcp_load_balancer.tcp_lb import (
+    TcpMemberPools,
+    Listener,
+    Member,
+    HealthMonitor,
+    TcpLoadBalancer,
+)
+
+
+class TestTcpMemberPools(unittest.TestCase):
+
+    def setUp(self):
+        self.harness = Harness(CharmBase, meta='''
+            name: haproxy
+            provides:
+              tcp-lb:
+                interface: tcp-load-balancer
+        ''')
+
+        self.harness.begin()
+        self.tcp_member_pools = TcpMemberPools(self.harness.charm, 'tcp-lb')
+
+    def test_pools(self):
+        relation_id = self.harness.add_relation('tcp-lb', 'tcp-server')
+        self.harness.update_relation_data(
+            relation_id, 'haproxy/0', {'ingress-address': '192.0.2.1'})
+
+        self.harness.add_relation_unit(
+            relation_id, 'tcp-server/0', {
+                'ingress-address': '192.0.2.2',
+                'member': pickle.dumps(Member(name='tcp-server-0.example', port=80,
+                                              address='192.0.2.2'), 0).decode('utf-8')
+            })
+        self.harness.add_relation_unit(
+            relation_id, 'tcp-server/1', {
+                'ingress-address': '192.0.2.3',
+                'member': pickle.dumps(Member(name='tcp-server-1.example', port=80,
+                                              address='192.0.2.3'), 0).decode('utf-8')
+            })
+        self.harness.update_relation_data(relation_id, 'tcp-server', {
+            'listener': pickle.dumps(Listener('tcp-server', 80), 0).decode('utf-8'),
+            'health_monitor': pickle.dumps(
+                HealthMonitor(timeout=datetime.timedelta(seconds=10)), 0).decode('utf-8')
+        })
+
+        pools = self.tcp_member_pools.pools
+        test_pool = pools[0]
+        self.assertEqual(test_pool.listener.port, 80)
+        self.assertEqual(test_pool.listener.name, 'tcp-server')
+        self.assertEqual(test_pool.health_monitor.timeout, datetime.timedelta(seconds=10))
+
+
+class TestLoadBalancer(unittest.TestCase):
+
+    def setUp(self):
+        self.harness = Harness(CharmBase, meta='''
+            name: tcp-server
+            requires:
+              tcp-lb:
+                interface: tcp-load-balancer
+        ''')
+
+        self.harness.begin()
+        self.tcp_lb = TcpLoadBalancer(self.harness.charm, 'tcp-lb', 'round_robin')
+
+    def test_expose_member(self):
+        relation_id = self.harness.add_relation('tcp-lb', 'tcp-server')
+        self.harness.update_relation_data(
+            relation_id, 'tcp-server/0', {'ingress-address': '192.0.2.1'})
+
+        listener = Listener('tcp-server', 80)
+        member = Member(name='tcp-server-0.example', port=80, address='192.0.2.1')
+        health_monitor = HealthMonitor(timeout=datetime.timedelta(seconds=10))
+
+        self.tcp_lb.expose_member(member, listener, health_monitor)
+
+        rel = self.harness.charm.model.get_relation('tcp-lb')
+        self.assertEqual(rel.data[self.harness.charm.unit]['member'],
+                         pickle.dumps(member, 0).decode('utf-8'))
+        with self.assertRaises(KeyError):
+            rel.data[self.harness.charm.app]['listener']
+        with self.assertRaises(KeyError):
+            rel.data[self.harness.charm.app]['health_monitor'],
+
+        self.harness.set_leader()
+        self.tcp_lb.expose_member(member, listener, health_monitor)
+        self.assertEqual(rel.data[self.harness.charm.unit]['member'],
+                         pickle.dumps(member, 0).decode('utf-8'))
+        self.assertEqual(rel.data[self.harness.charm.app]['listener'],
+                         pickle.dumps(listener, 0).decode('utf-8'))
+        self.assertEqual(rel.data[self.harness.charm.app]['health_monitor'],
+                         pickle.dumps(health_monitor, 0).decode('utf-8'))
+        self.assertEqual(rel.data[self.harness.charm.app]['lb_algorithm'], 'round_robin')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/lib/tcp_load_balancer/test_tcp_lb.py
+++ b/test/lib/tcp_load_balancer/test_tcp_lb.py
@@ -22,16 +22,16 @@ from ops.charm import CharmBase
 from ops.testing import Harness
 
 from ops.lib.tcp_load_balancer.tcp_lb import (
-    TcpBackendManager,
+    TCPBackendManager,
     Listener,
     Backend,
     HealthMonitor,
-    TcpLoadBalancer,
+    TCPLoadBalancer,
     JSON_ENCODE_OPTIONS,
 )
 
 
-class TestTcpBackendManager(unittest.TestCase):
+class TestTCPBackendManager(unittest.TestCase):
 
     def setUp(self):
         self.harness = Harness(CharmBase, meta='''
@@ -42,7 +42,7 @@ class TestTcpBackendManager(unittest.TestCase):
         ''')
 
         self.harness.begin()
-        self.tcp_backend_manager = TcpBackendManager(self.harness.charm, 'tcp-lb')
+        self.tcp_backend_manager = TCPBackendManager(self.harness.charm, 'tcp-lb')
 
     def test_pools(self):
         relation_id = self.harness.add_relation('tcp-lb', 'tcp-server')
@@ -95,7 +95,7 @@ class TestLoadBalancer(unittest.TestCase):
         ''')
 
         self.harness.begin()
-        self.tcp_lb = TcpLoadBalancer(self.harness.charm, 'tcp-lb', 'round_robin')
+        self.tcp_lb = TCPLoadBalancer(self.harness.charm, 'tcp-lb', 'round_robin')
 
     def test_expose_backend(self):
         relation_id = self.harness.add_relation('tcp-lb', 'tcp-server')

--- a/test/lib/tcp_load_balancer/test_tcp_lb.py
+++ b/test/lib/tcp_load_balancer/test_tcp_lb.py
@@ -40,7 +40,6 @@ class TestTCPBackendManager(unittest.TestCase):
               tcp-lb:
                 interface: tcp-load-balancer
         ''')
-
         self.harness.begin()
         self.tcp_backend_manager = TCPBackendManager(self.harness.charm, 'tcp-lb')
 
@@ -93,7 +92,6 @@ class TestLoadBalancer(unittest.TestCase):
               tcp-lb:
                 interface: tcp-load-balancer
         ''')
-
         self.harness.begin()
         self.tcp_lb = TCPLoadBalancer(self.harness.charm, 'tcp-lb', 'round_robin')
 

--- a/test/lib/tcp_load_balancer/test_tcp_lb.py
+++ b/test/lib/tcp_load_balancer/test_tcp_lb.py
@@ -1,21 +1,18 @@
 #!/usr/bin/env python3
 
-"""Unit tests for the tcp-load-balancer interface
-
-Copyright 2020 Canonical Ltd.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2020 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import unittest
 import datetime


### PR DESCRIPTION
Implements types for provides and requires sides of the 'tcp-load-balancer' relation.

The main idea of this interface is to expose TCP members to a load-balancer and provide additional information about ports in-use, load-balancing algorithm and means of health-checking.