### PR TITLE
ops: get version from git

### DIFF
--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -14,7 +14,7 @@
 
 """The Operator Framework."""
 
-__version__ = '0.6.1'
+from .version import version as __version__  # noqa: F401 (imported but unused)
 
 # Import here the bare minimum to break the circular import between modules
-from . import charm  # NOQA
+from . import charm  # noqa: F401 (imported but unused)

--- a/ops/version.py
+++ b/ops/version.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os.path
+import subprocess
+
+__all__ = ('version',)
+
+
+def _get_version():
+    version = "UNKNOWN"
+
+    p = os.path.dirname(__file__)
+    if os.path.exists(os.path.join(p, "../.git")):
+        try:
+            proc = subprocess.run(
+                ['git', 'describe', '--tags', '--long', '--dirty'],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                cwd=p,
+                check=True)
+        except Exception:
+            pass
+        else:
+            version = proc.stdout.strip().decode('utf8')
+            if '-' in version:
+                # version will look like <tag>-<#commits>-g<hex>[-dirty]
+                # everything after the first - is a 'local version' in PEP440 terms
+                # so mangle it to fit that spec
+                s = version.split('-', 1)
+                version = s[0] + '+' + s[1].replace('-', '.')
+                # version now <tag>+<#commits>.g<hex>[.dirty]
+                # which is PEP440-compliant (as long as <tag> is :-)
+    return version
+
+
+version = _get_version()

--- a/ops/version.py
+++ b/ops/version.py
@@ -19,7 +19,7 @@ __all__ = ('version',)
 
 
 def _get_version():
-    version = "UNKNOWN"
+    version = "0.7.dev+UNKNOWN"
 
     p = os.path.dirname(__file__)
     if os.path.exists(os.path.join(p, "../.git")):

--- a/ops/version.py
+++ b/ops/version.py
@@ -21,7 +21,7 @@ _FALLBACK = '0.7'  # this gets bumped after release
 
 
 def _get_version():
-    version = _FALLBACK + ".dev+UNKNOWN"
+    version = _FALLBACK + ".dev0+unknown"
 
     p = Path(__file__).parent
     if (p.parent / '.git').exists():

--- a/ops/version.py
+++ b/ops/version.py
@@ -17,9 +17,11 @@ from pathlib import Path
 
 __all__ = ('version',)
 
+_FALLBACK = '0.7'  # this gets bumped after release
+
 
 def _get_version():
-    version = "0.7.dev+UNKNOWN"
+    version = _FALLBACK + ".dev+UNKNOWN"
 
     p = Path(__file__).parent
     if (p.parent / '.git').exists():

--- a/ops/version.py
+++ b/ops/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os.path
 import subprocess
+from pathlib import Path
 
 __all__ = ('version',)
 
@@ -21,8 +21,8 @@ __all__ = ('version',)
 def _get_version():
     version = "0.7.dev+UNKNOWN"
 
-    p = os.path.dirname(__file__)
-    if os.path.exists(os.path.join(p, "../.git")):
+    p = Path(__file__).parent
+    if (p.parent / '.git').exists():
         try:
             proc = subprocess.run(
                 ['git', 'describe', '--tags', '--long', '--dirty'],
@@ -36,10 +36,10 @@ def _get_version():
             version = proc.stdout.strip().decode('utf8')
             if '-' in version:
                 # version will look like <tag>-<#commits>-g<hex>[-dirty]
-                # everything after the first - is a 'local version' in PEP440 terms
-                # so mangle it to fit that spec
-                s = version.split('-', 1)
-                version = s[0] + '+' + s[1].replace('-', '.')
+                # in terms of PEP 440, the tag we'll make sure is a 'public version identifier';
+                # everything after the first - needs to be a 'local version'
+                public, local = version.split('-', 1)
+                version = public + '+' + local.replace('-', '.')
                 # version now <tag>+<#commits>.g<hex>[.dirty]
                 # which is PEP440-compliant (as long as <tag> is :-)
     return version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e . #  i.e. get them from setup.py
+PyYAML


### PR DESCRIPTION
This rejuggles how we get the version info.

When running from git, the version will be retrieved via the
equivalent of

    git describe --tags --long --dirty | sed -e 's/-/+/; y/-/./'

This produces a PEP440-compatible version from the semantic versioning
we're using and tagging, plus the git describe output. Meaning that if at
any point we need to compare versions, `packaging.version.parse` will do
the right thing.

Then, `setup.py` replaces the code that does that with a constant string
just before running `setup`, and swaps it back out after. The constant
version it replacs it with is the one it gets from the code it swapped out,
sneakily.

This means that people using ops from git will always report something we
can use to figure out what they're running (or as close as we can get to
that), while people running from a release will have no overhead.

This does imply a small change in the release workflow to stop github from
publishing broken tarballs, but that should be fine (the tarballs it's been
auto-producing so far have not been completely up to par so we needed to do
something there anyway).