### PR TITLE
version-check to determine dispatch support

### DIFF
--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -96,3 +96,7 @@ class JujuVersion:
     def has_app_data(self) -> bool:
         """Determine whether this juju version knows about app data."""
         return (self.major, self.minor, self.patch) >= (2, 7, 0)
+
+    def is_dispatch_aware(self) -> bool:
+        """Determine whether this juju version knows about dispatch."""
+        return (self.major, self.minor, self.patch) >= (2, 8, 0)

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -135,15 +135,17 @@ class TestJujuVersion(unittest.TestCase):
             ("2.0.0.0", "2.0.0.0", False, True),
             ("2.0.0.1", "2.0.0.0", False, False),
             ("2.0.1.10", "2.0.0.0", False, False),
+            ("2.10.0", "2.8.0", False, False),
         ]
 
         for a, b, expected_strict, expected_weak in test_cases:
-            self.assertEqual(JujuVersion(a) < JujuVersion(b), expected_strict)
-            self.assertEqual(JujuVersion(a) <= JujuVersion(b), expected_weak)
-            self.assertEqual(JujuVersion(b) > JujuVersion(a), expected_strict)
-            self.assertEqual(JujuVersion(b) >= JujuVersion(a), expected_weak)
-            # Implicit conversion.
-            self.assertEqual(JujuVersion(a) < b, expected_strict)
-            self.assertEqual(JujuVersion(a) <= b, expected_weak)
-            self.assertEqual(b > JujuVersion(a), expected_strict)
-            self.assertEqual(b >= JujuVersion(a), expected_weak)
+            with self.subTest(a=a, b=b):
+                self.assertEqual(JujuVersion(a) < JujuVersion(b), expected_strict)
+                self.assertEqual(JujuVersion(a) <= JujuVersion(b), expected_weak)
+                self.assertEqual(JujuVersion(b) > JujuVersion(a), expected_strict)
+                self.assertEqual(JujuVersion(b) >= JujuVersion(a), expected_weak)
+                # Implicit conversion.
+                self.assertEqual(JujuVersion(a) < b, expected_strict)
+                self.assertEqual(JujuVersion(a) <= b, expected_weak)
+                self.assertEqual(b > JujuVersion(a), expected_strict)
+                self.assertEqual(b >= JujuVersion(a), expected_weak)

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -60,6 +60,10 @@ class TestJujuVersion(unittest.TestCase):
         self.assertTrue(JujuVersion('2.7.0').has_app_data())
         self.assertFalse(JujuVersion('2.6.9').has_app_data())
 
+    def test_is_dispatch_aware(self):
+        self.assertTrue(JujuVersion('2.8.0').is_dispatch_aware())
+        self.assertFalse(JujuVersion('2.7.9').is_dispatch_aware())
+
     def test_parsing_errors(self):
         invalid_versions = [
             "xyz",

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -179,20 +179,17 @@ class TestDispatch(unittest.TestCase):
         return mock_charm_event.call_args[0][1]
 
     def test_most_legacy(self):
-        """Without dispatch, sys.argv[0] is used
-        """
+        """Without dispatch, sys.argv[0] is used."""
         event = self._check()
         self.assertEqual(event, 'config_changed')
 
     def test_with_dispatch(self):
-        """With dispatch, dispatch is used
-        """
+        """With dispatch, dispatch is used."""
         event = self._check(with_dispatch=True, dispatch_path='hooks/potatos')
         self.assertEqual(event, 'potatos')
 
     def test_with_dispatch_path_but_no_dispatch(self):
-        """Dispatch path overwrites sys.argv[0] even if no actual dispatch
-        """
+        """Dispatch path overwrites sys.argv[0] even if no actual dispatch."""
         event = self._check(with_dispatch=False, dispatch_path='hooks/foo')
         self.assertEqual(event, 'foo')
 
@@ -494,8 +491,7 @@ class _TestMain(abc.ABC):
                                  expected_event_data[event_spec.event_name])
 
     def test_event_not_implemented(self):
-        """Make sure events without implementation do not cause non-zero exit.
-        """
+        """Make sure events without implementation do not cause non-zero exit."""
         # Simulate a scenario where there is a symlink for an event that
         # a charm does not know how to handle.
         hook_path = self.JUJU_CHARM_DIR / 'hooks/not-implemented-event'
@@ -632,8 +628,7 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
             check=True, env=env, cwd=str(self.JUJU_CHARM_DIR))
 
     def test_setup_event_links(self):
-        """Test auto-creation of symlinks caused by initial events.
-        """
+        """Test auto-creation of symlinks caused by initial events."""
         all_event_hooks = ['hooks/' + e.replace("_", "-")
                            for e in self.charm_module.Charm.on.events().keys()]
         initial_events = {
@@ -680,6 +675,12 @@ class TestMainWithNoDispatchButJujuIsDispatchAware(TestMainWithNoDispatch):
     def _call_event(self, rel_path, env):
         env['JUJU_DISPATCH_PATH'] = str(rel_path)
         env['JUJU_VERSION'] = '2.8.0'
+        super()._call_event(rel_path, env)
+
+
+class TestMainWithNoDispatchButDispatchPathIsSet(TestMainWithNoDispatch):
+    def _call_event(self, rel_path, env):
+        env['JUJU_DISPATCH_PATH'] = str(rel_path)
         super()._call_event(rel_path, env)
 
 
@@ -838,8 +839,7 @@ class TestMainWithDispatch(_TestMain, unittest.TestCase):
 
 
 class TestMainWithDispatchAsScript(TestMainWithDispatch):
-    """Here dispatch is a script that execs the charm.py instead of a symlink.
-    """
+    """Here dispatch is a script that execs the charm.py instead of a symlink."""
 
     has_dispatch = True
 


### PR DESCRIPTION
This branch introudces a change, and a simplification (or at least a
separation of concerns) for how the operator framework determines that
a juju is dispatch-aware, and how it determines what hook juju is
asking us to run.

In the existing code we used sys.argv[0] to determine the hook to run
unless JUJU_DISPATCH_PATH was set and a dispatch binary existed, in
which case that environment variable was used. This leads to
charmcraft setting this environment variable to signal what hook to
run (because it will be indirecting the call to the charm code to set
up PYTHONPATH etc). Together with it always creating a dispatch
binary, this means operator always thought it was running in a
dispatch-aware juju, which meant it never created all the missing
symlinks, which meant it never got events beyond those created by
charmcraft itself on non-dispatch-aware jujus.

With this branch, instead JUJU_VERSION is looked at to determine
dispatch-awareness, and JUJU_DISPATCH_PATH is used instead of argv[0]
to know which hook is wanted, and this separation means
non-dispatch-aware jujus should work with dispatch-enabled charms such
as what charmcraft produces.

One last change introduced is that, when creating the symlinks for
non-dispatch-aware jujus (or non-dispatch-enabled charms), the target
of the symlink will be the hook that is currently running, rather than
the charm entry point. This is because the hooks, like dispatch, may
well be shims that set up the environment (etc), without which the
charm entry point won't run.

fixes: #362