### PR TITLE
347 juju storage and collect metrics

### DIFF
--- a/ops/main.py
+++ b/ops/main.py
@@ -264,6 +264,12 @@ class _Dispatcher:
         self._set_name_from_path(self._dispatch_path)
 
     def is_restricted_context(self):
+        """"Return True if we are running in a restricted Juju context.
+
+        When in a restricted context, most commands (relation-get, config-get,
+        state-get) are not available. As such, we change how we interact with
+        Juju.
+        """
         return self.event_name in ('collect_metrics',)
 
 

--- a/ops/main.py
+++ b/ops/main.py
@@ -264,7 +264,7 @@ class _Dispatcher:
         self._set_name_from_path(self._dispatch_path)
 
     def is_restricted_context(self):
-        return self.event_name in ('collect-metrics',)
+        return self.event_name in ('collect_metrics',)
 
 
 def main(charm_class, use_juju_for_storage=False):


### PR DESCRIPTION
This addresses the issues of using `state-get` for Framework state during collect-metrics when the functionality is not available.

Essentially, we still trigger a script (hooks/collect-metrics) so people can still implement support for metrics, but we do *not* fire a collect-metrics event, because we are unable to instantiate a Framework backed by state-get.

This doesn't address the issue when Juju finally will allow state-get to be called by a charm during collect-metrics, because the specific implementation plan there has not been defined. We cannot just `shutil.which()` because `state-get` is still in $PATH, it just returns an error when called. We could trap the exception during `Framework.__init__` instead of refusing, but this seemed cleaner. (We can always change the policy once it *is* supported in the future.)

fixes: #347 