### PR TITLE
Higher-level Pebble integration into Operator Framework

### DIFF
--- a/ops/_yaml.py
+++ b/ops/_yaml.py
@@ -1,0 +1,32 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Internal YAML helpers."""
+
+import yaml
+
+
+# Use C speedups if available
+_safe_loader = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
+_safe_dumper = getattr(yaml, 'CSafeDumper', yaml.SafeDumper)
+
+
+def safe_load(stream):
+    """Same as yaml.safe_load, but use fast C loader if available."""
+    return yaml.load(stream, Loader=_safe_loader)
+
+
+def safe_dump(data, stream=None, **kwargs):
+    """Same as yaml.safe_dump, but use fast C dumper if available."""
+    return yaml.dump(data, stream=stream, Dumper=_safe_dumper, **kwargs)

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -687,6 +687,12 @@ class CharmMeta:
         self.extra_bindings = raw.get('extra-bindings', {})
         self.actions = {name: ActionMeta(name, action) for name, action in actions_raw.items()}
 
+        # This is taken from Charm Metadata v2, but only the "containers" and
+        # "containers.name" fields that we need right now for Pebble. See:
+        # https://discourse.charmhub.io/t/charm-metadata-v2/3674
+        self.containers = {name: ContainerMeta(name, container)
+                           for name, container in raw.get('containers', {}).items()}
+
     @classmethod
     def from_yaml(
             cls, metadata: typing.Union[str, typing.TextIO],
@@ -821,3 +827,17 @@ class ActionMeta:
         self.description = raw.get('description', '')
         self.parameters = raw.get('params', {})  # {<parameter name>: <JSON Schema definition>}
         self.required = raw.get('required', [])  # [<parameter name>, ...]
+
+
+class ContainerMeta:
+    """Metadata about an individual container.
+
+    NOTE: this is extremely lightweight right now, and just includes the fields we need for
+    Pebble interaction.
+
+    Attributes:
+        name: Name of container (key in the YAML)
+    """
+
+    def __init__(self, name, raw):
+        self.name = name

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -19,16 +19,9 @@ import os
 import pathlib
 import typing
 
-import yaml
-
 from ops.framework import Object, EventSource, EventBase, Framework, ObjectEvents
+from ops import _yaml
 from ops import model
-
-
-def _loadYaml(source):
-    if yaml.__with_libyaml__:
-        return yaml.load(source, Loader=yaml.CSafeLoader)
-    return yaml.load(source, Loader=yaml.SafeLoader)
 
 
 class HookEvent(EventBase):
@@ -704,10 +697,10 @@ class CharmMeta:
                 This can be a simple string, or a file-like object. (passed to `yaml.safe_load`).
             actions: YAML description of Actions for this charm (eg actions.yaml)
         """
-        meta = _loadYaml(metadata)
+        meta = _yaml.safe_load(metadata)
         raw_actions = {}
         if actions is not None:
-            raw_actions = _loadYaml(actions)
+            raw_actions = _yaml.safe_load(actions)
             if raw_actions is None:
                 raw_actions = {}
         return cls(meta, raw_actions)

--- a/ops/model.py
+++ b/ops/model.py
@@ -30,17 +30,11 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, MutableMapping
 from pathlib import Path
 from subprocess import run, PIPE, CalledProcessError
-import yaml
 
 import ops
 import ops.pebble as pebble
 from ops.jujuversion import JujuVersion
-
-
-if yaml.__with_libyaml__:
-    _DefaultDumper = yaml.CSafeDumper
-else:
-    _DefaultDumper = yaml.SafeDumper
+from ops import _yaml
 
 
 class Model:
@@ -1241,12 +1235,12 @@ class _ModelBackend:
         try:
             spec_path = tmpdir / 'spec.yaml'
             with spec_path.open("wt", encoding="utf8") as f:
-                yaml.dump(spec, stream=f, Dumper=_DefaultDumper)
+                _yaml.safe_dump(spec, stream=f)
             args = ['--file', str(spec_path)]
             if k8s_resources:
                 k8s_res_path = tmpdir / 'k8s-resources.yaml'
                 with k8s_res_path.open("wt", encoding="utf8") as f:
-                    yaml.dump(k8s_resources, stream=f, Dumper=_DefaultDumper)
+                    _yaml.safe_dump(k8s_resources, stream=f)
                 args.extend(['--k8s-resources', str(k8s_res_path)])
             self._run('pod-spec-set', *args)
         finally:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -28,14 +28,7 @@ import urllib.parse
 import urllib.request
 import sys
 
-import yaml
-
-
-_safe_dumper = None  # type: Any
-if yaml.__with_libyaml__:
-    _safe_dumper = yaml.CSafeDumper
-else:
-    _safe_dumper = yaml.SafeDumper
+from ops import _yaml
 
 
 _not_provided = object()
@@ -329,7 +322,7 @@ class Layer:
 
     def __init__(self, raw: Union[str, Dict] = None):
         if isinstance(raw, str):
-            d = yaml.safe_load(raw) or {}
+            d = _yaml.safe_load(raw) or {}
         else:
             d = raw or {}
         self.summary = d.get('summary', '')
@@ -339,7 +332,7 @@ class Layer:
 
     def to_yaml(self) -> str:
         """Convert this layer to its YAML representation."""
-        return yaml.dump(self.to_dict(), Dumper=_safe_dumper)
+        return _yaml.safe_dump(self.to_dict())
 
     def to_dict(self) -> Dict:
         """Convert this layer to its dict representation."""

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -824,3 +824,9 @@ class _TestingModelBackend:
 
     def network_get(self, endpoint_name, relation_id=None):
         raise NotImplementedError(self.network_get)
+
+    def add_metrics(self, metrics, labels=None):
+        raise NotImplementedError(self.add_metrics)
+
+    def get_pebble(self, container_name):
+        raise NotImplementedError(self.get_pebble)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -19,11 +19,11 @@ import pathlib
 import random
 import tempfile
 import typing
-import yaml
 from contextlib import contextmanager
 from textwrap import dedent
 
 from ops import (
+    _yaml,
     charm,
     framework,
     model,
@@ -273,7 +273,7 @@ class Harness:
                 charm_config = '{}'
         elif isinstance(charm_config, str):
             charm_config = dedent(charm_config)
-        charm_config = yaml.load(charm_config, Loader=yaml.SafeLoader)
+        charm_config = _yaml.safe_load(charm_config)
         charm_config = charm_config.get('options', {})
         return {key: value['default'] for key, value in charm_config.items()
                 if 'default' in value}
@@ -300,7 +300,7 @@ class Harness:
         if self._meta.resources[resource_name].type != "oci-image":
             raise RuntimeError('Resource {} is not an OCI Image'.format(resource_name))
 
-        as_yaml = yaml.dump(contents, Dumper=yaml.SafeDumper)
+        as_yaml = _yaml.safe_dump(contents)
         self._backend._resources_map[resource_name] = ('contents.yaml', as_yaml)
 
     def add_resource(self, resource_name: str, content: typing.AnyStr) -> None:

--- a/test/fake_pebble.py
+++ b/test/fake_pebble.py
@@ -1,0 +1,182 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fake (partial) Pebble server to allow testing the HTTP-over-Unix-socket protocol."""
+
+import http.server
+import json
+import os
+import re
+import socketserver
+import threading
+import urllib.parse
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def __init__(self, request, client_address, server):
+        self.routes = [
+            ('GET', re.compile(r'^/system-info$'), self.get_system_info),
+            ('POST', re.compile(r'^/services$'), self.services_action),
+        ]
+        self._services = ['foo']
+        super().__init__(request, ('unix-socket', 80), server)
+
+    def log_message(self, format, *args):
+        # Disable logging for tests
+        pass
+
+    def respond(self, d, status=200):
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        d_json = json.dumps(d, indent=4, sort_keys=True)
+        self.wfile.write(d_json.encode('utf-8'))
+
+    def bad_request(self, message):
+        d = {
+            "result": {
+                "message": message,
+            },
+            "status": "Bad Request",
+            "status-code": 400,
+            "type": "error"
+        }
+        self.respond(d, 400)
+
+    def not_found(self):
+        d = {
+            "result": {
+                "message": "invalid API endpoint requested"
+            },
+            "status": "Not Found",
+            "status-code": 404,
+            "type": "error"
+        }
+        self.respond(d, 404)
+
+    def method_not_allowed(self):
+        d = {
+            "result": {
+                "message": 'method "PUT" not allowed'
+            },
+            "status": "Method Not Allowed",
+            "status-code": 405,
+            "type": "error"
+        }
+        self.respond(d, 405)
+
+    def internal_server_error(self, msg):
+        d = {
+            "result": {
+                "message": "internal server error: {}".format(msg),
+            },
+            "status": "Internal Server Error",
+            "status-code": 500,
+            "type": "error"
+        }
+        self.respond(d, 500)
+
+    def do_GET(self):
+        self.do_request('GET')
+
+    def do_POST(self):
+        self.do_request('POST')
+
+    def do_request(self, request_method):
+        path, _, query = self.path.partition('?')
+        path = urllib.parse.unquote(path)
+        query = dict(urllib.parse.parse_qsl(query))
+
+        if not path.startswith('/v1/'):
+            self.not_found()
+            return
+        path = path[3:]
+
+        allowed = []
+        for method, regex, func in self.routes:
+            match = regex.match(path)
+            if match:
+                if request_method == method:
+                    data = self.read_body_json()
+                    try:
+                        func(match, query, data)
+                    except Exception as e:
+                        self.internal_server_error(e)
+                        raise
+                    return
+                allowed.append(method)
+
+        if allowed:
+            self.method_not_allowed()
+            return
+
+        self.not_found()
+
+    def read_body_json(self):
+        try:
+            content_len = int(self.headers.get('Content-Length', ''))
+        except ValueError:
+            content_len = 0
+        if not content_len:
+            return None
+        body = self.rfile.read(content_len)
+        if isinstance(body, bytes):
+            body = body.decode('utf-8')
+        return json.loads(body)
+
+    def get_system_info(self, match, query, data):
+        self.respond({
+            "result": {
+                "version": "3.14.159"
+            },
+            "status": "OK",
+            "status-code": 200,
+            "type": "sync"
+        })
+
+    def services_action(self, match, query, data):
+        action = data['action']
+        services = data['services']
+        if action == 'start':
+            for service in services:
+                if service not in self._services:
+                    self.bad_request('service "{}" does not exist'.format(service))
+                    return
+            self.respond({
+                "change": "1234",
+                "result": None,
+                "status": "Accepted",
+                "status-code": 202,
+                "type": "async"
+            })
+        else:
+            self.bad_request('action "{}" not implemented'.format(action))
+
+
+def start_server():
+    socket_path = 'test.socket'
+    if os.path.exists(socket_path):
+        os.remove(socket_path)
+
+    server = socketserver.UnixStreamServer(socket_path, Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+
+    return (server, thread, socket_path)
+
+
+if __name__ == '__main__':
+    _, thread, socket_path = start_server()
+    print('Serving HTTP over socket', socket_path)
+    thread.join()  # wait forever (or till Ctrl-C pressed)

--- a/test/fake_pebble.py
+++ b/test/fake_pebble.py
@@ -173,10 +173,20 @@ def start_server():
     thread = threading.Thread(target=server.serve_forever)
     thread.start()
 
-    return (server, thread, socket_path)
+    def shutdown():
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+    return (shutdown, socket_path)
 
 
 if __name__ == '__main__':
-    _, thread, socket_path = start_server()
+    import time
+
+    shutdown, socket_path = start_server()
     print('Serving HTTP over socket', socket_path)
-    thread.join()  # wait forever (or till Ctrl-C pressed)
+
+    # Wait forever (or till Ctrl-C pressed)
+    while True:
+        time.sleep(1)

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -1,0 +1,128 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pebble command-line interface (CLI) for local testing.
+
+Usage examples:
+
+python -m test.pebble_cli -h
+python -m test.pebble_cli --socket=pebble_dir/.pebble.socket system-info
+PEBBLE=pebble_dir python -m test.pebble_cli system-info
+"""
+
+import argparse
+import datetime
+import json
+import os
+import sys
+import urllib.error
+
+from ops import pebble
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--socket', help='pebble socket path, default $PEBBLE/.pebble.socket')
+    subparsers = parser.add_subparsers(dest='command', metavar='command')
+
+    p = subparsers.add_parser('abort', help='abort a change by ID')
+    p.add_argument('change_id', help='ID of change to abort')
+
+    p = subparsers.add_parser('ack', help='acknowledge warnings up to given time')
+    p.add_argument('--timestamp', help='time to acknowledge up to (YYYY-mm-ddTHH:MM:SS.f+ZZ:zz'
+                                       'format), default current time',
+                   type=pebble._parse_timestamp)
+
+    p = subparsers.add_parser('autostart', help='autostart default service(s)')
+
+    p = subparsers.add_parser('change', help='show a single change by ID')
+    p.add_argument('change_id', help='ID of change to fetch')
+
+    p = subparsers.add_parser('changes', help='show (filtered) changes')
+    p.add_argument('--select', help='change state to filter on, default %(default)s',
+                   choices=[s.value for s in pebble.ChangeState], default='all')
+    p.add_argument('--service', help='optional service name to filter on')
+
+    p = subparsers.add_parser('start', help='start service(s)')
+    p.add_argument('service', help='name of service to start (can specify multiple)', nargs='+')
+
+    p = subparsers.add_parser('stop', help='stop service(s)')
+    p.add_argument('service', help='name of service to stop (can specify multiple)', nargs='+')
+
+    p = subparsers.add_parser('system-info', help='show Pebble system information')
+
+    p = subparsers.add_parser('warnings', help='show (filtered) warnings')
+    p.add_argument('--select', help='warning state to filter on, default %(default)s',
+                   choices=[s.value for s in pebble.WarningState], default='all')
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.error('argument command: required')
+
+    socket_path = args.socket
+    if socket_path is None:
+        pebble_env = os.getenv('PEBBLE')
+        if not pebble_env:
+            print('cannot create Pebble client (set PEBBLE or specify --socket)', file=sys.stderr)
+            sys.exit(1)
+        socket_path = os.path.join(pebble_env, '.pebble.socket')
+
+    client = pebble.Client(socket_path=socket_path)
+
+    try:
+        if args.command == 'abort':
+            result = client.abort_change(pebble.ChangeID(args.change_id))
+        elif args.command == 'ack':
+            timestamp = args.timestamp or datetime.datetime.now(tz=datetime.timezone.utc)
+            result = client.ack_warnings(timestamp)
+        elif args.command == 'autostart':
+            result = client.autostart_services()
+        elif args.command == 'change':
+            result = client.get_change(pebble.ChangeID(args.change_id))
+        elif args.command == 'changes':
+            result = client.get_changes(select=pebble.ChangeState(args.select),
+                                        service=args.service)
+        elif args.command == 'start':
+            result = client.start_services(args.service)
+        elif args.command == 'stop':
+            result = client.stop_services(args.service)
+        elif args.command == 'system-info':
+            result = client.get_system_info()
+        elif args.command == 'warnings':
+            result = client.get_warnings(select=pebble.WarningState(args.select))
+        else:
+            raise AssertionError("shouldn't happen")
+    except urllib.error.HTTPError as e:
+        print(e, file=sys.stderr)
+        obj = json.load(e)
+        print(json.dumps(obj, sort_keys=True, indent=4), file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print('cannot connect to Pebble socket {!r}: {}'.format(socket_path, e.reason),
+              file=sys.stderr)
+        sys.exit(1)
+    except pebble.ServiceError as e:
+        print('ServiceError:', e.err, file=sys.stderr)
+        sys.exit(1)
+
+    if isinstance(result, list):
+        for x in result:
+            print(x)
+    else:
+        print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -23,6 +23,7 @@ from ops.charm import (
     CharmBase,
     CharmMeta,
     CharmEvents,
+    ContainerMeta,
 )
 from ops.framework import Framework, EventSource, EventBase
 from ops.model import Model, _ModelBackend
@@ -329,3 +330,17 @@ start:
 
     def test_action_event_defer_fails(self):
         self._test_action_event_defer_fails('action')
+
+    def test_containers(self):
+        meta = CharmMeta.from_yaml("""
+name: k8s-charm
+containers:
+  test1:
+    k: v
+  test2:
+    k: v
+""")
+        self.assertIsInstance(meta.containers['test1'], ContainerMeta)
+        self.assertIsInstance(meta.containers['test2'], ContainerMeta)
+        self.assertEqual(meta.containers['test1'].name, 'test1')
+        self.assertEqual(meta.containers['test2'].name, 'test2')

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -20,6 +20,8 @@ import shutil
 import tempfile
 import unittest
 
+import yaml
+
 from ops import _yaml
 from ops.framework import Framework
 from ops.model import Model, _ModelBackend
@@ -134,12 +136,20 @@ class BaseTestCase(unittest.TestCase):
         return model
 
 
+class YAMLTest:
+    pass
+
+
 class TestYAML(unittest.TestCase):
     def test_safe_load(self):
         d = _yaml.safe_load('foo: bar\nbaz: 123\n')
         self.assertEqual(len(d), 2)
         self.assertEqual(d['foo'], 'bar')
         self.assertEqual(d['baz'], 123)
+
+        # Should error -- it's not safe to load an instance of a user-defined class
+        with self.assertRaises(yaml.YAMLError):
+            _yaml.safe_load('!!python/object:test.test_helpers.YAMLTest {}')
 
     def test_safe_dump(self):
         s = _yaml.safe_dump({'foo': 'bar', 'baz': 123})
@@ -148,3 +158,7 @@ class TestYAML(unittest.TestCase):
         f = io.StringIO()
         s = _yaml.safe_dump({'foo': 'bar', 'baz': 123}, stream=f)
         self.assertEqual(f.getvalue(), 'baz: 123\nfoo: bar\n')
+
+        # Should error -- it's not safe to dump an instance of a user-defined class
+        with self.assertRaises(yaml.YAMLError):
+            _yaml.safe_dump(YAMLTest())

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import os
 import pathlib
 import subprocess
@@ -19,6 +20,7 @@ import shutil
 import tempfile
 import unittest
 
+from ops import _yaml
 from ops.framework import Framework
 from ops.model import Model, _ModelBackend
 from ops.charm import CharmMeta
@@ -130,3 +132,19 @@ class BaseTestCase(unittest.TestCase):
         meta = CharmMeta()
         model = Model(meta, backend)
         return model
+
+
+class TestYAML(unittest.TestCase):
+    def test_safe_load(self):
+        d = _yaml.safe_load('foo: bar\nbaz: 123\n')
+        self.assertEqual(len(d), 2)
+        self.assertEqual(d['foo'], 'bar')
+        self.assertEqual(d['baz'], 123)
+
+    def test_safe_dump(self):
+        s = _yaml.safe_dump({'foo': 'bar', 'baz': 123})
+        self.assertEqual(s, 'baz: 123\nfoo: bar\n')
+
+        f = io.StringIO()
+        s = _yaml.safe_dump({'foo': 'bar', 'baz': 123}, stream=f)
+        self.assertEqual(f.getvalue(), 'baz: 123\nfoo: bar\n')

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -638,7 +638,7 @@ class _TestMain(abc.ABC):
                     Path("hooks/install")))
 
         if not yaml.__with_libyaml__:
-            self.assertEquals(calls.pop(0), ' '.join(SLOW_YAML_LOGLINE))
+            self.assertEqual(calls.pop(0), ' '.join(SLOW_YAML_LOGLINE))
 
         self.assertRegex(calls.pop(0), 'Using local storage: not a kubernetes charm')
 

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -741,7 +741,7 @@ class TestSocketClient(unittest.TestCase):
 
     @unittest.skipIf(sys.platform == 'win32', "Unix sockets don't work on Windows")
     def test_real_client(self):
-        server, thread, socket_path = fake_pebble.start_server()
+        shutdown, socket_path = fake_pebble.start_server()
 
         try:
             client = pebble.Client(socket_path=socket_path)
@@ -756,5 +756,4 @@ class TestSocketClient(unittest.TestCase):
             self.assertEqual(cm.exception.code, 400)
 
         finally:
-            server.shutdown()
-            thread.join()
+            shutdown()


### PR DESCRIPTION
Includes addition of container-related metadata parsing (this is under discussion and may change!) Also rename `pebble.API` to `pebble.PebbleClient` per discussion. Still need to add tests - doing that now.

Initial work / feedback was done on [benhoyt/operator PR #1](https://github.com/benhoyt/operator/pull/1) ... this is squashed and rebased onto master now that the initial pebble PR is merged.

Intended usage is something like this:

```python
container = model.unit.containers['pgweb']
container = model.unit.get_container('pgweb')  # same as above

container.add_layer("""
summary: Simple override layer
services:
    srv1:
        override: merge
        environment:
            - var1: val1
""")
container.add_layer({  # supplying a dict works too
    'summary': 'Another layer',
    'services': {
        'srv1': {
            'override': 'merge',
            'environment': my_environ,
        },
    },
})
flattened_setup = container.get_setup()  # rich pebble.Setup object
print(flattened_setup.to_yaml())

container.start('foo', 'bar')
container.stop('foo')
container.stop('bar')
container.autostart()
```

Or you can drop down to manually accessing the `pebble.API` instance if you want:

```python
pebble = model.containers['pgweb'].pebble
pebble.stop_services(['postgres', 'redis'])
do_backup()
pebble.start_services(['postgres', 'redis'])
```

Notes:

* There can be multiple workload containers in a single charm, so need to distinguish them by name.
  - see https://github.com/hpidcock/testing-charms/blob/master/pebbletest/metadata.yaml
  - hence the need for model.get_container(name) instead of just model.container
* Unit ~= Pod in K8s
