### PR TITLE
give StoredFoo classes a useful __repr__

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -968,6 +968,14 @@ def _unwrap_stored(parent_data, value):
     return value
 
 
+def _wrapped_repr(obj):
+    t = type(obj)
+    if obj._under:
+        return "{}.{}({!r})".format(t.__module__, t.__name__, obj._under)
+    else:
+        return "{}.{}()".format(t.__module__, t.__name__)
+
+
 class StoredDict(collections.abc.MutableMapping):
     """A dict-like object that uses the StoredState as backend."""
 
@@ -999,6 +1007,8 @@ class StoredDict(collections.abc.MutableMapping):
             return self._under == other
         else:
             return NotImplemented
+
+    __repr__ = _wrapped_repr
 
 
 class StoredList(collections.abc.MutableSequence):
@@ -1072,6 +1082,8 @@ class StoredList(collections.abc.MutableSequence):
         else:
             return NotImplemented
 
+    __repr__ = _wrapped_repr
+
 
 class StoredSet(collections.abc.MutableSet):
     """A set-like object that uses the StoredState as backend."""
@@ -1139,3 +1151,5 @@ class StoredSet(collections.abc.MutableSet):
             return self._under == other
         else:
             return NotImplemented
+
+    __repr__ = _wrapped_repr

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -40,7 +40,9 @@ from ops.framework import (
     Handle,
     Object,
     PreCommitEvent,
+    StoredDict,
     StoredList,
+    StoredSet,
     StoredState,
     StoredStateData,
 )
@@ -887,6 +889,18 @@ class TestStoredState(BaseTestCase):
     def setUp(self):
         self.tmpdir = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, str(self.tmpdir))
+
+    def test_stored_dict_repr(self):
+        self.assertEqual(repr(StoredDict(None, {})), "ops.framework.StoredDict()")
+        self.assertEqual(repr(StoredDict(None, {"a": 1})), "ops.framework.StoredDict({'a': 1})")
+
+    def test_stored_list_repr(self):
+        self.assertEqual(repr(StoredList(None, [])), "ops.framework.StoredList()")
+        self.assertEqual(repr(StoredList(None, [1, 2, 3])), 'ops.framework.StoredList([1, 2, 3])')
+
+    def test_stored_set_repr(self):
+        self.assertEqual(repr(StoredSet(None, set())), 'ops.framework.StoredSet()')
+        self.assertEqual(repr(StoredSet(None, {1})), 'ops.framework.StoredSet({1})')
 
     def test_basic_state_storage(self):
         class SomeObject(Object):


### PR DESCRIPTION
Before this change the three StoredFoo classes (`StoredDict`,
`StoredList` and `StoredSet`) did not have a `__repr__`, meaning that
if for example you wrote them out to the log them you'd get e.g.

    <ops.framework.StoredList object at 0x7f8b3dca0b50>

which is not particularly useful. With this change instead you'd get

    ops.framework.StoredList(["hi"])

which is not completely correct (in that you can't `eval(repr(obj))`
to get back `obj`), but it is at least more useful than what was there
before.