### PR TITLE
Add config alias to CharmBase

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -388,6 +388,11 @@ class CharmBase(Object):
         """
         return self.framework.charm_dir
 
+    @property
+    def config(self) -> model.ConfigData:
+        """A mapping containing the charm's config and current values."""
+        return self.model.config
+
 
 class CharmMeta:
     """Object containing the metadata for the charm.

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -105,6 +105,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(charm.unit, framework.model.unit)
         self.assertEqual(charm.meta, framework.meta)
         self.assertEqual(charm.charm_dir, framework.charm_dir)
+        self.assertIs(charm.config, framework.model.config)
 
     def test_relation_events(self):
 


### PR DESCRIPTION
As [discussed on Discourse][comment], using `self.model.config` can cause the charm author to believe they are accessing the model-level config. It's also extra typing for something that is going to be frequently accessed, so like the other frequently accessed attributes like `self.app`, `self.unit`, etc, a `self.config` alias seems easier and less likely to lead to confusion.

[comment]: https://discourse.juju.is/t/first-steps-with-the-operator-framework/3006/12