### PR TITLE
ops/model: cover app.status and unit.status better

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -97,6 +97,9 @@ class Application:
         self._is_our_app = self.name == self._backend.app_name
         self._status = None
 
+    def _invalidate(self):
+        self._status = None
+
     @property
     def status(self):
         if not self._is_our_app:
@@ -143,6 +146,9 @@ class Unit:
         self._backend = backend
         self._cache = cache
         self._is_our_unit = self.name == self._backend.unit_name
+        self._status = None
+
+    def _invalidate(self):
         self._status = None
 
     @property
@@ -511,6 +517,14 @@ class StatusBase:
         cls._statuses[cls.name] = cls
         return super().__new__(cls)
 
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return False
+        return self.message == other.message
+
+    def __repr__(self):
+        return "{.__class__.__name__}({!r})".format(self, self.message)
+
     @classmethod
     def from_name(cls, name, message):
         return cls._statuses[name](message)
@@ -558,6 +572,9 @@ class UnknownStatus(StatusBase):
     def __init__(self):
         # Unknown status cannot be set and does not have a message associated with it.
         super().__init__('')
+
+    def __repr__(self):
+        return "UnknownStatus()"
 
 
 class WaitingStatus(StatusBase):

--- a/ops/model.py
+++ b/ops/model.py
@@ -508,7 +508,7 @@ class StatusBase:
 
     _statuses = {}
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         self.message = message
 
     def __new__(cls, *args, **kwargs):
@@ -526,8 +526,29 @@ class StatusBase:
         return "{.__class__.__name__}({!r})".format(self, self.message)
 
     @classmethod
-    def from_name(cls, name, message):
-        return cls._statuses[name](message)
+    def from_name(cls, name: str, message: str):
+        if name == 'unknown':
+            # unknown is special
+            return UnknownStatus()
+        else:
+            return cls._statuses[name](message)
+
+
+class UnknownStatus(StatusBase):
+    """The unit status is unknown.
+
+    A unit-agent has finished calling install, config-changed and start, but the
+    charm has not called status-set yet.
+
+    """
+    name = 'unknown'
+
+    def __init__(self):
+        # Unknown status cannot be set and does not have a message associated with it.
+        super().__init__('')
+
+    def __repr__(self):
+        return "UnknownStatus()"
 
 
 class ActiveStatus(StatusBase):
@@ -537,8 +558,8 @@ class ActiveStatus(StatusBase):
     """
     name = 'active'
 
-    def __init__(self, message=None):
-        super().__init__(message or '')
+    def __init__(self, message=''):
+        super().__init__(message)
 
 
 class BlockedStatus(StatusBase):
@@ -558,23 +579,6 @@ class MaintenanceStatus(StatusBase):
 
     """
     name = 'maintenance'
-
-
-class UnknownStatus(StatusBase):
-    """The unit status is unknown.
-
-    A unit-agent has finished calling install, config-changed and start, but the
-    charm has not called status-set yet.
-
-    """
-    name = 'unknown'
-
-    def __init__(self):
-        # Unknown status cannot be set and does not have a message associated with it.
-        super().__init__('')
-
-    def __repr__(self):
-        return "UnknownStatus()"
 
 
 class WaitingStatus(StatusBase):

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -429,9 +429,7 @@ class _TestingModelBackend:
         self._is_leader = False
         self._resources_map = {}
         self._pod_spec = None
-        # TODO: (jam 2020-05-08) Default _app_status and _unit_status to UnknownStatus
-        self._app_status = None
-        self._unit_status = None
+        self._app_status = self._unit_status = {'status': 'unknown', 'message': ''}
         self._workload_version = None
 
     def relation_ids(self, relation_name):
@@ -492,9 +490,9 @@ class _TestingModelBackend:
 
     def status_set(self, status, message='', *, is_app=False):
         if is_app:
-            self._app_status = (status, message)
+            self._app_status = {'status': status, 'message': message}
         else:
-            self._unit_status = (status, message)
+            self._unit_status = {'status': status, 'message': message}
 
     def storage_list(self, name):
         raise NotImplementedError(self.storage_list)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -429,7 +429,8 @@ class _TestingModelBackend:
         self._is_leader = False
         self._resources_map = {}
         self._pod_spec = None
-        self._app_status = self._unit_status = {'status': 'unknown', 'message': ''}
+        self._app_status = {'status': 'unknown', 'message': ''}
+        self._unit_status = {'status': 'maintenance', 'message': ''}
         self._workload_version = None
 
     def relation_ids(self, relation_name):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -30,6 +30,8 @@ from ops.framework import (
 )
 from ops.model import (
     ActiveStatus,
+    MaintenanceStatus,
+    UnknownStatus,
     ModelError,
     RelationNotFoundError,
 )
@@ -669,6 +671,26 @@ class TestHarness(unittest.TestCase):
              ('status_set', 'active', 'message', {'is_app': True})],
             harness._get_backend_calls())
 
+    def test_unit_status(self):
+        harness = Harness(CharmBase, meta='name: test-app')
+        harness.set_leader(True)
+        harness.begin()
+        # default status
+        self.assertEqual(harness.model.unit.status, MaintenanceStatus(''))
+        status = ActiveStatus('message')
+        harness.model.unit.status = status
+        self.assertEqual(harness.model.unit.status, status)
+
+    def test_app_status(self):
+        harness = Harness(CharmBase, meta='name: test-app')
+        harness.set_leader(True)
+        harness.begin()
+        # default status
+        self.assertEqual(harness.model.app.status, UnknownStatus())
+        status = ActiveStatus('message')
+        harness.model.app.status = status
+        self.assertEqual(harness.model.app.status, status)
+
 
 class DBRelationChangedHelper(Object):
     def __init__(self, parent, key):
@@ -788,7 +810,7 @@ class TestTestingModelBackend(unittest.TestCase):
             {'status': 'blocked', 'message': 'message'})
         self.assertEqual(
             backend.status_get(is_app=False),
-            {'status': 'unknown', 'message': ''})
+            {'status': 'maintenance', 'message': ''})
 
     def test_relation_ids_unknown_relation(self):
         harness = Harness(CharmBase, meta='''

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -770,8 +770,12 @@ class TestTestingModelBackend(unittest.TestCase):
             ''')
         backend = harness._backend
         backend.status_set('blocked', 'message', is_app=False)
-        self.assertEqual(backend.status_get(is_app=False), ('blocked', 'message'))
-        self.assertEqual(backend.status_get(is_app=True), None)
+        self.assertEqual(
+            backend.status_get(is_app=False),
+            {'status': 'blocked', 'message': 'message'})
+        self.assertEqual(
+            backend.status_get(is_app=True),
+            {'status': 'unknown', 'message': ''})
 
     def test_status_set_get_app(self):
         harness = Harness(CharmBase, meta='''
@@ -779,8 +783,12 @@ class TestTestingModelBackend(unittest.TestCase):
             ''')
         backend = harness._backend
         backend.status_set('blocked', 'message', is_app=True)
-        self.assertEqual(backend.status_get(is_app=True), ('blocked', 'message'))
-        self.assertEqual(backend.status_get(is_app=False), None)
+        self.assertEqual(
+            backend.status_get(is_app=True),
+            {'status': 'blocked', 'message': 'message'})
+        self.assertEqual(
+            backend.status_get(is_app=False),
+            {'status': 'unknown', 'message': ''})
 
     def test_relation_ids_unknown_relation(self):
         harness = Harness(CharmBase, meta='''


### PR DESCRIPTION
This also refactors some things to make statuses easier to test with.

Based on #264, obviously :-)