### PR TITLE
Basic goal-state exposure (num_units and pending_units)

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1008,6 +1008,18 @@ class GoalState:
         else:
             return len(units)
 
+    @property
+    def pending_units(self) -> int:
+        """Return the number of pending (non-Active) peer units."""
+        raw = self._backend.goal_state()
+        units = raw.get('units')
+        if units is None:
+            return 0
+        else:
+            return len([name
+                        for name, status in units.items()
+                        if status['status'].lower() != 'active'])
+
 
 class ModelError(Exception):
     """Base class for exceptions raised when interacting with the Model."""

--- a/ops/model.py
+++ b/ops/model.py
@@ -1002,7 +1002,11 @@ class GoalState:
     def num_units(self):
         """Return the number of expected peer units."""
         raw = self._backend.goal_state()
-        return len(raw['units'].keys())
+        units = raw.get('units')
+        if units is None:
+            return 0
+        else:
+            return len(units)
 
 
 class ModelError(Exception):

--- a/ops/model.py
+++ b/ops/model.py
@@ -1002,23 +1002,17 @@ class GoalState:
     def num_units(self) -> int:
         """Return the number of expected peer units."""
         raw = self._backend.goal_state()
-        units = raw.get('units')
-        if units is None:
-            return 0
-        else:
-            return len(units)
+        units = raw.get('units', {})
+        return len(units)
 
     @property
     def pending_units(self) -> int:
         """Return the number of pending (non-Active) peer units."""
         raw = self._backend.goal_state()
-        units = raw.get('units')
-        if units is None:
-            return 0
-        else:
-            return len([name
-                        for name, status in units.items()
-                        if status['status'].lower() != 'active'])
+        units = raw.get('units', {})
+        return len([name
+                    for name, status in units.items()
+                    if status['status'].lower() != 'active'])
 
 
 class ModelError(Exception):

--- a/ops/model.py
+++ b/ops/model.py
@@ -59,6 +59,7 @@ class Model:
         self._pod = Pod(self._backend)
         self._storages = StorageMapping(list(meta.storages), self._backend)
         self._bindings = BindingMapping(self._backend)
+        self._goal = GoalState(self._backend)
 
     @property
     def unit(self) -> 'Unit':
@@ -110,6 +111,11 @@ class Model:
         This is read from the environment variable ``JUJU_MODEL_NAME``.
         """
         return self._backend.model_name
+
+    @property
+    def goal(self) -> int:
+        """Return :class: GoalState object representing the goal-state of the Juju model."""
+        return self._goal
 
     def get_unit(self, unit_name: str) -> 'Unit':
         """Get an arbitrary unit by name.
@@ -987,6 +993,17 @@ class Storage:
         return self._location
 
 
+class GoalState:
+    """Represents goal state of the Juju model."""
+    def __init__(self, backend):
+        self._backend = backend
+
+    @property
+    def num_units(self):
+        raw = self._backend.goal_state()
+        return len(raw['units'].keys())
+
+
 class ModelError(Exception):
     """Base class for exceptions raised when interacting with the Model."""
     pass
@@ -1271,7 +1288,7 @@ class _ModelBackend:
         self._run(*cmd)
 
     def goal_state(self):
-        return self._run('goal-state', use_json=True)
+        return self._run('goal-state', return_output=True, use_json=True)
 
 
 class _ModelBackendValidator:

--- a/ops/model.py
+++ b/ops/model.py
@@ -1000,6 +1000,7 @@ class GoalState:
 
     @property
     def num_units(self):
+        """Return the number of expected peer units."""
         raw = self._backend.goal_state()
         return len(raw['units'].keys())
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -113,7 +113,7 @@ class Model:
         return self._backend.model_name
 
     @property
-    def goal(self) -> int:
+    def goal(self) -> 'GoalState':
         """Return :class: GoalState object representing the goal-state of the Juju model."""
         return self._goal
 
@@ -999,7 +999,7 @@ class GoalState:
         self._backend = backend
 
     @property
-    def num_units(self):
+    def num_units(self) -> int:
         """Return the number of expected peer units."""
         raw = self._backend.goal_state()
         units = raw.get('units')

--- a/ops/model.py
+++ b/ops/model.py
@@ -1270,6 +1270,9 @@ class _ModelBackend:
         cmd.extend(metric_args)
         self._run(*cmd)
 
+    def goal_state(self):
+        return self._run('goal-state', use_json=True)
+
 
 class _ModelBackendValidator:
     """Provides facilities for validating inputs and formatting them for model backends."""

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -399,7 +399,7 @@ class Harness:
             "app": remote_app,
             "units": [],
         }
-        self._backend._relation_unit_statues[rel_id] = {}
+        self._backend.relation_unit_statuses[rel_id] = {}
         # Reload the relation_ids list
         if self._model is not None:
             self._model.relations._invalidate(relation_name)
@@ -483,7 +483,7 @@ class Harness:
         Return:
             None
         """
-        self._backend._relation_unit_statues[relation_id].update(
+        self._backend.relation_unit_statuses[relation_id].update(
             {remote_unit_name: {"status": remote_unit_status}}
         )
 
@@ -730,7 +730,7 @@ class _TestingModelBackend:
         # {relation_id: {"app": app_name, "units": ["app/0",...]}
         self._relation_app_and_units = {}
         # {relation_id: {unit/0: unit0_status, unit/1: unit1_status,...}}
-        self._relation_unit_statues = {}
+        self.relation_unit_statuses = {}
         self._config = {}
         self._is_leader = False
         self._resources_map = {}  # {resource_name: resource_content}
@@ -866,7 +866,7 @@ class _TestingModelBackend:
                 continue
             peer_units = self._relation_list_map[peer_id]
             units.update(
-                {unit: self._relation_unit_statues[peer_id][unit] for unit in peer_units}
+                {unit: self.relation_unit_statuses[peer_id][unit] for unit in peer_units}
             )
 
         return units
@@ -892,7 +892,7 @@ class _TestingModelBackend:
                 relations.update({rel_name: {}})
             relations[rel_name].update({app: app_status})
             relations[rel_name].update(
-                {unit: self._relation_unit_statues[rel_id][unit] for unit in units}
+                {unit: self.relation_unit_statuses[rel_id][unit] for unit in units}
             )
 
         return relations

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -824,3 +824,6 @@ class _TestingModelBackend:
 
     def network_get(self, endpoint_name, relation_id=None):
         raise NotImplementedError(self.network_get)
+
+    def goal_state(self):
+        return {'units': {}, 'relations': {}}

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -725,6 +725,37 @@ class TestModel(unittest.TestCase):
         with self.assertRaises(AttributeError):
             self.model.storages = {}
 
+    def test_goal_state_num_units_with_no_relations(self):
+        self.assertEqual(
+            0,
+            self.harness.model.goal.num_units
+        )
+
+    def test_goal_state_num_units_with_peers_and_no_relations(self):
+        rel_id = self.harness.add_relation('db2', 'peer0')
+        self.harness.add_relation_unit(rel_id, 'app/0')
+        self.assertEqual(1, self.harness.model.goal.num_units)
+        self.harness.add_relation_unit(rel_id, 'app/1')
+        self.assertEqual(2, self.harness.model.goal.num_units)
+
+    def test_goal_state_num_units_with_peers_and_relations(self):
+        # add non-peer relations and units
+        rel_id0 = self.harness.add_relation('db0', 'remoteapp0')
+        self.harness.add_relation_unit(rel_id0, 'remoteapp0/0')
+        self.harness.add_relation_unit(rel_id0, 'remoteapp0/1')
+        self.harness.add_relation_unit(rel_id0, 'remoteapp0/2')
+        rel_id1 = self.harness.add_relation('db1', 'remoteapp1')
+        self.harness.add_relation_unit(rel_id1, 'remoteapp1/0')
+        self.harness.add_relation_unit(rel_id1, 'remoteapp1/1')
+        self.assertEqual(0, self.harness.model.goal.num_units)
+
+        # add peer relations and units
+        peer_rel_id = self.harness.add_relation('db2', 'peer')
+        self.harness.add_relation_unit(peer_rel_id, 'app/0')
+        self.assertEqual(1, self.harness.model.goal.num_units)
+        self.harness.add_relation_unit(peer_rel_id, 'app/1')
+        self.assertEqual(2, self.harness.model.goal.num_units)
+
     def resetBackendCalls(self):
         self.harness._get_backend_calls(reset=True)
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -756,6 +756,21 @@ class TestModel(unittest.TestCase):
         self.harness.add_relation_unit(peer_rel_id, 'app/1')
         self.assertEqual(2, self.harness.model.goal.num_units)
 
+    def test_goal_state_pending_units_with_peers_and_no_relations(self):
+        rel_id = self.harness.add_relation('db2', 'peer0')
+        self.harness.add_relation_unit(rel_id, 'app/0', 'waiting')
+        self.assertEqual(1, self.harness.model.goal.pending_units)
+        self.assertEqual(1, self.harness.model.goal.num_units)
+        self.harness.add_relation_unit(rel_id, 'app/1', 'maintenance')
+        self.assertEqual(2, self.harness.model.goal.pending_units)
+        self.assertEqual(2, self.harness.model.goal.num_units)
+        self.harness.update_unit_status(rel_id, 'app/0', 'active')
+        self.assertEqual(1, self.harness.model.goal.pending_units)
+        self.assertEqual(2, self.harness.model.goal.num_units)
+        self.harness.update_unit_status(rel_id, 'app/1', 'active')
+        self.assertEqual(0, self.harness.model.goal.pending_units)
+        self.assertEqual(2, self.harness.model.goal.num_units)
+
     def resetBackendCalls(self):
         self.harness._get_backend_calls(reset=True)
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1591,3 +1591,17 @@ class TestTestingModelBackend(unittest.TestCase):
         self.assertIn(
             "units/unit-test-app-0/resources/foo: resource#test-app/foo not found",
             str(cm.exception))
+
+    def test_goal_state_default(self):
+        harness = Harness(CharmBase, meta='''
+            name: test-app
+            peers:
+                test-app:
+                    interface: test-app-peer
+            ''')
+        self.addCleanup(harness.cleanup)
+        backend = harness._backend
+        goal_state = backend.goal_state()
+        self.assertEqual(
+            goal_state,
+            {'units': {}, 'relations': {}})

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1605,3 +1605,54 @@ class TestTestingModelBackend(unittest.TestCase):
         self.assertEqual(
             goal_state,
             {'units': {}, 'relations': {}})
+
+    def test_goal_state_with_peer_units(self):
+        harness = Harness(CharmBase, meta='''
+            name: test-app
+            peers:
+                test-app:
+                    interface: test-app-peer
+            ''')
+        self.addCleanup(harness.cleanup)
+        rel_id = harness.add_relation('test-app', 'app')
+        harness.add_relation_unit(rel_id, 'app/0')
+        backend = harness._backend
+        goal_state = backend.goal_state()
+        self.assertEqual(
+            goal_state,
+            {
+                'units': {
+                    'app/0': {
+                        'status': 'active'
+                    }
+                },
+                'relations': {}
+            })
+
+    def test_goal_state_with_relation_units(self):
+        harness = Harness(CharmBase, meta='''
+            name: test-app
+            requires:
+                test-app:
+                    interface: test-app
+            ''')
+        self.addCleanup(harness.cleanup)
+        rel_id = harness.add_relation('test-app', 'app')
+        harness.add_relation_unit(rel_id, 'app/0')
+        backend = harness._backend
+        goal_state = backend.goal_state()
+        self.assertEqual(
+            goal_state,
+            {
+                'units': {},
+                'relations': {
+                    'test-app': {
+                        'app': {
+                            'status': 'joined'
+                        },
+                        'app/0': {
+                            'status': 'active'
+                        }
+                    }
+                }
+            })


### PR DESCRIPTION
I believe there is still discussion that needs to take place about what exactly needs to be exposed.

Currently, we have `num_units` and `pending_units` exposed by GoalState.