### PR TITLE
add __repr__ for EventBase, LazyMapping, and RelationData

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -120,6 +120,9 @@ class EventBase:
         self.handle = handle
         self.deferred = False
 
+    def __repr__(self):
+        return "<%s via %s>" % (self.__class__.__name__, self.handle)
+
     def defer(self):
         self.deferred = True
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -348,6 +348,9 @@ class LazyMapping(Mapping, ABC):
     def __getitem__(self, key):
         return self._data[key]
 
+    def __repr__(self):
+        return repr(self._data)
+
 
 class RelationMapping(Mapping):
     """Map of relation names to lists of :class:`Relation` instances."""
@@ -647,6 +650,9 @@ class RelationData(Mapping):
 
     def __getitem__(self, key):
         return self._data[key]
+
+    def __repr__(self):
+        return repr(self._data)
 
 
 # We mix in MutableMapping here to get some convenience implementations, but whether it's actually

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -161,12 +161,15 @@ class TestFramework(BaseTestCase):
             def __init__(self, parent, key):
                 super().__init__(parent, key)
                 self.seen = []
+                self.reprs = []
 
             def on_any(self, event):
                 self.seen.append("on_any:" + event.handle.kind)
+                self.reprs.append(repr(event))
 
             def on_foo(self, event):
                 self.seen.append("on_foo:" + event.handle.kind)
+                self.reprs.append(repr(event))
 
         pub = MyNotifier(framework, "1")
         obs = MyObserver(framework, "1")
@@ -181,6 +184,10 @@ class TestFramework(BaseTestCase):
         pub.bar.emit()
 
         self.assertEqual(obs.seen, ["on_any:foo", "on_any:bar"])
+        self.assertEqual(obs.reprs, [
+            "<MyEvent via MyNotifier[1]/foo[1]>",
+            "<MyEvent via MyNotifier[1]/bar[2]>",
+        ])
 
     def test_bad_sig_observer(self):
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -209,6 +209,8 @@ class TestModel(unittest.TestCase):
                                    self.model.get_relation('db1').units))
         # Force memory cache to be loaded.
         self.assertIn('host', rel_db1.data[remoteapp1_0])
+        self.assertEqual(repr(rel_db1.data[remoteapp1_0]), "{'host': 'remoteapp1/0'}")
+
         with self.assertRaises(ops.model.RelationDataError):
             rel_db1.data[remoteapp1_0]['foo'] = 'bar'
         self.assertNotIn('foo', rel_db1.data[remoteapp1_0])
@@ -218,6 +220,14 @@ class TestModel(unittest.TestCase):
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'remoteapp1/0', False),
         ])
+
+        # this will fire more backend calls
+        self.assertEqual(
+            repr(rel_db1.data),
+            "{<ops.model.Unit myapp/0>: {},"
+            " <ops.model.Application myapp>: {},"
+            " <ops.model.Unit remoteapp1/0>: {'host': 'remoteapp1/0'},"
+            " <ops.model.Application remoteapp1>: {'secret': 'cafedeadbeef'}}")
 
     def test_relation_data_modify_our(self):
         relation_id = self.harness.add_relation('db1', 'remoteapp1')

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -222,12 +222,14 @@ class TestModel(unittest.TestCase):
         ])
 
         # this will fire more backend calls
-        self.assertEqual(
-            repr(rel_db1.data),
-            "{<ops.model.Unit myapp/0>: {},"
-            " <ops.model.Application myapp>: {},"
-            " <ops.model.Unit remoteapp1/0>: {'host': 'remoteapp1/0'},"
-            " <ops.model.Application remoteapp1>: {'secret': 'cafedeadbeef'}}")
+        # the CountEqual and weird (and brittle) splitting is to accommodate python 3.5
+        # TODO: switch to assertEqual when we drop 3.5
+        self.assertCountEqual(
+            repr(rel_db1.data)[1:-1].split(', '),
+            ["<ops.model.Unit myapp/0>: {}",
+             "<ops.model.Application myapp>: {}",
+             "<ops.model.Unit remoteapp1/0>: {'host': 'remoteapp1/0'}",
+             "<ops.model.Application remoteapp1>: {'secret': 'cafedeadbeef'}"])
 
     def test_relation_data_modify_our(self):
         relation_id = self.harness.add_relation('db1', 'remoteapp1')


### PR DESCRIPTION
This indirectly gets a `__repr__` for `RelationDataContent`.
`RelationData.__repr__` will trigger backend call, but as it's used for
debugging that seems reasonable to me.

fixes: #250