### PR TITLE
Treat empty actions.yaml as no actions.yaml.

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -702,6 +702,8 @@ class CharmMeta:
         raw_actions = {}
         if actions is not None:
             raw_actions = _loadYaml(actions)
+            if raw_actions is None:
+                raw_actions = {}
         return cls(meta, raw_actions)
 
 

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -73,18 +73,20 @@ class Charm(CharmBase):
         self.framework.observe(self.on.mon_relation_departed, self._on_mon_relation_departed)
         self.framework.observe(self.on.ha_relation_broken, self._on_ha_relation_broken)
 
-        self.framework.observe(self.on.start_action, self._on_start_action)
-        self.framework.observe(self.on.foo_bar_action, self._on_foo_bar_action)
-        self.framework.observe(self.on.get_model_name_action, self._on_get_model_name_action)
-        self.framework.observe(self.on.get_status_action, self._on_get_status_action)
+        actions = self.charm_dir / 'actions.yaml'
+        if actions.exists() and actions.read_bytes():
+            self.framework.observe(self.on.start_action, self._on_start_action)
+            self.framework.observe(self.on.foo_bar_action, self._on_foo_bar_action)
+            self.framework.observe(self.on.get_model_name_action, self._on_get_model_name_action)
+            self.framework.observe(self.on.get_status_action, self._on_get_status_action)
+
+            self.framework.observe(self.on.log_critical_action, self._on_log_critical_action)
+            self.framework.observe(self.on.log_error_action, self._on_log_error_action)
+            self.framework.observe(self.on.log_warning_action, self._on_log_warning_action)
+            self.framework.observe(self.on.log_info_action, self._on_log_info_action)
+            self.framework.observe(self.on.log_debug_action, self._on_log_debug_action)
 
         self.framework.observe(self.on.collect_metrics, self._on_collect_metrics)
-
-        self.framework.observe(self.on.log_critical_action, self._on_log_critical_action)
-        self.framework.observe(self.on.log_error_action, self._on_log_error_action)
-        self.framework.observe(self.on.log_warning_action, self._on_log_warning_action)
-        self.framework.observe(self.on.log_info_action, self._on_log_info_action)
-        self.framework.observe(self.on.log_debug_action, self._on_log_debug_action)
 
         if os.getenv('TRY_EXCEPTHOOK', False):
             raise RuntimeError("failing as requested")

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -94,6 +94,9 @@ class TestCharm(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "observer methods must now be explicitly provided"):
             framework.observe(charm.on.start, charm)
 
+    def test_empty_action(self):
+        CharmMeta.from_yaml('name: my-charm', '')
+
     def test_helper_properties(self):
         framework = self.create_framework()
 

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -95,7 +95,8 @@ class TestCharm(unittest.TestCase):
             framework.observe(charm.on.start, charm)
 
     def test_empty_action(self):
-        CharmMeta.from_yaml('name: my-charm', '')
+        meta = CharmMeta.from_yaml('name: my-charm', '')
+        self.assertEqual(meta.actions, {})
 
     def test_helper_properties(self):
         framework = self.create_framework()


### PR DESCRIPTION
Without this change the operator framework would fall over hard if a
charm had an empty `actions.yaml`.

This was found and reported by @davigar15 (thanks!).

Fixes: #458