### PR TITLE
Set Relation.app via JUJU_REMOTE_APP or "relation-list --app" if no units

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -655,9 +655,12 @@ class Relation:
         if is_peer:
             # For peer relations, both the remote and the local app are the same.
             self.app = our_unit.app
-        elif backend.remote_app_name is not None:
-            # For non-peer relations, use the remote app name directly.
-            self.app = cache.get(Application, backend.remote_app_name)
+        else:
+            # For non-peer relations, use the remote app name for this
+            # relation (if we have it).
+            app_name = backend.relation_remote_app(relation_id)
+            if app_name is not None:
+                self.app = cache.get(Application, app_name)
 
         try:
             for unit_name in backend.relation_list(self.id):
@@ -665,9 +668,9 @@ class Relation:
                 self.units.add(unit)
                 if self.app is None:
                     # Fallback to using the app of one of the units if
-                    # JUJU_REMOTE_APP is not set (should only happen on Juju
-                    # before 2.7, when we added JUJU_REMOTE_APP). This is not
-                    # great, as the event can fire before any units are up.
+                    # JUJU_REMOTE_APP is not set (pre Juju 2.7) or this is not
+                    # the current event's relation. The fallback is not
+                    # perfect, as an event can fire before any units are up.
                     self.app = unit.app
         except RelationNotFoundError:
             # If the relation is dead, just treat it as if it has no remote units.
@@ -1128,7 +1131,8 @@ class _ModelBackend:
 
     LEASE_RENEWAL_PERIOD = datetime.timedelta(seconds=30)
 
-    def __init__(self, unit_name=None, model_name=None, remote_app_name=None):
+    def __init__(self, unit_name=None, model_name=None, remote_app_name=None,
+                 event_relation_id=None):
         if unit_name is None:
             self.unit_name = os.environ['JUJU_UNIT_NAME']
         else:
@@ -1141,6 +1145,10 @@ class _ModelBackend:
         if remote_app_name is None:
             remote_app_name = os.environ.get('JUJU_REMOTE_APP')
         self.remote_app_name = remote_app_name
+
+        if event_relation_id is None and 'JUJU_RELATION_ID' in os.environ:
+            event_relation_id = int(os.environ['JUJU_RELATION_ID'].split(':')[-1])
+        self.event_relation_id = event_relation_id
 
         self._is_leader = None
         self._leader_check_time = None
@@ -1176,6 +1184,14 @@ class _ModelBackend:
             if 'relation not found' in str(e):
                 raise RelationNotFoundError() from e
             raise
+
+    def relation_remote_app(self, relation_id: int):
+        """Return remote app name for given relation ID, or None if not known."""
+        if relation_id == self.event_relation_id:
+            return self.remote_app_name
+        # TODO(benhoyt) - implement for other relation IDs, perhaps via a new
+        # "--app" arg on relation-list command
+        return None
 
     def relation_get(self, relation_id, member_name, is_app):
         if not isinstance(is_app, bool):

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -74,7 +74,8 @@ class Harness:
             *,
             meta: OptionalYAML = None,
             actions: OptionalYAML = None,
-            config: OptionalYAML = None):
+            config: OptionalYAML = None,
+            remote_app_name: str = None):
         self._charm_cls = charm_cls
         self._charm = None
         self._charm_dir = 'no-disk-path'  # this may be updated by _create_meta
@@ -83,7 +84,7 @@ class Harness:
         self._framework = None
         self._hooks_enabled = True
         self._relation_id_counter = 0
-        self._backend = _TestingModelBackend(self._unit_name, self._meta)
+        self._backend = _TestingModelBackend(self._unit_name, self._meta, remote_app_name)
         self._model = model.Model(self._meta, self._backend)
         self._storage = storage.SQLiteStorage(':memory:')
         self._oci_resources = {}
@@ -687,10 +688,11 @@ class _TestingModelBackend:
     as the only public methods of this type are for implementing ModelBackend.
     """
 
-    def __init__(self, unit_name, meta):
+    def __init__(self, unit_name, meta, remote_app_name):
         self.unit_name = unit_name
         self.app_name = self.unit_name.split('/')[0]
         self.model_name = None
+        self.remote_app_name = remote_app_name
         self._calls = []
         self._meta = meta
         self._is_leader = None

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -736,7 +736,7 @@ class _TestingModelBackend:
         except KeyError as e:
             raise model.RelationNotFoundError from e
 
-    def relation_remote_app(self, relation_id):
+    def relation_remote_app_name(self, relation_id: int) -> typing.Optional[str]:
         if relation_id not in self._relation_app_and_units:
             # Non-existent or dead relation
             return None

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -47,7 +47,7 @@ class TestModel(unittest.TestCase):
             resources:
               foo: {type: file, filename: foo.txt}
               bar: {type: file, filename: bar.txt}
-        ''', remote_app_name='remoteapp1')
+        ''')
         self.addCleanup(self.harness.cleanup)
         self.relation_id_db0 = self.harness.add_relation('db0', 'db')
         self.model = self.harness.model
@@ -88,7 +88,9 @@ class TestModel(unittest.TestCase):
 
         self.assertBackendCalls([
             ('relation_ids', 'db1'),
+            ('relation_remote_app', 1),
             ('relation_list', rel_app1),
+            ('relation_remote_app', 2),
             ('relation_list', rel_app2),
         ])
 
@@ -112,17 +114,15 @@ class TestModel(unittest.TestCase):
         self.assertIsInstance(rel_db1, ops.model.Relation)
         self.assertBackendCalls([
             ('relation_ids', 'db1'),
+            ('relation_remote_app', 1),
             ('relation_list', relation_id_db1),
         ])
         dead_rel = self.model.get_relation('db1', 7)
         self.assertIsInstance(dead_rel, ops.model.Relation)
-        self.assertEqual(set(dead_rel.data.keys()), {
-            self.model.unit,
-            self.model.unit.app,
-            self.model.get_app('remoteapp1'),
-        })
+        self.assertEqual(set(dead_rel.data.keys()), {self.model.unit, self.model.unit.app})
         self.assertEqual(dead_rel.data[self.model.unit], {})
         self.assertBackendCalls([
+            ('relation_remote_app', 7),
             ('relation_list', 7),
             ('relation_get', 7, 'myapp/0', False),
         ])
@@ -137,7 +137,9 @@ class TestModel(unittest.TestCase):
 
         self.assertBackendCalls([
             ('relation_ids', 'db0'),
+            ('relation_remote_app', 0),
             ('relation_list', self.relation_id_db0),
+            ('relation_remote_app', 2),
             ('relation_list', relation_id_db0_b),
         ])
 
@@ -158,6 +160,7 @@ class TestModel(unittest.TestCase):
 
         self.assertBackendCalls([
             ('relation_ids', 'db1'),
+            ('relation_remote_app', 1),
             ('relation_list', relation_id)
         ])
 
@@ -185,6 +188,7 @@ class TestModel(unittest.TestCase):
 
         self.assertBackendCalls([
             ('relation_ids', 'db1'),
+            ('relation_remote_app', 1),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'remoteapp1/0', False),
         ])
@@ -209,6 +213,7 @@ class TestModel(unittest.TestCase):
 
         self.assertBackendCalls([
             ('relation_ids', 'db1'),
+            ('relation_remote_app', 1),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'remoteapp1', True),
         ])
@@ -234,6 +239,7 @@ class TestModel(unittest.TestCase):
 
         self.assertBackendCalls([
             ('relation_ids', 'db1'),
+            ('relation_remote_app', 1),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'remoteapp1/0', False),
         ])
@@ -282,6 +288,7 @@ class TestModel(unittest.TestCase):
 
         self.assertBackendCalls([
             ('relation_ids', 'db1'),
+            ('relation_remote_app', 1),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'myapp', True),
             ('is_leader',),
@@ -305,6 +312,7 @@ class TestModel(unittest.TestCase):
 
         self.assertBackendCalls([
             ('relation_ids', 'db1'),
+            ('relation_remote_app', 1),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'myapp', True),
             ('is_leader',),
@@ -325,6 +333,7 @@ class TestModel(unittest.TestCase):
 
         self.assertBackendCalls([
             ('relation_ids', 'db1'),
+            ('relation_remote_app', 1),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'myapp/0', False),
             ('relation_set', relation_id, 'host', '', False),
@@ -345,6 +354,7 @@ class TestModel(unittest.TestCase):
 
         self.assertBackendCalls([
             ('relation_ids', 'db1'),
+            ('relation_remote_app', 1),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'myapp/0', False),
             ('relation_set', relation_id, 'port', '', False),
@@ -379,6 +389,7 @@ class TestModel(unittest.TestCase):
 
         self.assertBackendCalls([
             ('relation_ids', 'db1'),
+            ('relation_remote_app', 1),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'myapp/0', False),
             ('relation_set', relation_id, 'host', 'bar', False),
@@ -403,6 +414,7 @@ class TestModel(unittest.TestCase):
 
         self.assertBackendCalls([
             ('relation_ids', 'db1'),
+            ('relation_remote_app', 1),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'myapp/0', False),
         ])
@@ -455,6 +467,7 @@ class TestModel(unittest.TestCase):
         self.assertBackendCalls([
             ('is_leader',),
             ('relation_ids', 'db1'),
+            ('relation_remote_app', 1),
             ('relation_list', relation_id),
             ('is_leader',),
         ])

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -762,8 +762,8 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(
             harness._get_backend_calls(reset=True), [
                 ('relation_ids', 'db'),
-                ('relation_remote_app', 0),
                 ('relation_list', rel_id),
+                ('relation_remote_app_name', 0),
             ])
         # add_relation_unit resets the relation_list, but doesn't trigger backend calls
         harness.add_relation_unit(rel_id, 'postgresql/0')
@@ -773,14 +773,12 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(
             harness._get_backend_calls(reset=False), [
                 ('relation_ids', 'db'),
-                ('relation_remote_app', 0),
                 ('relation_list', rel_id),
             ])
         # If we check again, they are still there, but now we reset it
         self.assertEqual(
             harness._get_backend_calls(reset=True), [
                 ('relation_ids', 'db'),
-                ('relation_remote_app', 0),
                 ('relation_list', rel_id),
             ])
         # And the calls are gone
@@ -1594,3 +1592,20 @@ class TestTestingModelBackend(unittest.TestCase):
         self.assertIn(
             "units/unit-test-app-0/resources/foo: resource#test-app/foo not found",
             str(cm.exception))
+
+    def test_relation_remote_app_name(self):
+        harness = Harness(CharmBase, meta='''
+            name: test-charm
+            ''')
+        self.addCleanup(harness.cleanup)
+        backend = harness._backend
+
+        self.assertIs(backend.relation_remote_app_name(1), None)
+
+        rel_id = harness.add_relation('db', 'postgresql')
+        self.assertEqual(backend.relation_remote_app_name(rel_id), 'postgresql')
+        harness.add_relation_unit(rel_id, 'postgresql/0')
+        harness.add_relation_unit(rel_id, 'postgresql/1')
+        self.assertEqual(backend.relation_remote_app_name(rel_id), 'postgresql')
+
+        self.assertIs(backend.relation_remote_app_name(7), None)

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -762,6 +762,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(
             harness._get_backend_calls(reset=True), [
                 ('relation_ids', 'db'),
+                ('relation_remote_app', 0),
                 ('relation_list', rel_id),
             ])
         # add_relation_unit resets the relation_list, but doesn't trigger backend calls
@@ -772,12 +773,14 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(
             harness._get_backend_calls(reset=False), [
                 ('relation_ids', 'db'),
+                ('relation_remote_app', 0),
                 ('relation_list', rel_id),
             ])
         # If we check again, they are still there, but now we reset it
         self.assertEqual(
             harness._get_backend_calls(reset=True), [
                 ('relation_ids', 'db'),
+                ('relation_remote_app', 0),
                 ('relation_list', rel_id),
             ])
         # And the calls are gone


### PR DESCRIPTION
Charm errors were happening because we were setting `Relation.app` from the app of the first unit, but if an event was fired before any units had started up (this happens on `relation-created`, for example), the `app` field was None and this caused a `KeyError` later when charms did things like `event.relation.data[event.app]` (`event.app` was `None`).

The code still starts with the current method (first app of the units), but in the case when that doesn't work because there are no units, we fall back to:

1) If the relation in question is this event's relation (`JUJU_RELATION_ID`), then use `JUJU_REMOTE_APP` as the remote app name.
2) If it's not this event's relation, use `relation-list --app` to fetch the remote app name (`--app` was [introduced](https://github.com/juju/juju/commit/3e3a16891b002d770125581139f26836a291c4bf) in Juju 2.8.1).

Fixes #175 and manifests itself as issues like https://bugs.launchpad.net/juju/+bug/1914415
