### PR TITLE
ops.framework: Remove default target for Framework.observe

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -643,6 +643,11 @@ class Framework(Object):
                 'Framework.observe requires a BoundEvent as second parameter, got {}'.format(
                     bound_event))
         if not isinstance(observer, types.MethodType):
+            # help users of older versions of the framework
+            if isinstance(observer, charm.CharmBase):
+                raise TypeError(
+                    'observer methods must now be explicitly provided,'
+                    ' please replace observe(…, self) with observe(…, self._on_…)')
             raise RuntimeError(
                 'Framework.observe requires a method as third parameter, got {}'.format(observer))
 

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -72,31 +72,31 @@ class Charm(CharmBase):
                 'observed_event_types': [],
             }
 
-        self.framework.observe(self.on.install, self)
-        self.framework.observe(self.on.start, self)
-        self.framework.observe(self.on.config_changed, self)
-        self.framework.observe(self.on.update_status, self)
-        self.framework.observe(self.on.leader_settings_changed, self)
+        self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.on.start, self._on_start)
+        self.framework.observe(self.on.config_changed, self._on_config_changed)
+        self.framework.observe(self.on.update_status, self._on_update_status)
+        self.framework.observe(self.on.leader_settings_changed, self._on_leader_settings_changed)
         # Test relation events with endpoints from different
         # sections (provides, requires, peers) as well.
-        self.framework.observe(self.on.db_relation_joined, self)
-        self.framework.observe(self.on.mon_relation_changed, self)
-        self.framework.observe(self.on.mon_relation_departed, self)
-        self.framework.observe(self.on.ha_relation_broken, self)
+        self.framework.observe(self.on.db_relation_joined, self._on_db_relation_joined)
+        self.framework.observe(self.on.mon_relation_changed, self._on_mon_relation_changed)
+        self.framework.observe(self.on.mon_relation_departed, self._on_mon_relation_departed)
+        self.framework.observe(self.on.ha_relation_broken, self._on_ha_relation_broken)
 
         if self._charm_config.get('USE_ACTIONS'):
-            self.framework.observe(self.on.start_action, self)
-            self.framework.observe(self.on.foo_bar_action, self)
+            self.framework.observe(self.on.start_action, self._on_start_action)
+            self.framework.observe(self.on.foo_bar_action, self._on_foo_bar_action)
             self.framework.observe(self.on.get_model_name_action, self._on_get_model_name_action)
 
-        self.framework.observe(self.on.collect_metrics, self)
+        self.framework.observe(self.on.collect_metrics, self._on_collect_metrics)
 
         if self._charm_config.get('USE_LOG_ACTIONS'):
-            self.framework.observe(self.on.log_critical_action, self)
-            self.framework.observe(self.on.log_error_action, self)
-            self.framework.observe(self.on.log_warning_action, self)
-            self.framework.observe(self.on.log_info_action, self)
-            self.framework.observe(self.on.log_debug_action, self)
+            self.framework.observe(self.on.log_critical_action, self._on_log_critical_action)
+            self.framework.observe(self.on.log_error_action, self._on_log_error_action)
+            self.framework.observe(self.on.log_warning_action, self._on_log_warning_action)
+            self.framework.observe(self.on.log_info_action, self._on_log_info_action)
+            self.framework.observe(self.on.log_debug_action, self._on_log_debug_action)
 
     def _write_state(self):
         """Write state variables so that the parent process can read them.
@@ -107,40 +107,40 @@ class Charm(CharmBase):
             with self._state_file.open('wb') as f:
                 pickle.dump(self._state, f)
 
-    def on_install(self, event):
+    def _on_install(self, event):
         self._state['on_install'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()
 
-    def on_start(self, event):
+    def _on_start(self, event):
         self._state['on_start'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()
 
-    def on_config_changed(self, event):
+    def _on_config_changed(self, event):
         self._state['on_config_changed'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         event.defer()
         self._write_state()
 
-    def on_update_status(self, event):
+    def _on_update_status(self, event):
         self._state['on_update_status'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()
 
-    def on_leader_settings_changed(self, event):
+    def _on_leader_settings_changed(self, event):
         self._state['on_leader_settings_changed'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()
 
-    def on_db_relation_joined(self, event):
+    def _on_db_relation_joined(self, event):
         assert event.app is not None, 'application name cannot be None for a relation-joined event'
         self._state['on_db_relation_joined'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._state['db_relation_joined_data'] = event.snapshot()
         self._write_state()
 
-    def on_mon_relation_changed(self, event):
+    def _on_mon_relation_changed(self, event):
         assert event.app is not None, (
             'application name cannot be None for a relation-changed event')
         if os.environ.get('JUJU_REMOTE_UNIT'):
@@ -152,7 +152,7 @@ class Charm(CharmBase):
         self._state['mon_relation_changed_data'] = event.snapshot()
         self._write_state()
 
-    def on_mon_relation_departed(self, event):
+    def _on_mon_relation_departed(self, event):
         assert event.app is not None, (
             'application name cannot be None for a relation-departed event')
         self._state['on_mon_relation_departed'].append(type(event))
@@ -160,7 +160,7 @@ class Charm(CharmBase):
         self._state['mon_relation_departed_data'] = event.snapshot()
         self._write_state()
 
-    def on_ha_relation_broken(self, event):
+    def _on_ha_relation_broken(self, event):
         assert event.app is None, (
             'relation-broken events cannot have a reference to a remote application')
         assert event.unit is None, (
@@ -170,39 +170,39 @@ class Charm(CharmBase):
         self._state['ha_relation_broken_data'] = event.snapshot()
         self._write_state()
 
-    def on_start_action(self, event):
+    def _on_start_action(self, event):
         assert event.handle.kind == 'start_action', (
             'event action name cannot be different from the one being handled')
         self._state['on_start_action'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()
 
-    def on_foo_bar_action(self, event):
+    def _on_foo_bar_action(self, event):
         assert event.handle.kind == 'foo_bar_action', (
             'event action name cannot be different from the one being handled')
         self._state['on_foo_bar_action'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         self._write_state()
 
-    def on_collect_metrics(self, event):
+    def _on_collect_metrics(self, event):
         self._state['on_collect_metrics'].append(type(event))
         self._state['observed_event_types'].append(type(event))
         event.add_metrics({'foo': 42}, {'bar': 4.2})
         self._write_state()
 
-    def on_log_critical_action(self, event):
+    def _on_log_critical_action(self, event):
         logger.critical('super critical')
 
-    def on_log_error_action(self, event):
+    def _on_log_error_action(self, event):
         logger.error('grave error')
 
-    def on_log_warning_action(self, event):
+    def _on_log_warning_action(self, event):
         logger.warning('wise warning')
 
-    def on_log_info_action(self, event):
+    def _on_log_info_action(self, event):
         logger.info('useful info')
 
-    def on_log_debug_action(self, event):
+    def _on_log_debug_action(self, event):
         logger.debug('insightful debug')
 
     def _on_get_model_name_action(self, event):

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -89,7 +89,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(charm.started, True)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, "observer methods must now be explicitly provided"):
             framework.observe(charm.on.start, charm)
 
     def test_helper_properties(self):

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -89,6 +89,9 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(charm.started, True)
 
+        with self.assertRaises(TypeError):
+            framework.observe(charm.on.start, charm)
+
     def test_helper_properties(self):
         framework = self.create_framework()
 

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -74,9 +74,9 @@ class TestCharm(unittest.TestCase):
                 super().__init__(*args)
 
                 self.started = False
-                framework.observe(self.on.start, self)
+                framework.observe(self.on.start, self._on_start)
 
-            def on_start(self, event):
+            def _on_start(self, event):
                 self.started = True
 
         events = list(MyCharm.on.events())
@@ -167,21 +167,21 @@ peers:
             def __init__(self, *args):
                 super().__init__(*args)
                 self.seen = []
-                self.framework.observe(self.on['stor1'].storage_attached, self)
-                self.framework.observe(self.on['stor2'].storage_detaching, self)
-                self.framework.observe(self.on['stor3'].storage_attached, self)
-                self.framework.observe(self.on['stor-4'].storage_attached, self)
+                self.framework.observe(self.on['stor1'].storage_attached, self._on_stor1_attach)
+                self.framework.observe(self.on['stor2'].storage_detaching, self._on_stor2_detach)
+                self.framework.observe(self.on['stor3'].storage_attached, self._on_stor3_attach)
+                self.framework.observe(self.on['stor-4'].storage_attached, self._on_stor4_attach)
 
-            def on_stor1_storage_attached(self, event):
+            def _on_stor1_attach(self, event):
                 self.seen.append(type(event).__name__)
 
-            def on_stor2_storage_detaching(self, event):
+            def _on_stor2_detach(self, event):
                 self.seen.append(type(event).__name__)
 
-            def on_stor3_storage_attached(self, event):
+            def _on_stor3_attach(self, event):
                 self.seen.append(type(event).__name__)
 
-            def on_stor_4_storage_attached(self, event):
+            def _on_stor4_attach(self, event):
                 self.seen.append(type(event).__name__)
 
         # language=YAML
@@ -251,16 +251,16 @@ start:
 
             def __init__(self, *args):
                 super().__init__(*args)
-                framework.observe(self.on.foo_bar_action, self)
-                framework.observe(self.on.start_action, self)
+                framework.observe(self.on.foo_bar_action, self._on_foo_bar_action)
+                framework.observe(self.on.start_action, self._on_start_action)
 
-            def on_foo_bar_action(self, event):
+            def _on_foo_bar_action(self, event):
                 self.seen_action_params = event.params
                 event.log('test-log')
                 event.set_results({'res': 'val with spaces'})
                 event.fail('test-fail')
 
-            def on_start_action(self, event):
+            def _on_start_action(self, event):
                 pass
 
         fake_script(self, cmd_type + '-get', """echo '{"foo-name": "name", "silent": true}'""")
@@ -300,9 +300,9 @@ start:
 
             def __init__(self, *args):
                 super().__init__(*args)
-                framework.observe(self.on.start_action, self)
+                framework.observe(self.on.start_action, self._on_start_action)
 
-            def on_start_action(self, event):
+            def _on_start_action(self, event):
                 event.defer()
 
         fake_script(self, cmd_type + '-get', """echo '{"foo-name": "name", "silent": true}'""")

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -162,7 +162,7 @@ class TestFramework(BaseTestCase):
         framework.observe(pub.foo, obs.on_any)
         framework.observe(pub.bar, obs.on_any)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "^Framework.observe requires a method"):
             framework.observe(pub.baz, obs)
 
         pub.foo.emit()
@@ -198,11 +198,11 @@ class TestFramework(BaseTestCase):
         pub = MyNotifier(framework, "pub")
         obs = MyObserver(framework, "obs")
 
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, "must accept event parameter"):
             framework.observe(pub.foo, obs._on_foo)
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, "has extra required parameter"):
             framework.observe(pub.bar, obs._on_bar)
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, "has extra required parameter"):
             framework.observe(pub.baz, obs._on_baz)
         framework.observe(pub.qux, obs._on_qux)
 


### PR DESCRIPTION
Our experience so far has shown that the implicit dependencies for
Framework.observe push people down a path that actually makes their
charms less maintainable. Especially when it comes to writing
components, it is better to have clearly named functions and clearly
defined targets.  For components, it is usually better to have private
methods, because the handlers are an implementation detail rather than
something you want to advertise to people who want to interact with
your component.

This is a breaking change (all charms that have been using
self.framework.observe(self.on.config_changed, self) will break. So we
want to make this change before we do an official release version.

fixes: #297