### PR TITLE
ops/testing.py: Basic support for checking pod spec

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -849,6 +849,7 @@ class Pod:
             k8s_resources: Additional kubernetes specific specification.
 
         Returns:
+            None
         """
         if not self._backend.is_leader():
             raise ModelError('cannot set a pod spec as this unit is not a leader')

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -324,6 +324,14 @@ class Harness:
         """
         return self._backend._relation_data[relation_id].get(app_or_unit, None)
 
+    def get_pod_spec(self) -> (typing.Mapping, typing.Mapping):
+        """Return the content of the pod spec as last set by the charm.
+
+        This returns both the pod spec and any k8s_resources that were supplied.
+        See the signature of Model.pod.set_spec
+        """
+        return self._backend._pod_spec
+
     def get_workload_version(self) -> str:
         """Read the workload version that was set by the unit."""
         return self._backend._workload_version

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -891,6 +891,17 @@ class TestHarness(unittest.TestCase):
             str(path).endswith('/image/image'),
             msg='expected {} to end with /image/image')
 
+    def test_get_pod_spec(self):
+        harness = Harness(CharmBase, meta='''
+            name: test-app
+            ''')
+        self.addCleanup(harness.cleanup)
+        harness.set_leader(True)
+        container_spec = {'container': 'spec'}
+        k8s_resources = {'k8s': 'spec'}
+        harness.model.pod.set_spec(container_spec, k8s_resources)
+        self.assertEqual(harness.get_pod_spec(), (container_spec, k8s_resources))
+
 
 class DBRelationChangedHelper(Object):
     def __init__(self, parent, key):


### PR DESCRIPTION
fixes: #261

This is minimal, but it is at the level of what we do in the Operator
framework for pod-spec-set. It allows for having a charm trigger and
event, and then checking that the pod spec matches expectations.