### PR TITLE
Stop test harness relation_ids raising KeyError

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -356,7 +356,7 @@ class _TestingModelBackend:
         self._unit_status = None
 
     def relation_ids(self, relation_name):
-        return self._relation_ids_map[relation_name]
+        return self._relation_ids_map.get(relation_name, [])
 
     def relation_list(self, relation_id):
         return self._relation_list_map[relation_id]

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -36,6 +36,17 @@ from ops.testing import Harness
 
 class TestHarness(unittest.TestCase):
 
+    def test_relation_ids(self):
+        # language=YAML
+        harness = Harness(CharmBase, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            ''')
+        backend = harness._backend
+        self.assertEqual(backend.relation_ids('db'), [])
+
     def test_add_relation(self):
         # language=YAML
         harness = Harness(CharmBase, meta='''


### PR DESCRIPTION
relation_ids from _TestingModelBackend should return an empty list if
there is no relation matching the supplied realtion_id (as per the
behaviour of the ModelBackend *1) instead of throwing a KeyError.

*1 https://github.com/canonical/operator/blob/master/ops/model.py#L699

fixes: #241