### PR TITLE
Parse "environment" correctly from YAML: [{k: v}, ...], not {k: v, ...}

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -447,7 +447,12 @@ class Layer:
 
 
 class Service:
-    """Represents a service description in a Pebble configuration layer."""
+    """Represents a service description in a Pebble configuration layer.
+
+    The "environment" attribute is parsed as a list of (key, value) tuples,
+    because that seems most natural for ordered keys and values in Python.
+    In the YAML, however, it's a list of 1-item {key: value} objects.
+    """
 
     def __init__(self, name: str, raw: Dict = None):
         self.name = name
@@ -460,7 +465,18 @@ class Service:
         self.after = list(raw.get('after', []))
         self.before = list(raw.get('before', []))
         self.requires = list(raw.get('requires', []))
-        self.environment = dict(raw.get('environment') or {})
+        self.environment = self._dicts_to_tuples(raw.get('environment') or [])
+
+    @staticmethod
+    def _dicts_to_tuples(dicts):
+        """Convert list of 1-item {k: v} dicts to list of (k, v) tuples."""
+        tuples = []
+        for d in dicts:
+            if len(d) != 1:
+                raise ValueError('expected 1-item dict, got {!r}'.format(d))
+            kv = list(d.items())[0]
+            tuples.append(kv)
+        return tuples
 
     def to_dict(self) -> Dict:
         """Convert this service object to its dict representation."""
@@ -473,7 +489,7 @@ class Service:
             ('after', self.after),
             ('before', self.before),
             ('requires', self.requires),
-            ('environment', self.environment),
+            ('environment', [{k: v} for k, v in self.environment]),
         ]
         return {name: value for name, value in fields if value}
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -465,7 +465,7 @@ class Service:
         self.after = list(raw.get('after', []))
         self.before = list(raw.get('before', []))
         self.requires = list(raw.get('requires', []))
-        self.environment = self._dicts_to_tuples(raw.get('environment') or [])
+        self.environment = self._dicts_to_tuples(raw.get('environment', []))
 
     @staticmethod
     def _dicts_to_tuples(dicts):

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -109,7 +109,7 @@ def main():
             result = client.get_changes(select=pebble.ChangeState(args.select),
                                         service=args.service)
         elif args.command == 'plan':
-            result = client.get_plan().raw_yaml
+            result = client.get_plan().to_yaml()
         elif args.command == 'start':
             result = client.start_services(args.service)
         elif args.command == 'stop':

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -418,6 +418,9 @@ class TestLayer(unittest.TestCase):
 services:
   bar:
     command: echo bar
+    environment:
+    - ENV1: value1
+    - ENV2: value2
     summary: Bar
   foo:
     command: echo foo
@@ -449,7 +452,7 @@ class TestService(unittest.TestCase):
         self.assertEqual(service.after, [])
         self.assertEqual(service.before, [])
         self.assertEqual(service.requires, [])
-        self.assertEqual(service.environment, {})
+        self.assertEqual(service.environment, [])
         self.assertEqual(service.to_dict(), {})
 
     def test_name_only(self):
@@ -469,7 +472,7 @@ class TestService(unittest.TestCase):
             'after': ['a1', 'a2'],
             'before': ['b1', 'b2'],
             'requires': ['r1', 'r2'],
-            'environment': {'k1': 'v1', 'k2': 'v2'},
+            'environment': [{'k1': 'v1'}, {'k2': 'v2'}],
         }
         s = pebble.Service('Name 2', d)
         self.assertEqual(s.name, 'Name 2')
@@ -480,7 +483,7 @@ class TestService(unittest.TestCase):
         self.assertEqual(s.after, ['a1', 'a2'])
         self.assertEqual(s.before, ['b1', 'b2'])
         self.assertEqual(s.requires, ['r1', 'r2'])
-        self.assertEqual(s.environment, {'k1': 'v1', 'k2': 'v2'})
+        self.assertEqual(s.environment, [('k1', 'v1'), ('k2', 'v2')])
 
         self.assertEqual(s.to_dict(), d)
 
@@ -488,15 +491,15 @@ class TestService(unittest.TestCase):
         s.after.append('a3')
         s.before.append('b3')
         s.requires.append('r3')
-        s.environment['k3'] = 'v3'
+        s.environment.append(('k3', 'v3'))
         self.assertEqual(s.after, ['a1', 'a2', 'a3'])
         self.assertEqual(s.before, ['b1', 'b2', 'b3'])
         self.assertEqual(s.requires, ['r1', 'r2', 'r3'])
-        self.assertEqual(s.environment, {'k1': 'v1', 'k2': 'v2', 'k3': 'v3'})
+        self.assertEqual(s.environment, [('k1', 'v1'), ('k2', 'v2'), ('k3', 'v3')])
         self.assertEqual(d['after'], ['a1', 'a2'])
         self.assertEqual(d['before'], ['b1', 'b2'])
         self.assertEqual(d['requires'], ['r1', 'r2'])
-        self.assertEqual(d['environment'], {'k1': 'v1', 'k2': 'v2'})
+        self.assertEqual(d['environment'], [{'k1': 'v1'}, {'k2': 'v2'}])
 
 
 class MockClient(pebble.Client):

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -436,6 +436,8 @@ summary: Sum Mary
         self.assertEqual(s.services['bar'].name, 'bar')
         self.assertEqual(s.services['bar'].summary, 'Bar')
         self.assertEqual(s.services['bar'].command, 'echo bar')
+        self.assertEqual(s.services['bar'].environment,
+                         [('ENV1', 'value1'), ('ENV2', 'value2')])
 
         self.assertEqual(s.to_yaml(), yaml)
         self.assertEqual(str(s), yaml)


### PR DESCRIPTION
Fixes #486