### PR TITLE
many: move Model.name to be read from _ModelBackend

### DIFF
--- a/ops/main.py
+++ b/ops/main.py
@@ -290,9 +290,7 @@ def main(charm_class):
 
     metadata, actions_metadata = _load_metadata(charm_dir)
     meta = ops.charm.CharmMeta(metadata, actions_metadata)
-    unit_name = os.environ['JUJU_UNIT_NAME']
-    model_name = os.environ.get('JUJU_MODEL_NAME')
-    model = ops.model.Model(unit_name, meta, model_backend, model_name=model_name)
+    model = ops.model.Model(meta, model_backend)
 
     # TODO: If Juju unit agent crashes after exit(0) from the charm code
     # the framework will commit the snapshot but Juju will not commit its

--- a/ops/model.py
+++ b/ops/model.py
@@ -35,6 +35,9 @@ import ops
 class Model:
     """Represents the Juju Model as seen from this unit.
 
+    This should not be instantiated directly by Charmers, but can be accessed as `self.model`
+    from any class that derives from Object.
+
     Attributes:
         unit: A :class:`Unit` that represents the unit that is running this code (eg yourself)
         app: A :class:`Application` that represents the application this unit is a part of.
@@ -49,12 +52,10 @@ class Model:
             for Kubernetes charms.
     """
 
-    def __init__(
-            self, unit_name: str, meta: 'ops.charm.CharmMeta', backend: '_ModelBackend', *,
-            model_name: str = None):
+    def __init__(self, meta: 'ops.charm.CharmMeta', backend: '_ModelBackend'):
         self._cache = _ModelCache(backend)
         self._backend = backend
-        self.unit = self.get_unit(unit_name)
+        self.unit = self.get_unit(self._backend.unit_name)
         self.app = self.unit.app
         self.relations = RelationMapping(meta.relations, self.unit, self._backend, self._cache)
         self.config = ConfigData(self._backend)
@@ -62,7 +63,6 @@ class Model:
         self.pod = Pod(self._backend)
         self.storages = StorageMapping(list(meta.storages), self._backend)
         self._bindings = BindingMapping(self._backend)
-        self._model_name = model_name
 
     @property
     def name(self) -> str:
@@ -70,7 +70,7 @@ class Model:
 
         This is read from the environment variable ``JUJU_MODEL_NAME``.
         """
-        return self._model_name
+        return self._backend.model_name
 
     def get_unit(self, unit_name: str) -> 'Unit':
         """Get an arbitrary unit by name.
@@ -954,8 +954,14 @@ class _ModelBackend:
 
     LEASE_RENEWAL_PERIOD = datetime.timedelta(seconds=30)
 
-    def __init__(self):
-        self.unit_name = os.environ['JUJU_UNIT_NAME']
+    def __init__(self, unit_name=None, model_name=None):
+        if unit_name is None:
+            self.unit_name = os.environ['JUJU_UNIT_NAME']
+        else:
+            self.unit_name = unit_name
+        if model_name is None:
+            model_name = os.environ.get('JUJU_MODEL_NAME')
+        self.model_name = model_name
         self.app_name = self.unit_name.split('/')[0]
 
         self._is_leader = None

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -75,7 +75,7 @@ class Harness:
         self._hooks_enabled = True
         self._relation_id_counter = 0
         self._backend = _TestingModelBackend(self._unit_name, self._meta)
-        self._model = model.Model(self._unit_name, self._meta, self._backend)
+        self._model = model.Model(self._meta, self._backend)
         self._framework = framework.Framework(":memory:", self._charm_dir, self._meta, self._model)
 
     @property
@@ -304,6 +304,16 @@ class Harness:
         """Read the workload version that was set by the unit."""
         return self._backend._workload_version
 
+    def set_model_name(self, name: str) -> None:
+        """Set the name of the Model that this is representing.
+
+        This cannot be called once begin() has been called. But it lets you set the value that
+        will be returned by Model.name.
+        """
+        if self._charm is not None:
+            raise RuntimeError('cannot set the Model name after begin()')
+        self._backend.model_name = name
+
     def update_relation_data(
             self,
             relation_id: int,
@@ -466,6 +476,7 @@ class _TestingModelBackend:
     def __init__(self, unit_name, meta):
         self.unit_name = unit_name
         self.app_name = self.unit_name.split('/')[0]
+        self.model_name = None
         self._calls = []
         self._meta = meta
         self._is_leader = None

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -60,7 +60,7 @@ class TestCharm(unittest.TestCase):
         self.addCleanup(cleanup)
 
     def create_framework(self):
-        model = Model('local/0', self.meta, _ModelBackend())
+        model = Model(self.meta, _ModelBackend('local/0'))
         framework = Framework(self.tmpdir / "framework.data", self.tmpdir, self.meta, model)
         self.addCleanup(framework.close)
         return framework

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -18,7 +18,6 @@ import subprocess
 import shutil
 import tempfile
 import unittest
-from unittest.mock import patch
 
 from ops.framework import Framework
 from ops.model import Model, _ModelBackend
@@ -109,12 +108,7 @@ class BaseTestCase(unittest.TestCase):
 
     def create_model(self):
         """Create a Model object."""
-        unit_name = 'myapp/0'
-        patcher = patch.dict(os.environ, {'JUJU_UNIT_NAME': unit_name})
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
-        backend = _ModelBackend()
+        backend = _ModelBackend(unit_name='myapp/0')
         meta = CharmMeta()
-        model = Model('myapp/0', meta, backend)
+        model = Model(meta, backend)
         return model

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -16,7 +16,6 @@
 from collections import OrderedDict
 import json
 import ipaddress
-import os
 import pathlib
 from textwrap import dedent
 import unittest
@@ -32,12 +31,6 @@ from test.test_helpers import fake_script, fake_script_calls
 class TestModel(unittest.TestCase):
 
     def setUp(self):
-        def restore_env(env):
-            os.environ.clear()
-            os.environ.update(env)
-        self.addCleanup(restore_env, os.environ.copy())
-
-        os.environ['JUJU_UNIT_NAME'] = 'myapp/0'
         self.harness = ops.testing.Harness(ops.charm.CharmBase, meta='''
             name: myapp
             provides:
@@ -57,9 +50,9 @@ class TestModel(unittest.TestCase):
         self.assertIs(self.model.app, self.model.unit.app)
         self.assertIsNone(self.model.name)
 
-    def test_model_name(self):
-        m = ops.model.Model('unit/0', ops.charm.CharmMeta(), self.harness._backend,
-                            model_name='default')
+    def test_model_name_from_backend(self):
+        self.harness.set_model_name('default')
+        m = ops.model.Model(ops.charm.CharmMeta(), self.harness._backend)
         self.assertEqual(m.name, 'default')
         with self.assertRaises(AttributeError):
             m.name = "changes-disallowed"
@@ -418,7 +411,7 @@ class TestModel(unittest.TestCase):
         # TODO: (jam) 2020-05-07 Harness doesn't yet support resource-get issue #262
         meta = ops.charm.CharmMeta()
         meta.resources = {'foo': None, 'bar': None}
-        model = ops.model.Model('myapp/0', meta, ops.model._ModelBackend())
+        model = ops.model.Model(meta, ops.model._ModelBackend('myapp/0'))
 
         with self.assertRaises(RuntimeError):
             model.resources.fetch('qux')
@@ -437,7 +430,7 @@ class TestModel(unittest.TestCase):
         meta = ops.charm.CharmMeta.from_yaml('''
             name: myapp
         ''')
-        model = ops.model.Model('myapp/0', meta, ops.model._ModelBackend())
+        model = ops.model.Model(meta, ops.model._ModelBackend('myapp/0'))
         fake_script(self, 'pod-spec-set', """
                     cat $2 > $(dirname $0)/spec.json
                     [[ -n $4 ]] && cat $4 > $(dirname $0)/k8s_res.json || true
@@ -472,9 +465,9 @@ class TestModel(unittest.TestCase):
         check_calls(fake_calls)
 
         # Create a new model to drop is-leader caching result.
-        self.backend = ops.model._ModelBackend()
+        self.backend = ops.model._ModelBackend('myapp/0')
         meta = ops.charm.CharmMeta()
-        model = ops.model.Model('myapp/0', meta, self.backend)
+        model = ops.model.Model(meta, self.backend)
         fake_script(self, 'is-leader', 'echo false')
         with self.assertRaises(ops.model.ModelError):
             model.pod.set_spec({'foo': 'bar'})
@@ -651,7 +644,7 @@ class TestModel(unittest.TestCase):
         # TODO: (jam) 2020-05-07 Harness doesn't yet expose storage-get issue #263
         meta = ops.charm.CharmMeta()
         meta.storages = {'disks': None, 'data': None}
-        model = ops.model.Model('myapp/0', meta, ops.model._ModelBackend())
+        model = ops.model.Model(meta, ops.model._ModelBackend('myapp/0'))
 
         fake_script(self, 'storage-list', '''
             if [ "$1" = disks ]; then
@@ -716,13 +709,6 @@ class TestModel(unittest.TestCase):
 class TestModelBindings(unittest.TestCase):
 
     def setUp(self):
-        def restore_env(env):
-            os.environ.clear()
-            os.environ.update(env)
-        self.addCleanup(restore_env, os.environ.copy())
-
-        os.environ['JUJU_UNIT_NAME'] = 'myapp/0'
-
         meta = ops.charm.CharmMeta()
         meta.relations = {
             'db0': RelationMeta(
@@ -732,8 +718,8 @@ class TestModelBindings(unittest.TestCase):
             'db2': RelationMeta(
                 RelationRole.peer, 'db2', {'interface': 'db2', 'scope': 'global'}),
         }
-        self.backend = ops.model._ModelBackend()
-        self.model = ops.model.Model('myapp/0', meta, self.backend)
+        self.backend = ops.model._ModelBackend('myapp/0')
+        self.model = ops.model.Model(meta, self.backend)
 
         fake_script(self, 'relation-ids',
                     """([ "$1" = db0 ] && echo '["db0:4"]') || echo '[]'""")
@@ -866,15 +852,12 @@ class TestModelBindings(unittest.TestCase):
 class TestModelBackend(unittest.TestCase):
 
     def setUp(self):
-        os.environ['JUJU_UNIT_NAME'] = 'myapp/0'
-        self.addCleanup(os.environ.pop, 'JUJU_UNIT_NAME')
-
         self._backend = None
 
     @property
     def backend(self):
         if self._backend is None:
-            self._backend = ops.model._ModelBackend()
+            self._backend = ops.model._ModelBackend('myapp/0')
         return self._backend
 
     def test_relation_get_set_is_app_arg(self):
@@ -897,7 +880,7 @@ class TestModelBackend(unittest.TestCase):
         meta = ops.charm.CharmMeta.from_yaml('''
             name: myapp
         ''')
-        model = ops.model.Model('myapp/0', meta, self.backend)
+        model = ops.model.Model(meta, self.backend)
         fake_script(self, 'is-leader', 'echo false')
         self.assertFalse(model.unit.is_leader())
 
@@ -1008,7 +991,7 @@ class TestModelBackend(unittest.TestCase):
         meta = ops.charm.CharmMeta.from_yaml('''
             name: myapp
         ''')
-        model = ops.model.Model('myapp/0', meta, self.backend)
+        model = ops.model.Model(meta, self.backend)
         fake_script(self, 'status-set', 'exit 1')
         fake_script(self, 'is-leader', 'echo true')
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -533,6 +533,23 @@ class TestHarness(unittest.TestCase):
         # The charm_dir also gets set
         self.assertEqual(harness.framework.charm_dir, tmp)
 
+    def test_set_model_name(self):
+        harness = Harness(CharmBase, meta='''
+            name: test-charm
+        ''')
+        harness.set_model_name('foo')
+        self.assertEqual('foo', harness.model.name)
+
+    def test_set_model_name_after_begin(self):
+        harness = Harness(CharmBase, meta='''
+            name: test-charm
+        ''')
+        harness.set_model_name('bar')
+        harness.begin()
+        with self.assertRaises(RuntimeError):
+            harness.set_model_name('foo')
+        self.assertEqual(harness.model.name, 'bar')
+
     def test_actions_from_directory(self):
         tmp = pathlib.Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, str(tmp))
@@ -889,7 +906,7 @@ class TestTestingModelBackend(unittest.TestCase):
             "registrypath": "custompath",
             "username": "custom_username",
             "password": "custom_password",
-            }
+        }
         harness.add_oci_resource('image', custom)
         resource = harness._resource_dir / "image" / "contents.yaml"
         with resource.open('r') as resource_file:


### PR DESCRIPTION
Unit name was already being read by _ModelBackend, as well as being
read by main(). We wanted to eliminate the duplication. We could either
pass more names down the stack, or we can pull them out of the backend.
This ended up a bit cleaner because we pass the Backend into Model
anyway, so it means having fewer args to the same object.

This also gave me an opportunity to eliminate a bunch of code that was
poking at os.environ just to set JUJU_UNIT_NAME.