### PR TITLE
model: don't use --app for relation-get/-set before 2.7.0

### DIFF
--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -95,4 +95,4 @@ class JujuVersion:
 
     def has_app_data(self) -> bool:
         """Determine whether this juju version knows about app data."""
-        return (self.major, self.minor, self.patch) >= (2, 7, 1)
+        return (self.major, self.minor, self.patch) >= (2, 7, 0)

--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import re
 from functools import total_ordering
 
@@ -83,3 +84,15 @@ class JujuVersion:
         elif self.build != other.build:
             return self.build < other.build
         return False
+
+    @classmethod
+    def from_environ(cls) -> 'JujuVersion':
+        """Build a JujuVersion from JUJU_VERSION."""
+        v = os.environ.get('JUJU_VERSION')
+        if not v:
+            raise RuntimeError('environ has no JUJU_VERSION')
+        return cls(v)
+
+    def has_app_data(self) -> bool:
+        """Determine whether this juju version knows about app data."""
+        return (self.major, self.minor, self.patch) >= (2, 7, 1)

--- a/ops/model.py
+++ b/ops/model.py
@@ -997,8 +997,11 @@ class _ModelBackend:
         if not isinstance(is_app, bool):
             raise TypeError('is_app parameter to relation_get must be a boolean')
 
-        if is_app and not JujuVersion.from_environ().has_app_data():
-            raise RuntimeError('trying to relation-get app data on a Juju too old for it')
+        if is_app:
+            version = JujuVersion.from_environ()
+            if not version.has_app_data():
+                raise RuntimeError(
+                    'getting application data is not supported on Juju version {}'.format(version))
 
         args = ['relation-get', '-r', str(relation_id), '-', member_name]
         if is_app:
@@ -1015,8 +1018,11 @@ class _ModelBackend:
         if not isinstance(is_app, bool):
             raise TypeError('is_app parameter to relation_set must be a boolean')
 
-        if is_app and not JujuVersion.from_environ().has_app_data():
-            raise RuntimeError('trying to relation-set app data on a Juju too old for it')
+        if is_app:
+            version = JujuVersion.from_environ()
+            if not version.has_app_data():
+                raise RuntimeError(
+                    'setting application data is not supported on Juju version {}'.format(version))
 
         args = ['relation-set', '-r', str(relation_id), '{}={}'.format(key, value)]
         if is_app:

--- a/ops/model.py
+++ b/ops/model.py
@@ -1018,9 +1018,12 @@ class _ModelBackend:
         if is_app and not JujuVersion.from_environ().has_app_data():
             raise RuntimeError('trying to relation-set app data on a Juju too old for it')
 
+        args = ['relation-set', '-r', str(relation_id), '{}={}'.format(key, value)]
+        if is_app:
+            args.append('--app')
+
         try:
-            return self._run('relation-set', '-r', str(relation_id),
-                             '{}={}'.format(key, value), '--app={}'.format(is_app))
+            return self._run(*args)
         except ModelError as e:
             if 'relation not found' in str(e):
                 raise RelationNotFoundError() from e

--- a/ops/model.py
+++ b/ops/model.py
@@ -998,7 +998,7 @@ class _ModelBackend:
             raise TypeError('is_app parameter to relation_get must be a boolean')
 
         if is_app and not JujuVersion.from_environ().has_app_data():
-            return {}
+            raise RuntimeError('trying to relation-get app data on a Juju too old for it')
 
         args = ['relation-get', '-r', str(relation_id), '-', member_name]
         if is_app:

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -57,7 +57,8 @@ class TestJujuVersion(unittest.TestCase):
 
     def test_has_app_data(self):
         self.assertTrue(JujuVersion('2.8.0').has_app_data())
-        self.assertFalse(JujuVersion('2.7.0').has_app_data())
+        self.assertTrue(JujuVersion('2.7.0').has_app_data())
+        self.assertFalse(JujuVersion('2.6.9').has_app_data())
 
     def test_parsing_errors(self):
         invalid_versions = [

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2019 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
+import unittest.mock  # in this file, importing just 'patch' would be confusing
 
 from ops.jujuversion import JujuVersion
 
@@ -40,6 +41,23 @@ class TestJujuVersion(unittest.TestCase):
             self.assertEqual(v.tag, tag)
             self.assertEqual(v.patch, patch)
             self.assertEqual(v.build, build)
+
+    @unittest.mock.patch('os.environ', new={})
+    def test_from_environ(self):
+        with self.assertRaisesRegex(RuntimeError, 'environ has no JUJU_VERSION'):
+            JujuVersion.from_environ()
+
+        os.environ['JUJU_VERSION'] = 'no'
+        with self.assertRaisesRegex(RuntimeError, 'not a valid Juju version'):
+            JujuVersion.from_environ()
+
+        os.environ['JUJU_VERSION'] = '2.8.0'
+        v = JujuVersion.from_environ()
+        self.assertEqual(v, JujuVersion('2.8.0'))
+
+    def test_has_app_data(self):
+        self.assertTrue(JujuVersion('2.8.0').has_app_data())
+        self.assertFalse(JujuVersion('2.7.0').has_app_data())
 
     def test_parsing_errors(self):
         invalid_versions = [
@@ -124,7 +142,3 @@ class TestJujuVersion(unittest.TestCase):
             self.assertEqual(JujuVersion(a) <= b, expected_weak)
             self.assertEqual(b > JujuVersion(a), expected_strict)
             self.assertEqual(b >= JujuVersion(a), expected_weak)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -941,12 +941,12 @@ class TestModelBackend(unittest.TestCase):
             lambda: fake_script(self, 'relation-get', 'echo fooerror >&2 ; exit 1'),
             lambda: self.backend.relation_get(3, 'remote/0', is_app=False),
             ops.model.ModelError,
-            [['relation-get', '-r', '3', '-', 'remote/0', '--app=False', '--format=json']],
+            [['relation-get', '-r', '3', '-', 'remote/0', '--format=json']],
         ), (
             lambda: fake_script(self, 'relation-get', 'echo {} >&2 ; exit 2'.format(err_msg)),
             lambda: self.backend.relation_get(3, 'remote/0', is_app=False),
             ops.model.RelationNotFoundError,
-            [['relation-get', '-r', '3', '-', 'remote/0', '--app=False', '--format=json']],
+            [['relation-get', '-r', '3', '-', 'remote/0', '--format=json']],
         )]
 
         for do_fake, run, exception, calls in test_cases:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -984,7 +984,7 @@ class TestModelBackend(unittest.TestCase):
 
         # before 2.7.0, it just fails (no --app support)
         os.environ['JUJU_VERSION'] = '2.6.9'
-        with self.assertRaisesRegex(RuntimeError, 'Juju too old'):
+        with self.assertRaisesRegex(RuntimeError, 'not supported on Juju version 2.6.9'):
             self.backend.relation_get(1, 'foo/0', is_app=True)
         self.assertEqual(fake_script_calls(self), [])
 
@@ -1003,7 +1003,7 @@ class TestModelBackend(unittest.TestCase):
 
         # before 2.7.0, it just fails always (no --app support)
         os.environ['JUJU_VERSION'] = '2.6.9'
-        with self.assertRaisesRegex(RuntimeError, 'Juju too old'):
+        with self.assertRaisesRegex(RuntimeError, 'not supported on Juju version 2.6.9'):
             self.backend.relation_set(1, 'foo', 'bar', is_app=True)
         self.assertEqual(fake_script_calls(self), [])
 


### PR DESCRIPTION
Juju before 2.7.0 didn't support the `--app` parameter for
`relation-get` and `relation-set`, meaning that the current code
breaks in 2.6.9.

This fixes that by avoiding `--app` entirely when not needed,
raising an explicit `RuntimeError` when an attempt is made to get
or set app data in an old Juju (where we know adding `--app` will
fail).

fixes: #223