### PR TITLE
ops.main: only do _init_dispatch() if dispatch exists

### DIFF
--- a/ops/main.py
+++ b/ops/main.py
@@ -176,7 +176,7 @@ class _Dispatcher:
         self._charm_dir = charm_dir
         self._exec_path = Path(sys.argv[0])
 
-        if 'JUJU_DISPATCH_PATH' in os.environ:
+        if 'JUJU_DISPATCH_PATH' in os.environ and (charm_dir / 'dispatch').exists():
             self._init_dispatch()
         else:
             self._init_legacy()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -573,6 +573,12 @@ class TestMainWithNoDispatch(TestMain, unittest.TestCase):
         self.assertTrue(action_hook.exists())
 
 
+class TestMainWithNoDispatchButJujuIsDispatchAware(TestMainWithNoDispatch):
+    def _call_event(self, rel_path, env):
+        env["JUJU_DISPATCH_PATH"] = str(rel_path)
+        super()._call_event(rel_path, env)
+
+
 class TestMainWithNoDispatchButScriptsAreCopies(TestMainWithNoDispatch):
     hooks_are_symlinks = False
 


### PR DESCRIPTION
This avoids the situation where Juju is dispatch-aware but the charm
is not resulting in no symlinks getting created.

fixes: #310