### PR TITLE
Move "build container socket path" logic to Container where it belongs

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1016,7 +1016,8 @@ class Container:
         self.name = name
 
         if pebble_client is None:
-            pebble_client = backend.get_pebble(name)
+            socket_path = '/charm/containers/{}/pebble/.pebble.socket'.format(name)
+            pebble_client = backend.get_pebble(socket_path)
         self._pebble = pebble_client
 
     @property
@@ -1359,9 +1360,8 @@ class _ModelBackend:
         cmd.extend(metric_args)
         self._run(*cmd)
 
-    def get_pebble(self, container_name: str) -> 'pebble.Client':
-        """Create a pebble.Client instance for given container name."""
-        socket_path = '/charm/containers/{}/pebble/.pebble.socket'.format(container_name)
+    def get_pebble(self, socket_path: str) -> 'pebble.Client':
+        """Create a pebble.Client instance from given socket path."""
         return pebble.Client(socket_path=socket_path)
 
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -20,7 +20,6 @@ import os
 import pathlib
 from textwrap import dedent
 import unittest
-import unittest.mock
 
 import ops.model
 import ops.charm
@@ -789,9 +788,8 @@ containers:
   c1:
     k: v
 """)
-        backend = ops.model._ModelBackend('myapp/0')
-        with unittest.mock.patch('ops.pebble.Client', MockPebbleClient):
-            self.model = ops.model.Model(meta, backend)
+        backend = MockPebbleBackend('myapp/0')
+        self.model = ops.model.Model(meta, backend)
         self.container = self.model.unit.containers['c1']
         self.pebble = self.container.pebble
 
@@ -834,6 +832,11 @@ containers:
         self.assertEqual(self.pebble.requests, [('get_layer',)])
         self.assertIsInstance(layer, ops.pebble.Layer)
         self.assertEqual(layer.summary, 'foo')
+
+
+class MockPebbleBackend(ops.model._ModelBackend):
+    def get_pebble(self, socket_path):
+        return MockPebbleClient(socket_path)
 
 
 class MockPebbleClient:


### PR DESCRIPTION
This logic is specific to containers, so it shouldn't be in `_ModelBackend.get_pebble()`, but on `Container`. Pebble itself doesn't require containers to work.

This was from Gustavo's [comment on PR 472](https://github.com/canonical/operator/pull/472#discussion_r572791023).