### PR TITLE
turns out universal_newlines is the wrong answer, on 3.5

### DIFF
--- a/test/test_infra.py
+++ b/test/test_infra.py
@@ -109,7 +109,10 @@ class InfrastructureTests(unittest.TestCase):
             (sys.executable, 'setup.py') + args,
             stdout=subprocess.PIPE,
             check=True)
-        return proc.stdout.strip().replace(b"\r\n", b"\n").decode("utf8")
+        out = proc.stdout.strip().decode("utf8")
+        if os.linesep != '\n':
+            out = out.replace(os.linesep, '\n')
+        return out
 
     def test_setup_version(self):
         setup_version = self._run_setup('--version')

--- a/test/test_infra.py
+++ b/test/test_infra.py
@@ -103,12 +103,13 @@ class InfrastructureTests(unittest.TestCase):
             self.fail("Please add copyright headers to the following files:\n" + "\n".join(issues))
 
     def _run_setup(self, *args):
+        # from 3.6 we could just use encoding="utf8" here, but 3.5
+        # doesn't expose that and instead defaults to the wrong thing
         proc = subprocess.run(
             (sys.executable, 'setup.py') + args,
             stdout=subprocess.PIPE,
-            universal_newlines=True,
             check=True)
-        return proc.stdout.strip()
+        return proc.stdout.strip().replace(b"\r\n", b"\n").decode("utf8")
 
     def test_setup_version(self):
         setup_version = self._run_setup('--version')


### PR DESCRIPTION
subprocess.run's universal_newlines decodes the output of the command,
but doesn't let you say which encoding to use and in some situations
that will not be the right guess. From 3.6 we could make things
explicit, but 3.5 doesn't yet expose that, so we need to do things by
hand.