### PR TITLE
Make add_layer()'s "combine" a keyword-only parameter

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1047,7 +1047,7 @@ class Container:
         """Stop given service(s) by name."""
         self._pebble.stop_services(service_names)
 
-    def add_layer(self, label: str, layer: typing.Union[str, typing.Dict, 'pebble.Layer'],
+    def add_layer(self, label: str, layer: typing.Union[str, typing.Dict, 'pebble.Layer'], *,
                   combine: bool = False):
         """Dynamically add a new layer onto the Pebble configuration layers.
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -720,7 +720,7 @@ class Client:
         raise TimeoutError(
             'timed out waiting for change {} ({} seconds)'.format(change_id, timeout))
 
-    def add_layer(self, label: str, layer: Union[str, dict, Layer], combine: bool = False):
+    def add_layer(self, label: str, layer: Union[str, dict, Layer], *, combine: bool = False):
         """Dynamically add a new layer onto the Pebble configuration layers.
 
         If combine is False (the default), append the new layer as the top

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -860,6 +860,10 @@ containers:
             ('add_layer', 'd', 'summary: str\n', True),
         ])
 
+        # combine is a keyword-only arg (should be combine=True)
+        with self.assertRaises(TypeError):
+            self.container.add_layer('x', {}, True)
+
     def test_get_plan(self):
         plan_yaml = 'services:\n foo:\n  override: replace\n  command: bar'
         self.pebble.responses.append(ops.pebble.Plan(plan_yaml))

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -961,6 +961,10 @@ services:
         with self.assertRaises(TypeError):
             self.client.add_layer(42, 'foo')
 
+        # combine is a keyword-only arg (should be combine=True)
+        with self.assertRaises(TypeError):
+            self.client.add_layer('foo', {}, True)
+
     def test_get_plan(self):
         plan_yaml = """
 services:


### PR DESCRIPTION
Per https://github.com/canonical/operator/issues/495, a bare `True` at the end of an `add_layer()` call does not read well. Make `combine` a keyword-only parameter, so you have to say `combine=True`.