### PR TITLE
ops/model.py: Document public methods and types

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -337,8 +337,6 @@ class CharmBase(Object):
         key: Arbitrary key to distinguish this instance of CharmBase from another.
             Generally is None when initialized by the framework. For charms instantiated by
             main.main(), this is currenly None.
-    Attributes:
-        on: Defines all events that the Charm will fire.
     """
 
     on = CharmEvents()

--- a/ops/main.py
+++ b/ops/main.py
@@ -163,7 +163,7 @@ def main(charm_class):
     """
     charm_dir = _get_charm_dir()
 
-    model_backend = ops.model.ModelBackend()
+    model_backend = ops.model._ModelBackend()
     debug = ('JUJU_DEBUG' in os.environ)
     setup_root_logging(model_backend, debug=debug)
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -36,12 +36,12 @@ class Model:
     Attributes:
         unit: A :class:`Unit` that represents the unit that is running this code (eg yourself)
         app: A :class:`Application` that represents the application this unit is a part of.
-        relations: Mapping of {endpoint: [`:class:Relation`]} answering the question "what am I
-            currently related to". See also :meth:`.get_relation`
+        relations: Mapping of endpoint to list of :class:`Relation` answering the question
+            "what am I currently related to". See also :meth:`.get_relation`
         config: A dict of the config for the current application.
         resources: Access to resources for this charm. Use ``model.resources.fetch(resource_name)``
             to get the path on disk where the resource can be found.
-        storages: Mapping of {storage_name: :class:`Storage`} for the storage points defined in
+        storages: Mapping of storage_name to :class:`Storage` for the storage points defined in
             metadata.yaml
         pod: Used to get access to ``model.pod.set_spec`` to set the container specification
             for Kubernetes charms.
@@ -577,8 +577,8 @@ class RelationData(Mapping):
     """Represents the various data buckets of a given relation.
 
     Each unit and application involved in a relation has their own data bucket.
-    Eg: {entity: RelationDataContent}
-    Where entity can be either a :class:Unit or a :class:Application.
+    Eg: ``{entity: RelationDataContent}``
+    where entity can be either a :class:`Unit` or a :class:`Application`.
 
     Units can read and write their own data, and if they are the leader,
     they can read and write their application data. They are allowed to read
@@ -877,7 +877,7 @@ class TooManyRelatedAppsError(ModelError):
 
 
 class RelationDataError(ModelError):
-    """Raised by ``Relation.data[entity][value] = 'foo'`` if the data is invalid.
+    """Raised by ``Relation.data[entity][key] = 'foo'`` if the data is invalid.
 
     This is raised if you're either trying to set a value to something that isn't a string,
     or if you are trying to set a value in a bucket that you don't have access to. (eg,

--- a/ops/model.py
+++ b/ops/model.py
@@ -270,7 +270,8 @@ class Unit:
             return self._backend.is_leader()
         else:
             raise RuntimeError(
-                'cannot determine leadership status for remote applications: {}'.format(self)
+                'leadership status of remote units ({}) is not visible to other'
+                ' applications'.format(self)
             )
 
     def set_workload_version(self, version: str) -> None:

--- a/ops/model.py
+++ b/ops/model.py
@@ -584,7 +584,7 @@ class RelationData(Mapping):
     they can read and write their application data. They are allowed to read
     remote unit and application data.
 
-    This class should not be created directly. It should be accessed via:
+    This class should not be created directly. It should be accessed via
     :attr:`Relation.data`
     """
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import tempfile
 import time
+import typing
 import datetime
 import re
 import ipaddress
@@ -30,6 +31,21 @@ from subprocess import run, PIPE, CalledProcessError
 
 
 class Model:
+    """Represents the Juju Model as seen from this unit.
+
+    Attributes:
+        unit: A :class:`Unit` that represents the unit that is running this code (eg yourself)
+        app: A :class:`Application` that represents the application this unit is a part of.
+        relations: Mapping of {endpoint: [`:class:Relation`]} answering the question "what am I
+            currently related to". See also :meth:`.get_relation`
+        config: A dict of the config for the current application.
+        resources: Access to resources for this charm. Use ``model.resources.fetch(resource_name)``
+            to get the path on disk where the resource can be found.
+        storages: Mapping of {storage_name: :class:`Storage`} for the storage points defined in
+            metadata.yaml
+        pod: Used to get access to ``model.pod.set_spec`` to set the container specification
+            for Kubernetes charms.
+    """
 
     def __init__(self, unit_name, meta, backend):
         self._cache = _ModelCache(backend)
@@ -43,32 +59,51 @@ class Model:
         self.storages = StorageMapping(list(meta.storages), self._backend)
         self._bindings = BindingMapping(self._backend)
 
-    def get_unit(self, unit_name):
+    def get_unit(self, unit_name: str) -> 'Unit':
+        """Get an arbitrary unit by name.
+
+        Internally this uses a cache, so asking for the same unit two times will
+        return the same object.
+        """
         return self._cache.get(Unit, unit_name)
 
-    def get_app(self, app_name):
+    def get_app(self, app_name: str) -> 'Application':
+        """Get an application by name.
+
+        Internally this uses a cache, so asking for the same application two times will
+        return the same object.
+        """
         return self._cache.get(Application, app_name)
 
-    def get_relation(self, relation_name, relation_id=None):
+    def get_relation(
+            self, relation_name: str,
+            relation_id: typing.Optional[int] = None) -> 'Relation':
         """Get a specific Relation instance.
-
-        If relation_id is given, this will return that Relation instance.
 
         If relation_id is not given, this will return the Relation instance if the
         relation is established only once or None if it is not established. If this
         same relation is established multiple times the error TooManyRelatedAppsError is raised.
+
+        Parameters:
+            relation_name: The name of the endpoint for this charm
+            relation_id: An identifier for a specific relation. Used to disambiguate when a
+                given application has more than one relation on a given endpoint.
+        Raises:
+            TooManyRelatedAppsError: is raised if there is more than one relation to the
+                supplied relation_name and no relation_id was supplied
         """
         return self.relations._get_unique(relation_name, relation_id)
 
-    def get_binding(self, binding_key):
+    def get_binding(self, binding_key: typing.Union[str, 'Relation']) -> 'Binding':
         """Get a network space binding.
 
-        binding_key -- The relation name or instance to obtain bindings for.
-
-        If binding_key is a relation name, the method returns the default binding for that
-        relation. If a relation instance is provided, the method first looks up a more specific
-        binding for that specific relation ID, and if none is found falls back to the default
-        binding for the relation name.
+        Parameters:
+            binding_key -- The relation name or instance to obtain bindings for.
+        Returns:
+            If ``binding_key`` is a relation name, the method returns the default binding
+            for that relation. If a relation instance is provided, the method first looks
+            up a more specific binding for that specific relation ID, and if none is found
+            falls back to the default binding for the relation name.
         """
         return self._bindings.get(binding_key)
 
@@ -89,6 +124,16 @@ class _ModelCache:
 
 
 class Application:
+    """Represents a named application in the model.
+
+    This might be your application, or might be an application that you are related to.
+    Charmers should not instantiate Application objects directly, but should use
+    :meth:`Model.get_app` if they need a reference to a given application.
+
+    Attributes:
+        name: The name of this application (eg, 'mysql'). This name may differ from the name of
+            the charm, if the user has deployed it to a different name.
+    """
 
     def __init__(self, name, backend, cache):
         self.name = name
@@ -98,7 +143,23 @@ class Application:
         self._status = None
 
     @property
-    def status(self):
+    def status(self) -> 'StatusBase':
+        """Used to report or read the status of the overall application.
+
+        Can only be read and set by the lead unit of the application.
+
+        The status of remote units is always Unknown.
+
+        Raises:
+            RuntimeError: if you try to set the status of another application, or if you try to
+                set the status of this application as a unit that is not the leader.
+            InvalidStatusError: if you try to set the status to something that is not a
+                :class:`StatusBase`
+
+        Example::
+
+            self.model.app.status = BlockedStatus('I need a human to come help me')
+        """
         if not self._is_our_app:
             return UnknownStatus()
 
@@ -113,7 +174,7 @@ class Application:
         return self._status
 
     @status.setter
-    def status(self, value):
+    def status(self, value: 'StatusBase'):
         if not isinstance(value, StatusBase):
             raise InvalidStatusError(
                 'invalid value provided for application {} status: {}'.format(self, value)
@@ -133,6 +194,15 @@ class Application:
 
 
 class Unit:
+    """Represents a named unit in the model.
+
+    This might be your unit, another unit of your application, or a unit of another application
+    that you are related to.
+
+    Attributes:
+        name: The name of the unit (eg, 'mysql/0')
+        app: The Application the unit is a part of.
+    """
 
     def __init__(self, name, backend, cache):
         self.name = name
@@ -146,7 +216,19 @@ class Unit:
         self._status = None
 
     @property
-    def status(self):
+    def status(self) -> 'StatusBase':
+        """Used to report or read the status of a specific unit.
+
+        The status of any unit other than yourself is always Unknown.
+
+        Raises:
+            RuntimeError: if you try to set the status of a unit other than yourself.
+            InvalidStatusError: if you try to set the status to something other than
+                a :class:`StatusBase`
+        Example::
+
+            self.model.unit.status = MaintenanceStatus('reconfiguring the frobnicators')
+        """
         if not self._is_our_unit:
             return UnknownStatus()
 
@@ -158,7 +240,7 @@ class Unit:
         return self._status
 
     @status.setter
-    def status(self, value):
+    def status(self, value: 'StatusBase'):
         if not isinstance(value, StatusBase):
             raise InvalidStatusError(
                 'invalid value provided for unit {} status: {}'.format(self, value)
@@ -173,7 +255,15 @@ class Unit:
     def __repr__(self):
         return '<{}.{} {}>'.format(type(self).__module__, type(self).__name__, self.name)
 
-    def is_leader(self):
+    def is_leader(self) -> bool:
+        """Return whether this unit is the leader of its application.
+
+        This can only be called for your own unit.
+        Returns:
+            True if you are the leader, False otherwise
+        Raises:
+            RuntimeError: if called for a unit that is not yourself
+        """
         if self._is_our_unit:
             # This value is not cached as it is not guaranteed to persist for the whole duration
             # of a hook execution.
@@ -183,7 +273,7 @@ class Unit:
                 'cannot determine leadership status for remote applications: {}'.format(self)
             )
 
-    def set_workload_version(self, version):
+    def set_workload_version(self, version: str) -> None:
         """Record the version of the software running as the workload.
 
         This shouldn't be confused with the revision of the charm. This is informative only;
@@ -196,6 +286,11 @@ class Unit:
 
 
 class LazyMapping(Mapping, ABC):
+    """Represents a dict that isn't populated until it is accessed.
+
+    Charm authors should generally never need to use this directly, but it forms
+    the basis for many of the dicts that the framework tracks.
+    """
 
     _lazy_data = None
 
@@ -227,7 +322,7 @@ class LazyMapping(Mapping, ABC):
 
 
 class RelationMapping(Mapping):
-    """Map of relation names to lists of Relation instances."""
+    """Map of relation names to lists of :class:`Relation` instances."""
 
     def __init__(self, relations_meta, our_unit, backend, cache):
         self._peers = set()
@@ -260,6 +355,12 @@ class RelationMapping(Mapping):
         return relation_list
 
     def _invalidate(self, relation_name):
+        """Used to wipe the cache of a given relation_name.
+
+        Not meant to be used by Charm authors. The content of relation data is
+        static for the lifetime of a hook, so it is safe to cache in memory once
+        accessed.
+        """
         self._data[relation_name] = None
 
     def _get_unique(self, relation_name, relation_id=None):
@@ -288,12 +389,21 @@ class RelationMapping(Mapping):
 
 
 class BindingMapping:
+    """Mapping of endpoints to network bindings.
+
+    Charm authors should instantiate this directly, but access it via
+    :meth:`Model.get_binding`
+    """
 
     def __init__(self, backend):
         self._backend = backend
         self._data = {}
 
-    def get(self, binding_key):
+    def get(self, binding_key: typing.Union[str, 'Relation']) -> 'Binding':
+        """Get a specific Binding for an endpoint/relation.
+
+        Not used directly by Charm authors. See :meth:`Model.get_binding`
+        """
         if isinstance(binding_key, Relation):
             binding_name = binding_key.name
             relation_id = binding_key.id
@@ -311,7 +421,11 @@ class BindingMapping:
 
 
 class Binding:
-    """Binding to a network space."""
+    """Binding to a network space.
+
+    Attributes:
+        name: The name of the endpoint this binding represents (eg, 'db')
+    """
 
     def __init__(self, name, relation_id, backend):
         self.name = name
@@ -320,7 +434,8 @@ class Binding:
         self._network = None
 
     @property
-    def network(self):
+    def network(self) -> 'Network':
+        """The network information for this binding."""
         if self._network is None:
             try:
                 self._network = Network(self._backend.network_get(self.name, self._relation_id))
@@ -334,9 +449,24 @@ class Binding:
 
 
 class Network:
-    """Network space details."""
+    """Network space details.
 
-    def __init__(self, network_info):
+    Attributes:
+        interfaces: A list of :class:`NetworkInterface` details. This includes the
+            information about how your application should be configured (eg, what
+            IP addresses should you bind to.)
+            Note that multiple addresses for a single interface are represented as multiple
+            interfaces. (eg, ``[NetworKInfo('ens1', '10.1.1.1/32'),
+            NetworkInfo('ens1', '10.1.2.1/32'])``)
+        ingress_addresses: A list of :class:`ipaddress.ip_address` objects representing the IP
+            addresses that other units should use to get in touch with you.
+        egress_subnets: A list of :class:`ipaddress.ip_network` representing the subnets that
+            other units will see you connecting from. Due to things like NAT it isn't always
+            possible to narrow it down to a single address, but when it is clear, the CIDRs
+            will be constrained to a single address. (eg, 10.0.0.1/32)
+    """
+
+    def __init__(self, network_info: dict):
         self.interfaces = []
         # Treat multiple addresses on an interface as multiple logical
         # interfaces with the same name.
@@ -353,16 +483,38 @@ class Network:
 
     @property
     def bind_address(self):
+        """A single address that your application should bind() to.
+
+        For the common case where there is a single answer. This represents a single
+        address from :attr:`.interfaces` that can be used to configure where your
+        application should bind() and listen().
+        """
         return self.interfaces[0].address
 
     @property
     def ingress_address(self):
+        """The address other applications should use to connect to your unit.
+
+        Due to things like public/private addresses, NAT and tunneling, the address you bind()
+        to is not always the address other people can use to connect() to you.
+        This is just the first address from :attr:`.ingress_addresses`.
+        """
         return self.ingress_addresses[0]
 
 
 class NetworkInterface:
+    """Represents a single network interface that the charm needs to know about.
 
-    def __init__(self, name, address_info):
+    Charmers should not instantiate this type directly. Instead use :meth:`Model.get_binding`
+    to get the network information for a given endpoint.
+
+    Attributes:
+        name: The name of the interface (eg. 'eth0', or 'ens1')
+        subnet: An :class:`ipaddress.ip_network` representation of the IP for the network
+            interface. This may be a single address (eg '10.0.1.2/32')
+    """
+
+    def __init__(self, name: str, address_info: dict):
         self.name = name
         # TODO: expose a hardware address here, see LP: #1864070.
         self.address = ipaddress.ip_address(address_info['value'])
@@ -377,7 +529,24 @@ class NetworkInterface:
 
 
 class Relation:
-    def __init__(self, relation_name, relation_id, is_peer, our_unit, backend, cache):
+    """Represents an established relation between this application and another application.
+
+    This class should not be instantiated directly, instead use :meth:`Model.get_relation`
+    or :attr:`RelationEvent.relation`.
+
+    Attributes:
+        name: The name of the local endpoint of the relation (eg 'db')
+        id: The identifier for a particular relation (integer)
+        app: An :class:`Application` representing the remote application of this relation.
+            For peer relations this will be the local application.
+        units: A set of :class:`Unit` for units that have started and joined this relation.
+        data: A :class:`RelationData` holding the data buckets for each entity
+            of a relation. Accessed via eg Relation.data[unit]['foo']
+    """
+
+    def __init__(
+            self, relation_name: str, relation_id: int, is_peer: bool, our_unit: Unit,
+            backend: '_ModelBackend', cache: '_ModelCache'):
         self.name = relation_name
         self.id = relation_id
         self.app = None
@@ -405,7 +574,21 @@ class Relation:
 
 
 class RelationData(Mapping):
-    def __init__(self, relation, our_unit, backend):
+    """Represents the various data buckets of a given relation.
+
+    Each unit and application involved in a relation has their own data bucket.
+    Eg: {entity: RelationDataContent}
+    Where entity can be either a :class:Unit or a :class:Application.
+
+    Units can read and write their own data, and if they are the leader,
+    they can read and write their application data. They are allowed to read
+    remote unit and application data.
+
+    This class should not be created directly. It should be accessed via:
+    :attr:`Relation.data`
+    """
+
+    def __init__(self, relation: Relation, our_unit: Unit, backend: '_ModelBackend'):
         self.relation = weakref.proxy(relation)
         self._data = {
             our_unit: RelationDataContent(self.relation, our_unit, backend),
@@ -498,11 +681,15 @@ class ConfigData(LazyMapping):
 
 
 class StatusBase:
-    """Status values specific to applications and units."""
+    """Status values specific to applications and units.
+
+    To access a status by name, see :meth:`StatusBase.from_name`, most use cases will just
+    directly use the child class to indicate their status.
+    """
 
     _statuses = {}
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         self.message = message
 
     def __new__(cls, *args, **kwargs):
@@ -523,7 +710,7 @@ class ActiveStatus(StatusBase):
     """
     name = 'active'
 
-    def __init__(self, message=None):
+    def __init__(self, message: typing.Optional[str] = None):
         super().__init__(message or '')
 
 
@@ -574,11 +761,11 @@ class Resources:
     """Object representing resources for the charm.
     """
 
-    def __init__(self, names, backend):
+    def __init__(self, names: typing.Iterable[str], backend: '_ModelBackend'):
         self._backend = backend
         self._paths = {name: None for name in names}
 
-    def fetch(self, name):
+    def fetch(self, name: str) -> Path:
         """Fetch the resource from the controller or store.
 
         If successfully fetched, this returns a Path object to where the resource is stored
@@ -592,10 +779,24 @@ class Resources:
 
 
 class Pod:
-    def __init__(self, backend):
+    """Represents the definition of a pod spec in Kubernetes models.
+
+    Currently only supports simple access to setting the Juju pod spec via :attr:`.set_spec`.
+    """
+
+    def __init__(self, backend: '_ModelBackend'):
         self._backend = backend
 
-    def set_spec(self, spec, k8s_resources=None):
+    def set_spec(self, spec: typing.Mapping, k8s_resources: typing.Mapping = None):
+        """Set the specification for pods that Juju should start in kubernetes.
+
+        See `juju help-tool pod-spec-set` for details of what should be passed.
+        Args:
+            spec: The mapping defining the pod specification
+            k8s_resources: Additional kubernetes specific specification.
+
+        Returns:
+        """
         if not self._backend.is_leader():
             raise ModelError('cannot set a pod spec as this unit is not a leader')
         self._backend.pod_spec_set(spec, k8s_resources)
@@ -604,11 +805,11 @@ class Pod:
 class StorageMapping(Mapping):
     """Map of storage names to lists of Storage instances."""
 
-    def __init__(self, storage_names, backend):
+    def __init__(self, storage_names: typing.Iterable[str], backend: '_ModelBackend'):
         self._backend = backend
         self._storage_map = {storage_name: None for storage_name in storage_names}
 
-    def __contains__(self, key):
+    def __contains__(self, key: str):
         return key in self._storage_map
 
     def __len__(self):
@@ -617,7 +818,7 @@ class StorageMapping(Mapping):
     def __iter__(self):
         return iter(self._storage_map)
 
-    def __getitem__(self, storage_name):
+    def __getitem__(self, storage_name: str) -> typing.List['Storage']:
         storage_list = self._storage_map[storage_name]
         if storage_list is None:
             storage_list = self._storage_map[storage_name] = []
@@ -625,7 +826,7 @@ class StorageMapping(Mapping):
                 storage_list.append(Storage(storage_name, storage_id, self._backend))
         return storage_list
 
-    def request(self, storage_name, count=1):
+    def request(self, storage_name: str, count: int = 1):
         """Requests new storage instances of a given name.
 
         Uses storage-add tool to request additional storage. Juju will notify the unit
@@ -638,6 +839,12 @@ class StorageMapping(Mapping):
 
 
 class Storage:
+    """"Represents a storage as defined in metadata.yaml
+
+    Attributes:
+        name: Simple string name of the storage
+        id: The provider id for storage
+    """
 
     def __init__(self, storage_name, storage_id, backend):
         self.name = storage_name
@@ -654,10 +861,13 @@ class Storage:
 
 
 class ModelError(Exception):
+    """Base class for exceptions raised when interacting with the Model."""
     pass
 
 
 class TooManyRelatedAppsError(ModelError):
+    """Raised by :meth:`Model.get_relation` if there is more than one related application."""
+
     def __init__(self, relation_name, num_related, max_supported):
         super().__init__('Too many remote applications on {} ({} > {})'.format(
             relation_name, num_related, max_supported))
@@ -667,18 +877,28 @@ class TooManyRelatedAppsError(ModelError):
 
 
 class RelationDataError(ModelError):
-    pass
+    """Raised by ``Relation.data[entity][value] = 'foo'`` if the data is invalid.
+
+    This is raised if you're either trying to set a value to something that isn't a string,
+    or if you are trying to set a value in a bucket that you don't have access to. (eg,
+    another application/unit or setting your application data but you aren't the leader.)
+    """
 
 
 class RelationNotFoundError(ModelError):
-    pass
+    """Backend error when querying juju for a given relation and that relation doesn't exist."""
 
 
 class InvalidStatusError(ModelError):
-    pass
+    """Raised if trying to set an Application or Unit status to something invalid."""
 
 
-class ModelBackend:
+class _ModelBackend:
+    """Represents the connection between the Model representation and talking to Juju.
+
+    Charm authors should not directly interact with the ModelBackend, it is a private
+    implementation of Model.
+    """
 
     LEASE_RENEWAL_PERIOD = datetime.timedelta(seconds=30)
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -84,7 +84,7 @@ class Model:
         relation is established only once or None if it is not established. If this
         same relation is established multiple times the error TooManyRelatedAppsError is raised.
 
-        Parameters:
+        Args:
             relation_name: The name of the endpoint for this charm
             relation_id: An identifier for a specific relation. Used to disambiguate when a
                 given application has more than one relation on a given endpoint.
@@ -97,8 +97,8 @@ class Model:
     def get_binding(self, binding_key: typing.Union[str, 'Relation']) -> 'Binding':
         """Get a network space binding.
 
-        Parameters:
-            binding_key -- The relation name or instance to obtain bindings for.
+        Args:
+            binding_key: The relation name or instance to obtain bindings for.
         Returns:
             If ``binding_key`` is a relation name, the method returns the default binding
             for that relation. If a relation instance is provided, the method first looks
@@ -392,7 +392,7 @@ class RelationMapping(Mapping):
 class BindingMapping:
     """Mapping of endpoints to network bindings.
 
-    Charm authors should instantiate this directly, but access it via
+    Charm authors should not instantiate this directly, but access it via
     :meth:`Model.get_binding`
     """
 
@@ -452,6 +452,9 @@ class Binding:
 class Network:
     """Network space details.
 
+    Charm authors should not instantiate this directly, but should get access to the Network
+    definition from :meth:`Model.get_binding` and its ``network`` attribute.
+
     Attributes:
         interfaces: A list of :class:`NetworkInterface` details. This includes the
             information about how your application should be configured (eg, what
@@ -465,6 +468,8 @@ class Network:
             other units will see you connecting from. Due to things like NAT it isn't always
             possible to narrow it down to a single address, but when it is clear, the CIDRs
             will be constrained to a single address. (eg, 10.0.0.1/32)
+    Args:
+        network_info: A dict of network information as returned by ``network-get``.
     """
 
     def __init__(self, network_info: dict):
@@ -1008,16 +1013,18 @@ class _ModelBackend:
     def status_get(self, *, is_app=False):
         """Get a status of a unit or an application.
 
-        app -- A boolean indicating whether the status should be retrieved for a unit
-               or an application.
+        Args:
+            is_app: A boolean indicating whether the status should be retrieved for a unit
+                or an application.
         """
         return self._run('status-get', '--include-data', '--application={}'.format(is_app))
 
     def status_set(self, status, message='', *, is_app=False):
         """Set a status of a unit or an application.
 
-        app -- A boolean indicating whether the status should be set for a unit or an
-               application.
+        Args:
+            app: A boolean indicating whether the status should be set for a unit or an
+                application.
         """
         if not isinstance(is_app, bool):
             raise TypeError('is_app parameter must be boolean')
@@ -1058,8 +1065,9 @@ class _ModelBackend:
     def network_get(self, binding_name, relation_id=None):
         """Return network info provided by network-get for a given binding.
 
-        binding_name -- A name of a binding (relation name or extra-binding name).
-        relation_id -- An optional relation id to get network info for.
+        Args:
+            binding_name: A name of a binding (relation name or extra-binding name).
+            relation_id: An optional relation id to get network info for.
         """
         cmd = ['network-get', binding_name]
         if relation_id is not None:

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -26,7 +26,7 @@ from ops.charm import (
     CharmEvents,
 )
 from ops.framework import Framework, EventSource, EventBase
-from ops.model import Model, ModelBackend
+from ops.model import Model, _ModelBackend
 
 from .test_helpers import fake_script, fake_script_calls
 
@@ -61,7 +61,7 @@ class TestCharm(unittest.TestCase):
         self.addCleanup(cleanup)
 
     def create_framework(self):
-        model = Model('local/0', self.meta, ModelBackend())
+        model = Model('local/0', self.meta, _ModelBackend())
         framework = Framework(self.tmpdir / "framework.data", self.tmpdir, self.meta, model)
         self.addCleanup(framework.close)
         return framework

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -1385,7 +1385,7 @@ def create_model(testcase):
     patcher.start()
     testcase.addCleanup(patcher.stop)
 
-    backend = model.ModelBackend()
+    backend = model._ModelBackend()
     meta = charm.CharmMeta()
     test_model = model.Model('myapp/0', meta, backend)
     return test_model

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -37,7 +37,7 @@ class TestModel(unittest.TestCase):
 
         os.environ['JUJU_UNIT_NAME'] = 'myapp/0'
 
-        self.backend = ops.model.ModelBackend()
+        self.backend = ops.model._ModelBackend()
         meta = ops.charm.CharmMeta()
         meta.relations = {
             'db0': RelationMeta('provides', 'db0', {'interface': 'db0', 'scope': 'global'}),
@@ -405,7 +405,7 @@ fi
         ])
 
     def test_relation_get_set_is_app_arg(self):
-        self.backend = ops.model.ModelBackend()
+        self.backend = ops.model._ModelBackend()
 
         # No is_app provided.
         with self.assertRaises(TypeError):
@@ -479,7 +479,7 @@ fi
         check_remote_units()
 
         # Create a new model and backend to drop a cached is-leader output.
-        self.backend = ops.model.ModelBackend()
+        self.backend = ops.model._ModelBackend()
         meta = ops.charm.CharmMeta()
         meta.relations = {
             'db0': RelationMeta('provides', 'db0', {'interface': 'db0', 'scope': 'global'}),
@@ -580,7 +580,7 @@ fi
         check_calls(fake_calls)
 
         # Create a new model to drop is-leader caching result.
-        self.backend = ops.model.ModelBackend()
+        self.backend = ops.model._ModelBackend()
         meta = ops.charm.CharmMeta()
         self.model = ops.model.Model('myapp/0', meta, self.backend)
         fake_script(self, 'is-leader', 'echo false')
@@ -690,7 +690,7 @@ fi
         ])
 
     def test_status_set_is_app_not_bool_raises(self):
-        self.backend = ops.model.ModelBackend()
+        self.backend = ops.model._ModelBackend()
 
         for is_app_v in [None, 1, 2.0, 'a', b'beef', object]:
             with self.assertRaises(TypeError):
@@ -827,7 +827,7 @@ class TestModelBindings(unittest.TestCase):
             'db1': RelationMeta('requires', 'db1', {'interface': 'db1', 'scope': 'global'}),
             'db2': RelationMeta('peers', 'db2', {'interface': 'db2', 'scope': 'global'}),
         }
-        self.backend = ops.model.ModelBackend()
+        self.backend = ops.model._ModelBackend()
         self.model = ops.model.Model('myapp/0', meta, self.backend)
 
         fake_script(self, 'relation-ids',
@@ -969,7 +969,7 @@ class TestModelBackend(unittest.TestCase):
     @property
     def backend(self):
         if self._backend is None:
-            self._backend = ops.model.ModelBackend()
+            self._backend = ops.model._ModelBackend()
         return self._backend
 
     def test_relation_tool_errors(self):


### PR DESCRIPTION
Make ModelBackend a private class (_ModelBackend), because it isn't
something we want charmers to directly engage with anyway.