### PR TITLE
Dynamic add_layer API and get_plan API

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1047,23 +1047,25 @@ class Container:
         """Stop given service(s) by name."""
         self._pebble.stop_services(service_names)
 
-    def merge_layer(self, layer: typing.Union[str, typing.Dict, 'pebble.Layer']):
-        """Dynamically merge layer onto the Pebble setup layers.
-
-        Pebble merges the layer with the existing dynamic layer according to
-        its flattening/override rules, or adds a new dynamic if there are no
-        dynamic layers.
+    def add_layer(self, label: str, layer: typing.Union[str, typing.Dict, 'pebble.Layer'],
+                  combine: bool = False):
+        """Dynamically add a new layer onto the Pebble configuration layers.
 
         Args:
-            layer: A YAML string, setup layer dict, or pebble.Layer object
-                containing the Pebble layer to add.
+            label: Label for new layer (and label of layer to merge with if
+                combining).
+            layer: A YAML string, configuration layer dict, or pebble.Layer
+                object containing the Pebble layer to add.
+            combine: If combine is False (the default), append the new layer
+                as the top layer with the given label. If combine is True,
+                combine the new layer with the layer that has the given label;
+                combining is done according to Pebble's override rules.
         """
-        self._pebble.merge_layer(layer)
+        self._pebble.add_layer(label, layer, combine=combine)
 
-    def get_layer(self) -> 'pebble.Layer':
-        """Fetch the flattened setup layers as a pebble.Layer object."""
-        setup_yaml = self._pebble.get_layer()
-        return pebble.Layer(setup_yaml)
+    def get_plan(self) -> 'pebble.Plan':
+        """Get the Pebble plan (currently contains only combined services)."""
+        return self._pebble.get_plan()
 
 
 class ContainerMapping(Mapping):

--- a/ops/model.py
+++ b/ops/model.py
@@ -1057,14 +1057,15 @@ class Container:
             layer: A YAML string, configuration layer dict, or pebble.Layer
                 object containing the Pebble layer to add.
             combine: If combine is False (the default), append the new layer
-                as the top layer with the given label. If combine is True,
-                combine the new layer with the layer that has the given label;
-                combining is done according to Pebble's override rules.
+                as the top layer with the given label (must be unique). If
+                combine is True and the label already exists, the two layers
+                are combined into a single one considering the layer override
+                rules; if the layer doesn't exist, it is added as usual.
         """
         self._pebble.add_layer(label, layer, combine=combine)
 
     def get_plan(self) -> 'pebble.Plan':
-        """Get the Pebble plan (currently contains only combined services)."""
+        """Get the current effective pebble configuration."""
         return self._pebble.get_plan()
 
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -1047,8 +1047,12 @@ class Container:
         """Stop given service(s) by name."""
         self._pebble.stop_services(service_names)
 
-    def add_layer(self, layer: typing.Union[str, typing.Dict, 'pebble.Layer']):
-        """Dynamically add a setup layer.
+    def merge_layer(self, layer: typing.Union[str, typing.Dict, 'pebble.Layer']):
+        """Dynamically merge layer onto the Pebble setup layers.
+
+        Pebble merges the layer with the existing dynamic layer according to
+        its flattening/override rules, or adds a new dynamic if there are no
+        dynamic layers.
 
         Args:
             layer: A YAML string, setup layer dict, or pebble.Layer object
@@ -1056,7 +1060,7 @@ class Container:
         """
         if isinstance(layer, dict):
             layer = pebble.Layer(layer)
-        self._pebble.add_layer(layer)
+        self._pebble.merge_layer(layer)
 
     def get_layer(self) -> 'pebble.Layer':
         """Fetch the flattened setup layers as a pebble.Layer object."""

--- a/ops/model.py
+++ b/ops/model.py
@@ -1058,8 +1058,6 @@ class Container:
             layer: A YAML string, setup layer dict, or pebble.Layer object
                 containing the Pebble layer to add.
         """
-        if isinstance(layer, dict):
-            layer = pebble.Layer(layer)
         self._pebble.merge_layer(layer)
 
     def get_layer(self) -> 'pebble.Layer':

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -638,8 +638,11 @@ class Client:
             layer_yaml = layer
         elif isinstance(layer, dict):
             layer_yaml = Layer(layer).to_yaml()
-        else:
+        elif isinstance(layer, Layer):
             layer_yaml = layer.to_yaml()
+        else:
+            raise TypeError('layer must be str, dict, or pebble.Layer, not {}'.format(
+                type(layer).__name__))
 
         body = {'action': 'merge', 'format': 'yaml', 'layer': layer_yaml}
         result = self._request('POST', '/v1/layers', body=body)

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -403,7 +403,7 @@ class Plan:
         """
         return self._services
 
-    def as_yaml(self) -> str:
+    def to_yaml(self) -> str:
         """Return this plan's YAML representation.
 
         This returns the exact YAML passed to Plan() without re-serialization,
@@ -411,7 +411,7 @@ class Plan:
         """
         return self._raw
 
-    __str__ = as_yaml
+    __str__ = to_yaml
 
 
 class Layer:
@@ -431,23 +431,23 @@ class Layer:
         self.services = {name: Service(name, service)
                          for name, service in d.get('services', {}).items()}
 
-    def as_yaml(self) -> str:
+    def to_yaml(self) -> str:
         """Convert this layer to its YAML representation."""
-        return yaml.safe_dump(self.as_dict())
+        return yaml.safe_dump(self.to_dict())
 
-    def as_dict(self) -> Dict:
+    def to_dict(self) -> Dict:
         """Convert this layer to its dict representation."""
         fields = [
             ('summary', self.summary),
             ('description', self.description),
-            ('services', {name: service.as_dict() for name, service in self.services.items()})
+            ('services', {name: service.to_dict() for name, service in self.services.items()})
         ]
         return {name: value for name, value in fields if value}
 
     def __repr__(self) -> str:
-        return 'Layer({!r})'.format(self.as_dict())
+        return 'Layer({!r})'.format(self.to_dict())
 
-    __str__ = as_yaml
+    __str__ = to_yaml
 
 
 class Service:
@@ -466,7 +466,7 @@ class Service:
         self.requires = list(raw.get('requires', []))
         self.environment = dict(raw.get('environment') or {})
 
-    def as_dict(self) -> Dict:
+    def to_dict(self) -> Dict:
         """Convert this service object to its dict representation."""
         fields = [
             ('summary', self.summary),
@@ -482,7 +482,7 @@ class Service:
         return {name: value for name, value in fields if value}
 
     def __repr__(self) -> str:
-        return 'Service({!r})'.format(self.as_dict())
+        return 'Service({!r})'.format(self.to_dict())
 
 
 class Client:
@@ -669,9 +669,9 @@ class Client:
         if isinstance(layer, str):
             layer_yaml = layer
         elif isinstance(layer, dict):
-            layer_yaml = Layer(layer).as_yaml()
+            layer_yaml = Layer(layer).to_yaml()
         elif isinstance(layer, Layer):
-            layer_yaml = layer.as_yaml()
+            layer_yaml = layer.to_yaml()
         else:
             raise TypeError('layer must be str, dict, or pebble.Layer, not {}'.format(
                 type(layer).__name__))

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -627,19 +627,20 @@ class Client:
         raise TimeoutError(
             'timed out waiting for change {} ({} seconds)'.format(change_id, timeout))
 
-    def add_layer(self, layer: Union[str, dict, Layer]):
-        """Dynamically add a layer to the Pebble setup."""
+    def add_layer(self, layer: Union[str, dict, Layer]) -> int:
+        """Dynamically add a layer to the Pebble setup and return the layer's order."""
         if isinstance(layer, str):
             layer_yaml = layer
         elif isinstance(layer, dict):
             layer_yaml = Layer(layer).to_yaml()
         else:
             layer_yaml = layer.to_yaml()
-        _ = layer_yaml
-        # TODO(benhoyt) - send layer_yaml to Pebble when that API is implemented
-        raise NotImplementedError('add_layer not yet implemented in Pebble')
+
+        body = {'layer': layer_yaml}
+        result = self._request('POST', '/v1/layers', body=body)
+        return result['result']
 
     def get_layer(self) -> str:
         """Get the flattened setup layers as a YAML string."""
-        # TODO(benhoyt) - fetch setup YAML from Pebble when that API is implemented
-        raise NotImplementedError('get_layer not yet implemented in Pebble')
+        result = self._request('GET', '/v1/layers')
+        return result['result']

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -404,11 +404,7 @@ class Plan:
         return self._services
 
     def to_yaml(self) -> str:
-        """Return this plan's YAML representation.
-
-        This returns the exact YAML passed to Plan() without re-serialization,
-        that is, the YAML that Client.get_plan() received from Pebble.
-        """
+        """Return this plan's YAML representation."""
         return self._raw
 
     __str__ = to_yaml

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -42,6 +42,9 @@ def main():
                                        'format), default current time',
                    type=pebble._parse_timestamp)
 
+    p = subparsers.add_parser('add-layer', help='add a setup layer dynamically')
+    p.add_argument('layer_path', help='path of layer YAML file')
+
     p = subparsers.add_parser('autostart', help='autostart default service(s)')
 
     p = subparsers.add_parser('change', help='show a single change by ID')
@@ -51,6 +54,8 @@ def main():
     p.add_argument('--select', help='change state to filter on, default %(default)s',
                    choices=[s.value for s in pebble.ChangeState], default='all')
     p.add_argument('--service', help='optional service name to filter on')
+
+    p = subparsers.add_parser('layer', help='show flattened setup layers')
 
     p = subparsers.add_parser('start', help='start service(s)')
     p.add_argument('service', help='name of service to start (can specify multiple)', nargs='+')
@@ -100,6 +105,15 @@ def main():
             result = client.get_system_info()
         elif args.command == 'warnings':
             result = client.get_warnings(select=pebble.WarningState(args.select))
+        elif args.command == 'add-layer':
+            try:
+                with open(args.layer_path, encoding='utf-8') as f:
+                    layer = f.read()
+            except IOError as e:
+                parser.error('cannot read layer YAML: {}'.format(e))
+            result = client.add_layer(layer)
+        elif args.command == 'layer':
+            result = client.get_layer()
         else:
             raise AssertionError("shouldn't happen")
     except pebble.APIError as e:

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -42,6 +42,11 @@ def main():
                                        'format), default current time',
                    type=pebble._parse_timestamp)
 
+    p = subparsers.add_parser('add', help='add a configuration layer dynamically')
+    p.add_argument('--combine', action='store_true', help='combine layer instead of appending')
+    p.add_argument('label', help='label for new layer')
+    p.add_argument('layer_path', help='path of layer YAML file')
+
     p = subparsers.add_parser('autostart', help='autostart default service(s)')
 
     p = subparsers.add_parser('change', help='show a single change by ID')
@@ -52,10 +57,7 @@ def main():
                    choices=[s.value for s in pebble.ChangeState], default='all')
     p.add_argument('--service', help='optional service name to filter on')
 
-    p = subparsers.add_parser('flatten', help='show flattened setup layer')
-
-    p = subparsers.add_parser('merge', help='merge a dynamic setup layer')
-    p.add_argument('layer_path', help='path of layer YAML file')
+    p = subparsers.add_parser('plan', help='show configuration plan (combined layers)')
 
     p = subparsers.add_parser('start', help='start service(s)')
     p.add_argument('service', help='name of service to start (can specify multiple)', nargs='+')
@@ -90,6 +92,15 @@ def main():
         elif args.command == 'ack':
             timestamp = args.timestamp or datetime.datetime.now(tz=datetime.timezone.utc)
             result = client.ack_warnings(timestamp)
+        elif args.command == 'add':
+            try:
+                with open(args.layer_path, encoding='utf-8') as f:
+                    layer_yaml = f.read()
+            except IOError as e:
+                parser.error('cannot read layer YAML: {}'.format(e))
+            client.add_layer(args.label, layer_yaml, combine=bool(args.combine))
+            result = 'Layer {!r} added successfully from {!r}'.format(
+                args.label, args.layer_path)
         elif args.command == 'autostart':
             result = client.autostart_services()
         elif args.command == 'change':
@@ -97,15 +108,8 @@ def main():
         elif args.command == 'changes':
             result = client.get_changes(select=pebble.ChangeState(args.select),
                                         service=args.service)
-        elif args.command == 'flatten':
-            result = client.get_layer()
-        elif args.command == 'merge':
-            try:
-                with open(args.layer_path, encoding='utf-8') as f:
-                    layer_yaml = f.read()
-            except IOError as e:
-                parser.error('cannot read layer YAML: {}'.format(e))
-            result = client.merge_layer(layer_yaml)
+        elif args.command == 'plan':
+            result = client.get_plan().raw_yaml
         elif args.command == 'start':
             result = client.start_services(args.service)
         elif args.command == 'stop':

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -887,7 +887,9 @@ class MockPebbleClient:
         self.requests.append(('stop', service_names))
 
     def merge_layer(self, layer):
-        if isinstance(layer, ops.pebble.Layer):
+        if isinstance(layer, dict):
+            layer = ops.pebble.Layer(layer).to_yaml()
+        elif isinstance(layer, ops.pebble.Layer):
             layer = layer.to_yaml()
         self.requests.append(('merge_layer', layer))
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -848,14 +848,14 @@ containers:
         with self.assertRaises(TypeError):
             container.stop(['foo'])
 
-    def test_add_layer(self):
-        self.container.add_layer('summary: str\n')
-        self.container.add_layer({'summary': 'dict'})
-        self.container.add_layer(ops.pebble.Layer('summary: Layer'))
+    def test_merge_layer(self):
+        self.container.merge_layer('summary: str\n')
+        self.container.merge_layer({'summary': 'dict'})
+        self.container.merge_layer(ops.pebble.Layer('summary: Layer'))
         self.assertEqual(self.pebble.requests, [
-            ('add_layer', 'summary: str\n'),
-            ('add_layer', 'summary: dict\n'),
-            ('add_layer', 'summary: Layer\n'),
+            ('merge_layer', 'summary: str\n'),
+            ('merge_layer', 'summary: dict\n'),
+            ('merge_layer', 'summary: Layer\n'),
         ])
 
     def test_get_layer(self):
@@ -886,10 +886,10 @@ class MockPebbleClient:
     def stop_services(self, service_names):
         self.requests.append(('stop', service_names))
 
-    def add_layer(self, layer):
+    def merge_layer(self, layer):
         if isinstance(layer, ops.pebble.Layer):
             layer = layer.to_yaml()
-        self.requests.append(('add_layer', layer))
+        self.requests.append(('merge_layer', layer))
 
     def get_layer(self):
         self.requests.append(('get_layer',))

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -866,7 +866,7 @@ containers:
         plan = self.container.get_plan()
         self.assertEqual(self.pebble.requests, [('get_plan',)])
         self.assertIsInstance(plan, ops.pebble.Plan)
-        self.assertEqual(plan.as_yaml(), plan_yaml)
+        self.assertEqual(plan.to_yaml(), plan_yaml)
 
 
 class MockPebbleBackend(ops.model._ModelBackend):
@@ -891,9 +891,9 @@ class MockPebbleClient:
 
     def add_layer(self, label, layer, combine=False):
         if isinstance(layer, dict):
-            layer = ops.pebble.Layer(layer).as_yaml()
+            layer = ops.pebble.Layer(layer).to_yaml()
         elif isinstance(layer, ops.pebble.Layer):
-            layer = layer.as_yaml()
+            layer = layer.to_yaml()
         self.requests.append(('add_layer', label, layer, combine))
 
     def get_plan(self):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -866,7 +866,7 @@ containers:
         plan = self.container.get_plan()
         self.assertEqual(self.pebble.requests, [('get_plan',)])
         self.assertIsInstance(plan, ops.pebble.Plan)
-        self.assertEqual(plan.raw_yaml, plan_yaml)
+        self.assertEqual(plan.as_yaml(), plan_yaml)
 
 
 class MockPebbleBackend(ops.model._ModelBackend):
@@ -891,9 +891,9 @@ class MockPebbleClient:
 
     def add_layer(self, label, layer, combine=False):
         if isinstance(layer, dict):
-            layer = ops.pebble.Layer(layer).to_yaml()
+            layer = ops.pebble.Layer(layer).as_yaml()
         elif isinstance(layer, ops.pebble.Layer):
-            layer = layer.to_yaml()
+            layer = layer.as_yaml()
         self.requests.append(('add_layer', label, layer, combine))
 
     def get_plan(self):

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -338,12 +338,43 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(change.spawn_time, datetime_utc(2021, 1, 28, 14, 37, 2, 247202))
 
 
+class TestPlan(unittest.TestCase):
+    def test_no_args(self):
+        with self.assertRaises(TypeError):
+            pebble.Plan()
+
+    def test_services(self):
+        plan = pebble.Plan('')
+        self.assertEqual(plan.services, {})
+
+        plan = pebble.Plan('services:\n foo:\n  override: replace\n  command: echo foo')
+
+        self.assertEqual(len(plan.services), 1)
+        self.assertEqual(plan.services['foo'].name, 'foo')
+        self.assertEqual(plan.services['foo'].override, 'replace')
+        self.assertEqual(plan.services['foo'].command, 'echo foo')
+
+        # Should be read-only ("can't set attribute")
+        with self.assertRaises(AttributeError):
+            plan.services = {}
+
+    def test_yaml(self):
+        plan = pebble.Plan('')
+        self.assertEqual(plan.as_yaml(), '')
+        self.assertEqual(str(plan), '')
+
+        yaml = 'services:\n foo:\n  override: replace\n  command: echo foo'
+        plan = pebble.Plan(yaml)
+        self.assertEqual(plan.as_yaml(), yaml)
+        self.assertEqual(str(plan), yaml)
+
+
 class TestLayer(unittest.TestCase):
     def _assert_empty(self, layer):
         self.assertEqual(layer.summary, '')
         self.assertEqual(layer.description, '')
         self.assertEqual(layer.services, {})
-        self.assertEqual(layer.to_dict(), {})
+        self.assertEqual(layer.as_dict(), {})
 
     def test_no_args(self):
         s = pebble.Layer()
@@ -377,7 +408,7 @@ class TestLayer(unittest.TestCase):
         self.assertEqual(s.services['bar'].summary, 'Bar')
         self.assertEqual(s.services['bar'].command, 'echo bar')
 
-        self.assertEqual(s.to_dict(), d)
+        self.assertEqual(s.as_dict(), d)
 
     def test_yaml(self):
         s = pebble.Layer('')
@@ -403,7 +434,7 @@ summary: Sum Mary
         self.assertEqual(s.services['bar'].summary, 'Bar')
         self.assertEqual(s.services['bar'].command, 'echo bar')
 
-        self.assertEqual(s.to_yaml(), yaml)
+        self.assertEqual(s.as_yaml(), yaml)
         self.assertEqual(str(s), yaml)
 
 
@@ -419,7 +450,7 @@ class TestService(unittest.TestCase):
         self.assertEqual(service.before, [])
         self.assertEqual(service.requires, [])
         self.assertEqual(service.environment, {})
-        self.assertEqual(service.to_dict(), {})
+        self.assertEqual(service.as_dict(), {})
 
     def test_name_only(self):
         s = pebble.Service('Name 0')
@@ -451,7 +482,7 @@ class TestService(unittest.TestCase):
         self.assertEqual(s.requires, ['r1', 'r2'])
         self.assertEqual(s.environment, {'k1': 'v1', 'k2': 'v2'})
 
-        self.assertEqual(s.to_dict(), d)
+        self.assertEqual(s.as_dict(), d)
 
         # Ensure pebble.Service has made copies of mutable objects
         s.after.append('a3')
@@ -855,8 +886,8 @@ services:
         layer = pebble.Layer(layer_yaml)
 
         self.client.add_layer('a', layer)
-        self.client.add_layer('b', layer.to_yaml())
-        self.client.add_layer('c', layer.to_dict())
+        self.client.add_layer('b', layer.as_yaml())
+        self.client.add_layer('c', layer.as_dict())
         self.client.add_layer('d', layer, combine=True)
 
         def build_expected(label, combine):
@@ -895,7 +926,7 @@ services:
             "type": "sync"
         })
         plan = self.client.get_plan()
-        self.assertEqual(plan.raw_yaml, plan_yaml)
+        self.assertEqual(plan.as_yaml(), plan_yaml)
         self.assertEqual(len(plan.services), 1)
         self.assertEqual(plan.services['foo'].command, 'echo bar')
         self.assertEqual(plan.services['foo'].override, 'replace')

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -360,12 +360,12 @@ class TestPlan(unittest.TestCase):
 
     def test_yaml(self):
         plan = pebble.Plan('')
-        self.assertEqual(plan.as_yaml(), '')
+        self.assertEqual(plan.to_yaml(), '')
         self.assertEqual(str(plan), '')
 
         yaml = 'services:\n foo:\n  override: replace\n  command: echo foo'
         plan = pebble.Plan(yaml)
-        self.assertEqual(plan.as_yaml(), yaml)
+        self.assertEqual(plan.to_yaml(), yaml)
         self.assertEqual(str(plan), yaml)
 
 
@@ -374,7 +374,7 @@ class TestLayer(unittest.TestCase):
         self.assertEqual(layer.summary, '')
         self.assertEqual(layer.description, '')
         self.assertEqual(layer.services, {})
-        self.assertEqual(layer.as_dict(), {})
+        self.assertEqual(layer.to_dict(), {})
 
     def test_no_args(self):
         s = pebble.Layer()
@@ -408,7 +408,7 @@ class TestLayer(unittest.TestCase):
         self.assertEqual(s.services['bar'].summary, 'Bar')
         self.assertEqual(s.services['bar'].command, 'echo bar')
 
-        self.assertEqual(s.as_dict(), d)
+        self.assertEqual(s.to_dict(), d)
 
     def test_yaml(self):
         s = pebble.Layer('')
@@ -434,7 +434,7 @@ summary: Sum Mary
         self.assertEqual(s.services['bar'].summary, 'Bar')
         self.assertEqual(s.services['bar'].command, 'echo bar')
 
-        self.assertEqual(s.as_yaml(), yaml)
+        self.assertEqual(s.to_yaml(), yaml)
         self.assertEqual(str(s), yaml)
 
 
@@ -450,7 +450,7 @@ class TestService(unittest.TestCase):
         self.assertEqual(service.before, [])
         self.assertEqual(service.requires, [])
         self.assertEqual(service.environment, {})
-        self.assertEqual(service.as_dict(), {})
+        self.assertEqual(service.to_dict(), {})
 
     def test_name_only(self):
         s = pebble.Service('Name 0')
@@ -482,7 +482,7 @@ class TestService(unittest.TestCase):
         self.assertEqual(s.requires, ['r1', 'r2'])
         self.assertEqual(s.environment, {'k1': 'v1', 'k2': 'v2'})
 
-        self.assertEqual(s.as_dict(), d)
+        self.assertEqual(s.to_dict(), d)
 
         # Ensure pebble.Service has made copies of mutable objects
         s.after.append('a3')
@@ -886,8 +886,8 @@ services:
         layer = pebble.Layer(layer_yaml)
 
         self.client.add_layer('a', layer)
-        self.client.add_layer('b', layer.as_yaml())
-        self.client.add_layer('c', layer.as_dict())
+        self.client.add_layer('b', layer.to_yaml())
+        self.client.add_layer('c', layer.to_dict())
         self.client.add_layer('d', layer, combine=True)
 
         def build_expected(label, combine):
@@ -926,7 +926,7 @@ services:
             "type": "sync"
         })
         plan = self.client.get_plan()
-        self.assertEqual(plan.as_yaml(), plan_yaml)
+        self.assertEqual(plan.to_yaml(), plan_yaml)
         self.assertEqual(len(plan.services), 1)
         self.assertEqual(plan.services['foo'].command, 'echo bar')
         self.assertEqual(plan.services['foo'].override, 'replace')

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -866,6 +866,10 @@ services:
                 {'action': 'merge', 'format': 'yaml', 'layer': layer_yaml}),
         ])
 
+    def test_merge_layer_invalid_type(self):
+        with self.assertRaises(TypeError):
+            self.client.merge_layer(42)
+
     def test_get_layer(self):
         layer_yaml = """
 services:


### PR DESCRIPTION
The Python / Operator Framework end of https://github.com/canonical/pebble/pull/10

This adds `add_layer` and `get_plan` to both the `Pebble` instance as well as `model.Container`.

Note that these changes would be a breaking change, but the functions in question currently raise `NotImplementedError`, and nobody except me is using it yet anyway.