### PR TITLE
test/test_model.py: racing tests

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -16,6 +16,7 @@
 from collections import OrderedDict
 import json
 import ipaddress
+import os
 import pathlib
 from textwrap import dedent
 import unittest


### PR DESCRIPTION
This is the general problem I've had with Travis. The tests passed on my
branch, and they passed on master. But chipaca landed a patch which
added calls to 'os' and I landed a patch that removed 'import os'. We
can live with occasional failures like this, or we can add the policy
that you can't land code unless it already includes the tip of master.