### PR TITLE
Fix tests when PyYAML is missing libyaml extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ Or you can use a virtualenv:
 
 Then you can try `./run_tests`, it should all go green.
 
-If you see the error `yaml does not have libyaml extensions, using slower pure
-Python yaml`, you need to reinstall pyyaml with the correct extensions:
+For improved performance on the tests, you will ensure that you have PyYAML
+installed with the correct extensions:
 
     apt-get install libyaml-dev
     pip install --force-reinstall --no-cache-dir pyyaml

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Or you can use a virtualenv:
 
 Then you can try `./run_tests`, it should all go green.
 
-For improved performance on the tests, you will ensure that you have PyYAML
+For improved performance on the tests, ensure that you have PyYAML
 installed with the correct extensions:
 
     apt-get install libyaml-dev


### PR DESCRIPTION
When running the tests locally, I ran into failures due to the log message checks in the tests not accounting for the extra warning emitted if the libyaml extensions were not available for PyYAML.