### PR TITLE
Add empty list as default return if no relation ids in map

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -181,7 +181,7 @@ class Harness:
                     for rel_id in rel_ids:
                         self._emit_relation_created(relname, rel_id, this_app_name)
             else:
-                rel_ids = self._backend._relation_ids_map.get(relname)
+                rel_ids = self._backend._relation_ids_map.get(relname, [])
                 random.shuffle(rel_ids)
                 for rel_id in rel_ids:
                     app_name = self._backend._relation_app_and_units[rel_id]["app"]

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1032,6 +1032,29 @@ class TestHarness(unittest.TestCase):
                 {'name': 'start'},
             ])
 
+    def test_begin_with_initial_hooks_relation_charm_with_no_relation(self):
+        class CharmWithDB(RelationEventCharm):
+            def __init__(self, framework):
+                super().__init__(framework)
+                self.observe_relation_events('db')
+        harness = Harness(CharmWithDB, meta='''
+            name: test-app
+            requires:
+              db:
+                interface: sql
+            ''')
+        self.addCleanup(harness.cleanup)
+        harness.set_leader()
+        harness.begin_with_initial_hooks()
+        self.assertEqual(
+            harness.charm.changes,
+            [
+                {'name': 'install'},
+                {'name': 'leader-elected'},
+                {'name': 'config-changed', 'data': {}},
+                {'name': 'start'},
+            ])
+
     def test_begin_with_initial_hooks_with_one_relation(self):
         class CharmWithDB(RelationEventCharm):
             def __init__(self, framework):


### PR DESCRIPTION
This returns an empty list if no relations added during setup of harness when the charm has a possible relation. If no relations specified, we hit a `TypeError: object of type 'NoneType' has no len()` when trying to `random.shuffle()` the `rel_ids` retrieved from `_relation_ids_map`.

Fixes canonical#405