### PR TITLE
ops/log.py: Default to DEBUG logging.

### DIFF
--- a/ops/log.py
+++ b/ops/log.py
@@ -18,7 +18,7 @@ import logging
 class JujuLogHandler(logging.Handler):
     """A handler for sending logs to Juju via juju-log."""
 
-    def __init__(self, model_backend, level=logging.INFO):
+    def __init__(self, model_backend, level=logging.DEBUG):
         super().__init__(level)
         self.model_backend = model_backend
 
@@ -29,15 +29,16 @@ class JujuLogHandler(logging.Handler):
 def setup_root_logging(model_backend, debug=False):
     """Setup python logging to forward messages to juju-log.
 
+    By default, logging is set to DEBUG level, and messages will be filtered by Juju.
+    Charmers can also set their own default log level with::
+
+      logging.getLogger().setLevel(logging.INFO)
+
     model_backend -- a ModelBackend to use for juju-log
-    debug -- if True, enable DEBUG level logging, and write logs to stderr as well as to juju-log.
+    debug -- if True, write logs to stderr as well as to juju-log.
     """
-    if debug:
-        level = logging.DEBUG
-    else:
-        level = logging.INFO
     logger = logging.getLogger()
-    logger.setLevel(level)
+    logger.setLevel(logging.DEBUG)
     logger.addHandler(JujuLogHandler(model_backend))
     if debug:
         handler = logging.StreamHandler()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -447,11 +447,16 @@ start:
             'INDICATOR_FILE': indicator_file
         }))
         fake_script(self, 'add-metric', 'exit 0')
+        fake_script(self, 'juju-log', 'exit 0')
         self._simulate_event(EventSpec(InstallEvent, 'install', charm_config=charm_config))
+        # Clear the calls during 'install'
+        fake_script_calls(self, clear=True)
         self._simulate_event(EventSpec(CollectMetricsEvent, 'collect_metrics',
                                        charm_config=charm_config))
-        self.assertEqual(fake_script_calls(self),
-                         [['add-metric', '--labels', 'bar=4.2', 'foo=42']])
+        self.assertEqual(
+            fake_script_calls(self),
+            [['juju-log', '--log-level', 'DEBUG', 'Emitting Juju event collect_metrics'],
+             ['add-metric', '--labels', 'bar=4.2', 'foo=42']])
 
     def test_logger(self):
         charm_config = base64.b64encode(pickle.dumps({


### PR DESCRIPTION
Pass DEBUG logging through to juju-log, and default to DEBUG level. That
way users can chose something different at runtime, if they actually
want/don't want to see DEBUG messages.
This goes along with https://github.com/juju/juju/pull/11476 which
changes Juju itself to default to not displaying DEBUG messages from
units.

This should address issue #198.
