### PR TITLE
Add custom pebble.Error subtypes for better error handling

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1029,11 +1029,11 @@ class Container:
         """Autostart all default services."""
         self._pebble.autostart_services()
 
-    def start(self, *service_names: typing.List[str]):
+    def start(self, *service_names: str):
         """Start given service(s) by name."""
         self._pebble.start_services(service_names)
 
-    def stop(self, *service_names: typing.List[str]):
+    def stop(self, *service_names: str):
         """Stop given service(s) by name."""
         self._pebble.stop_services(service_names)
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -17,7 +17,7 @@
 For a command-line interface for local testing, see test/pebble_cli.py.
 """
 
-from typing import Dict, List, Optional, Union
+from typing import Dict, Iterable, List, Optional, Union
 import datetime
 import enum
 import http.client
@@ -133,13 +133,17 @@ class ConnectionError(Error):
 class APIError(Error):
     """Raised when an HTTP API error occurs talking to the Pebble server."""
 
-    def __init__(self, body, code, status, message):
+    def __init__(self, body: Dict, code: int, status: str, message: str):
         """This shouldn't be instantiated directly."""
-        super().__init__(message)
+        super().__init__(message)  # Makes str(e) return message
         self.body = body
         self.code = code
         self.status = status
         self.message = message
+
+    def __repr__(self):
+        return 'APIError({!r}, {!r}, {!r}, {!r})'.format(
+            self.body, self.code, self.status, self.message)
 
 
 class ServiceError(Error):
@@ -152,11 +156,14 @@ class ServiceError(Error):
     - Start service "test" (service "test" was previously started)
     """
 
-    def __init__(self, err, change):
+    def __init__(self, err: str, change: 'Change'):
         """This shouldn't be instantiated directly."""
-        super().__init__(err)
+        super().__init__(err)  # Makes str(e) return err
         self.err = err
         self.change = change
+
+    def __repr__(self):
+        return 'ServiceError({!r}, {!r})'.format(self.err, self.change)
 
 
 class WarningState(enum.Enum):
@@ -580,7 +587,7 @@ class Client:
         return self._services_action('stop', services, timeout, delay)
 
     def _services_action(
-        self, action: str, services: List[str], timeout: float, delay: float,
+        self, action: str, services: Iterable[str], timeout: float, delay: float,
     ) -> ChangeID:
         if not isinstance(services, (list, tuple)):
             raise TypeError('services must be a list of str, not {}'.format(

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -101,8 +101,8 @@ class Error(Exception):
     """Base class of most errors raised by the Pebble client."""
 
 
-class PollTimeout(TimeoutError, Error):
-    """Raised when the wait_change() polling times out."""
+class TimeoutError(TimeoutError, Error):
+    """Raised when a polling timeout occurs."""
 
 
 class ConnectionError(Error):
@@ -572,7 +572,7 @@ class Client:
 
             time.sleep(delay)
 
-        raise PollTimeout(
+        raise TimeoutError(
             'timed out waiting for change {} ({} seconds)'.format(change_id, timeout))
 
     def add_layer(self, layer: Union[str, dict, Layer]):

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -105,7 +105,7 @@ def main():
     except pebble.APIError as e:
         print('{} {}: {}'.format(e.code, e.status, e.message), file=sys.stderr)
         sys.exit(1)
-    except pebble.SocketError as e:
+    except pebble.ConnectionError as e:
         print('cannot connect to socket {!r}: {}'.format(socket_path, e),
               file=sys.stderr)
         sys.exit(1)

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -23,10 +23,8 @@ PEBBLE=pebble_dir python -m test.pebble_cli system-info
 
 import argparse
 import datetime
-import json
 import os
 import sys
-import urllib.error
 
 from ops import pebble
 
@@ -104,17 +102,15 @@ def main():
             result = client.get_warnings(select=pebble.WarningState(args.select))
         else:
             raise AssertionError("shouldn't happen")
-    except urllib.error.HTTPError as e:
-        print(e, file=sys.stderr)
-        obj = json.load(e)
-        print(json.dumps(obj, sort_keys=True, indent=4), file=sys.stderr)
+    except pebble.APIError as e:
+        print('{} {}: {}'.format(e.code, e.status, e.message), file=sys.stderr)
         sys.exit(1)
-    except urllib.error.URLError as e:
-        print('cannot connect to Pebble socket {!r}: {}'.format(socket_path, e.reason),
+    except pebble.SocketError as e:
+        print('cannot connect to socket {!r}: {}'.format(socket_path, e),
               file=sys.stderr)
         sys.exit(1)
     except pebble.ServiceError as e:
-        print('ServiceError:', e.err, file=sys.stderr)
+        print('ServiceError:', e, file=sys.stderr)
         sys.exit(1)
 
     if isinstance(result, list):

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -109,8 +109,8 @@ def main():
         print('cannot connect to socket {!r}: {}'.format(socket_path, e),
               file=sys.stderr)
         sys.exit(1)
-    except pebble.ServiceError as e:
-        print('ServiceError:', e, file=sys.stderr)
+    except pebble.ChangeError as e:
+        print('ChangeError:', e, file=sys.stderr)
         sys.exit(1)
 
     if isinstance(result, list):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -816,6 +816,24 @@ containers:
             ('stop', ('foo', 'bar')),
         ])
 
+    def test_type_errors(self):
+        meta = ops.charm.CharmMeta.from_yaml("""
+name: k8s-charm
+containers:
+  c1:
+    k: v
+""")
+        # Only the real pebble Client checks types, so use actual backend class
+        backend = ops.model._ModelBackend('myapp/0')
+        model = ops.model.Model(meta, backend)
+        container = model.unit.containers['c1']
+
+        with self.assertRaises(TypeError):
+            container.start(['foo'])
+
+        with self.assertRaises(TypeError):
+            container.stop(['foo'])
+
     def test_add_layer(self):
         self.container.add_layer('summary: str\n')
         self.container.add_layer({'summary': 'dict'})

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -89,6 +89,24 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(error.message, 'no services')
         self.assertEqual(str(error), 'no services')
 
+    def test_service_error(self):
+        change = pebble.Change(
+            id=pebble.ChangeID('1234'),
+            kind='start',
+            summary='Start service "foo"',
+            status='Done',
+            tasks=[],
+            ready=True,
+            err=None,
+            spawn_time=datetime.datetime.now(),
+            ready_time=datetime.datetime.now(),
+        )
+        error = pebble.ServiceError('Some error', change)
+        self.assertIsInstance(error, pebble.Error)
+        self.assertEqual(error.err, 'Some error')
+        self.assertEqual(error.change, change)
+        self.assertEqual(str(error), 'Some error')
+
     def test_warning_state(self):
         self.assertEqual(list(pebble.WarningState), [
             pebble.WarningState.ALL,
@@ -720,7 +738,14 @@ class TestClient(unittest.TestCase):
             return self.client.stop_services(['svc'], timeout=timeout)
         self._services_action_async_helper('stop', api_func, ['svc'])
 
-    def test_change_error(self):
+    def test_service_error(self):
+        self.client.responses.append({
+            "change": "70",
+            "result": None,
+            "status": "Accepted",
+            "status-code": 202,
+            "type": "async"
+        })
         change = self.build_mock_change_dict()
         change['err'] = 'Some kind of service error'
         self.client.responses.append({
@@ -729,10 +754,12 @@ class TestClient(unittest.TestCase):
             "status-code": 200,
             "type": "sync"
         })
-        change = self.client.wait_change(pebble.ChangeID('70'))
-        self.assertIsInstance(change, pebble.Change)
-        self.assertEqual(change.id, '70')
-        self.assertEqual(change.err, 'Some kind of service error')
+        with self.assertRaises(pebble.ServiceError) as cm:
+            self.client.autostart_services()
+        self.assertIsInstance(cm.exception, pebble.Error)
+        self.assertEqual(cm.exception.err, 'Some kind of service error')
+        self.assertIsInstance(cm.exception.change, pebble.Change)
+        self.assertEqual(cm.exception.change.id, '70')
 
     def test_wait_change_timeout(self):
         with unittest.mock.patch('ops.pebble.time', MockTime()):

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -61,9 +61,10 @@ class TestTypes(unittest.TestCase):
         error = pebble.Error('error')
         self.assertIsInstance(error, Exception)
 
-    def test_poll_timeout(self):
-        error = pebble.PollTimeout('timeout!')
+    def test_timeout_error(self):
+        error = pebble.TimeoutError('timeout!')
         self.assertIsInstance(error, pebble.Error)
+        self.assertIsInstance(error, TimeoutError)
         self.assertEqual(str(error), 'timeout!')
 
     def test_connection_error(self):
@@ -745,7 +746,7 @@ class TestClient(unittest.TestCase):
                     "type": "sync"
                 })
 
-            with self.assertRaises(pebble.PollTimeout) as cm:
+            with self.assertRaises(pebble.TimeoutError) as cm:
                 self.client.wait_change('70', timeout=3, delay=1)
             self.assertIsInstance(cm.exception, pebble.Error)
             self.assertIsInstance(cm.exception, TimeoutError)

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -116,7 +116,7 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(error.message, 'no services')
         self.assertEqual(str(error), 'no services')
 
-    def test_service_error(self):
+    def test_change_error(self):
         change = pebble.Change(
             id=pebble.ChangeID('1234'),
             kind='start',
@@ -128,7 +128,7 @@ class TestTypes(unittest.TestCase):
             spawn_time=datetime.datetime.now(),
             ready_time=datetime.datetime.now(),
         )
-        error = pebble.ServiceError('Some error', change)
+        error = pebble.ChangeError('Some error', change)
         self.assertIsInstance(error, pebble.Error)
         self.assertEqual(error.err, 'Some error')
         self.assertEqual(error.change, change)
@@ -765,7 +765,7 @@ class TestClient(unittest.TestCase):
             return self.client.stop_services(['svc'], timeout=timeout)
         self._services_action_async_helper('stop', api_func, ['svc'])
 
-    def test_service_error(self):
+    def test_change_error(self):
         self.client.responses.append({
             "change": "70",
             "result": None,
@@ -781,7 +781,7 @@ class TestClient(unittest.TestCase):
             "status-code": 200,
             "type": "sync"
         })
-        with self.assertRaises(pebble.ServiceError) as cm:
+        with self.assertRaises(pebble.ChangeError) as cm:
             self.client.autostart_services()
         self.assertIsInstance(cm.exception, pebble.Error)
         self.assertEqual(cm.exception.err, 'Some kind of service error')
@@ -810,6 +810,20 @@ class TestClient(unittest.TestCase):
                 ('GET', '/v1/changes/70', None, None),
                 ('GET', '/v1/changes/70', None, None),
             ])
+
+    def test_wait_change_error(self):
+        change = self.build_mock_change_dict()
+        change['err'] = 'Some kind of service error'
+        self.client.responses.append({
+            "result": change,
+            "status": "OK",
+            "status-code": 200,
+            "type": "sync"
+        })
+        # wait_change() itself shouldn't raise an error
+        response = self.client.wait_change('70')
+        self.assertEqual(response.id, '70')
+        self.assertEqual(response.err, 'Some kind of service error')
 
 
 class TestSocketClient(unittest.TestCase):


### PR DESCRIPTION
Also do some `isinstance` checks so you know sooner (rather than the Pebble server having to tell you).

This came from testing Harry did, where he was passing a list of service names like `['foo']` to `container.start()`, instead of varargs (partly because the low-level client takes a list not varargs). So this makes two improvements:

1) If an error like this did happen again, the traceback and error string would include the helpful error message from the server. While we're at it, we make all client errors subclasses of a new `pebble.Error`. Strictly speaking this is a breaking change, but we haven't released anything Pebble-related yet, so that's fine.
2) Make the `pebble.Client` `start_services` and `stop_services` methods do isinstance checks to check the types upfront. This just lets the user (e.g., Charm writer) know sooner rather than later about this type error, before the client even tries to send the request. This fits how we're type checking argument types in a bunch of other places in the framework.