### PR TITLE
Low-level Pebble API client

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -28,14 +28,14 @@ import urllib.parse
 import urllib.request
 
 
-_default_timeout = object()
+_not_provided = object()
 
 
 class _UnixSocketConnection(http.client.HTTPConnection):
     """Implementation of HTTPConnection that connects to a named Unix socket."""
 
-    def __init__(self, host, timeout=_default_timeout, socket_path=None):
-        if timeout is _default_timeout:
+    def __init__(self, host, timeout=_not_provided, socket_path=None):
+        if timeout is _not_provided:
             super().__init__(host)
         else:
             super().__init__(host, timeout=timeout)
@@ -45,7 +45,7 @@ class _UnixSocketConnection(http.client.HTTPConnection):
         """Override connect to use Unix socket (instead of TCP socket)."""
         self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.sock.connect(self.socket_path)
-        if self.timeout is not _default_timeout:
+        if self.timeout is not _not_provided:
             self.sock.settimeout(self.timeout)
 
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -14,11 +14,6 @@
 
 """Client for the Pebble API (HTTP over Unix socket)."""
 
-# TODO(benhoyt): consider the following:
-# - think about how we'll handle API versioning
-# - add automatic retries
-# - unify errors into package-local error
-
 from typing import Any, Dict, List, Optional
 import datetime
 import enum

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -499,7 +499,7 @@ if __name__ == '__main__':
     api = API(socket_path=args.socket)
 
     try:
-        result: Any = None
+        result = None  # type: Any
         if args.command == 'abort':
             result = api.abort_change(ChangeID(args.change_id))
         elif args.command == 'ack':
@@ -527,7 +527,7 @@ if __name__ == '__main__':
         print(json.dumps(obj, sort_keys=True, indent=4))
         sys.exit(1)
     except ServiceError as e:
-        print(e.err)
+        print('ServiceError:', e.err)
         sys.exit(1)
 
     if isinstance(result, list):

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -83,12 +83,9 @@ class ServiceError(Exception):
     """Raised by API.wait_change when a service change is ready but has an error."""
 
     def __init__(self, err, change):
-        super().__init__(err, change)
+        super().__init__(err)
         self.err = err
         self.change = change
-
-    def __str__(self):
-        return self.err
 
 
 class WarningState(enum.Enum):

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1,0 +1,371 @@
+
+from typing import Dict, List, Optional
+import datetime
+import enum
+import http.client
+import json
+import os
+import re
+import socket
+import time
+import urllib.parse
+import urllib.request
+
+
+class UnixSocketConnection(http.client.HTTPConnection):
+    def __init__(self, host, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, socket_path=None):
+        super(UnixSocketConnection, self).__init__(host, timeout=timeout)
+        self.socket_path = socket_path
+
+    def connect(self):
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(self.socket_path)
+        if self.timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
+            self.sock.settimeout(self.timeout)
+
+
+class UnixSocketHandler(urllib.request.AbstractHTTPHandler):
+    def __init__(self, socket_path):
+        super(UnixSocketHandler, self).__init__()
+        self.socket_path = socket_path
+
+    def http_open(self, req):
+        return self.do_open(UnixSocketConnection, req, socket_path=self.socket_path)
+
+    http_request = urllib.request.AbstractHTTPHandler.do_request_
+
+
+TIMESTAMP_RE = re.compile(r'(.*)\.(\d+)(.*)')
+
+def parse_timestamp(s):
+    match = TIMESTAMP_RE.match(s)
+    if not match:
+        return datetime.datetime.fromisoformat(s)
+    head, subsecond, rest = match.groups()
+    subsecond = subsecond[:6]  # fromisoformat supports at most 6 decimal places
+    return datetime.datetime.fromisoformat(head + '.' + subsecond + rest)
+
+
+def indent(s, indent='    '):
+    return '\n'.join(indent+l for l in s.splitlines())
+
+
+class ServiceError(Exception):
+    def __init__(self, err, change):
+        self.err = err
+        self.change = change
+
+    def __str__(self):
+        return self.err
+
+
+class WarningState(enum.Enum):
+    ALL = 'all'
+    PENDING = 'pending'
+
+
+class ChangeState(enum.Enum):
+    ALL = 'all'
+    IN_PROGRESS = 'in-progress'
+    READY = 'ready'
+
+
+class SystemInfo:
+    version: str
+
+    @classmethod
+    def from_dict(cls, d):
+        s = cls()
+        s.version = d['version']
+        return s
+
+    def __repr__(self):
+        return 'SystemInfo(version={!r})'.format(self.version)
+
+    __str__ = __repr__
+
+
+class Warning:
+    message: str
+    first_added: datetime.datetime
+    last_added: datetime.datetime
+    last_shown: Optional[datetime.datetime]
+    expire_after: str
+    repeat_after: str
+
+    @classmethod
+    def from_dict(cls, d):
+        w = cls()
+        w.message = d['message']
+        w.first_added = parse_timestamp(d['first-added'])
+        w.last_added = parse_timestamp(d['last-added'])
+        w.last_shown = parse_timestamp(d['last-shown']) if d.get('last-shown') else None
+        w.expire_after = d['expire-after']
+        w.repeat_after = d['repeat-after']
+        return w
+
+    def __repr__(self):
+        return """Warning(
+    message={!r},
+    first_added={!r},
+    last_added={!r},
+    last_shown={!r},
+    expire_after={!r},
+    repeat_after={!r},
+)""".format(
+            self.message,
+            self.first_added,
+            self.last_added,
+            self.last_shown,
+            self.expire_after,
+            self.repeat_after,
+        )
+
+    __str__ = __repr__
+
+
+class TaskProgress:
+    label: str
+    done: int
+    total: int
+
+    @classmethod
+    def from_dict(cls, d):
+        t = cls()
+        t.label = d['label']
+        t.done = d['done']
+        t.total = d['total']
+        return t
+
+    def __repr__(self):
+        return 'TaskProgress(label={!r}, done={!r}, total={!r})'.format(
+            self.label,
+            self.done,
+            self.total,
+        )
+
+    __str__ = __repr__
+
+
+class Task:
+    id: str
+    kind: str
+    summary: str
+    status: str
+    log: List[str]
+    progress: TaskProgress
+    spawn_time: datetime.datetime
+    ready_time: Optional[datetime.datetime]
+
+    @classmethod
+    def from_dict(cls, d):
+        t = cls()
+        t.id = d['id']
+        t.kind = d['kind']
+        t.summary = d['summary']
+        t.status = d['status']
+        t.log = d.get('log') or []
+        t.progress = TaskProgress.from_dict(d['progress'])
+        t.spawn_time = parse_timestamp(d['spawn-time'])
+        t.ready_time = parse_timestamp(d['ready-time']) if d.get('ready-time') else None
+        return t
+
+    def __repr__(self):
+        return """Task(
+    id={!r},
+    kind={!r},
+    summary={!r},
+    status={!r},
+    log={!r},
+    progress={!r},
+    spawn_time={!r},
+    ready_time={!r},
+)""".format(
+            self.id,
+            self.kind,
+            self.summary,
+            self.status,
+            self.log,
+            self.progress,
+            self.spawn_time,
+            self.ready_time,
+        )
+
+    __str__ = __repr__
+
+
+class Change:
+    id: str
+    kind: str
+    summary: str
+    status: str
+    tasks: List[Task]
+    ready: bool
+    err: str
+    spawn_time: datetime.datetime
+    ready_time: Optional[datetime.datetime]
+
+    @classmethod
+    def from_dict(cls, d):
+        c = cls()
+        c.id = d['id']
+        c.kind = d['kind']
+        c.summary = d['summary']
+        c.status = d['status']
+        c.tasks = [Task.from_dict(t) for t in d.get('tasks') or []]
+        c.ready = d['ready']
+        c.err = d.get('err')
+        c.spawn_time = parse_timestamp(d['spawn-time'])
+        c.ready_time = parse_timestamp(d['ready-time']) if d.get('ready-time') else None
+        return c
+
+    def __repr__(self):
+        return """Change(
+    id={!r},
+    kind={!r},
+    summary={!r},
+    status={!r},
+    tasks={},
+    ready={!r},
+    err={!r},
+    spawn_time={!r},
+    ready_time={!r},
+)""".format(
+            self.id,
+            self.kind,
+            self.summary,
+            self.status,
+            '[\n' + indent(',\n'.join(indent(repr(t)) for t in self.tasks)) + ',\n    ]' if self.tasks else '[]',
+            self.ready,
+            self.err,
+            self.spawn_time,
+            self.ready_time,
+        )
+
+    __str__ = __repr__
+
+
+class API:
+    def __init__(self, socket_path=None, opener=None, base_url='http://localhost', timeout=5.0):
+        if opener is None:
+            opener = self._get_default_opener(socket_path)
+        self.opener = opener
+        self.base_url = base_url
+        self.timeout = timeout
+
+    @classmethod
+    def _get_default_opener(cls, socket_path):
+        if socket_path is None:
+            PEBBLE = os.getenv('PEBBLE')
+            if not PEBBLE:
+                raise Exception('You must specify socket_path or set $PEBBLE')
+            socket_path = os.path.join(PEBBLE, '.pebble.socket')
+
+        opener = urllib.request.OpenerDirector()
+        opener.add_handler(UnixSocketHandler(socket_path))
+        opener.add_handler(urllib.request.HTTPDefaultErrorHandler())
+        opener.add_handler(urllib.request.HTTPRedirectHandler())
+        opener.add_handler(urllib.request.HTTPErrorProcessor())
+        return opener
+
+    def _request(self, method: str, path: str, query: Dict = None, body: Dict = None) -> Dict:
+        url = self.base_url + path
+        if query:
+            url = url + '?' + urllib.parse.urlencode(query)
+
+        headers = {'Accept': 'application/json'}
+        data = None
+        if body is not None:
+            data = json.dumps(body).encode('utf-8')
+            headers['Content-Type'] = 'application/json'
+
+        request = urllib.request.Request(url, method=method, data=data, headers=headers)
+        response = self.opener.open(request, timeout=self.timeout)
+        result = json.load(response)
+        return result
+
+    def get_system_info(self) -> SystemInfo:
+        """Get system info."""
+        result = self._request('GET', '/v1/system-info')
+        return SystemInfo.from_dict(result['result'])
+
+    def get_warnings(self, select=WarningState.PENDING) -> List[Warning]:
+        """Get list of warnings in given state (pending or all)."""
+        query = {'select': select.value}
+        result = self._request('GET', '/v1/warnings', query)
+        return [Warning.from_dict(w) for w in result['result']]
+
+    def ack_warnings(self, timestamp: datetime.datetime) -> int:
+        """Acknowledge warnings up to given timestamp."""
+        body = {'action': 'okay', 'timestamp': timestamp.isoformat()}
+        result = self._request('POST', '/v1/warnings', body=body)
+        return result['result']
+
+    def get_changes(self, select=ChangeState.IN_PROGRESS, service=None) -> List[Change]:
+        """Get list of changes in given state, filter by service name if given."""
+        query = {'select': select.value}
+        if service is not None:
+            query['for'] = service
+        result = self._request('GET', '/v1/changes', query)
+        return [Change.from_dict(c) for c in result['result']]
+
+    def get_change(self, change_id: str) -> Change:
+        """Get single change by ID."""
+        result = self._request('GET', '/v1/changes/{}'.format(change_id))
+        return Change.from_dict(result['result'])
+
+    def abort_change(self, change_id: str) -> Change:
+        """Abort change with given ID."""
+        body = {'action': 'abort'}
+        result = self._request('POST', '/v1/changes/{}'.format(change_id), body=body)
+        return Change.from_dict(result['result'])
+
+    def autostart_services(self, timeout: float = 30.0, delay: float = 0.1) -> str:
+        """Start the autostart services and wait (poll) for them to be started.
+        If timeout is 0, submit the action but don't wait.
+        """
+        return self._services_action('autostart', [], timeout, delay)
+
+    def start_services(self, services: List[str], timeout: float = 30.0, delay: float = 0.1) -> str:
+        """Start services by name and wait (poll) for them to be started.
+        If timeout is 0 or None, submit the action but don't wait.
+        """
+        return self._services_action('start', services, timeout, delay)
+
+    def stop_services(self, services: List[str], timeout: float = 30.0, delay: float = 0.1) -> str:
+        """Stop services by name and wait (poll) for them to be started.
+        If timeout is 0 or None, submit the action but don't wait.
+        """
+        return self._services_action('stop', services, timeout, delay)
+
+    def _services_action(self, action: str, services: List[str], timeout: float, delay: float) -> str:
+        body = {'action': action, 'services': services}
+        result = self._request('POST', '/v1/services', body=body)
+        change_id = result['change']
+        if timeout:
+            self.wait_change(change_id, timeout=timeout, delay=delay)
+        return change_id
+
+    def wait_change(self, change_id: str, timeout: float = 30.0, delay: float = 0.1) -> Change:
+        """Poll change every delay seconds (up to timeout) for it to be ready."""
+        deadline = time.time() + timeout
+
+        while time.time() < deadline:
+            change = self.get_change(change_id)
+            if change.ready:
+                if change.err:
+                    raise ServiceError(change.err, change)
+                return change
+
+            time.sleep(delay)
+
+        raise TimeoutError('timed out waiting for change {} ({} seconds)'.format(change_id, timeout))
+
+
+api = API()
+try:
+    for c in api.get_changes(select=ChangeState.ALL):
+        print(c)
+except urllib.error.HTTPError as e:
+    print(e)
+    print(e.read().decode('utf-8'))

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -36,22 +36,21 @@ def datetime_nzdt(y, m, d, hour, min, sec, micro=0):
     return datetime.datetime(y, m, d, hour, min, sec, micro, tzinfo=tz)
 
 
-class TestMisc(unittest.TestCase):
-    def test_fromisoformat(self):
-        self.assertEqual(pebble._fromisoformat('2020-12-25T13:45:50.123456+13:00'),
-                         datetime_nzdt(2020, 12, 25, 13, 45, 50, 123456))
-        with self.assertRaises(ValueError):
-            pebble._fromisoformat('xyz')
-
+class TestHelpers(unittest.TestCase):
     def test_parse_timestamp(self):
-        self.assertEqual(pebble._fromisoformat('2020-12-25T13:45:50.123456+13:00'),
-                         datetime_nzdt(2020, 12, 25, 13, 45, 50, 123456))
         self.assertEqual(pebble._parse_timestamp('2020-12-25T13:45:50.123456789+13:00'),
                          datetime_nzdt(2020, 12, 25, 13, 45, 50, 123456))
-        self.assertEqual(pebble._fromisoformat('2020-12-25T13:45:50.123456+00:00'),
-                         datetime_utc(2020, 12, 25, 13, 45, 50, 123456))
+
         self.assertEqual(pebble._parse_timestamp('2020-12-25T13:45:50.123456789+00:00'),
                          datetime_utc(2020, 12, 25, 13, 45, 50, 123456))
+
+        tzinfo = datetime.timezone(datetime.timedelta(hours=-11, minutes=-30))
+        self.assertEqual(pebble._parse_timestamp('2020-12-25T13:45:50.123456789-1130'),
+                         datetime.datetime(2020, 12, 25, 13, 45, 50, 123456, tzinfo=tzinfo))
+
+        tzinfo = datetime.timezone(datetime.timedelta(hours=4))
+        self.assertEqual(pebble._parse_timestamp('2000-01-02T03:04:05.006000+0400'),
+                         datetime.datetime(2000, 1, 2, 3, 4, 5, 6000, tzinfo=tzinfo))
 
 
 class TestTypes(unittest.TestCase):

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -158,3 +158,419 @@ class TestTypes(unittest.TestCase):
         d['last-shown'] = '2021-08-04T03:02:01.000000000+13:00'
         warning = pebble.Warning.from_dict(d)
         self.assertEqual(warning.last_shown, datetime_nzdt(2021, 8, 4, 3, 2, 1))
+
+    def test_task_progress_init(self):
+        tp = pebble.TaskProgress(label='foo', done=3, total=7)
+        self.assertEqual(tp.label, 'foo')
+        self.assertEqual(tp.done, 3)
+        self.assertEqual(tp.total, 7)
+        self.assertEqual(repr(tp), "TaskProgress(label='foo', done=3, total=7)")
+
+    def test_task_progress_from_dict(self):
+        tp = pebble.TaskProgress.from_dict({
+            'label': 'foo',
+            'done': 3,
+            'total': 7,
+        })
+        self.assertEqual(tp.label, 'foo')
+        self.assertEqual(tp.done, 3)
+        self.assertEqual(tp.total, 7)
+        self.assertEqual(repr(tp), "TaskProgress(label='foo', done=3, total=7)")
+
+    def test_task_id(self):
+        task_id = pebble.TaskID('1234')
+        self.assertEqual(repr(task_id), "TaskID('1234')")
+        self.assertEqual(task_id, '1234')
+
+    def test_task_init(self):
+        task = pebble.Task(
+            id=pebble.TaskID('42'),
+            kind='start',
+            summary='Start service "svc"',
+            status='Done',
+            log=[],
+            progress=pebble.TaskProgress(label='foo', done=3, total=7),
+            spawn_time=datetime_nzdt(2021, 1, 28, 14, 37, 3, 270218),
+            ready_time=datetime_nzdt(2021, 1, 28, 14, 37, 2, 247158),
+        )
+        self.assertEqual(task.id, '42')
+        self.assertEqual(task.kind, 'start')
+        self.assertEqual(task.summary, 'Start service "svc"')
+        self.assertEqual(task.status, 'Done')
+        self.assertEqual(task.log, [])
+        self.assertEqual(task.progress.label, 'foo')
+        self.assertEqual(task.progress.done, 3)
+        self.assertEqual(task.progress.total, 7)
+        self.assertEqual(task.spawn_time, datetime_nzdt(2021, 1, 28, 14, 37, 3, 270218))
+        self.assertEqual(task.ready_time, datetime_nzdt(2021, 1, 28, 14, 37, 2, 247158))
+        self.assertEqual(repr(task), (
+            "Task(id=TaskID('42'), "
+            "kind='start', "
+            "summary='Start service \"svc\"', "
+            "status='Done', "
+            "log=[], "
+            "progress=TaskProgress(label='foo', done=3, total=7), "
+            "spawn_time=datetime.datetime(2021, 1, 28, 14, 37, 3, 270218, "+NZDT_STR+"), "
+            "ready_time=datetime.datetime(2021, 1, 28, 14, 37, 2, 247158, "+NZDT_STR+"))"),
+        )
+
+    def test_task_from_dict(self):
+        task = pebble.Task.from_dict({
+            "id": "78",
+            "kind": "start",
+            "progress": {
+                "done": 1,
+                "label": "",
+                "total": 1,
+            },
+            "ready-time": "2021-01-28T14:37:03.270218778+13:00",
+            "spawn-time": "2021-01-28T14:37:02.247158162+13:00",
+            "status": "Done",
+            "summary": "Start service \"svc\"",
+        })
+        self.assertEqual(task.id, '78')
+        self.assertEqual(task.kind, 'start')
+        self.assertEqual(task.summary, 'Start service "svc"')
+        self.assertEqual(task.status, 'Done')
+        self.assertEqual(task.log, [])
+        self.assertEqual(task.progress.label, '')
+        self.assertEqual(task.progress.done, 1)
+        self.assertEqual(task.progress.total, 1)
+        self.assertEqual(task.ready_time, datetime_nzdt(2021, 1, 28, 14, 37, 3, 270218))
+        self.assertEqual(task.spawn_time, datetime_nzdt(2021, 1, 28, 14, 37, 2, 247158))
+        self.assertEqual(repr(task), (
+            "Task(id=TaskID('78'), "
+            "kind='start', "
+            "summary='Start service \"svc\"', "
+            "status='Done', "
+            "log=[], "
+            "progress=TaskProgress(label='', done=1, total=1), "
+            "spawn_time=datetime.datetime(2021, 1, 28, 14, 37, 2, 247158, "+NZDT_STR+"), "
+            "ready_time=datetime.datetime(2021, 1, 28, 14, 37, 3, 270218, "+NZDT_STR+"))"),
+        )
+
+    def test_change_id(self):
+        change_id = pebble.ChangeID('1234')
+        self.assertEqual(repr(change_id), "ChangeID('1234')")
+        self.assertEqual(change_id, '1234')
+
+    def test_change_init(self):
+        change = pebble.Change(
+            id=pebble.ChangeID('70'),
+            kind='autostart',
+            err='SILLY',
+            ready=True,
+            ready_time=datetime_nzdt(2021, 1, 28, 14, 37, 4, 291517),
+            spawn_time=datetime_nzdt(2021, 1, 28, 14, 37, 2, 247202),
+            status='Done',
+            summary='Autostart service "svc"',
+            tasks=[],
+        )
+        self.assertEqual(change.id, '70')
+        self.assertEqual(change.kind, 'autostart')
+        self.assertEqual(change.err, 'SILLY')
+        self.assertEqual(change.ready, True)
+        self.assertEqual(change.ready_time, datetime_nzdt(2021, 1, 28, 14, 37, 4, 291517))
+        self.assertEqual(change.spawn_time, datetime_nzdt(2021, 1, 28, 14, 37, 2, 247202))
+        self.assertEqual(change.status, 'Done')
+        self.assertEqual(change.summary, 'Autostart service "svc"')
+        self.assertEqual(change.tasks, [])
+        self.assertEqual(repr(change), (
+            "Change(id=ChangeID('70'), "
+            "kind='autostart', "
+            "summary='Autostart service \"svc\"', "
+            "status='Done', "
+            "tasks=[], "
+            "ready=True, "
+            "err='SILLY', "
+            "spawn_time=datetime.datetime(2021, 1, 28, 14, 37, 2, 247202, "+NZDT_STR+"), "
+            "ready_time=datetime.datetime(2021, 1, 28, 14, 37, 4, 291517, "+NZDT_STR+"))"))
+
+    def test_change_from_dict(self):
+        change = pebble.Change.from_dict({
+            "id": "70",
+            "kind": "autostart",
+            "err": "SILLY",
+            "ready": True,
+            "ready-time": "2021-01-28T14:37:04.291517768+13:00",
+            "spawn-time": "2021-01-28T14:37:02.247202105+13:00",
+            "status": "Done",
+            "summary": "Autostart service \"svc\"",
+            "tasks": [],
+        })
+        self.assertEqual(change.id, '70')
+        self.assertEqual(change.kind, 'autostart')
+        self.assertEqual(change.err, 'SILLY')
+        self.assertEqual(change.ready, True)
+        self.assertEqual(change.ready_time, datetime_nzdt(2021, 1, 28, 14, 37, 4, 291517))
+        self.assertEqual(change.spawn_time, datetime_nzdt(2021, 1, 28, 14, 37, 2, 247202))
+        self.assertEqual(change.status, 'Done')
+        self.assertEqual(change.summary, 'Autostart service "svc"')
+        self.assertEqual(change.tasks, [])
+        self.assertEqual(repr(change), (
+            "Change(id=ChangeID('70'), "
+            "kind='autostart', "
+            "summary='Autostart service \"svc\"', "
+            "status='Done', "
+            "tasks=[], "
+            "ready=True, "
+            "err='SILLY', "
+            "spawn_time=datetime.datetime(2021, 1, 28, 14, 37, 2, 247202, "+NZDT_STR+"), "
+            "ready_time=datetime.datetime(2021, 1, 28, 14, 37, 4, 291517, "+NZDT_STR+"))"))
+
+
+class MockAPI(pebble.API):
+    def __init__(self):
+        self.requests = []
+        self.responses = []
+
+    def _request(self, method, path, query=None, body=None):
+        self.requests.append((method, path, query, body))
+        return self.responses.pop(0)
+
+
+class TestAPI(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.api = MockAPI()
+
+    def test_get_system_info(self):
+        self.api.responses.append({
+            "result": {
+                "version": "1.2.3",
+                "extra-field": "foo",
+            },
+            "status": "OK",
+            "status-code": 200,
+            "type": "sync"
+        })
+        info = self.api.get_system_info()
+        self.assertEqual(info.version, '1.2.3')
+        self.assertEqual(self.api.requests, [
+            ('GET', '/v1/system-info', None, None),
+        ])
+
+    def test_get_warnings(self):
+        empty = {
+            "result": [],
+            "status": "OK",
+            "status-code": 200,
+            "type": "sync"
+        }
+        self.api.responses.append(empty)
+        warnings = self.api.get_warnings()
+        self.assertEqual(warnings, [])
+
+        self.api.responses.append(empty)
+        warnings = self.api.get_warnings(select=pebble.WarningState.ALL)
+        self.assertEqual(warnings, [])
+
+        self.assertEqual(self.api.requests, [
+            ('GET', '/v1/warnings', {'select': 'pending'}, None),
+            ('GET', '/v1/warnings', {'select': 'all'}, None),
+        ])
+
+    def test_ack_warnings(self):
+        self.api.responses.append({
+            "result": 0,
+            "status": "OK",
+            "status-code": 200,
+            "type": "sync"
+        })
+        num = self.api.ack_warnings(datetime_nzdt(2021, 1, 28, 15, 11, 0))
+        self.assertEqual(num, 0)
+        self.assertEqual(self.api.requests, [
+            ('POST', '/v1/warnings', None, {
+                'action': 'okay',
+                'timestamp': '2021-01-28T15:11:00+13:00',
+            }),
+        ])
+
+    def get_mock_change_dict(self):
+        return {
+            "id": "70",
+            "kind": "autostart",
+            "ready": True,
+            "ready-time": "2021-01-28T14:37:04.291517768+13:00",
+            "spawn-time": "2021-01-28T14:37:02.247202105+13:00",
+            "status": "Done",
+            "summary": "Autostart service \"svc\"",
+            "tasks": [
+                {
+                    "id": "78",
+                    "kind": "start",
+                    "progress": {
+                        "done": 1,
+                        "label": "",
+                        "total": 1,
+                        "extra-field": "foo",
+                    },
+                    "ready-time": "2021-01-28T14:37:03.270218778+13:00",
+                    "spawn-time": "2021-01-28T14:37:02.247158162+13:00",
+                    "status": "Done",
+                    "summary": "Start service \"svc\"",
+                    "extra-field": "foo",
+                },
+            ],
+            "extra-field": "foo",
+        }
+
+    def assert_mock_change(self, change):
+        self.assertEqual(change.id, '70')
+        self.assertEqual(change.kind, 'autostart')
+        self.assertEqual(change.summary, 'Autostart service "svc"')
+        self.assertEqual(change.status, 'Done')
+        self.assertEqual(len(change.tasks), 1)
+        self.assertEqual(change.tasks[0].id, '78')
+        self.assertEqual(change.tasks[0].kind, 'start')
+        self.assertEqual(change.tasks[0].summary, 'Start service "svc"')
+        self.assertEqual(change.tasks[0].status, 'Done')
+        self.assertEqual(change.tasks[0].log, [])
+        self.assertEqual(change.tasks[0].progress.done, 1)
+        self.assertEqual(change.tasks[0].progress.label, '')
+        self.assertEqual(change.tasks[0].progress.total, 1)
+        self.assertEqual(change.tasks[0].ready_time,
+                         datetime_nzdt(2021, 1, 28, 14, 37, 3, 270218))
+        self.assertEqual(change.tasks[0].spawn_time,
+                         datetime_nzdt(2021, 1, 28, 14, 37, 2, 247158))
+        self.assertEqual(change.ready, True)
+        self.assertEqual(change.err, None)
+        self.assertEqual(change.ready_time, datetime_nzdt(2021, 1, 28, 14, 37, 4, 291517))
+        self.assertEqual(change.spawn_time, datetime_nzdt(2021, 1, 28, 14, 37, 2, 247202))
+
+    def test_get_changes(self):
+        empty = {
+            "result": [],
+            "status": "OK",
+            "status-code": 200,
+            "type": "sync"
+        }
+        self.api.responses.append(empty)
+        changes = self.api.get_changes()
+        self.assertEqual(changes, [])
+
+        self.api.responses.append(empty)
+        changes = self.api.get_changes(select=pebble.ChangeState.ALL)
+        self.assertEqual(changes, [])
+
+        self.api.responses.append(empty)
+        changes = self.api.get_changes(select=pebble.ChangeState.ALL, service='foo')
+        self.assertEqual(changes, [])
+
+        self.api.responses.append({
+            "result": [
+                self.get_mock_change_dict(),
+            ],
+            "status": "OK",
+            "status-code": 200,
+            "type": "sync"
+        })
+        changes = self.api.get_changes()
+        self.assertEqual(len(changes), 1)
+        self.assert_mock_change(changes[0])
+
+        self.assertEqual(self.api.requests, [
+            ('GET', '/v1/changes', {'select': 'in-progress'}, None),
+            ('GET', '/v1/changes', {'select': 'all'}, None),
+            ('GET', '/v1/changes', {'select': 'all', 'for': 'foo'}, None),
+            ('GET', '/v1/changes', {'select': 'in-progress'}, None),
+        ])
+
+    def test_get_change(self):
+        self.api.responses.append({
+            "result": self.get_mock_change_dict(),
+            "status": "OK",
+            "status-code": 200,
+            "type": "sync"
+        })
+        change = self.api.get_change('70')
+        self.assert_mock_change(change)
+        self.assertEqual(self.api.requests, [
+            ('GET', '/v1/changes/70', None, None),
+        ])
+
+    def test_abort_change(self):
+        self.api.responses.append({
+            "result": self.get_mock_change_dict(),
+            "status": "OK",
+            "status-code": 200,
+            "type": "sync"
+        })
+        change = self.api.abort_change('70')
+        self.assert_mock_change(change)
+        self.assertEqual(self.api.requests, [
+            ('POST', '/v1/changes/70', None, {'action': 'abort'}),
+        ])
+
+    def _test_services_action(self, action, api_func, services):
+        self.api.responses.append({
+            "change": "70",
+            "result": None,
+            "status": "Accepted",
+            "status-code": 202,
+            "type": "async"
+        })
+        change = self.get_mock_change_dict()
+        change['ready'] = False
+        self.api.responses.append({
+            "result": change,
+            "status": "OK",
+            "status-code": 200,
+            "type": "sync"
+        })
+        change = self.get_mock_change_dict()
+        change['ready'] = True
+        self.api.responses.append({
+            "result": change,
+            "status": "OK",
+            "status-code": 200,
+            "type": "sync"
+        })
+        change_id = api_func()
+        self.assertEqual(change_id, '70')
+        self.assertEqual(self.api.requests, [
+            ('POST', '/v1/services', None, {'action': action, 'services': services}),
+            ('GET', '/v1/changes/70', None, None),
+            ('GET', '/v1/changes/70', None, None),
+        ])
+
+    def _test_services_action_async(self, action, api_func, services):
+        self.api.responses.append({
+            "change": "70",
+            "result": None,
+            "status": "Accepted",
+            "status-code": 202,
+            "type": "async"
+        })
+        change_id = api_func(timeout=0)
+        self.assertEqual(change_id, '70')
+        self.assertEqual(self.api.requests, [
+            ('POST', '/v1/services', None, {'action': action, 'services': services}),
+        ])
+
+    def test_autostart_services(self):
+        self._test_services_action('autostart', self.api.autostart_services, [])
+
+    def test_autostart_services_async(self):
+        self._test_services_action_async('autostart', self.api.autostart_services, [])
+
+    def test_start_services(self):
+        def api_func():
+            return self.api.start_services(['svc'])
+        self._test_services_action('start', api_func, ['svc'])
+
+    def test_start_services_async(self):
+        def api_func(timeout=30):
+            return self.api.start_services(['svc'], timeout=timeout)
+        self._test_services_action_async('start', api_func, ['svc'])
+
+    def test_stop_services(self):
+        def api_func():
+            return self.api.stop_services(['svc'])
+        self._test_services_action('stop', api_func, ['svc'])
+
+    def test_stop_services_async(self):
+        def api_func(timeout=30):
+            return self.api.stop_services(['svc'], timeout=timeout)
+        self._test_services_action_async('stop', api_func, ['svc'])

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -205,7 +205,7 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(repr(task), (
             "Task(id=TaskID('42'), "
             "kind='start', "
-            "summary='Start service \"svc\"', "
+            "summary='Start service \"svc\"', "  # NOQA
             "status='Done', "
             "log=[], "
             "progress=TaskProgress(label='foo', done=3, total=7), "
@@ -225,7 +225,7 @@ class TestTypes(unittest.TestCase):
             "ready-time": "2021-01-28T14:37:03.270218778+13:00",
             "spawn-time": "2021-01-28T14:37:02.247158162+13:00",
             "status": "Done",
-            "summary": "Start service \"svc\"",
+            "summary": 'Start service "svc"',
         })
         self.assertEqual(task.id, '78')
         self.assertEqual(task.kind, 'start')
@@ -240,7 +240,7 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(repr(task), (
             "Task(id=TaskID('78'), "
             "kind='start', "
-            "summary='Start service \"svc\"', "
+            "summary='Start service \"svc\"', "  # NOQA
             "status='Done', "
             "log=[], "
             "progress=TaskProgress(label='', done=1, total=1), "
@@ -277,7 +277,7 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(repr(change), (
             "Change(id=ChangeID('70'), "
             "kind='autostart', "
-            "summary='Autostart service \"svc\"', "
+            "summary='Autostart service \"svc\"', "  # NOQA
             "status='Done', "
             "tasks=[], "
             "ready=True, "
@@ -294,7 +294,7 @@ class TestTypes(unittest.TestCase):
             "ready-time": "2021-01-28T14:37:04.291517768+13:00",
             "spawn-time": "2021-01-28T14:37:02.247202105+13:00",
             "status": "Done",
-            "summary": "Autostart service \"svc\"",
+            "summary": 'Autostart service "svc"',
             "tasks": [],
         })
         self.assertEqual(change.id, '70')
@@ -309,7 +309,7 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(repr(change), (
             "Change(id=ChangeID('70'), "
             "kind='autostart', "
-            "summary='Autostart service \"svc\"', "
+            "summary='Autostart service \"svc\"', "  # NOQA
             "status='Done', "
             "tasks=[], "
             "ready=True, "
@@ -394,7 +394,7 @@ class TestAPI(unittest.TestCase):
             "ready-time": "2021-01-28T14:37:04.291517768+13:00",
             "spawn-time": "2021-01-28T14:37:02.247202105+13:00",
             "status": "Done",
-            "summary": "Autostart service \"svc\"",
+            "summary": 'Autostart service "svc"',
             "tasks": [
                 {
                     "id": "78",
@@ -408,7 +408,7 @@ class TestAPI(unittest.TestCase):
                     "ready-time": "2021-01-28T14:37:03.270218778+13:00",
                     "spawn-time": "2021-01-28T14:37:02.247158162+13:00",
                     "status": "Done",
-                    "summary": "Start service \"svc\"",
+                    "summary": 'Start service "svc"',
                     "extra-field": "foo",
                 },
             ],

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -71,7 +71,6 @@ class TestTypes(unittest.TestCase):
         error = pebble.ServiceError('Some error', change)
         self.assertEqual(error.err, 'Some error')
         self.assertEqual(error.change, change)
-        self.assertEqual(error.args, ('Some error', change))
         self.assertEqual(str(error), 'Some error')
 
     def test_warning_state(self):
@@ -95,12 +94,10 @@ class TestTypes(unittest.TestCase):
     def test_system_info_init(self):
         info = pebble.SystemInfo(version='1.2.3')
         self.assertEqual(info.version, '1.2.3')
-        self.assertEqual(repr(info), "SystemInfo(version='1.2.3')")
 
     def test_system_info_from_dict(self):
         info = pebble.SystemInfo.from_dict({'version': '3.2.1'})
         self.assertEqual(info.version, '3.2.1')
-        self.assertEqual(repr(info), "SystemInfo(version='3.2.1')")
 
     def test_warning_init(self):
         warning = pebble.Warning(
@@ -117,14 +114,6 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(warning.last_shown, None)
         self.assertEqual(warning.expire_after, '1s')
         self.assertEqual(warning.repeat_after, '2s')
-        self.assertEqual(repr(warning), (
-            "Warning("
-            "message='Beware!', "
-            "first_added=datetime.datetime(2021, 1, 1, 1, 1, 1, tzinfo=datetime.timezone.utc), "
-            "last_added=datetime.datetime(2021, 1, 26, 2, 3, 4, tzinfo=datetime.timezone.utc), "
-            "last_shown=None, "
-            "expire_after='1s', "
-            "repeat_after='2s')"))
 
     def test_warning_from_dict(self):
         d = {
@@ -141,14 +130,6 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(warning.last_shown, None)
         self.assertEqual(warning.expire_after, '1s')
         self.assertEqual(warning.repeat_after, '2s')
-        self.assertEqual(repr(warning), (
-            "Warning("
-            "message='Look out...', "
-            "first_added=datetime.datetime(2020, 12, 25, 17, 18, 54, 16273, "+NZDT_STR+"), "
-            "last_added=datetime.datetime(2021, 1, 26, 17, 1, 2, 123450, "+NZDT_STR+"), "
-            "last_shown=None, "
-            "expire_after='1s', "
-            "repeat_after='2s')"))
 
         d['last-shown'] = None
         warning = pebble.Warning.from_dict(d)
@@ -163,7 +144,6 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(tp.label, 'foo')
         self.assertEqual(tp.done, 3)
         self.assertEqual(tp.total, 7)
-        self.assertEqual(repr(tp), "TaskProgress(label='foo', done=3, total=7)")
 
     def test_task_progress_from_dict(self):
         tp = pebble.TaskProgress.from_dict({
@@ -174,11 +154,9 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(tp.label, 'foo')
         self.assertEqual(tp.done, 3)
         self.assertEqual(tp.total, 7)
-        self.assertEqual(repr(tp), "TaskProgress(label='foo', done=3, total=7)")
 
     def test_task_id(self):
         task_id = pebble.TaskID('1234')
-        self.assertEqual(repr(task_id), "TaskID('1234')")
         self.assertEqual(task_id, '1234')
 
     def test_task_init(self):
@@ -202,16 +180,6 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(task.progress.total, 7)
         self.assertEqual(task.spawn_time, datetime_nzdt(2021, 1, 28, 14, 37, 3, 270218))
         self.assertEqual(task.ready_time, datetime_nzdt(2021, 1, 28, 14, 37, 2, 247158))
-        self.assertEqual(repr(task), (
-            "Task(id=TaskID('42'), "
-            "kind='start', "
-            "summary='Start service \"svc\"', "  # NOQA
-            "status='Done', "
-            "log=[], "
-            "progress=TaskProgress(label='foo', done=3, total=7), "
-            "spawn_time=datetime.datetime(2021, 1, 28, 14, 37, 3, 270218, "+NZDT_STR+"), "
-            "ready_time=datetime.datetime(2021, 1, 28, 14, 37, 2, 247158, "+NZDT_STR+"))"),
-        )
 
     def test_task_from_dict(self):
         task = pebble.Task.from_dict({
@@ -237,20 +205,9 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(task.progress.total, 1)
         self.assertEqual(task.ready_time, datetime_nzdt(2021, 1, 28, 14, 37, 3, 270218))
         self.assertEqual(task.spawn_time, datetime_nzdt(2021, 1, 28, 14, 37, 2, 247158))
-        self.assertEqual(repr(task), (
-            "Task(id=TaskID('78'), "
-            "kind='start', "
-            "summary='Start service \"svc\"', "  # NOQA
-            "status='Done', "
-            "log=[], "
-            "progress=TaskProgress(label='', done=1, total=1), "
-            "spawn_time=datetime.datetime(2021, 1, 28, 14, 37, 2, 247158, "+NZDT_STR+"), "
-            "ready_time=datetime.datetime(2021, 1, 28, 14, 37, 3, 270218, "+NZDT_STR+"))"),
-        )
 
     def test_change_id(self):
         change_id = pebble.ChangeID('1234')
-        self.assertEqual(repr(change_id), "ChangeID('1234')")
         self.assertEqual(change_id, '1234')
 
     def test_change_init(self):
@@ -274,16 +231,6 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(change.status, 'Done')
         self.assertEqual(change.summary, 'Autostart service "svc"')
         self.assertEqual(change.tasks, [])
-        self.assertEqual(repr(change), (
-            "Change(id=ChangeID('70'), "
-            "kind='autostart', "
-            "summary='Autostart service \"svc\"', "  # NOQA
-            "status='Done', "
-            "tasks=[], "
-            "ready=True, "
-            "err='SILLY', "
-            "spawn_time=datetime.datetime(2021, 1, 28, 14, 37, 2, 247202, "+NZDT_STR+"), "
-            "ready_time=datetime.datetime(2021, 1, 28, 14, 37, 4, 291517, "+NZDT_STR+"))"))
 
     def test_change_from_dict(self):
         change = pebble.Change.from_dict({
@@ -306,16 +253,6 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(change.status, 'Done')
         self.assertEqual(change.summary, 'Autostart service "svc"')
         self.assertEqual(change.tasks, [])
-        self.assertEqual(repr(change), (
-            "Change(id=ChangeID('70'), "
-            "kind='autostart', "
-            "summary='Autostart service \"svc\"', "  # NOQA
-            "status='Done', "
-            "tasks=[], "
-            "ready=True, "
-            "err='SILLY', "
-            "spawn_time=datetime.datetime(2021, 1, 28, 14, 37, 2, 247202, "+NZDT_STR+"), "
-            "ready_time=datetime.datetime(2021, 1, 28, 14, 37, 4, 291517, "+NZDT_STR+"))"))
 
 
 class MockAPI(pebble.API):

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -1,0 +1,160 @@
+#!/usr/bin/python3
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import unittest
+import unittest.util
+
+import ops.pebble as pebble
+
+
+# Ensure unittest diffs don't get truncated like "[17 chars]"
+unittest.util._MAX_LENGTH = 1000
+
+NZDT_STR = 'tzinfo=datetime.timezone(datetime.timedelta(seconds=46800))'
+
+
+def datetime_utc(y, m, d, hour, min, sec, micro=0):
+    tz = datetime.timezone.utc
+    return datetime.datetime(y, m, d, hour, min, sec, micro, tzinfo=tz)
+
+
+def datetime_nzdt(y, m, d, hour, min, sec, micro=0):
+    tz = datetime.timezone(datetime.timedelta(hours=13))
+    return datetime.datetime(y, m, d, hour, min, sec, micro, tzinfo=tz)
+
+
+class TestMisc(unittest.TestCase):
+    def test_fromisoformat(self):
+        self.assertEqual(pebble._fromisoformat('2020-12-25T13:45:50.123456+13:00'),
+                         datetime_nzdt(2020, 12, 25, 13, 45, 50, 123456))
+        with self.assertRaises(ValueError):
+            pebble._fromisoformat('xyz')
+
+    def test_parse_timestamp(self):
+        self.assertEqual(pebble._fromisoformat('2020-12-25T13:45:50.123456+13:00'),
+                         datetime_nzdt(2020, 12, 25, 13, 45, 50, 123456))
+        self.assertEqual(pebble._parse_timestamp('2020-12-25T13:45:50.123456789+13:00'),
+                         datetime_nzdt(2020, 12, 25, 13, 45, 50, 123456))
+        self.assertEqual(pebble._fromisoformat('2020-12-25T13:45:50.123456+00:00'),
+                         datetime_utc(2020, 12, 25, 13, 45, 50, 123456))
+        self.assertEqual(pebble._parse_timestamp('2020-12-25T13:45:50.123456789+00:00'),
+                         datetime_utc(2020, 12, 25, 13, 45, 50, 123456))
+
+
+class TestTypes(unittest.TestCase):
+    maxDiff = None
+
+    def test_service_error(self):
+        change = pebble.Change(
+            id=pebble.ChangeID('1234'),
+            kind='start',
+            summary='Start service "foo"',
+            status='Done',
+            tasks=[],
+            ready=True,
+            err=None,
+            spawn_time=datetime.datetime.now(),
+            ready_time=datetime.datetime.now(),
+        )
+        error = pebble.ServiceError('Some error', change)
+        self.assertEqual(error.err, 'Some error')
+        self.assertEqual(error.change, change)
+        self.assertEqual(error.args, ('Some error', change))
+        self.assertEqual(str(error), 'Some error')
+
+    def test_warning_state(self):
+        self.assertEqual(list(pebble.WarningState), [
+            pebble.WarningState.ALL,
+            pebble.WarningState.PENDING,
+        ])
+        self.assertEqual(pebble.WarningState.ALL.value, 'all')
+        self.assertEqual(pebble.WarningState.PENDING.value, 'pending')
+
+    def test_change_state(self):
+        self.assertEqual(list(pebble.ChangeState), [
+            pebble.ChangeState.ALL,
+            pebble.ChangeState.IN_PROGRESS,
+            pebble.ChangeState.READY,
+        ])
+        self.assertEqual(pebble.ChangeState.ALL.value, 'all')
+        self.assertEqual(pebble.ChangeState.IN_PROGRESS.value, 'in-progress')
+        self.assertEqual(pebble.ChangeState.READY.value, 'ready')
+
+    def test_system_info_init(self):
+        info = pebble.SystemInfo(version='1.2.3')
+        self.assertEqual(info.version, '1.2.3')
+        self.assertEqual(repr(info), "SystemInfo(version='1.2.3')")
+
+    def test_system_info_from_dict(self):
+        info = pebble.SystemInfo.from_dict({'version': '3.2.1'})
+        self.assertEqual(info.version, '3.2.1')
+        self.assertEqual(repr(info), "SystemInfo(version='3.2.1')")
+
+    def test_warning_init(self):
+        warning = pebble.Warning(
+            message='Beware!',
+            first_added=datetime_utc(2021, 1, 1, 1, 1, 1),
+            last_added=datetime_utc(2021, 1, 26, 2, 3, 4),
+            last_shown=None,
+            expire_after='1s',
+            repeat_after='2s',
+        )
+        self.assertEqual(warning.message, 'Beware!')
+        self.assertEqual(warning.first_added, datetime_utc(2021, 1, 1, 1, 1, 1))
+        self.assertEqual(warning.last_added, datetime_utc(2021, 1, 26, 2, 3, 4))
+        self.assertEqual(warning.last_shown, None)
+        self.assertEqual(warning.expire_after, '1s')
+        self.assertEqual(warning.repeat_after, '2s')
+        self.assertEqual(repr(warning), (
+            "Warning("
+            "message='Beware!', "
+            "first_added=datetime.datetime(2021, 1, 1, 1, 1, 1, tzinfo=datetime.timezone.utc), "
+            "last_added=datetime.datetime(2021, 1, 26, 2, 3, 4, tzinfo=datetime.timezone.utc), "
+            "last_shown=None, "
+            "expire_after='1s', "
+            "repeat_after='2s')"))
+
+    def test_warning_from_dict(self):
+        d = {
+            'message': 'Look out...',
+            'first-added': '2020-12-25T17:18:54.016273778+13:00',
+            'last-added': '2021-01-26T17:01:02.12345+13:00',
+            'expire-after': '1s',
+            'repeat-after': '2s',
+        }
+        warning = pebble.Warning.from_dict(d)
+        self.assertEqual(warning.message, 'Look out...')
+        self.assertEqual(warning.first_added, datetime_nzdt(2020, 12, 25, 17, 18, 54, 16273))
+        self.assertEqual(warning.last_added, datetime_nzdt(2021, 1, 26, 17, 1, 2, 123450))
+        self.assertEqual(warning.last_shown, None)
+        self.assertEqual(warning.expire_after, '1s')
+        self.assertEqual(warning.repeat_after, '2s')
+        self.assertEqual(repr(warning), (
+            "Warning("
+            "message='Look out...', "
+            "first_added=datetime.datetime(2020, 12, 25, 17, 18, 54, 16273, "+NZDT_STR+"), "
+            "last_added=datetime.datetime(2021, 1, 26, 17, 1, 2, 123450, "+NZDT_STR+"), "
+            "last_shown=None, "
+            "expire_after='1s', "
+            "repeat_after='2s')"))
+
+        d['last-shown'] = None
+        warning = pebble.Warning.from_dict(d)
+        self.assertEqual(warning.last_shown, None)
+
+        d['last-shown'] = '2021-08-04T03:02:01.000000000+13:00'
+        warning = pebble.Warning.from_dict(d)
+        self.assertEqual(warning.last_shown, datetime_nzdt(2021, 8, 4, 3, 2, 1))


### PR DESCRIPTION
Basic support for talking to the Pebble API (HTTP over Unix socket). This PR adds the low-level API and unit tests for it (though no functional tests -- still thinking about the best way to do that).

Note that this doesn't integrate the API into the Operator Framework model. We'll want a slightly higher-level layer of abstraction for that, attached to the operator framework model. Still working on the design for that -- coming in a subsequent PR.

To test manually, you can run pebble locally (check out the `operator/pebble` repo, `go build`, and `pebble run`). Then you can run `python3 ops/pebble.py` as a command line client to exercise the Python API. For example:

``` bash
PEBBLE=/pebble/dir python3 ops/pebble.py --help
PEBBLE=/pebble/dir python3 ops/pebble.py changes
```
