### PR TITLE
test_main: set up PYTHONPATH so the sub-process picks up this ops

### DIFF
--- a/test/test_main.py
+++ b/test/test_main.py
@@ -183,9 +183,12 @@ get-model-name:
 
     def _simulate_event(self, event_spec):
         ppath = Path(__file__).parent
+        pypath = str(ppath.parent)
+        if 'PYTHONPATH' in os.environ:
+            pypath += ':' + os.environ['PYTHONPATH']
         env = {
             'PATH': "{}:{}".format(ppath / 'bin', os.environ['PATH']),
-            'PYTHONPATH': str(ppath.parent),
+            'PYTHONPATH': pypath,
             'JUJU_CHARM_DIR': str(self.JUJU_CHARM_DIR),
             'JUJU_UNIT_NAME': 'test_main/0',
             'CHARM_CONFIG': event_spec.charm_config,

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -182,8 +182,10 @@ get-model-name:
         return state
 
     def _simulate_event(self, event_spec):
+        ppath = Path(__file__).parent
         env = {
-            'PATH': "{}:{}".format(Path(__file__).parent / 'bin', os.environ['PATH']),
+            'PATH': "{}:{}".format(ppath / 'bin', os.environ['PATH']),
+            'PYTHONPATH': str(ppath.parent),
             'JUJU_CHARM_DIR': str(self.JUJU_CHARM_DIR),
             'JUJU_UNIT_NAME': 'test_main/0',
             'CHARM_CONFIG': event_spec.charm_config,


### PR DESCRIPTION
Without this change, if you had done a `pip install ops`, the tests
from test_main would be testing the installed ops instead of the one
in tree. This change fixes that.

Fixes: #313