### PR TITLE
don't use --long in "get describe" for version

### DIFF
--- a/ops/version.py
+++ b/ops/version.py
@@ -27,7 +27,7 @@ def _get_version():
     if (p.parent / '.git').exists():
         try:
             proc = subprocess.run(
-                ['git', 'describe', '--tags', '--long', '--dirty'],
+                ['git', 'describe', '--tags', '--dirty'],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 cwd=p,


### PR DESCRIPTION
With `--long`, the version is e.g. `0.7.0+0.g51234ce` even when 51234ce *is* 0.7.0 :-(