### PR TITLE
Support tests for removed relations and units

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -407,26 +407,30 @@ class Harness:
         self._emit_relation_created(relation_name, rel_id, remote_app)
         return rel_id
 
-    def remove_relation(self, relation_name: str, remote_app: str) -> None:
+    def remove_relation(self, relation_id: int) -> None:
         """Remove a relation.
 
         Args:
-            relation_name: The relation on Charm that is being related to
-            remote_app: The name of the application that is being related to
+            relation_id: The relation ID for the relation to be removed.
 
         Raises:
-            ValueError: if relation_name is invalid
-            RelationNotFoundError: if valid relation id for relation_name is not found
+            RelationNotFoundError: if relation id is not valid
         """
-        rel_id = self._backend._relation_ids_map[relation_name][0]
-        for unit_name in self._backend._relation_list_map[rel_id]:
-            self.remove_relation_unit(rel_id, unit_name)
-        self._emit_relation_broken(relation_name, rel_id, remote_app)
-        self._backend._relation_app_and_units.pop(rel_id)
-        self._backend._relation_data.pop(rel_id)
-        self._backend._relation_list_map.pop(rel_id)
-        self._backend._relation_ids_map.pop(relation_name)
-        self._backend._relation_names.pop(rel_id)
+        try:
+            relation_name = self._backend._relation_names[relation_id]
+            remote_app = self._backend.relation_remote_app_name(relation_id)
+        except KeyError as e:
+            raise model.RelationNotFoundError from e
+
+        for unit_name in self._backend._relation_list_map[relation_id]:
+            self.remove_relation_unit(relation_id, unit_name)
+
+        self._emit_relation_broken(relation_name, relation_id, remote_app)
+        self._backend._relation_app_and_units.pop(relation_id)
+        self._backend._relation_data.pop(relation_id)
+        self._backend._relation_list_map.pop(relation_id)
+        self._backend._relation_ids_map[relation_name].remove(relation_id)
+        self._backend._relation_names.pop(relation_id)
 
     def _emit_relation_created(self, relation_name: str, relation_id: int,
                                remote_app: str) -> None:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -746,7 +746,6 @@ class _TestingModelBackend:
         self.model_name = None
         self._calls = []
         self._meta = meta
-        self._is_leader = None
         self._relation_ids_map = {}  # relation name to [relation_ids,...]
         self._relation_names = {}  # reverse map from relation_id to relation_name
         self._relation_list_map = {}  # relation_id: [unit_name,...]

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -407,16 +407,45 @@ class Harness:
         self._emit_relation_created(relation_name, rel_id, remote_app)
         return rel_id
 
+    def remove_relation(self, relation_name: str, remote_app: str) -> None:
+        """Remove a relation.
+
+        Args:
+            relation_name: The relation on Charm that is being related to
+            remote_app: The name of the application that is being related to
+
+        Raises:
+            ValueError: if relation_name is invalid
+            RelationNotFoundError: if valid relation id for relation_name is not found
+        """
+        rel_id = self._backend._relation_ids_map[relation_name][0]
+        for unit_name in self._backend._relation_list_map[rel_id]:
+            self.remove_relation_unit(rel_id, unit_name)
+        self._emit_relation_broken(relation_name, rel_id, remote_app)
+        self._backend._relation_app_and_units.pop(rel_id)
+        self._backend._relation_data.pop(rel_id)
+        self._backend._relation_list_map.pop(rel_id)
+        self._backend._relation_ids_map.pop(relation_name)
+        self._backend._relation_names.pop(rel_id)
+
     def _emit_relation_created(self, relation_name: str, relation_id: int,
                                remote_app: str) -> None:
         """Trigger relation-created for a given relation with a given remote application."""
         if self._charm is None or not self._hooks_enabled:
             return
+        relation = self._model.get_relation(relation_name, relation_id)
+        app = self._model.get_app(remote_app)
+        self._charm.on[relation_name].relation_created.emit(
+            relation, app)
+
+    def _emit_relation_broken(self, relation_name: str, relation_id: int,
+                              remote_app: str) -> None:
+        """Trigger relation-broken for a given relation with a given remote application."""
         if self._charm is None or not self._hooks_enabled:
             return
         relation = self._model.get_relation(relation_name, relation_id)
         app = self._model.get_app(remote_app)
-        self._charm.on[relation_name].relation_created.emit(
+        self._charm.on[relation_name].relation_broken.emit(
             relation, app)
 
     def add_relation_unit(self, relation_id: int, remote_unit_name: str) -> None:
@@ -448,17 +477,73 @@ class Harness:
         relation_name = self._backend._relation_names[relation_id]
         # Make sure that the Model reloads the relation_list for this relation_id, as well as
         # reloading the relation data for this unit.
-        if self._model is not None:
-            remote_unit = self._model.get_unit(remote_unit_name)
-            relation = self._model.get_relation(relation_name, relation_id)
-            unit_cache = relation.data.get(remote_unit, None)
-            if unit_cache is not None:
-                unit_cache._invalidate()
-            self._model.relations._invalidate(relation_name)
+        remote_unit = self._model.get_unit(remote_unit_name)
+        relation = self._model.get_relation(relation_name, relation_id)
+        unit_cache = relation.data.get(remote_unit, None)
+        if unit_cache is not None:
+            unit_cache._invalidate()
+        self._model.relations._invalidate(relation_name)
         if self._charm is None or not self._hooks_enabled:
             return
         self._charm.on[relation_name].relation_joined.emit(
             relation, remote_unit.app, remote_unit)
+
+    def remove_relation_unit(self, relation_id: int, remote_unit_name: str) -> None:
+        """Remove a unit from a relation.
+
+        Example::
+
+          rel_id = harness.add_relation('db', 'postgresql')
+          harness.add_relation_unit(rel_id, 'postgresql/0')
+          ...
+          harness.remove_relation_unit(rel_id, 'postgresql/0')
+
+        This will trigger a `relation_departed` event. This would
+        normally be followed by a `relation_changed` event triggered
+        by Juju. However when using the test harness a
+        `relation_changed` event must be triggererd using
+        :meth:`.update_relation_data`. This deviation from normal Juju
+        behaviour, facilitates testing by making each step in the
+        charm life cycle explicit.
+
+        Args:
+            relation_id: The integer relation identifier (as returned by add_relation).
+            remote_unit_name: A string representing the remote unit that is being added.
+
+        Raises:
+            KeyError: if relation_id or remote_unit_name is not valid
+            ValueError: if remote_unit_name is not valid
+        """
+        relation_name = self._backend._relation_names[relation_id]
+
+        # gather data to invalidate cache later
+        remote_unit = self._model.get_unit(remote_unit_name)
+        relation = self._model.get_relation(relation_name, relation_id)
+        unit_cache = relation.data.get(remote_unit, None)
+
+        # statements which could access cache
+        self._emit_relation_departed(relation_id, remote_unit_name)
+        self._backend._relation_data[relation_id].pop(remote_unit_name)
+        self._backend._relation_app_and_units[relation_id][
+            "units"].remove(remote_unit_name)
+        self._backend._relation_list_map[relation_id].remove(remote_unit_name)
+
+        if unit_cache is not None:
+            unit_cache._invalidate()
+
+    def _emit_relation_departed(self, relation_id, unit_name):
+        """Trigger relation-departed event for a given relation id and unit."""
+        if self._charm is None or not self._hooks_enabled:
+            return
+        rel_name = self._backend._relation_names[relation_id]
+        relation = self.model.get_relation(rel_name, relation_id)
+        if '/' in unit_name:
+            app_name = unit_name.split('/')[0]
+            app = self.model.get_app(app_name)
+            unit = self.model.get_unit(unit_name)
+        else:
+            raise ValueError('Invalid Unit Name')
+        self._charm.on[rel_name].relation_departed.emit(relation, app, unit)
 
     def get_relation_data(self, relation_id: int, app_or_unit: str) -> typing.Mapping:
         """Get the relation data bucket for a single app or unit in a given relation.

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -203,6 +203,190 @@ class TestHarness(unittest.TestCase):
         self.assertTrue(len(harness.charm.observed_events), 1)
         self.assertIsInstance(harness.charm.observed_events[0], RelationEvent)
 
+    def test_remove_relation(self):
+        harness = Harness(RelationEventCharm, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            ''')
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        harness.charm.observe_relation_events('db')
+        # First create a relation
+        rel_id = harness.add_relation('db', 'postgresql')
+        self.assertIsInstance(rel_id, int)
+        harness.add_relation_unit(rel_id, 'postgresql/0')
+        backend = harness._backend
+        # Check relation was created
+        self.assertEqual(backend.relation_ids('db'), [rel_id])
+        self.assertEqual(backend.relation_list(rel_id), ['postgresql/0'])
+        harness.charm.get_changes(reset=True)  # created event ignored
+        # Now remove relation
+        harness.remove_relation('db', 'postgresql')
+        # Check relation no longer exists
+        self.assertEqual(backend.relation_ids('db'), [])
+        self.assertRaises(RelationNotFoundError, backend.relation_list, rel_id)
+        # Check relation broken event is raised with correct data
+        changes = harness.charm.get_changes()
+        self.assertEqual(changes[0],
+                         {'name': 'relation-departed',
+                          'relation': 'db',
+                          'data': {'app': 'postgresql',
+                                   'unit': 'postgresql/0',
+                                   'relation_id': 0}})
+        self.assertEqual(changes[1],
+                         {'name': 'relation-broken',
+                          'relation': 'db',
+                          'data': {'app': 'postgresql',
+                                   'unit': None,
+                                   'relation_id': rel_id}})
+
+    def test_remove_relation_unit(self):
+        harness = Harness(RelationEventCharm, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            ''')
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        harness.charm.observe_relation_events('db')
+        # First add a relation and unit
+        rel_id = harness.add_relation('db', 'postgresql')
+        self.assertIsInstance(rel_id, int)
+        harness.add_relation_unit(rel_id, 'postgresql/0')
+        # Check relation and unit were created
+        backend = harness._backend
+        self.assertEqual(backend.relation_ids('db'), [rel_id])
+        self.assertEqual(backend.relation_list(rel_id), ['postgresql/0'])
+        harness.charm.get_changes(reset=True)  # ignore relation created events
+        # Now remove unit
+        harness.remove_relation_unit(rel_id, 'postgresql/0')
+        # Check relation still exists
+        self.assertEqual(backend.relation_ids('db'), [rel_id])
+        # Check removed unit does not exist
+        self.assertEqual(backend.relation_list(rel_id), [])
+        # Check relation departed was raised with correct data
+        self.assertEqual(harness.charm.get_changes()[0],
+                         {'name': 'relation-departed',
+                          'relation': 'db',
+                          'data': {'app': 'postgresql',
+                                   'unit': 'postgresql/0',
+                                   'relation_id': rel_id}})
+
+    def test_removing_relation_removes_remote_app_data(self):
+        # language=YAML
+        harness = Harness(RelationEventCharm, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            ''')
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        harness.charm.observe_relation_events('db')
+        # Add a relation and update app data
+        remote_app = 'postgresql'
+        rel_id = harness.add_relation('db', remote_app)
+        harness.update_relation_data(rel_id, 'postgresql', {'app': 'data'})
+        self.assertIsInstance(rel_id, int)
+        # Check relation app data exists
+        backend = harness._backend
+        self.assertEqual(backend.relation_ids('db'), [rel_id])
+        self.assertEqual({'app': 'data'}, backend.relation_get(rel_id, remote_app, is_app=True))
+        harness.remove_relation('db', 'postgresql')
+        # Check relation and app data are removed
+        self.assertEqual(backend.relation_ids('db'), [])
+        self.assertRaises(RelationNotFoundError, backend.relation_get,
+                          rel_id, remote_app, is_app=True)
+
+    def test_removing_relation_unit_removes_data_also(self):
+        harness = Harness(RelationEventCharm, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            ''')
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        harness.charm.observe_relation_events('db')
+        # Add a relation and unit with data
+        rel_id = harness.add_relation('db', 'postgresql')
+        self.assertIsInstance(rel_id, int)
+        harness.add_relation_unit(rel_id, 'postgresql/0')
+        harness.update_relation_data(rel_id, 'postgresql/0', {'foo': 'bar'})
+        # Check relation, unit and data exist
+        backend = harness._backend
+        self.assertEqual(backend.relation_ids('db'), [rel_id])
+        self.assertEqual(backend.relation_list(rel_id), ['postgresql/0'])
+        self.assertEqual(
+            backend.relation_get(rel_id, 'postgresql/0', is_app=False),
+            {'foo': 'bar'})
+        harness.charm.get_changes(reset=True)  # ignore relation created events
+        # Remove unit but not relation
+        harness.remove_relation_unit(rel_id, 'postgresql/0')
+        # Check relation exists but unit and data are removed
+        self.assertEqual(backend.relation_ids('db'), [rel_id])
+        self.assertEqual(backend.relation_list(rel_id), [])
+        self.assertRaises(KeyError,
+                          backend.relation_get,
+                          rel_id,
+                          'postgresql/0',
+                          is_app=False)
+        # Check relation departed was raised with correct data
+        self.assertEqual(harness.charm.get_changes()[0],
+                         {'name': 'relation-departed',
+                          'relation': 'db',
+                          'data': {'app': 'postgresql',
+                                   'unit': 'postgresql/0',
+                                   'relation_id': rel_id}})
+
+    def test_removing_relation_unit_does_not_remove_other_unit_and_data(self):
+        harness = Harness(RelationEventCharm, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            ''')
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        harness.charm.observe_relation_events('db')
+        # Add a relation with two units with data
+        rel_id = harness.add_relation('db', 'postgresql')
+        self.assertIsInstance(rel_id, int)
+        harness.add_relation_unit(rel_id, 'postgresql/0')
+        harness.add_relation_unit(rel_id, 'postgresql/1')
+        harness.update_relation_data(rel_id, 'postgresql/0', {'foo0': 'bar0'})
+        harness.update_relation_data(rel_id, 'postgresql/1', {'foo1': 'bar1'})
+        # Check both unit and data are present
+        backend = harness._backend
+        self.assertEqual(backend.relation_ids('db'), [rel_id])
+        self.assertEqual(backend.relation_list(rel_id),
+                         ['postgresql/0', 'postgresql/1'])
+        self.assertEqual(
+            backend.relation_get(rel_id, 'postgresql/0', is_app=False),
+            {'foo0': 'bar0'})
+        self.assertEqual(
+            backend.relation_get(rel_id, 'postgresql/1', is_app=False),
+            {'foo1': 'bar1'})
+        harness.charm.get_changes(reset=True)  # ignore relation created events
+        # Remove only one unit
+        harness.remove_relation_unit(rel_id, 'postgresql/1')
+        # Check other unit and data still exists
+        self.assertEqual(backend.relation_list(rel_id),
+                         ['postgresql/0'])
+        self.assertEqual(
+            backend.relation_get(rel_id, 'postgresql/0', is_app=False),
+            {'foo0': 'bar0'})
+        # Check relation departed was raised with correct data
+        self.assertEqual(harness.charm.get_changes()[0],
+                         {'name': 'relation-departed',
+                          'relation': 'db',
+                          'data': {'app': 'postgresql',
+                                   'unit': 'postgresql/1',
+                                   'relation_id': rel_id}})
+
     def test_relation_events(self):
         harness = Harness(RelationEventCharm, meta='''
             name: test-app


### PR DESCRIPTION
This pull request add support for testing relation departed and relation broken events, by adding methods in the test harness to remove relations and their units.