### PR TITLE
Give ObjectEvents a useful __repr__

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -339,7 +339,7 @@ class ObjectEvents(Object):
         setattr(cls, event_kind, event_descriptor)
 
     def _event_kinds(self):
-        event_kinds = list()
+        event_kinds = []
         # We have to iterate over the class rather than instance to allow for properties which
         # might call this method (e.g., event views), leading to infinite recursion.
         for attr_name, attr_value in inspect.getmembers(type(self)):
@@ -358,9 +358,8 @@ class ObjectEvents(Object):
 
     def __repr__(self):
         k = type(self)
-        return '<{}.{}: {}>'.format(
-            k.__module__, k.__qualname__,
-            ', '.join(sorted(self._event_kinds())))
+        event_kinds = ', '.join(sorted(self._event_kinds()))
+        return '<{}.{}: {}>'.format(k.__module__, k.__qualname__, event_kinds)
 
 
 class PrefixedEvents:

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -147,6 +147,8 @@ peers:
 
         charm = MyCharm(self.create_framework())
 
+        self.assertIn('pro_2_relation_broken', repr(charm.on))
+
         rel = charm.framework.model.get_relation('req1', 1)
         unit = charm.framework.model.get_unit('remote/0')
         charm.on['req1'].relation_joined.emit(rel, unit)

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -528,6 +528,8 @@ class TestFramework(BaseTestCase):
         pub.on.foo.emit()
 
         self.assertEqual(obs.seen, ["on_foo:foo"])
+        fqn = pub.on.__class__.__module__ + "." + pub.on.__class__.__qualname__
+        self.assertEqual(repr(pub.on), "<{}: bar, foo>".format(fqn))
 
     def test_conflicting_event_attributes(self):
         class MyEvent(EventBase):


### PR DESCRIPTION
This change has ObjectEvents instances show useful information in
their `__repr__`, not just the default `<yadda object at 0xdeadbeef>`.

In particular, it now lists all the events the object can handle.

Fixes: #416