### PR TITLE
fix up logging tests impacting global state so much

### DIFF
--- a/test/test_log.py
+++ b/test/test_log.py
@@ -17,7 +17,6 @@
 import io
 import unittest
 from unittest.mock import patch
-import importlib
 
 import logging
 import ops.log
@@ -38,25 +37,20 @@ class FakeModelBackend:
         self._calls.append((message, level))
 
 
-def reset_logging():
-    logging.shutdown()
-    importlib.reload(logging)
-
-
 class TestLogging(unittest.TestCase):
 
     def setUp(self):
         self.backend = FakeModelBackend()
 
-        reset_logging()
-        self.addCleanup(reset_logging)
+    def tearDown(self):
+        logging.getLogger().handlers.clear()
 
     def test_default_logging(self):
         ops.log.setup_root_logging(self.backend)
 
         logger = logging.getLogger()
         self.assertEqual(logger.level, logging.DEBUG)
-        self.assertIsInstance(logger.handlers[0], ops.log.JujuLogHandler)
+        self.assertIsInstance(logger.handlers[-1], ops.log.JujuLogHandler)
 
         test_cases = [(
             lambda: logger.critical('critical'), [('CRITICAL', 'critical')]

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -81,6 +81,7 @@ class EventSpec:
         self.set_in_env = set_in_env
 
 
+@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class CharmInitTestCase(unittest.TestCase):
 
     def _check(self, charm_class):
@@ -90,7 +91,6 @@ class CharmInitTestCase(unittest.TestCase):
             'JUJU_MODEL_NAME': 'mymodel',
             'JUJU_VERSION': '2.7.0',
         }
-        fake_script(self, 'juju-log', "exit 0")
         with patch.dict(os.environ, fake_environ):
             with patch('ops.main._emit_charm_event'):
                 with patch('ops.main._get_charm_dir') as mock_charmdir:
@@ -140,6 +140,7 @@ class CharmInitTestCase(unittest.TestCase):
 
 
 @patch('sys.argv', new=("hooks/config-changed",))
+@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class TestDispatch(unittest.TestCase):
     def _check(self, *, with_dispatch=False, dispatch_path=''):
         """Helper for below tests."""
@@ -156,7 +157,6 @@ class TestDispatch(unittest.TestCase):
             fake_environ['JUJU_VERSION'] = '2.8.0'
         else:
             fake_environ['JUJU_VERSION'] = '2.7.0'
-        fake_script(self, 'juju-log', "exit 0")
 
         with tempfile.TemporaryDirectory() as tmpdir:
             tmpdir = Path(tmpdir)
@@ -506,7 +506,6 @@ class _TestMain(abc.ABC):
 
     def test_collect_metrics(self):
         fake_script(self, 'add-metric', 'exit 0')
-        fake_script(self, 'juju-log', 'exit 0')
         self._simulate_event(EventSpec(InstallEvent, 'install'))
         # Clear the calls during 'install'
         fake_script_calls(self, clear=True)
@@ -610,6 +609,7 @@ class _TestMain(abc.ABC):
         self.assertEqual(state.status_message, 'help meeee')
 
 
+@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
     has_dispatch = False
     hooks_are_symlinks = True
@@ -671,6 +671,7 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
         self.assertTrue(action_hook.exists())
 
 
+@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class TestMainWithNoDispatchButJujuIsDispatchAware(TestMainWithNoDispatch):
     def _call_event(self, rel_path, env):
         env['JUJU_DISPATCH_PATH'] = str(rel_path)
@@ -678,12 +679,14 @@ class TestMainWithNoDispatchButJujuIsDispatchAware(TestMainWithNoDispatch):
         super()._call_event(rel_path, env)
 
 
+@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class TestMainWithNoDispatchButDispatchPathIsSet(TestMainWithNoDispatch):
     def _call_event(self, rel_path, env):
         env['JUJU_DISPATCH_PATH'] = str(rel_path)
         super()._call_event(rel_path, env)
 
 
+@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class TestMainWithNoDispatchButScriptsAreCopies(TestMainWithNoDispatch):
     hooks_are_symlinks = False
 
@@ -693,6 +696,7 @@ class TestMainWithNoDispatchButScriptsAreCopies(TestMainWithNoDispatch):
         shutil.copy(charm_path, str(path))
 
 
+@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class TestMainWithDispatch(_TestMain, unittest.TestCase):
     has_dispatch = True
 
@@ -820,7 +824,6 @@ class TestMainWithDispatch(_TestMain, unittest.TestCase):
         hook_path = self.hooks_dir / 'install'
         path = (self.hooks_dir / self.charm_exec_path).resolve()
         shutil.copy(str(path), str(hook_path))
-        fake_script(self, 'juju-log', 'exit 0')
 
         event = EventSpec(InstallEvent, 'install')
         state = self._simulate_event(event)
@@ -838,6 +841,7 @@ class TestMainWithDispatch(_TestMain, unittest.TestCase):
         ])
 
 
+@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class TestMainWithDispatchAsScript(TestMainWithDispatch):
     """Here dispatch is a script that execs the charm.py instead of a symlink."""
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -609,7 +609,6 @@ class _TestMain(abc.ABC):
         self.assertEqual(state.status_message, 'help meeee')
 
 
-@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
     has_dispatch = False
     hooks_are_symlinks = True
@@ -671,7 +670,6 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
         self.assertTrue(action_hook.exists())
 
 
-@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class TestMainWithNoDispatchButJujuIsDispatchAware(TestMainWithNoDispatch):
     def _call_event(self, rel_path, env):
         env['JUJU_DISPATCH_PATH'] = str(rel_path)
@@ -679,14 +677,12 @@ class TestMainWithNoDispatchButJujuIsDispatchAware(TestMainWithNoDispatch):
         super()._call_event(rel_path, env)
 
 
-@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class TestMainWithNoDispatchButDispatchPathIsSet(TestMainWithNoDispatch):
     def _call_event(self, rel_path, env):
         env['JUJU_DISPATCH_PATH'] = str(rel_path)
         super()._call_event(rel_path, env)
 
 
-@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class TestMainWithNoDispatchButScriptsAreCopies(TestMainWithNoDispatch):
     hooks_are_symlinks = False
 
@@ -696,7 +692,6 @@ class TestMainWithNoDispatchButScriptsAreCopies(TestMainWithNoDispatch):
         shutil.copy(charm_path, str(path))
 
 
-@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class TestMainWithDispatch(_TestMain, unittest.TestCase):
     has_dispatch = True
 
@@ -841,7 +836,6 @@ class TestMainWithDispatch(_TestMain, unittest.TestCase):
         ])
 
 
-@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class TestMainWithDispatchAsScript(TestMainWithDispatch):
     """Here dispatch is a script that execs the charm.py instead of a symlink."""
 


### PR DESCRIPTION
The way we were doing the log tests, and some main tests, meant that
we'd the logging module's global state was leaking, accumulating
handlers and otherwise messing things up. In some situations this
could lead to failures where logassert and our juju-log handling got
into a squabble due to arbitrary ordering of handlers.

This change means that we only actually set up our juju-log handler
when we need it, and actually reset the logging global state when we
do.

HTH, HAND.