### PR TITLE
ops/testing.py: Harness.begin_with_initial_hooks()

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -165,9 +165,7 @@ class Harness:
         if self._backend._is_leader:
             self._charm.on.leader_elected.emit()
         else:
-            # TODO: jam 2020-08-03 confirm if Juju triggers leader_settings_changed for non leader
-            #   units before or after config-changed et al.
-            pass
+            self._charm.on.leader_settings_changed.emit()
         self._charm.on.config_changed.emit()
         self._charm.on.start.emit()
         # TODO: jam 2020-08-03 relation-joined and relation-changed hooks fire here

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -922,6 +922,25 @@ class TestHarness(unittest.TestCase):
             ]
         )
 
+    def test_begin_with_initial_hooks_no_relations_not_leader(self):
+        harness = Harness(RecordingCharm, meta='''
+            name: test-app
+            ''')
+        self.addCleanup(harness.cleanup)
+        harness.update_config({'foo': 'bar'})
+        self.assertIsNone(harness.charm)
+        harness.begin_with_initial_hooks()
+        self.assertIsNotNone(harness.charm)
+        self.assertEqual(
+            harness.charm.changes,
+            [
+                {'name': 'install'},
+                {'name': 'leader-settings-changed'},
+                {'name': 'config-changed', 'data': {'foo': 'bar'}},
+                {'name': 'start'},
+            ]
+        )
+
 
 class DBRelationChangedHelper(Object):
     def __init__(self, parent, key):


### PR DESCRIPTION
This adds a new method to the testing Harness called `begin_with_initial_hooks()`.

This runs the same hooks that Juju would run when deploying a new charm. It also handles relation events that happen based on what is defined at the point that you trigger begin*. It will make sure that peer relations are initialized and it will fire relation-created for all defined relations and relation-joined for all units of related applications.

fixes: #237 
