### PR TITLE
0.8 test charm no pickle

### DIFF
--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -14,14 +14,13 @@
 # limitations under the License.
 
 import os
-import base64
-import pickle
 import sys
 import logging
 
 sys.path.append('lib')
 
 from ops.charm import CharmBase  # noqa: E402 (module-level import after non-import code)
+from ops.framework import StoredState  # noqa: E402
 from ops.main import main        # noqa: E402 (ditto)
 
 logger = logging.getLogger()
@@ -29,48 +28,38 @@ logger = logging.getLogger()
 
 class Charm(CharmBase):
 
+    _stored = StoredState()
+
     def __init__(self, *args):
         super().__init__(*args)
 
-        # This environment variable controls the test charm behavior.
-        charm_config = os.environ.get('CHARM_CONFIG')
-        if charm_config is not None:
-            self._charm_config = pickle.loads(base64.b64decode(charm_config))
-        else:
-            self._charm_config = {}
+        self._stored.set_default(
+            try_excepthook=False,
 
-        # TODO: refactor to use StoredState
-        # (this implies refactoring most of test_main.py)
-        self._state_file = self._charm_config.get('STATE_FILE')
-        try:
-            with open(str(self._state_file), 'rb') as f:
-                self._state = pickle.load(f)
-        except (FileNotFoundError, EOFError):
-            self._state = {
-                'on_install': [],
-                'on_start': [],
-                'on_config_changed': [],
-                'on_update_status': [],
-                'on_leader_settings_changed': [],
-                'on_db_relation_joined': [],
-                'on_mon_relation_changed': [],
-                'on_mon_relation_departed': [],
-                'on_ha_relation_broken': [],
-                'on_foo_bar_action': [],
-                'on_start_action': [],
-                '_on_get_model_name_action': [],
-                'on_collect_metrics': [],
+            on_install=[],
+            on_start=[],
+            on_config_changed=[],
+            on_update_status=[],
+            on_leader_settings_changed=[],
+            on_db_relation_joined=[],
+            on_mon_relation_changed=[],
+            on_mon_relation_departed=[],
+            on_ha_relation_broken=[],
+            on_foo_bar_action=[],
+            on_start_action=[],
+            _on_get_model_name_action=[],
+            on_collect_metrics=[],
 
-                'on_log_critical_action': [],
-                'on_log_error_action': [],
-                'on_log_warning_action': [],
-                'on_log_info_action': [],
-                'on_log_debug_action': [],
+            on_log_critical_action=[],
+            on_log_error_action=[],
+            on_log_warning_action=[],
+            on_log_info_action=[],
+            on_log_debug_action=[],
 
-                # Observed event types per invocation. A list is used to preserve the
-                # order in which charm handlers have observed the events.
-                'observed_event_types': [],
-            }
+            # Observed event type names per invocation. A list is used to preserve the
+            # order in which charm handlers have observed the events.
+            observed_event_types=[],
+        )
 
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.start, self._on_start)
@@ -84,65 +73,48 @@ class Charm(CharmBase):
         self.framework.observe(self.on.mon_relation_departed, self._on_mon_relation_departed)
         self.framework.observe(self.on.ha_relation_broken, self._on_ha_relation_broken)
 
-        if self._charm_config.get('USE_ACTIONS'):
-            self.framework.observe(self.on.start_action, self._on_start_action)
-            self.framework.observe(self.on.foo_bar_action, self._on_foo_bar_action)
-            self.framework.observe(self.on.get_model_name_action, self._on_get_model_name_action)
-            self.framework.observe(self.on.get_status_action, self._on_get_status_action)
+        self.framework.observe(self.on.start_action, self._on_start_action)
+        self.framework.observe(self.on.foo_bar_action, self._on_foo_bar_action)
+        self.framework.observe(self.on.get_model_name_action, self._on_get_model_name_action)
+        self.framework.observe(self.on.get_status_action, self._on_get_status_action)
 
         self.framework.observe(self.on.collect_metrics, self._on_collect_metrics)
 
-        if self._charm_config.get('USE_LOG_ACTIONS'):
-            self.framework.observe(self.on.log_critical_action, self._on_log_critical_action)
-            self.framework.observe(self.on.log_error_action, self._on_log_error_action)
-            self.framework.observe(self.on.log_warning_action, self._on_log_warning_action)
-            self.framework.observe(self.on.log_info_action, self._on_log_info_action)
-            self.framework.observe(self.on.log_debug_action, self._on_log_debug_action)
+        self.framework.observe(self.on.log_critical_action, self._on_log_critical_action)
+        self.framework.observe(self.on.log_error_action, self._on_log_error_action)
+        self.framework.observe(self.on.log_warning_action, self._on_log_warning_action)
+        self.framework.observe(self.on.log_info_action, self._on_log_info_action)
+        self.framework.observe(self.on.log_debug_action, self._on_log_debug_action)
 
-        if self._charm_config.get('TRY_EXCEPTHOOK'):
+        if os.getenv('TRY_EXCEPTHOOK', False):
             raise RuntimeError("failing as requested")
 
-    def _write_state(self):
-        """Write state variables so that the parent process can read them.
-
-        Each invocation will override the previous state which is intentional.
-        """
-        if self._state_file is not None:
-            with self._state_file.open('wb') as f:
-                pickle.dump(self._state, f)
-
     def _on_install(self, event):
-        self._state['on_install'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
-        self._write_state()
+        self._stored.on_install.append(type(event).__name__)
+        self._stored.observed_event_types.append(type(event).__name__)
 
     def _on_start(self, event):
-        self._state['on_start'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
-        self._write_state()
+        self._stored.on_start.append(type(event).__name__)
+        self._stored.observed_event_types.append(type(event).__name__)
 
     def _on_config_changed(self, event):
-        self._state['on_config_changed'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
+        self._stored.on_config_changed.append(type(event).__name__)
+        self._stored.observed_event_types.append(type(event).__name__)
         event.defer()
-        self._write_state()
 
     def _on_update_status(self, event):
-        self._state['on_update_status'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
-        self._write_state()
+        self._stored.on_update_status.append(type(event).__name__)
+        self._stored.observed_event_types.append(type(event).__name__)
 
     def _on_leader_settings_changed(self, event):
-        self._state['on_leader_settings_changed'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
-        self._write_state()
+        self._stored.on_leader_settings_changed.append(type(event).__name__)
+        self._stored.observed_event_types.append(type(event).__name__)
 
     def _on_db_relation_joined(self, event):
         assert event.app is not None, 'application name cannot be None for a relation-joined event'
-        self._state['on_db_relation_joined'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
-        self._state['db_relation_joined_data'] = event.snapshot()
-        self._write_state()
+        self._stored.on_db_relation_joined.append(type(event).__name__)
+        self._stored.observed_event_types.append(type(event).__name__)
+        self._stored.db_relation_joined_data = event.snapshot()
 
     def _on_mon_relation_changed(self, event):
         assert event.app is not None, (
@@ -151,53 +123,46 @@ class Charm(CharmBase):
             assert event.unit is not None, (
                 'a unit name cannot be None for a relation-changed event'
                 ' associated with a remote unit')
-        self._state['on_mon_relation_changed'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
-        self._state['mon_relation_changed_data'] = event.snapshot()
-        self._write_state()
+        self._stored.on_mon_relation_changed.append(type(event).__name__)
+        self._stored.observed_event_types.append(type(event).__name__)
+        self._stored.mon_relation_changed_data = event.snapshot()
 
     def _on_mon_relation_departed(self, event):
         assert event.app is not None, (
             'application name cannot be None for a relation-departed event')
-        self._state['on_mon_relation_departed'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
-        self._state['mon_relation_departed_data'] = event.snapshot()
-        self._write_state()
+        self._stored.on_mon_relation_departed.append(type(event).__name__)
+        self._stored.observed_event_types.append(type(event).__name__)
+        self._stored.mon_relation_departed_data = event.snapshot()
 
     def _on_ha_relation_broken(self, event):
         assert event.app is None, (
             'relation-broken events cannot have a reference to a remote application')
         assert event.unit is None, (
             'relation broken events cannot have a reference to a remote unit')
-        self._state['on_ha_relation_broken'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
-        self._state['ha_relation_broken_data'] = event.snapshot()
-        self._write_state()
+        self._stored.on_ha_relation_broken.append(type(event).__name__)
+        self._stored.observed_event_types.append(type(event).__name__)
+        self._stored.ha_relation_broken_data = event.snapshot()
 
     def _on_start_action(self, event):
         assert event.handle.kind == 'start_action', (
             'event action name cannot be different from the one being handled')
-        self._state['on_start_action'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
-        self._write_state()
+        self._stored.on_start_action.append(type(event).__name__)
+        self._stored.observed_event_types.append(type(event).__name__)
 
     def _on_foo_bar_action(self, event):
         assert event.handle.kind == 'foo_bar_action', (
             'event action name cannot be different from the one being handled')
-        self._state['on_foo_bar_action'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
-        self._write_state()
+        self._stored.on_foo_bar_action.append(type(event).__name__)
+        self._stored.observed_event_types.append(type(event).__name__)
 
     def _on_get_status_action(self, event):
-        self._state['status_name'] = self.unit.status.name
-        self._state['status_message'] = self.unit.status.message
-        self._write_state()
+        self._stored.status_name = self.unit.status.name
+        self._stored.status_message = self.unit.status.message
 
     def _on_collect_metrics(self, event):
-        self._state['on_collect_metrics'].append(type(event))
-        self._state['observed_event_types'].append(type(event))
+        self._stored.on_collect_metrics.append(type(event).__name__)
+        self._stored.observed_event_types.append(type(event).__name__)
         event.add_metrics({'foo': 42}, {'bar': 4.2})
-        self._write_state()
 
     def _on_log_critical_action(self, event):
         logger.critical('super critical')
@@ -215,8 +180,7 @@ class Charm(CharmBase):
         logger.debug('insightful debug')
 
     def _on_get_model_name_action(self, event):
-        self._state['_on_get_model_name_action'].append(self.model.name)
-        self._write_state()
+        self._stored._on_get_model_name_action.append(self.model.name)
 
 
 if __name__ == '__main__':

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 import abc
-import base64
 import logging
 import os
-import pickle
 import shutil
 import subprocess
 import sys
@@ -47,9 +45,9 @@ from ops.charm import (
     ActionEvent,
     CollectMetricsEvent,
 )
-from ops.framework import Framework, StoredStateData, Handle
+from ops.framework import Framework, StoredStateData
 from ops.main import main, CHARM_STATE_FILE
-from ops.storage import NoSnapshotError, SQLiteStorage
+from ops.storage import SQLiteStorage
 from ops.version import version
 
 from .test_helpers import fake_script, fake_script_calls
@@ -91,6 +89,7 @@ class CharmInitTestCase(unittest.TestCase):
             'JUJU_UNIT_NAME': 'test_main/0',
             'JUJU_MODEL_NAME': 'mymodel',
         }
+        fake_script(self, 'juju-log', "exit 0")
         with patch.dict(os.environ, fake_environ):
             with patch('ops.main._emit_charm_event'):
                 with patch('ops.main._get_charm_dir') as mock_charmdir:
@@ -451,7 +450,6 @@ class _TestMain(abc.ABC):
                       ' results in a non-zero exit code returned')
 
     def test_collect_metrics(self):
-        indicator_file = self.JUJU_CHARM_DIR / 'indicator'
         fake_script(self, 'add-metric', 'exit 0')
         fake_script(self, 'juju-log', 'exit 0')
         self._simulate_event(EventSpec(InstallEvent, 'install'))


### PR DESCRIPTION
Change test_main charm to use StoredState instead of a custom pickle-based state file.

This touches a lot of tests but hopefully in a good way. It cleans up all the tests to use strings to pass what events fired, rather than types (because StoredState doesn't let you pass types).  It also simplifies all the tests so they don't need to pass in a 'charm_config' that just defines where the state file should be. We also now always have actions registered, rather than passing in what actions we want registered when. (We already had actions.yaml that defined them all anyway.)

fixes: #286 