### PR TITLE
Allow nesting of disable_hooks context manager

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -360,11 +360,14 @@ class Harness:
                 harness.update_config(unset=['foo', 'bar'])
             # things here will again fire events
         """
-        self.disable_hooks()
-        try:
+        if self._hooks_enabled:
+            self.disable_hooks()
+            try:
+                yield None
+            finally:
+                self.enable_hooks()
+        else:
             yield None
-        finally:
-            self.enable_hooks()
 
     def _next_relation_id(self):
         rel_id = self._relation_id_counter


### PR DESCRIPTION
This corrects behavior when a test is using the disable_hooks
context manager and calls a helper that also uses disable_hooks.