### PR TITLE
Clarify ops.testing.Harness.update_config usage

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -517,6 +517,9 @@ class Harness:
 
         This will trigger a `config_changed` event.
 
+        Note that the `key_values` mapping will only add or update configuration items.
+        To remove existing ones, see the `unset` parameter.
+
         Args:
             key_values: A Mapping of key:value pairs to update in config.
             unset: An iterable of keys to remove from Config. (Note that this does


### PR DESCRIPTION
All mappings set into the `key_values` argument are only added or updated.
To remove a configuration item, use the `unset` parameter.