### PR TITLE
ops/main.py: Use CSafeLoader

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -23,6 +23,12 @@ from ops.framework import Object, EventSource, EventBase, Framework, ObjectEvent
 from ops import model
 
 
+def _loadYaml(source):
+    if yaml.__with_libyaml__:
+        return yaml.load(source, Loader=yaml.CSafeLoader)
+    return yaml.load(source, Loader=yaml.SafeLoader)
+
+
 class HookEvent(EventBase):
     """A base class for events that trigger because of a Juju hook firing."""
 
@@ -475,10 +481,10 @@ class CharmMeta:
                 This can be a simple string, or a file-like object. (passed to `yaml.safe_load`).
             actions: YAML description of Actions for this charm (eg actions.yaml)
         """
-        meta = yaml.safe_load(metadata)
+        meta = _loadYaml(metadata)
         raw_actions = {}
         if actions is not None:
-            raw_actions = yaml.safe_load(actions)
+            raw_actions = _loadYaml(actions)
         return cls(meta, raw_actions)
 
 

--- a/ops/main.py
+++ b/ops/main.py
@@ -13,16 +13,18 @@
 # limitations under the License.
 
 import inspect
+import logging
 import os
 import subprocess
 import sys
 import warnings
 from pathlib import Path
 
+import yaml
+
 import ops.charm
 import ops.framework
 import ops.model
-import logging
 
 from ops.log import setup_root_logging
 
@@ -282,6 +284,8 @@ def main(charm_class):
     else:
         actions_metadata = None
 
+    if not yaml.__with_libyaml__:
+        logger.debug('yaml does not have libyaml extensions, using slower pure Python yaml loader')
     meta = ops.charm.CharmMeta.from_yaml(metadata, actions_metadata)
     unit_name = os.environ['JUJU_UNIT_NAME']
     model_name = os.environ.get('JUJU_MODEL_NAME')


### PR DESCRIPTION
Testing shows that on a modest yaml file, it can be 2ms instead of 25ms
to load a config.yaml. (postgresql's config.yaml).

By default 'yaml.safe_load' doesn't use the C loader (neither does
yaml.load).

This also unifies the code path that loads YAML for both main.main() and our test suites.
