### PR TITLE
ops/framework.py: remove StoredStateChanged.

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -793,17 +793,7 @@ class Framework(Object):
             pdb.Pdb().set_trace(code_frame)
 
 
-class StoredStateChanged(EventBase):
-    pass
-
-
-class StoredStateEvents(EventSetBase):
-    changed = EventSource(StoredStateChanged)
-
-
 class StoredStateData(Object):
-
-    on = StoredStateEvents()
 
     def __init__(self, parent, attr_name):
         super().__init__(parent, attr_name)
@@ -870,7 +860,6 @@ class BoundStoredState:
                     key, type(value).__name__))
 
         self._data[key] = _unwrap_stored(self._data, value)
-        self.on.changed.emit()
 
     def set_default(self, **kwargs):
         """"Set the value of any given key if it has not already been set"""


### PR DESCRIPTION
The implementation was buggy. We can either fix it (pull #226), or we
can get rid of it.

We've had a general feeling that Charm.state should become Charm._stored
because other attributes shouldn't be peeking at it. And waiting for an
event indicating the state has changed is very much peeking at it.

Nothing inside our own framework depends on it, so for now it seems
possible to remove it.