### PR TITLE
Handle removal of non-existant relation data

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -694,8 +694,7 @@ class RelationDataContent(LazyMapping, MutableMapping):
             if value == '':
                 # Match the behavior of Juju, which is that setting the value to an
                 # empty string will remove the key entirely from the relation data.
-                if key in self._data:
-                    del self._data[key]
+                self._data.pop(key, None)
             else:
                 self._data[key] = value
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -694,7 +694,8 @@ class RelationDataContent(LazyMapping, MutableMapping):
             if value == '':
                 # Match the behavior of Juju, which is that setting the value to an
                 # empty string will remove the key entirely from the relation data.
-                del self._data[key]
+                if key in self._data:
+                    del self._data[key]
             else:
                 self._data[key] = value
 


### PR DESCRIPTION
'relation-set foo=' should not fail, even if the key does not
exist in the relation data.