### PR TITLE
protect calls to juju-log from messages starting with dashes

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1230,7 +1230,7 @@ class _ModelBackend:
         self._run('application-version-set', '--', version)
 
     def juju_log(self, level, message):
-        self._run('juju-log', '--log-level', level, message)
+        self._run('juju-log', '--log-level', level, "--", message)
 
     def network_get(self, binding_name, relation_id=None):
         """Return network info provided by network-get for a given binding.

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -52,22 +52,19 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(logger.level, logging.DEBUG)
         self.assertIsInstance(logger.handlers[-1], ops.log.JujuLogHandler)
 
-        test_cases = [(
-            lambda: logger.critical('critical'), [('CRITICAL', 'critical')]
-        ), (
-            lambda: logger.error('error'), [('ERROR', 'error')]
-        ), (
-            lambda: logger.warning('warning'), [('WARNING', 'warning')]
-        ), (
-            lambda: logger.info('info'), [('INFO', 'info')]
-        ), (
-            lambda: logger.debug('debug'), [('DEBUG', 'debug')]
-        )]
+        test_cases = [
+            (logger.critical, 'critical', ('CRITICAL', 'critical')),
+            (logger.error, 'error', ('ERROR', 'error')),
+            (logger.warning, 'warning', ('WARNING', 'warning')),
+            (logger.info, 'info', ('INFO', 'info')),
+            (logger.debug, 'debug', ('DEBUG', 'debug')),
+        ]
 
-        for do, res in test_cases:
-            do()
-            calls = self.backend.calls(clear=True)
-            self.assertEqual(calls, res)
+        for method, message, result in test_cases:
+            with self.subTest(message):
+                method(message)
+                calls = self.backend.calls(clear=True)
+                self.assertEqual(calls, [result])
 
     def test_handler_filtering(self):
         logger = logging.getLogger()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1337,7 +1337,7 @@ class TestModelBackend(unittest.TestCase):
         fake_script(self, 'juju-log', 'exit 0')
         self.backend.juju_log('WARNING', 'foo')
         self.assertEqual(fake_script_calls(self, clear=True),
-                         [['juju-log', '--log-level', 'WARNING', 'foo']])
+                         [['juju-log', '--log-level', 'WARNING', '--', 'foo']])
 
         with self.assertRaises(TypeError):
             self.backend.juju_log('DEBUG')
@@ -1347,7 +1347,7 @@ class TestModelBackend(unittest.TestCase):
         with self.assertRaises(ops.model.ModelError):
             self.backend.juju_log('BAR', 'foo')
         self.assertEqual(fake_script_calls(self, clear=True),
-                         [['juju-log', '--log-level', 'BAR', 'foo']])
+                         [['juju-log', '--log-level', 'BAR', '--', 'foo']])
 
     def test_valid_metrics(self):
         fake_script(self, 'add-metric', 'exit 0')


### PR DESCRIPTION
Without this change, logging a message that starts with a dash will raise an exception in charm code.