### PR TITLE
ops/main: handle dispatch being a shim 

### DIFF
--- a/ops/main.py
+++ b/ops/main.py
@@ -172,10 +172,11 @@ class _JujuEvent:
     def __init__(self, charm_dir: Path):
         self._charm_dir = charm_dir
         self._exec_path = Path(sys.argv[0])
-        if self._exec_path.is_symlink() and self._exec_path.name != 'dispatch':
-            self._init_legacy()
-        else:
+
+        if 'JUJU_DISPATCH_PATH' in os.environ:
             self._init_dispatch()
+        else:
+            self._init_legacy()
 
     def ensure_event_links(self, charm):
         if self.is_dispatch:
@@ -237,9 +238,6 @@ class _JujuEvent:
         self._set_name_from_path(self._exec_path)
 
     def _init_dispatch(self):
-        if 'JUJU_DISPATCH_PATH' not in os.environ:
-            logger.critical("Charm called via dispatch but no JUJU_DISPATCH_PATH set.")
-            sys.exit(1)
         self._dispatch_path = Path(os.environ['JUJU_DISPATCH_PATH'])
 
         if 'OPERATOR_DISPATCH' in os.environ:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -528,7 +528,7 @@ class TestMainWithNoDispatch(TestMain, unittest.TestCase):
                 hook_path = self.JUJU_CHARM_DIR / event_hook
                 self.assertTrue(hook_path.exists(), 'Missing hook: ' + event_hook)
                 if self.hooks_are_symlinks:
-                    self.assertEqual(os.readlink(hook_path), self.charm_exec_path)
+                    self.assertEqual(os.readlink(str(hook_path)), self.charm_exec_path)
 
         for initial_event in initial_events:
             self._setup_charm_dir()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -652,23 +652,22 @@ class TestMainWithDispatch(TestMain, unittest.TestCase):
                     hook_path.unlink()
 
 
-# TODO: this does not work
-# class TestMainWithDispatchAsScript(TestMainWithDispatch):
-#     """Here dispatch is a script that execs the charm.py instead of a symlink.
-#     """
-#     def _setup_entry_point(self, directory, entry_point):
-#         path = self.JUJU_CHARM_DIR / 'dispatch'
-#         if not path.exists():
-#             path.write_text('#!/bin/sh\nexec "{}" "{}"\n'.format(
-#                 sys.executable,
-#                 self.JUJU_CHARM_DIR / 'src/charm.py'))
-#             path.chmod(0o755)
+class TestMainWithDispatchAsScript(TestMainWithDispatch):
+    """Here dispatch is a script that execs the charm.py instead of a symlink.
+    """
+    def _setup_entry_point(self, directory, entry_point):
+        path = self.JUJU_CHARM_DIR / 'dispatch'
+        if not path.exists():
+            path.write_text('#!/bin/sh\nexec "{}" "{}"\n'.format(
+                sys.executable,
+                self.JUJU_CHARM_DIR / 'src/charm.py'))
+            path.chmod(0o755)
 
-#     def _call_event(self, rel_path, env):
-#         env["JUJU_DISPATCH_PATH"] = str(rel_path)
-#         dispatch = self.JUJU_CHARM_DIR / 'dispatch'
-#         subprocess.check_call([str(dispatch)],
-#                               env=env, cwd=str(self.JUJU_CHARM_DIR))
+    def _call_event(self, rel_path, env):
+        env["JUJU_DISPATCH_PATH"] = str(rel_path)
+        dispatch = self.JUJU_CHARM_DIR / 'dispatch'
+        subprocess.check_call([str(dispatch)],
+                              env=env, cwd=str(self.JUJU_CHARM_DIR))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Without this change we supported `dispatch` being a symlink to the main charm file. However, the real power of dispatch comes from being able to be a shim to the charm code, so this change enables that.