### PR TITLE
test/test_main: move actions.yaml into the charm

### DIFF
--- a/test/charms/test_main/actions.yaml
+++ b/test/charms/test_main/actions.yaml
@@ -1,0 +1,29 @@
+foo-bar:
+  description: Foos the bar.
+  title: foo-bar
+  params:
+    foo-name:
+      type: string
+      description: A foo name to bar.
+    silent:
+      type: boolean
+      description:
+      default: false
+  required:
+    - foo-name
+start:
+  description: Start the unit.
+get-model-name:
+  description: Return the name of the model
+get-status:
+  description: Return the Status of the unit
+log_critical:
+  description: log a message at Critical level
+log_error:
+  description: log a message at Error level
+log_warning:
+  description: log a message at Warning level
+log_info:
+  description: log a message at Info level
+log_debug:
+  description: log a message at Debug level

--- a/test/charms/test_main/actions.yaml
+++ b/test/charms/test_main/actions.yaml
@@ -7,7 +7,7 @@ foo-bar:
       description: A foo name to bar.
     silent:
       type: boolean
-      description:
+      description: ""
       default: false
   required:
     - foo-name
@@ -17,13 +17,13 @@ get-model-name:
   description: Return the name of the model
 get-status:
   description: Return the Status of the unit
-log_critical:
+log-critical:
   description: log a message at Critical level
-log_error:
+log-error:
   description: log a message at Error level
-log_warning:
+log-warning:
   description: log a message at Warning level
-log_info:
+log-info:
   description: log a message at Info level
-log_debug:
+log-debug:
   description: log a message at Debug level

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -160,7 +160,7 @@ class _TestMain(abc.ABC):
     def setUp(self):
         self._setup_charm_dir()
 
-        _, tmp_file = tempfile.mkstemp(dir=self._tmpdir)
+        _, tmp_file = tempfile.mkstemp(dir=str(self._tmpdir))
         self._state_file = Path(tmp_file)
 
         # Relations events are defined dynamically and modify the class attributes.

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -889,7 +889,7 @@ class TestTestingModelBackend(unittest.TestCase):
             "registrypath": "custompath",
             "username": "custom_username",
             "password": "custom_password",
-            }
+        }
         harness.add_oci_resource('image', custom)
         resource = harness._resource_dir / "image" / "contents.yaml"
         with resource.open('r') as resource_file:


### PR DESCRIPTION
The test suite had been setting up actions.yaml for each test that
needed it, but we might as well just set it up always. This makes the
test suite a bit less special, and will make it easier to use
'test_main' as a real deployable charm.

This also fixes a small bug where the test suite was deleting TMPDIR/test_main but not TMPDIR itself. (I had 1200 /tmp/tmp* directories on my machine.) (I've confirmed that with this patch my /tmp ends up clean.)

Note that this isn't sufficient to deploy test_charm. The remaining differences are:
a) 'ops' is a symlink outside of the charm dir. This is papered over by the test suite because shutil.copytree() follows symlinks and copies the contents, if you don't pass `symlinks=True`. (So we are copying ops for each test.)
b) We don't have a 'dispatch' or 'hook/install', but that is necessary as the test suite intentionally does that differently in various tests.