### PR TITLE
Get-services API to talk to Pebble /v1/services

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1068,6 +1068,26 @@ class Container:
         """Get the current effective pebble configuration."""
         return self._pebble.get_plan()
 
+    def get_services(self, *service_names: str) -> typing.List['pebble.ServiceInfo']:
+        """Get a list of service status information.
+
+        If no service names are specified, return status information for all
+        services, otherwise return information for only the given services.
+        """
+        return self._pebble.get_services(service_names)
+
+    def get_service(self, service_name: str) -> 'pebble.ServiceInfo':
+        """Get status information for a single named service.
+
+        Raises model error if service_name is not found.
+        """
+        services = self.get_services(service_name)
+        if not services:
+            raise ModelError('service {} not found'.format(service_name))
+        if len(services) > 1:
+            raise RuntimeError('expected 1 service, got {}'.format(len(services)))
+        return services[0]
+
 
 class ContainerMapping(Mapping):
     """Map of container names to Container objects.

--- a/ops/model.py
+++ b/ops/model.py
@@ -1083,7 +1083,7 @@ class Container:
         """
         services = self.get_services(service_name)
         if not services:
-            raise ModelError('service {} not found'.format(service_name))
+            raise ModelError('service {!r} not found'.format(service_name))
         if len(services) > 1:
             raise RuntimeError('expected 1 service, got {}'.format(len(services)))
         return services[0]

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -737,7 +737,8 @@ class Client:
         If names is specified, only fetch the service status for the services
         named.
         """
-        if names is None:
-            names = []
-        result = self._request('GET', '/v1/services', {'names': ','.join(names)})
+        query = None
+        if names is not None:
+            query = {'names': ','.join(names)}
+        result = self._request('GET', '/v1/services', query)
         return [ServiceInfo.from_dict(info) for info in result['result']]

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -518,8 +518,8 @@ class ServiceInfo:
     def __init__(
         self,
         name: str,
-        startup: ServiceStartup,
-        current: ServiceStatus,
+        startup: Union[ServiceStartup, str],
+        current: Union[ServiceStatus, str],
     ):
         self.name = name
         self.startup = startup
@@ -528,10 +528,18 @@ class ServiceInfo:
     @classmethod
     def from_dict(cls, d: Dict) -> 'ServiceInfo':
         """Create new object from dict parsed from JSON."""
+        try:
+            startup = ServiceStartup(d['startup'])
+        except ValueError:
+            startup = d['startup']
+        try:
+            current = ServiceStatus(d['current'])
+        except ValueError:
+            current = d['current']
         return cls(
             name=d['name'],
-            startup=ServiceStartup(d['startup']),
-            current=ServiceStatus(d['current']),
+            startup=startup,
+            current=current,
         )
 
     def __repr__(self):

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -481,11 +481,11 @@ class Service:
         return 'Service({!r})'.format(self.to_dict())
 
 
-class ServiceDefault(enum.Enum):
-    """Enum of service default configurations."""
+class ServiceStartup(enum.Enum):
+    """Enum of service startup options."""
 
-    START = 'start'
-    STOP = 'stop'
+    ENABLED = 'enabled'
+    DISABLED = 'disabled'
 
 
 class ServiceStatus(enum.Enum):
@@ -502,31 +502,27 @@ class ServiceInfo:
     def __init__(
         self,
         name: str,
-        default: ServiceDefault,
-        status: ServiceStatus,
-        message: Optional[str],
+        startup: ServiceStartup,
+        current: ServiceStatus,
     ):
         self.name = name
-        self.default = default
-        self.status = status
-        self.message = message
+        self.startup = startup
+        self.current = current
 
     @classmethod
     def from_dict(cls, d: Dict) -> 'ServiceInfo':
         """Create new object from dict parsed from JSON."""
         return cls(
             name=d['name'],
-            default=ServiceDefault(d['default']),
-            status=ServiceStatus(d['status']),
-            message=d.get('message') or None,
+            startup=ServiceStartup(d['startup']),
+            current=ServiceStatus(d['current']),
         )
 
     def __repr__(self):
         return ('ServiceInfo('
                 'name={self.name!r}, '
-                'default={self.default}, '
-                'status={self.status}, '
-                'message={self.message!r})'
+                'startup={self.startup}, '
+                'current={self.current})'
                 ).format(self=self)
 
 

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -59,6 +59,9 @@ def main():
 
     p = subparsers.add_parser('plan', help='show configuration plan (combined layers)')
 
+    p = subparsers.add_parser('services', help='show service status')
+    p.add_argument('service', help='name of service (can specify multiple; none means all services)', nargs='*')
+
     p = subparsers.add_parser('start', help='start service(s)')
     p.add_argument('service', help='name of service to start (can specify multiple)', nargs='+')
 
@@ -110,6 +113,8 @@ def main():
                                         service=args.service)
         elif args.command == 'plan':
             result = client.get_plan().raw_yaml
+        elif args.command == 'services':
+            result = client.get_services(args.service)
         elif args.command == 'start':
             result = client.start_services(args.service)
         elif args.command == 'stop':

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -112,7 +112,7 @@ def main():
             result = client.get_changes(select=pebble.ChangeState(args.select),
                                         service=args.service)
         elif args.command == 'plan':
-            result = client.get_plan().raw_yaml
+            result = client.get_plan().to_yaml()
         elif args.command == 'services':
             result = client.get_services(args.service)
         elif args.command == 'start':

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -60,7 +60,7 @@ def main():
     p = subparsers.add_parser('plan', help='show configuration plan (combined layers)')
 
     p = subparsers.add_parser('services', help='show service status')
-    p.add_argument('service', help='name of service (can specify multiple; none means all services)', nargs='*')
+    p.add_argument('service', help='name of service (none means all; multiple ok)', nargs='*')
 
     p = subparsers.add_parser('start', help='start service(s)')
     p.add_argument('service', help='name of service to start (can specify multiple)', nargs='+')

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -538,6 +538,15 @@ class TestServiceInfo(unittest.TestCase):
         self.assertEqual(s.startup, pebble.ServiceStartup.DISABLED)
         self.assertEqual(s.current, pebble.ServiceStatus.INACTIVE)
 
+        s = pebble.ServiceInfo.from_dict({
+            'name': 'svc2',
+            'startup': 'thingy',
+            'current': 'bob',
+        })
+        self.assertEqual(s.name, 'svc2')
+        self.assertEqual(s.startup, 'thingy')
+        self.assertEqual(s.current, 'bob')
+
 
 class MockClient(pebble.Client):
     """Mock Pebble client that simply records reqeusts and returns stored responses."""

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -998,7 +998,7 @@ services:
         self.assertEqual(services[1].current, pebble.ServiceStatus.ACTIVE)
 
         self.assertEqual(self.client.requests, [
-            ('GET', '/v1/services', {'names': ''}, None),
+            ('GET', '/v1/services', None, None),
         ])
 
     def test_get_services_names(self):

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -499,6 +499,41 @@ class TestService(unittest.TestCase):
         self.assertEqual(d['environment'], {'k1': 'v1', 'k2': 'v2'})
 
 
+class TestServiceInfo(unittest.TestCase):
+    def test_service_startup(self):
+        self.assertEqual(list(pebble.ServiceStartup), [
+            pebble.ServiceStartup.ENABLED,
+            pebble.ServiceStartup.DISABLED,
+        ])
+        self.assertEqual(pebble.ServiceStartup.ENABLED.value, 'enabled')
+        self.assertEqual(pebble.ServiceStartup.DISABLED.value, 'disabled')
+
+    def test_service_status(self):
+        self.assertEqual(list(pebble.ServiceStatus), [
+            pebble.ServiceStatus.ACTIVE,
+            pebble.ServiceStatus.INACTIVE,
+            pebble.ServiceStatus.ERROR,
+        ])
+        self.assertEqual(pebble.ServiceStatus.ACTIVE.value, 'active')
+        self.assertEqual(pebble.ServiceStatus.INACTIVE.value, 'inactive')
+        self.assertEqual(pebble.ServiceStatus.ERROR.value, 'error')
+
+    def test_service_info(self):
+        s = pebble.ServiceInfo('svc1', pebble.ServiceStartup.ENABLED, pebble.ServiceStatus.ACTIVE)
+        self.assertEqual(s.name, 'svc1')
+        self.assertEqual(s.startup, pebble.ServiceStartup.ENABLED)
+        self.assertEqual(s.current, pebble.ServiceStatus.ACTIVE)
+
+        s = pebble.ServiceInfo.from_dict({
+            'name': 'svc2',
+            'startup': 'disabled',
+            'current': 'inactive',
+        })
+        self.assertEqual(s.name, 'svc2')
+        self.assertEqual(s.startup, pebble.ServiceStartup.DISABLED)
+        self.assertEqual(s.current, pebble.ServiceStatus.INACTIVE)
+
+
 class MockClient(pebble.Client):
     """Mock Pebble client that simply records reqeusts and returns stored responses."""
 
@@ -933,6 +968,87 @@ services:
 
         self.assertEqual(self.client.requests, [
             ('GET', '/v1/plan', {'format': 'yaml'}, None),
+        ])
+
+    def test_get_services_all(self):
+        self.client.responses.append({
+            "result": [
+                {
+                    "current": "inactive",
+                    "name": "svc1",
+                    "startup": "disabled"
+                },
+                {
+                    "current": "active",
+                    "name": "svc2",
+                    "startup": "enabled"
+                }
+            ],
+            "status": "OK",
+            "status-code": 200,
+            "type": "sync"
+        })
+        services = self.client.get_services()
+        self.assertEqual(len(services), 2)
+        self.assertEqual(services[0].name, 'svc1')
+        self.assertEqual(services[0].startup, pebble.ServiceStartup.DISABLED)
+        self.assertEqual(services[0].current, pebble.ServiceStatus.INACTIVE)
+        self.assertEqual(services[1].name, 'svc2')
+        self.assertEqual(services[1].startup, pebble.ServiceStartup.ENABLED)
+        self.assertEqual(services[1].current, pebble.ServiceStatus.ACTIVE)
+
+        self.assertEqual(self.client.requests, [
+            ('GET', '/v1/services', {'names': ''}, None),
+        ])
+
+    def test_get_services_names(self):
+        self.client.responses.append({
+            "result": [
+                {
+                    "current": "inactive",
+                    "name": "svc1",
+                    "startup": "disabled"
+                },
+                {
+                    "current": "active",
+                    "name": "svc2",
+                    "startup": "enabled"
+                }
+            ],
+            "status": "OK",
+            "status-code": 200,
+            "type": "sync"
+        })
+        services = self.client.get_services(['svc1', 'svc2'])
+        self.assertEqual(len(services), 2)
+        self.assertEqual(services[0].name, 'svc1')
+        self.assertEqual(services[0].startup, pebble.ServiceStartup.DISABLED)
+        self.assertEqual(services[0].current, pebble.ServiceStatus.INACTIVE)
+        self.assertEqual(services[1].name, 'svc2')
+        self.assertEqual(services[1].startup, pebble.ServiceStartup.ENABLED)
+        self.assertEqual(services[1].current, pebble.ServiceStatus.ACTIVE)
+
+        self.client.responses.append({
+            "result": [
+                {
+                    "current": "active",
+                    "name": "svc2",
+                    "startup": "enabled"
+                }
+            ],
+            "status": "OK",
+            "status-code": 200,
+            "type": "sync"
+        })
+        services = self.client.get_services(['svc2'])
+        self.assertEqual(len(services), 1)
+        self.assertEqual(services[0].name, 'svc2')
+        self.assertEqual(services[0].startup, pebble.ServiceStartup.ENABLED)
+        self.assertEqual(services[0].current, pebble.ServiceStatus.ACTIVE)
+
+        self.assertEqual(self.client.requests, [
+            ('GET', '/v1/services', {'names': 'svc1,svc2'}, None),
+            ('GET', '/v1/services', {'names': 'svc2'}, None),
         ])
 
 


### PR DESCRIPTION
This adds a `get_services` API to the Pebble client, and `get_services` to `model.Container` (along with a `get_service` helper to fetch a single service's status). This corresponds to the Pebble change https://github.com/canonical/pebble/pull/14
