### PR TITLE
ops/lib: use repr less with paths, and os.path.join more

### DIFF
--- a/ops/lib/__init__.py
+++ b/ops/lib/__init__.py
@@ -109,9 +109,9 @@ def _find_all_specs(path):
         except (FileNotFoundError, NotADirectoryError):
             continue
         except OSError as e:
-            logger.debug("Tried to look for ops.lib packages under %r: %s", sys_dir, e)
+            logger.debug("Tried to look for ops.lib packages under '%s': %s", sys_dir, e)
             continue
-        logger.debug("Looking for ops.lib packages under %r", sys_dir)
+        logger.debug("Looking for ops.lib packages under '%s'", sys_dir)
         for top_dir in top_dirs:
             opslib = os.path.join(sys_dir, top_dir, 'opslib')
             try:
@@ -119,16 +119,16 @@ def _find_all_specs(path):
             except (FileNotFoundError, NotADirectoryError):
                 continue
             except OSError as e:
-                logger.debug("  Tried %r: %s", opslib, e)  # *lots* of things checked here
+                logger.debug("  Tried '%s': %s", opslib, e)  # *lots* of things checked here
                 continue
             else:
-                logger.debug("  Trying %r", opslib)
+                logger.debug("  Trying '%s'", opslib)
             finder = get_importer(opslib)
             if finder is None:
-                logger.debug("  Finder for %r is None", opslib)
+                logger.debug("  Finder for '%s' is None", opslib)
                 continue
             if not hasattr(finder, 'find_spec'):
-                logger.debug("  Finder for %r has no find_spec", opslib)
+                logger.debug("  Finder for '%s' has no find_spec", opslib)
                 continue
             for lib_dir in lib_dirs:
                 spec_name = "{}.opslib.{}".format(top_dir, lib_dir)

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -80,7 +80,7 @@ class TestLibFinder(TestCase):
 
         self.assertEqual(
             _flatten(ops.lib._find_all_specs([tmpdir])),
-            [tmpdir + '/foo/opslib/bar'])
+            [os.path.join(tmpdir, 'foo', 'opslib', 'bar')])
         self.assertLoggedDebug("Found", "foo.opslib.bar")
 
     def test_multi(self):
@@ -125,7 +125,7 @@ class TestLibFinder(TestCase):
 
         self.assertEqual(
             _flatten(ops.lib._find_all_specs(dirs)),
-            ['./foo/opslib/bar'])
+            [os.path.join('.', 'foo', 'opslib', 'bar')])
 
     def test_bogus_topdir(self):
         """Check that having one bogus dir in sys.path doesn't cause the finder to abort."""
@@ -139,7 +139,7 @@ class TestLibFinder(TestCase):
 
         self.assertEqual(
             _flatten(ops.lib._find_all_specs(dirs)),
-            [tmpdir + '/foo/opslib/bar'])
+            [os.path.join(tmpdir, 'foo', 'opslib', 'bar')])
 
     def test_bogus_opsdir(self):
         """Check that having one bogus opslib doesn't cause the finder to abort."""
@@ -156,7 +156,7 @@ class TestLibFinder(TestCase):
 
         self.assertEqual(
             _flatten(ops.lib._find_all_specs([tmpdir])),
-            [tmpdir + '/foo/opslib/bar'])
+            [os.path.join(tmpdir, 'foo', 'opslib', 'bar')])
 
     def test_namespace(self):
         """Check that namespace packages are ignored."""


### PR DESCRIPTION
with this, test/test_lib.py passes on windows (3 down, 8 to go...)