### PR TITLE
Minor clarification for deferred event doc string

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -138,8 +138,11 @@ class EventBase:
     def defer(self):
         """Defer the event to the future.
 
-        After being deferred, this event will be re-emited the next time there's
-        any other event for the charm.
+        After being deferred, this event will be re-emitted the next time there's
+        any other event for the charm. However the current event handler will
+        continue execution, in the absence of an explicit return statement. Further
+        when the event is re-emitted, the corresponding event handler will being
+        execution again from its first executable statement.
         """
         logger.debug("Deferring %s.", self)
         self.deferred = True

--- a/ops/main.py
+++ b/ops/main.py
@@ -391,7 +391,8 @@ def main(charm_class: ops.charm.CharmBase, use_juju_for_storage: bool = None):
         dispatcher.ensure_event_links(charm)
 
         # TODO: Remove the collect_metrics check below as soon as the relevant
-        #       Juju changes are made.
+        #       Juju changes are made. Also adjust the docstring on
+        #       EventBase.defer().
         #
         # Skip reemission of deferred events for collect-metrics events because
         # they do not have the full access to all hook tools.


### PR DESCRIPTION
This is a small clarification for the doc string of event.defer().