### PR TITLE
Set sys.breakpointhook in main instead of Framework.__init__

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -461,16 +461,33 @@ class Framework(Object):
             self._stored = StoredStateData(self, '_stored')
             self._stored['event_count'] = 0
 
-        # Hook into builtin breakpoint, so if Python >= 3.7, devs will be able to just do
-        # breakpoint(); if Python < 3.7, this doesn't affect anything
-        sys.breakpointhook = self.breakpoint
-
         # Flag to indicate that we already presented the welcome message in a debugger breakpoint
         self._breakpoint_welcomed = False
 
-        # Parse once the env var, which may be used multiple times later
+        # Parse the env var once, which may be used multiple times later
         debug_at = os.environ.get('JUJU_DEBUG_AT')
         self._juju_debug_at = debug_at.split(',') if debug_at else ()
+
+    def set_breakpointhook(self):
+        """Hook into sys.breakpointhook so the builtin breakpoint() works as expected.
+
+        This method is called by ``main``, and is not intended to be
+        called by users of the framework itself outside of perhaps
+        some testing scenarios.
+
+        It returns the old value of sys.excepthook.
+
+        The breakpoint function is a Python >= 3.7 feature.
+
+        This method was added in ops 1.0; before that, it was done as
+        part of the Framework's __init__.
+        """
+        old_breakpointhook = getattr(sys, 'breakpointhook', None)
+        if old_breakpointhook is not None:
+            # Hook into builtin breakpoint, so if Python >= 3.7, devs will be able to just do
+            # breakpoint()
+            sys.breakpointhook = self.breakpoint
+        return old_breakpointhook
 
     def close(self):
         self._storage.close()

--- a/ops/main.py
+++ b/ops/main.py
@@ -375,6 +375,7 @@ def main(charm_class: ops.charm.CharmBase, use_juju_for_storage: bool = None):
     else:
         store = ops.storage.SQLiteStorage(charm_state_path)
     framework = ops.framework.Framework(store, charm_dir, meta, model)
+    framework.set_breakpointhook()
     try:
         sig = inspect.signature(charm_class)
         try:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import abc
+import io
 import logging
 import logassert
 import os
@@ -89,13 +90,39 @@ class EventSpec:
 @patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class CharmInitTestCase(unittest.TestCase):
 
-    def _check(self, charm_class, **kwargs):
+    @unittest.skipIf(sys.version_info < (3, 7), "no breakpoint builtin for Python < 3.7")
+    @patch('sys.stderr', new_callable=io.StringIO)
+    def test_breakpoint(self, fake_stderr):
+        class MyCharm(CharmBase):
+            pass
+        self._check(MyCharm, extra_environ={'JUJU_DEBUG_AT': 'all'})
+
+        with patch('pdb.Pdb.set_trace') as mock:
+            breakpoint()
+
+        self.assertEqual(mock.call_count, 1)
+        self.assertIn('Starting pdb to debug charm operator', fake_stderr.getvalue())
+
+    @unittest.skipIf(sys.version_info < (3, 7), "no breakpoint builtin for Python < 3.7")
+    def test_no_debug_breakpoint(self):
+        class MyCharm(CharmBase):
+            pass
+        self._check(MyCharm, extra_environ={'JUJU_DEBUG_AT': ''})
+
+        with patch('pdb.Pdb.set_trace') as mock:
+            breakpoint()
+
+        self.assertEqual(mock.call_count, 0)
+
+    def _check(self, charm_class, *, extra_environ=None, **kwargs):
         """Helper for below tests."""
         fake_environ = {
             'JUJU_UNIT_NAME': 'test_main/0',
             'JUJU_MODEL_NAME': 'mymodel',
             'JUJU_VERSION': '2.7.0',
         }
+        if extra_environ is not None:
+            fake_environ.update(extra_environ)
         with patch.dict(os.environ, fake_environ):
             with patch('ops.main._emit_charm_event'):
                 with patch('ops.main._get_charm_dir') as mock_charmdir:


### PR DESCRIPTION
Before this change `Framework.__init__` would unconditionally
overwrite `sys.breakpointhook`, which can clash with some testing
and debugging approaches.

This change means that there is an explicit call that sets things up,
done from `main` after constructing the `Framework` object.

Fixes: #421