### PR TITLE
use controller-side storage automatically in some cases

### DIFF
--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -100,3 +100,7 @@ class JujuVersion:
     def is_dispatch_aware(self) -> bool:
         """Determine whether this juju version knows about dispatch."""
         return (self.major, self.minor, self.patch) >= (2, 8, 0)
+
+    def has_controller_storage(self) -> bool:
+        """Determine whether this juju version supports controller-side storage."""
+        return (self.major, self.minor, self.patch) >= (2, 8, 0)

--- a/ops/main.py
+++ b/ops/main.py
@@ -277,7 +277,7 @@ class _Dispatcher:
 
 
 def _should_use_controller_storage(db_path: Path, meta: ops.charm.CharmMeta) -> bool:
-    """Figure out whether we want to use controller storag or not."""
+    """Figure out whether we want to use controller storage or not."""
     # if you've previously used local state, carry on using that
     if db_path.exists():
         logger.debug("Using local storage: %s already exists", db_path)
@@ -288,17 +288,7 @@ def _should_use_controller_storage(db_path: Path, meta: ops.charm.CharmMeta) -> 
         logger.debug("Using local storage: not a kubernetes charm")
         return False
 
-    # if the charm specifies a min juju version, use that
-    if meta.min_juju_version is not None:
-        min_version = JujuVersion(meta.min_juju_version)
-        if min_version.has_controller_storage():
-            logger.debug("Using controller storage: min_juju_version: %s", min_version)
-            return True
-        else:
-            logger.debug("Using local storage: min_juju_version: %s", min_version)
-            return False
-
-    # min_juju_version not set, check current juju version
+    # are we in a new enough Juju?
     cur_version = JujuVersion.from_environ()
 
     if cur_version.has_controller_storage():

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -64,6 +64,10 @@ class TestJujuVersion(unittest.TestCase):
         self.assertTrue(JujuVersion('2.8.0').is_dispatch_aware())
         self.assertFalse(JujuVersion('2.7.9').is_dispatch_aware())
 
+    def test_has_controller_storage(self):
+        self.assertTrue(JujuVersion('2.8.0').has_controller_storage())
+        self.assertFalse(JujuVersion('2.7.9').has_controller_storage())
+
     def test_parsing_errors(self):
         invalid_versions = [
             "xyz",

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -241,7 +241,7 @@ class _TestMain(abc.ABC):
         self.stderr = None
 
     def _setup_charm_dir(self):
-        self._tmpdir = Path(tempfile.mkdtemp(prefix='tmp-ops-test-'))
+        self._tmpdir = Path(tempfile.mkdtemp(prefix='tmp-ops-test-')).resolve()
         self.addCleanup(shutil.rmtree, str(self._tmpdir))
         self.JUJU_CHARM_DIR = self._tmpdir / 'test_main'
         self.CHARM_STATE_FILE = self.JUJU_CHARM_DIR / CHARM_STATE_FILE

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -881,20 +881,6 @@ class TestStorageHeuristics(unittest.TestCase):
             self.assertTrue(_should_use_controller_storage(Path("/xyzzy"), meta))
             self.assertLogged('Using controller storage: JUJU_VERSION=2.8.0')
 
-    def test_use_min_juju_version_if_set__too_old(self):
-        meta = CharmMeta.from_yaml("{series: [kubernetes], min-juju-version: '1.0'}")
-        with patch.dict(os.environ, {"JUJU_VERSION": "2.8"}):
-            # note JUJU_VERSION is ignored
-            self.assertFalse(_should_use_controller_storage(Path("/xyzzy"), meta))
-            self.assertLogged('Using local storage: min_juju_version: 1.0.0')
-
-    def test_use_min_juju_version_if_set__new_enough(self):
-        meta = CharmMeta.from_yaml("{series: [kubernetes], min-juju-version: '2.8'}")
-        with patch.dict(os.environ, {"JUJU_VERSION": "1.0"}):
-            # note JUJU_VERSION is ignored
-            self.assertTrue(_should_use_controller_storage(Path("/xyzzy"), meta))
-            self.assertLogged('Using controller storage: min_juju_version: 2.8.0')
-
     def test_not_if_not_in_k8s(self):
         meta = CharmMeta.from_yaml("series: [ecs]")
         with patch.dict(os.environ, {"JUJU_VERSION": "2.8"}):


### PR DESCRIPTION
Before this change, controller-side storage needed to be asked for explicitly.
However, in some cases we _know_ you should probably be using it: When
running in k8s and on a new enough Juju you almost certainly want to
enable it so you don't need to have persistent storage for your
controller pod.

This change makes it so that when we detect that the charm is in this
exact scenario, it uses controller-side automatically unless
explicitly requested not to.