### PR TITLE
ops/model.py: Unit.set_workload_version

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -183,6 +183,14 @@ class Unit:
                 'cannot determine leadership status for remote applications: {}'.format(self)
             )
 
+    def set_workload_version(self, version):
+        """Record the version of the software running as the workload.
+
+        This shouldn't be confused with the revision of the charm. This is informative only,
+        show in the output of 'juju status'.
+        """
+        self._backend.application_version_set(version)
+
 
 class LazyMapping(Mapping, ABC):
 
@@ -816,6 +824,9 @@ class ModelBackend:
 
     def action_fail(self, message=''):
         self._run('action-fail', message)
+
+    def application_version_set(self, version):
+        self._run('application-version-set', version)
 
     def juju_log(self, level, message):
         self._run('juju-log', '--log-level', level, message)

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -41,11 +41,14 @@ def fake_script(test_case, name, content):
 
 
 def fake_script_calls(test_case, clear=False):
-    with open(str(test_case.fake_script_path / 'calls.txt'), 'r+') as f:
-        calls = [line.split(';') for line in f.read().splitlines()]
-        if clear:
-            f.truncate(0)
-        return calls
+    try:
+        with open(str(test_case.fake_script_path / 'calls.txt'), 'r+') as f:
+            calls = [line.split(';') for line in f.read().splitlines()]
+            if clear:
+                f.truncate(0)
+            return calls
+    except FileNotFoundError:
+        return []
 
 
 class FakeScriptTest(unittest.TestCase):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -516,6 +516,11 @@ fi
         self.backend._leader_check_time = None
         self.assertTrue(self.model.unit.is_leader())
 
+    def test_workload_version(self):
+        fake_script(self, 'application-version-set', 'exit 0')
+        self.model.unit.set_workload_version('1.2.3')
+        self.assertEqual(fake_script_calls(self), [['application-version-set', '1.2.3']])
+
     def test_resources(self):
         meta = ops.charm.CharmMeta()
         meta.resources = {'foo': None, 'bar': None}
@@ -1153,6 +1158,19 @@ class TestModelBackend(unittest.TestCase):
         fake_script(self, 'action-log', 'exit 0')
         self.backend.action_log('progress: 42%')
         self.assertEqual(fake_script_calls(self), [['action-log', 'progress: 42%']])
+
+    def test_application_version_set(self):
+        fake_script(self, 'application-version-set', 'exit 0')
+        self.backend.application_version_set('1.2b3')
+        self.assertEqual(fake_script_calls(self), [['application-version-set', '1.2b3']])
+
+    def test_application_version_set_invalid(self):
+        fake_script(self, 'application-version-set', 'exit 0')
+        with self.assertRaises(TypeError):
+            self.backend.application_version_set(2)
+        with self.assertRaises(TypeError):
+            self.backend.application_version_set()
+        self.assertEqual(fake_script_calls(self), [])
 
     def test_juju_log(self):
         fake_script(self, 'juju-log', 'exit 0')


### PR DESCRIPTION
Interact with application-version-set. The naming of the command is
poor, internally in Juju it is UnitWorkloadVersion, and that feels more
appropriate to expose in the Operator model.