### PR TITLE
charm: use magic strings a little less

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -449,13 +449,11 @@ class CharmMeta:
         self.series = raw.get('series', [])
         self.subordinate = raw.get('subordinate', False)
         self.min_juju_version = raw.get('min-juju-version')
-        self.requires = {name: RelationMeta('requires', name, rel)
+        self.requires = {name: RelationMeta._new_requires(name, rel)
                          for name, rel in raw.get('requires', {}).items()}
-        self.provides = {name: RelationMeta('provides', name, rel)
+        self.provides = {name: RelationMeta._new_provides(name, rel)
                          for name, rel in raw.get('provides', {}).items()}
-        # TODO: (jam 2020-05-11) The *role* should be 'peer' even though it comes from the
-        #  'peers' section.
-        self.peers = {name: RelationMeta('peers', name, rel)
+        self.peers = {name: RelationMeta._new_peer(name, rel)
                       for name, rel in raw.get('peers', {}).items()}
         self.relations = {}
         self.relations.update(self.requires)
@@ -507,6 +505,23 @@ class RelationMeta:
         self.relation_name = relation_name
         self.interface_name = raw['interface']
         self.scope = raw.get('scope')
+
+    @classmethod
+    def _new_requires(self, name, raw):
+        return RelationMeta('requires', name, raw)
+
+    @classmethod
+    def _new_provides(self, name, raw):
+        return RelationMeta('provides', name, raw)
+
+    @classmethod
+    def _new_peer(self, name, raw):
+        return RelationMeta('peer', name, raw)
+
+    def is_peer(self) -> bool:
+        """Return whether this is a peer relation.
+        """
+        return self.role == 'peer'
 
 
 class StorageMeta:

--- a/ops/model.py
+++ b/ops/model.py
@@ -347,7 +347,7 @@ class RelationMapping(Mapping):
     def __init__(self, relations_meta, our_unit, backend, cache):
         self._peers = set()
         for name, relation_meta in relations_meta.items():
-            if relation_meta.role == 'peers':
+            if relation_meta.is_peer():
                 self._peers.add(name)
         self._our_unit = our_unit
         self._backend = backend

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -298,7 +298,7 @@ class Harness:
         if app_or_unit == self._model.app.name:
             # updating our own app only generates an event if it is a peer relation and we
             # aren't the leader
-            is_peer = self._meta.relations[relation_name].role == 'peers'
+            is_peer = self._meta.relations[relation_name].is_peer()
             if not is_peer:
                 return
             if self._model.unit.is_leader():

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -720,7 +720,7 @@ class TestModelBindings(unittest.TestCase):
         meta.relations = {
             'db0': RelationMeta('provides', 'db0', {'interface': 'db0', 'scope': 'global'}),
             'db1': RelationMeta('requires', 'db1', {'interface': 'db1', 'scope': 'global'}),
-            'db2': RelationMeta('peers', 'db2', {'interface': 'db2', 'scope': 'global'}),
+            'db2': RelationMeta('peer', 'db2', {'interface': 'db2', 'scope': 'global'}),
         }
         self.backend = ops.model._ModelBackend()
         self.model = ops.model.Model('myapp/0', meta, self.backend)


### PR DESCRIPTION
This is a slightly less invasive fix for #271, where the role is still
a string, but an accessor is provided to avoid having to know the
string outside of some testing.