### PR TITLE
ops/model.py: Proper support for status-get

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -740,12 +740,14 @@ class StatusBase:
             return cls._statuses[name](message)
 
     @classmethod
-    def register_status(cls, child):
+    def register(cls, child):
         if child.name is None:
             raise AttributeError('cannot register a Status which has no name')
         cls._statuses[child.name] = child
+        return child
 
 
+@StatusBase.register
 class UnknownStatus(StatusBase):
     """The unit status is unknown.
 
@@ -763,6 +765,7 @@ class UnknownStatus(StatusBase):
         return "UnknownStatus()"
 
 
+@StatusBase.register
 class ActiveStatus(StatusBase):
     """The unit is ready.
 
@@ -774,9 +777,7 @@ class ActiveStatus(StatusBase):
         super().__init__(message)
 
 
-StatusBase.register_status(ActiveStatus)
-
-
+@StatusBase.register
 class BlockedStatus(StatusBase):
     """The unit requires manual intervention.
 
@@ -785,9 +786,7 @@ class BlockedStatus(StatusBase):
     name = 'blocked'
 
 
-StatusBase.register_status(BlockedStatus)
-
-
+@StatusBase.register
 class MaintenanceStatus(StatusBase):
     """The unit is performing maintenance tasks.
 
@@ -799,9 +798,7 @@ class MaintenanceStatus(StatusBase):
     name = 'maintenance'
 
 
-StatusBase.register_status(MaintenanceStatus)
-
-
+@StatusBase.register
 class WaitingStatus(StatusBase):
     """A unit is unable to progress.
 
@@ -810,9 +807,6 @@ class WaitingStatus(StatusBase):
 
     """
     name = 'waiting'
-
-
-StatusBase.register_status(WaitingStatus)
 
 
 class Resources:

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -88,6 +88,7 @@ class Charm(CharmBase):
             self.framework.observe(self.on.start_action, self._on_start_action)
             self.framework.observe(self.on.foo_bar_action, self._on_foo_bar_action)
             self.framework.observe(self.on.get_model_name_action, self._on_get_model_name_action)
+            self.framework.observe(self.on.get_status_action, self._on_get_status_action)
 
         self.framework.observe(self.on.collect_metrics, self._on_collect_metrics)
 
@@ -182,6 +183,11 @@ class Charm(CharmBase):
             'event action name cannot be different from the one being handled')
         self._state['on_foo_bar_action'].append(type(event))
         self._state['observed_event_types'].append(type(event))
+        self._write_state()
+
+    def _on_get_status_action(self, event):
+        self._state['status_name'] = self.unit.status.name
+        self._state['status_message'] = self.unit.status.message
         self._write_state()
 
     def _on_collect_metrics(self, event):

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -198,7 +198,7 @@ class TestLibParser(TestCase):
 
     def test_too_long(self):
         """Check that if the file is too long, nothing is returned"""
-        m = self._mkmod('foo', '\n'*ops.lib._MAX_LIB_LINES + '''
+        m = self._mkmod('foo', '\n' * ops.lib._MAX_LIB_LINES + '''
         LIBNAME = "foo"
         LIBAPI = 2
         LIBPATCH = 42


### PR DESCRIPTION
The StatusBase types weren't being properly registered without
instantiating one. Now they are registered once they are declared,
rather than only after being created.
Futher, actually parse the output of status-get properly, and the
application status output is structured differently from the unit status
output.

fixes: #288 