### PR TITLE
Pebble files API client functions

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1091,6 +1091,80 @@ class Container:
             raise RuntimeError('expected 1 service, got {}'.format(len(services)))
         return services[service_name]
 
+    def read_content(self, path: str, *, encoding: str = 'utf-8') -> typing.Union[bytes, str]:
+        """Read a file's content from the remote system to a string.
+
+        Args:
+            path: Path of the file to read from the remote system.
+            encoding: Encoding to use for decoding file's bytes to a text string
+                (or None to return raw bytes).
+
+        Returns:
+            File's content, decoded and returned as str if encoding is not None,
+            or returned as raw bytes if encoding is None.
+        """
+        return self._pebble.read_content(path, encoding=encoding)
+
+    def write_content(
+            self, path: str, content: typing.Union[bytes, str], *, encoding: str = 'utf-8',
+            make_dirs: bool = False, permissions: int = None, user: typing.Union[str, int] = None,
+            group: typing.Union[str, int] = None):
+        """Write content to a given file path on the remote system.
+
+        Args:
+            path: Path of the file to write to on the remote system.
+            content: Content to write (str or bytes).
+            encoding: Encoding to use for encoding content str to bytes.
+                Ignored if content is bytes.
+            make_dirs: If True, create parent directories if they don't exist.
+            permissions: Permissions (mode) to create file with (Pebble default
+                is 0o644).
+            user: UID or username for file.
+            group: GID or group name for file.
+        """
+        self._pebble.write_content(path, content, encoding=encoding, make_dirs=make_dirs,
+                                   permissions=permissions, user=user, group=group)
+
+    def list_files(
+        self, path: str, *, pattern: str = None, itself: bool = False,
+    ) -> typing.List['pebble.FileInfo']:
+        """Return list of file information from given path on remote system.
+
+        Args:
+            path: Path of the directory to list, or path of the file to return
+                information about.
+            pattern: If specified, filter the list to just the files that match,
+                for example "*.txt".
+            itself: If path refers to a directory, return information about the
+                directory itself, rather than its contents.
+        """
+        return self._pebble.list_files(path, pattern=pattern, itself=itself)
+
+    def make_dir(
+            self, path: str, *, make_parents: bool = False, permissions: int = None,
+            user: typing.Union[str, int] = None, group: typing.Union[str, int] = None):
+        """Create a directory on the remote system with the given attributes.
+
+        Args:
+            path: Path of the directory to create on the remote system.
+            make_parents: If True, create parent directories if they don't exist.
+            permissions: Permissions (mode) to create directory with (Pebble
+                default is 0o755).
+            user: UID or username for directory.
+            group: GID or group name for directory.
+        """
+        self._pebble.make_dir(path, make_parents=make_parents, permissions=permissions,
+                              user=user, group=group)
+
+    def remove_path(self, path: str, *, recursive: bool = False):
+        """Remove a file or directory on the remote system.
+
+        Args:
+            path: Path of the file or directory to delete from the remote system.
+            recursive: If True, recursively delete path and everything under it.
+        """
+        self._pebble.remove_path(path, recursive=recursive)
+
 
 class ContainerMapping(Mapping):
     """Map of container names to Container objects.

--- a/ops/model.py
+++ b/ops/model.py
@@ -1125,9 +1125,8 @@ class Container:
         self._pebble.write_content(path, content, encoding=encoding, make_dirs=make_dirs,
                                    permissions=permissions, user=user, group=group)
 
-    def list_files(
-        self, path: str, *, pattern: str = None, itself: bool = False,
-    ) -> typing.List['pebble.FileInfo']:
+    def list_files(self, path: str, *, pattern: str = None,
+                   itself: bool = False) -> typing.List['pebble.FileInfo']:
         """Return list of file information from given path on remote system.
 
         Args:

--- a/ops/model.py
+++ b/ops/model.py
@@ -1107,8 +1107,8 @@ class Container:
 
     def write_content(
             self, path: str, content: typing.Union[bytes, str], *, encoding: str = 'utf-8',
-            make_dirs: bool = False, permissions: int = None, user: typing.Union[str, int] = None,
-            group: typing.Union[str, int] = None):
+            make_dirs: bool = False, permissions: int = None, user_id: int = None,
+            user: str = None, group_id: int = None, group: str = None):
         """Write content to a given file path on the remote system.
 
         Args:
@@ -1119,11 +1119,14 @@ class Container:
             make_dirs: If True, create parent directories if they don't exist.
             permissions: Permissions (mode) to create file with (Pebble default
                 is 0o644).
-            user: UID or username for file.
-            group: GID or group name for file.
+            user_id: UID for file.
+            user: Username for file (user_id takes precedence).
+            group_id: GID for file.
+            group: Group name for file (group_id takes precedence).
         """
         self._pebble.write_content(path, content, encoding=encoding, make_dirs=make_dirs,
-                                   permissions=permissions, user=user, group=group)
+                                   permissions=permissions, user_id=user_id, user=user,
+                                   group_id=group_id, group=group)
 
     def list_files(self, path: str, *, pattern: str = None,
                    itself: bool = False) -> typing.List['pebble.FileInfo']:
@@ -1141,7 +1144,7 @@ class Container:
 
     def make_dir(
             self, path: str, *, make_parents: bool = False, permissions: int = None,
-            user: typing.Union[str, int] = None, group: typing.Union[str, int] = None):
+            user_id: int = None, user: str = None, group_id: int = None, group: str = None):
         """Create a directory on the remote system with the given attributes.
 
         Args:
@@ -1149,11 +1152,13 @@ class Container:
             make_parents: If True, create parent directories if they don't exist.
             permissions: Permissions (mode) to create directory with (Pebble
                 default is 0o755).
-            user: UID or username for directory.
-            group: GID or group name for directory.
+            user_id: UID for directory.
+            user: Username for directory (user_id takes precedence).
+            group_id: GID for directory.
+            group: Group name for directory (group_id takes precedence).
         """
         self._pebble.make_dir(path, make_parents=make_parents, permissions=permissions,
-                              user=user, group=group)
+                              user_id=user_id, user=user, group_id=group_id, group=group)
 
     def remove_path(self, path: str, *, recursive: bool = False):
         """Remove a file or directory on the remote system.

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -949,8 +949,8 @@ class Client:
 
     def write_content(
             self, path: str, content: typing.Union[bytes, str], *, encoding: str = 'utf-8',
-            make_dirs: bool = False, permissions: int = None, user: typing.Union[str, int] = None,
-            group: typing.Union[str, int] = None):
+            make_dirs: bool = False, permissions: int = None, user_id: int = None,
+            user: str = None, group_id: int = None, group: str = None):
         """Write content to a given file path on the remote system.
 
         Args:
@@ -961,10 +961,12 @@ class Client:
             make_dirs: If True, create parent directories if they don't exist.
             permissions: Permissions (mode) to create file with (Pebble default
                 is 0o644).
-            user: UID or username for file.
-            group: GID or group name for file.
+            user_id: UID for file.
+            user: Username for file (user_id takes precedence).
+            group_id: GID for file.
+            group: Group name for file (group_id takes precedence).
         """
-        info = self._make_auth_dict(permissions, user, group)
+        info = self._make_auth_dict(permissions, user_id, user, group_id, group)
         info['path'] = path
         if make_dirs:
             info['make-dirs'] = True
@@ -998,24 +1000,18 @@ class Client:
         self._raise_on_path_error(resp, path)
 
     @staticmethod
-    def _make_auth_dict(permissions, user, group) -> typing.Dict:
+    def _make_auth_dict(permissions, user_id, user, group_id, group) -> typing.Dict:
         d = {}
         if permissions is not None:
             d['permissions'] = format(permissions, '03o')
+        if user_id is not None:
+            d['user-id'] = user_id
         if user is not None:
-            if isinstance(user, int):
-                d['user-id'] = user
-            elif isinstance(user, str):
-                d['user'] = user
-            else:
-                raise TypeError('user must be int UID or string username')
+            d['user'] = user
+        if group_id is not None:
+            d['group-id'] = group_id
         if group is not None:
-            if isinstance(group, int):
-                d['group-id'] = group
-            elif isinstance(group, str):
-                d['group'] = group
-            else:
-                raise TypeError('group must be int GID or string group name')
+            d['group'] = group
         return d
 
     def list_files(self, path: str, *, pattern: str = None,
@@ -1044,7 +1040,7 @@ class Client:
 
     def make_dir(
             self, path: str, *, make_parents: bool = False, permissions: int = None,
-            user: typing.Union[str, int] = None, group: typing.Union[str, int] = None):
+            user_id: int = None, user: str = None, group_id: int = None, group: str = None):
         """Create a directory on the remote system with the given attributes.
 
         Args:
@@ -1052,10 +1048,12 @@ class Client:
             make_parents: If True, create parent directories if they don't exist.
             permissions: Permissions (mode) to create directory with (Pebble
                 default is 0o755).
-            user: UID or username for directory.
-            group: GID or group name for directory.
+            user_id: UID for directory.
+            user: Username for directory (user_id takes precedence).
+            group_id: GID for directory.
+            group: Group name for directory (group_id takes precedence).
         """
-        info = self._make_auth_dict(permissions, user, group)
+        info = self._make_auth_dict(permissions, user_id, user, group_id, group)
         info['path'] = path
         if make_parents:
             info['make-parents'] = True

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -583,6 +583,8 @@ class FileInfo:
         size: Optional[int],
         permissions: int,
         last_modified: datetime.datetime,
+        user_id: Optional[int],
+        group_id: Optional[int],
     ):
         self.path = path
         self.name = name
@@ -590,6 +592,8 @@ class FileInfo:
         self.size = size
         self.permissions = permissions
         self.last_modified = last_modified
+        self.user_id = user_id
+        self.group_id = group_id
 
     @classmethod
     def from_dict(cls, d: Dict) -> 'FileInfo':
@@ -605,6 +609,8 @@ class FileInfo:
             size=d.get('size'),
             permissions=int(d['permissions'], 8),
             last_modified=_parse_timestamp(d['last-modified']),
+            user_id=d.get('user-id'),
+            group_id=d.get('group-id'),
         )
 
     def __repr__(self):
@@ -614,7 +620,9 @@ class FileInfo:
                 'type={self.type}, '
                 'size={self.size}, '
                 'permissions=0o{self.permissions:o}, '
-                'last_modified={self.last_modified!r})'
+                'last_modified={self.last_modified!r}, '
+                'user_id={self.user_id}, '
+                'group_id={self.group_id})'
                 ).format(self=self)
 
 
@@ -1011,6 +1019,7 @@ class Client:
             query['itself'] = 'true'
         resp = self._request('GET', '/v1/files', query)
         result = resp['result'] or []  # in case it's null instead of []
+        print(json.dumps(result, sort_keys=True, indent=4))
         return [FileInfo.from_dict(d) for d in result]
 
     def make_dir(

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1042,14 +1042,17 @@ class Client:
         resp = self._request('POST', '/v1/files', None, body)
         self._raise_on_path_error(resp, path)
 
-    def remove_path(self, path: str, recursive=True):
+    def remove_path(self, path: str, recursive: bool = False):
         """Remove a file or directory on the remote system.
 
         If "recursive" is True, recursively delete path and everything under it.
         """
+        info = {'path': path}
+        if recursive:
+            info['recursive'] = True
         body = {
             'action': 'remove',
-            'paths': [{'path': path, 'recursive': recursive}],
+            'paths': [info],
         }
         resp = self._request('POST', '/v1/files', None, body)
         self._raise_on_path_error(resp, path)

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -828,8 +828,7 @@ class Client:
             'timed out waiting for change {} ({} seconds)'.format(change_id, timeout))
 
     def add_layer(
-        self, label: str, layer: typing.Union[str, dict, Layer], *, combine: bool = False,
-    ):
+            self, label: str, layer: typing.Union[str, dict, Layer], *, combine: bool = False):
         """Dynamically add a new layer onto the Pebble configuration layers.
 
         If combine is False (the default), append the new layer as the top
@@ -945,9 +944,9 @@ class Client:
         return resp
 
     def write_file(
-        self, path: str, source: typing.BinaryIO, make_dirs: bool = False, permissions: int = None,
-        user: typing.Union[str, int] = None, group: typing.Union[str, int] = None,
-    ):
+            self, path: str, source: typing.BinaryIO, make_dirs: bool = False,
+            permissions: int = None, user: typing.Union[str, int] = None,
+            group: typing.Union[str, int] = None):
         """Write data from source to given file path on remote system.
 
         If make_dirs is True, create parent directories if they don't exist.
@@ -1038,9 +1037,8 @@ class Client:
         return [FileInfo.from_dict(d) for d in result]
 
     def make_dir(
-        self, path: str, make_parents: bool = False, permissions: int = None,
-        user: typing.Union[str, int] = None, group: typing.Union[str, int] = None,
-    ):
+            self, path: str, make_parents: bool = False, permissions: int = None,
+            user: typing.Union[str, int] = None, group: typing.Union[str, int] = None):
         """Create a directory on the remote system with the given attributes.
 
         If make_parents is True, create parent directories if they don't exist.

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -875,7 +875,7 @@ class Client:
         resp = self._request('GET', '/v1/services', query)
         return [ServiceInfo.from_dict(info) for info in resp['result']]
 
-    def read_content(self, path: str, encoding: str = 'utf-8') -> typing.Union[bytes, str]:
+    def read_content(self, path: str, *, encoding: str = 'utf-8') -> typing.Union[bytes, str]:
         """Read a file's content from the remote system to a string.
 
         Args:
@@ -948,7 +948,7 @@ class Client:
             raise PathError(error['kind'], error['message'])
 
     def write_content(
-            self, path: str, content: typing.Union[bytes, str], encoding: str = 'utf-8',
+            self, path: str, content: typing.Union[bytes, str], *, encoding: str = 'utf-8',
             make_dirs: bool = False, permissions: int = None, user: typing.Union[str, int] = None,
             group: typing.Union[str, int] = None):
         """Write content to a given file path on the remote system.
@@ -1019,7 +1019,7 @@ class Client:
         return d
 
     def list_files(
-        self, path: str, pattern: str = None, itself: bool = False,
+        self, path: str, *, pattern: str = None, itself: bool = False,
     ) -> typing.List[FileInfo]:
         """Return list of file information from given path on remote system.
 
@@ -1044,7 +1044,7 @@ class Client:
         return [FileInfo.from_dict(d) for d in result]
 
     def make_dir(
-            self, path: str, make_parents: bool = False, permissions: int = None,
+            self, path: str, *, make_parents: bool = False, permissions: int = None,
             user: typing.Union[str, int] = None, group: typing.Union[str, int] = None):
         """Create a directory on the remote system with the given attributes.
 
@@ -1067,7 +1067,7 @@ class Client:
         resp = self._request('POST', '/v1/files', None, body)
         self._raise_on_path_error(resp, path)
 
-    def remove_path(self, path: str, recursive: bool = False):
+    def remove_path(self, path: str, *, recursive: bool = False):
         """Remove a file or directory on the remote system.
 
         Args:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1018,9 +1018,8 @@ class Client:
                 raise TypeError('group must be int GID or string group name')
         return d
 
-    def list_files(
-        self, path: str, *, pattern: str = None, itself: bool = False,
-    ) -> typing.List[FileInfo]:
+    def list_files(self, path: str, *, pattern: str = None,
+                   itself: bool = False) -> typing.List[FileInfo]:
         """Return list of file information from given path on remote system.
 
         Args:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -679,7 +679,7 @@ class Client:
         """
         ctype, options = cgi.parse_header(headers.get('Content-Type', ''))
         if ctype != expected:
-            raise ProtocolError('expected Content-Type {}, got {}'.format(expected, ctype))
+            raise ProtocolError('expected Content-Type {!r}, got {!r}'.format(expected, ctype))
         return options
 
     def _request_raw(
@@ -872,7 +872,7 @@ class Client:
         }
         headers = {'Accept': 'multipart/form-data'}
         response = self._request_raw('GET', '/v1/files', query, headers)
-        resp = self._parse_multipart(response, {path: destination})
+        resp = self._parse_read_multipart(response, {path: destination})
         self._raise_on_path_error(resp, path)
 
     @staticmethod
@@ -886,9 +886,9 @@ class Client:
             raise PathError(error['kind'], error['message'])
 
     @classmethod
-    def _parse_multipart(cls, response: http.client.HTTPResponse,
-                         destinations: Dict[str, BinaryIO]) -> Dict:
-        """Parse a multipart HTTP response.
+    def _parse_read_multipart(cls, response: http.client.HTTPResponse,
+                              destinations: Dict[str, BinaryIO]) -> Dict:
+        """Parse a multipart HTTP response from the read-files API.
 
         Return "response" metadata field decoded from JSON, and write content
         to file-like object in destinations dictionary (keyed by path).

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -584,7 +584,9 @@ class FileInfo:
         permissions: int,
         last_modified: datetime.datetime,
         user_id: Optional[int],
+        user: Optional[str],
         group_id: Optional[int],
+        group: Optional[str],
     ):
         self.path = path
         self.name = name
@@ -593,7 +595,9 @@ class FileInfo:
         self.permissions = permissions
         self.last_modified = last_modified
         self.user_id = user_id
+        self.user = user
         self.group_id = group_id
+        self.group = group
 
     @classmethod
     def from_dict(cls, d: Dict) -> 'FileInfo':
@@ -610,7 +614,9 @@ class FileInfo:
             permissions=int(d['permissions'], 8),
             last_modified=_parse_timestamp(d['last-modified']),
             user_id=d.get('user-id'),
+            user=d.get('user'),
             group_id=d.get('group-id'),
+            group=d.get('group'),
         )
 
     def __repr__(self):
@@ -622,7 +628,9 @@ class FileInfo:
                 'permissions=0o{self.permissions:o}, '
                 'last_modified={self.last_modified!r}, '
                 'user_id={self.user_id}, '
-                'group_id={self.group_id})'
+                'user={self.user!r}, '
+                'group_id={self.group_id}, '
+                'group={self.group!r})'
                 ).format(self=self)
 
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1019,7 +1019,6 @@ class Client:
             query['itself'] = 'true'
         resp = self._request('GET', '/v1/files', query)
         result = resp['result'] or []  # in case it's null instead of []
-        print(json.dumps(result, sort_keys=True, indent=4))
         return [FileInfo.from_dict(d) for d in result]
 
     def make_dir(

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -147,19 +147,21 @@ def main():
         elif args.command == 'plan':
             result = client.get_plan().to_yaml()
         elif args.command == 'pull':
+            content = client.read_content(args.remote_path, encoding=None)
             if args.local_path != '-':
                 with open(args.local_path, 'wb') as f:
-                    client.read_file(args.remote_path, f)
+                    f.write(content)
                 result = 'wrote remote file {} to {}'.format(args.remote_path, args.local_path)
             else:
-                client.read_file(args.remote_path, sys.stdout.buffer)
+                sys.stdout.buffer.write(content)
                 return
         elif args.command == 'push':
             with open(args.local_path, 'rb') as f:
-                client.write_file(
-                    args.remote_path, f, make_dirs=args.dirs,
-                    permissions=int(args.mode, 8) if args.mode is not None else None,
-                    user=args.user, group=args.group)
+                content = f.read()
+            client.write_content(
+                args.remote_path, content, make_dirs=args.dirs,
+                permissions=int(args.mode, 8) if args.mode is not None else None,
+                user=args.user, group=args.group)
             result = 'wrote {} to remote file {}'.format(args.local_path, args.remote_path)
         elif args.command == 'rm':
             client.remove_path(args.path, recursive=bool(args.recursive))

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -57,7 +57,30 @@ def main():
                    choices=[s.value for s in pebble.ChangeState], default='all')
     p.add_argument('--service', help='optional service name to filter on')
 
+    p = subparsers.add_parser('ls', help='list files')
+    p.add_argument('-d', '--directory', action='store_true',
+                   help='list directories themselves, not their contents')
+    p.add_argument('pattern', help='name of directory or file, or glob pattern')
+
+    p = subparsers.add_parser('mkdir', help='create directory')
+    p.add_argument('-p', '--parents', action='store_true',
+                   help='create parent directories if needed')
+    p.add_argument('path', help='path to create')
+
     p = subparsers.add_parser('plan', help='show configuration plan (combined layers)')
+
+    p = subparsers.add_parser('pull', help='copy file from remote system')
+    p.add_argument('remote_path', help='path of remote file')
+    p.add_argument('local_path', help='path of local file to copy to')
+
+    p = subparsers.add_parser('push', help='copy file to remote system')
+    p.add_argument('local_path', help='path of local file')
+    p.add_argument('remote_path', help='path of remote file to copy to')
+
+    p = subparsers.add_parser('rm', help='remove path')
+    p.add_argument('-r', '--recursive', action='store_true',
+                   help='recursively delete directory contents')
+    p.add_argument('path', help='path to remove')
 
     p = subparsers.add_parser('services', help='show service status')
     p.add_argument('service', help='name of service (none means all; multiple ok)', nargs='*')
@@ -111,8 +134,33 @@ def main():
         elif args.command == 'changes':
             result = client.get_changes(select=pebble.ChangeState(args.select),
                                         service=args.service)
+        elif args.command == 'ls':
+            result = client.list_files(args.pattern, directory=args.directory)
+            import json
+            result = json.dumps(result, sort_keys=True, indent=4)
+        elif args.command == 'mkdir':
+            result = client.make_dirs([args.path], make_parents=bool(args.parents))
+            import json
+            result = json.dumps(result, sort_keys=True, indent=4)
         elif args.command == 'plan':
             result = client.get_plan().to_yaml()
+        elif args.command == 'pull':
+            result = client.read_file(args.remote_path)
+            if args.local_path != '-':
+                with open(args.local_path, 'wb') as f:
+                    f.write(result)
+                    result = 'wrote remote file {} to {}'.format(args.remote_path, args.local_path)
+            else:
+                result = result.decode('utf-8')
+        elif args.command == 'push':
+            with open(args.local_path, 'rb') as f:
+                content = f.read()
+            client.write_file(content.decode('utf-8'), args.remote_path)
+            result = 'wrote {} to remote file {}'.format(args.local_path, args.remote_path)
+        elif args.command == 'rm':
+            result = client.remove_paths([args.path], recursive=bool(args.recursive))
+            import json
+            result = json.dumps(result, sort_keys=True, indent=4)
         elif args.command == 'services':
             result = client.get_services(args.service)
         elif args.command == 'start':

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -75,6 +75,10 @@ def main():
     p.add_argument('local_path', help='path of local file to copy to')
 
     p = subparsers.add_parser('push', help='copy file to remote system')
+    p.add_argument('-d', '--dirs', action='store_true', help='create parent directories')
+    p.add_argument('-m', '--mode', help='3-digit octal permissions')
+    p.add_argument('-u', '--user', help='user to set')
+    p.add_argument('-g', '--group', help='group to set')
     p.add_argument('local_path', help='path of local file')
     p.add_argument('remote_path', help='path of remote file to copy to')
 
@@ -152,7 +156,10 @@ def main():
                 return
         elif args.command == 'push':
             with open(args.local_path, 'rb') as f:
-                client.write_file(args.remote_path, f)
+                client.write_file(
+                    args.remote_path, f, make_dirs=args.dirs,
+                    permissions=int(args.mode, 8) if args.mode is not None else None,
+                    user=args.user, group=args.group)
             result = 'wrote {} to remote file {}'.format(args.local_path, args.remote_path)
         elif args.command == 'rm':
             client.remove_path(args.path, recursive=bool(args.recursive))

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -932,6 +932,76 @@ containers:
         with self.assertRaises(RuntimeError):
             self.container.get_service('s1')
 
+    def test_read_content(self):
+        self.pebble.responses.append('content1')
+        got = self.container.read_content('/path/1')
+        self.assertEqual(got, 'content1')
+        self.assertEqual(self.pebble.requests, [
+            ('read_content', '/path/1', 'utf-8'),
+        ])
+        self.pebble.requests = []
+
+        self.pebble.responses.append(b'content2')
+        got = self.container.read_content('/path/2', encoding=None)
+        self.assertEqual(got, b'content2')
+        self.assertEqual(self.pebble.requests, [
+            ('read_content', '/path/2', None),
+        ])
+
+    def test_write_content(self):
+        self.container.write_content('/path/1', 'content1')
+        self.assertEqual(self.pebble.requests, [
+            ('write_content', '/path/1', 'content1', 'utf-8', False, None, None, None),
+        ])
+        self.pebble.requests = []
+
+        self.container.write_content('/path/2', b'content2', encoding=None, make_dirs=True,
+                                     permissions=0o600, user='USER', group='GROUP')
+        self.assertEqual(self.pebble.requests, [
+            ('write_content', '/path/2', b'content2', None, True, 0o600, 'USER', 'GROUP'),
+        ])
+
+    def test_list_files(self):
+        self.pebble.responses.append('dummy1')
+        ret = self.container.list_files('/path/1')
+        self.assertEqual(ret, 'dummy1')
+        self.assertEqual(self.pebble.requests, [
+            ('list_files', '/path/1', None, False),
+        ])
+        self.pebble.requests = []
+
+        self.pebble.responses.append('dummy2')
+        ret = self.container.list_files('/path/2', pattern='*.txt', itself=True)
+        self.assertEqual(ret, 'dummy2')
+        self.assertEqual(self.pebble.requests, [
+            ('list_files', '/path/2', '*.txt', True),
+        ])
+
+    def test_make_dir(self):
+        self.container.make_dir('/path/1')
+        self.assertEqual(self.pebble.requests, [
+            ('make_dir', '/path/1', False, None, None, None),
+        ])
+        self.pebble.requests = []
+
+        self.container.make_dir('/path/2', make_parents=True, permissions=0o700, user='USER',
+                                group='GROUP')
+        self.assertEqual(self.pebble.requests, [
+            ('make_dir', '/path/2', True, 0o700, 'USER', 'GROUP'),
+        ])
+
+    def test_remove_path(self):
+        self.container.remove_path('/path/1')
+        self.assertEqual(self.pebble.requests, [
+            ('remove_path', '/path/1', False),
+        ])
+        self.pebble.requests = []
+
+        self.container.remove_path('/path/2', recursive=True)
+        self.assertEqual(self.pebble.requests, [
+            ('remove_path', '/path/2', True),
+        ])
+
 
 class MockPebbleBackend(ops.model._ModelBackend):
     def get_pebble(self, socket_path):
@@ -967,6 +1037,25 @@ class MockPebbleClient:
     def get_services(self, names=None):
         self.requests.append(('get_services', names))
         return self.responses.pop(0)
+
+    def read_content(self, path, *, encoding='utf-8'):
+        self.requests.append(('read_content', path, encoding))
+        return self.responses.pop(0)
+
+    def write_content(self, path, content, *, encoding='utf-8', make_dirs=False, permissions=None,
+                      user=None, group=None):
+        self.requests.append(('write_content', path, content, encoding, make_dirs, permissions,
+                              user, group))
+
+    def list_files(self, path, *, pattern=None, itself=False):
+        self.requests.append(('list_files', path, pattern, itself))
+        return self.responses.pop(0)
+
+    def make_dir(self, path, *, make_parents=False, permissions=None, user=None, group=None):
+        self.requests.append(('make_dir', path, make_parents, permissions, user, group))
+
+    def remove_path(self, path, *, recursive=False):
+        self.requests.append(('remove_path', path, recursive))
 
 
 class TestModelBindings(unittest.TestCase):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -951,14 +951,16 @@ containers:
     def test_write_content(self):
         self.container.write_content('/path/1', 'content1')
         self.assertEqual(self.pebble.requests, [
-            ('write_content', '/path/1', 'content1', 'utf-8', False, None, None, None),
+            ('write_content', '/path/1', 'content1', 'utf-8', False, None,
+             None, None, None, None),
         ])
         self.pebble.requests = []
 
         self.container.write_content('/path/2', b'content2', encoding=None, make_dirs=True,
-                                     permissions=0o600, user='USER', group='GROUP')
+                                     permissions=0o600, user_id=12, user='bob', group_id=34,
+                                     group='staff')
         self.assertEqual(self.pebble.requests, [
-            ('write_content', '/path/2', b'content2', None, True, 0o600, 'USER', 'GROUP'),
+            ('write_content', '/path/2', b'content2', None, True, 0o600, 12, 'bob', 34, 'staff'),
         ])
 
     def test_list_files(self):
@@ -980,14 +982,14 @@ containers:
     def test_make_dir(self):
         self.container.make_dir('/path/1')
         self.assertEqual(self.pebble.requests, [
-            ('make_dir', '/path/1', False, None, None, None),
+            ('make_dir', '/path/1', False, None, None, None, None, None),
         ])
         self.pebble.requests = []
 
-        self.container.make_dir('/path/2', make_parents=True, permissions=0o700, user='USER',
-                                group='GROUP')
+        self.container.make_dir('/path/2', make_parents=True, permissions=0o700,
+                                user_id=12, user='bob', group_id=34, group='staff')
         self.assertEqual(self.pebble.requests, [
-            ('make_dir', '/path/2', True, 0o700, 'USER', 'GROUP'),
+            ('make_dir', '/path/2', True, 0o700, 12, 'bob', 34, 'staff'),
         ])
 
     def test_remove_path(self):
@@ -1043,16 +1045,18 @@ class MockPebbleClient:
         return self.responses.pop(0)
 
     def write_content(self, path, content, *, encoding='utf-8', make_dirs=False, permissions=None,
-                      user=None, group=None):
+                      user_id=None, user=None, group_id=None, group=None):
         self.requests.append(('write_content', path, content, encoding, make_dirs, permissions,
-                              user, group))
+                              user_id, user, group_id, group))
 
     def list_files(self, path, *, pattern=None, itself=False):
         self.requests.append(('list_files', path, pattern, itself))
         return self.responses.pop(0)
 
-    def make_dir(self, path, *, make_parents=False, permissions=None, user=None, group=None):
-        self.requests.append(('make_dir', path, make_parents, permissions, user, group))
+    def make_dir(self, path, *, make_parents=False, permissions=None, user_id=None, user=None,
+                 group_id=None, group=None):
+        self.requests.append(('make_dir', path, make_parents, permissions, user_id, user,
+                              group_id, group))
 
     def remove_path(self, path, *, recursive=False):
         self.requests.append(('remove_path', path, recursive))

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -369,34 +369,42 @@ class TestTypes(unittest.TestCase):
 
     def test_file_info_init(self):
         info = pebble.FileInfo('/etc/hosts', 'hosts', pebble.FileType.FILE, 123, 0o644,
-                               datetime_nzdt(2021, 1, 28, 14, 37, 4, 291518))
+                               datetime_nzdt(2021, 1, 28, 14, 37, 4, 291518), 12, 34)
         self.assertEqual(info.path, '/etc/hosts')
         self.assertEqual(info.name, 'hosts')
         self.assertEqual(info.type, pebble.FileType.FILE)
         self.assertEqual(info.size, 123)
         self.assertEqual(info.permissions, 0o644)
         self.assertEqual(info.last_modified, datetime_nzdt(2021, 1, 28, 14, 37, 4, 291518))
+        self.assertEqual(info.user_id, 12)
+        self.assertEqual(info.group_id, 34)
 
     def test_file_info_from_dict(self):
         d = {
-            'path': '/etc/hosts',
-            'name': 'hosts',
-            'type': 'file',
-            'size': 123,
+            'path': '/etc',
+            'name': 'etc',
+            'type': 'directory',
             'permissions': '644',
             'last-modified': '2021-01-28T14:37:04.291517768+13:00',
         }
         info = pebble.FileInfo.from_dict(d)
-        self.assertEqual(info.path, '/etc/hosts')
-        self.assertEqual(info.name, 'hosts')
-        self.assertEqual(info.type, pebble.FileType.FILE)
-        self.assertEqual(info.size, 123)
+        self.assertEqual(info.path, '/etc')
+        self.assertEqual(info.name, 'etc')
+        self.assertEqual(info.type, pebble.FileType.DIRECTORY)
         self.assertEqual(info.permissions, 0o644)
         self.assertEqual(info.last_modified, datetime_nzdt(2021, 1, 28, 14, 37, 4, 291518))
+        self.assertIs(info.user_id, None)
+        self.assertIs(info.group_id, None)
 
         d['type'] = 'foobar'
+        d['size'] = 123
+        d['user-id'] = 12
+        d['group-id'] = 34
         info = pebble.FileInfo.from_dict(d)
         self.assertEqual(info.type, 'foobar')
+        self.assertEqual(info.size, 123)
+        self.assertEqual(info.user_id, 12)
+        self.assertEqual(info.group_id, 34)
 
 
 class TestPlan(unittest.TestCase):

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -1377,7 +1377,7 @@ bad path
         ))
 
         self.client.write_content('/foo/bar', 'content', make_dirs=True, permissions=0o600,
-                                  user='bob', group='staff')
+                                  user_id=12, user='bob', group_id=34, group='staff')
 
         self.assertEqual(len(self.client.requests), 1)
         request = self.client.requests[0]
@@ -1394,7 +1394,9 @@ bad path
                 'path': '/foo/bar',
                 'make-dirs': True,
                 'permissions': '600',
+                'user-id': 12,
                 'user': 'bob',
+                'group-id': 34,
                 'group': 'staff',
             }],
         })
@@ -1414,7 +1416,7 @@ bad path
 """,
         ))
 
-        self.client.write_content('/foo/bar', 'content', user=12, group=34)
+        self.client.write_content('/foo/bar', 'content', user_id=12, group_id=34)
 
         self.assertEqual(len(self.client.requests), 1)
         request = self.client.requests[0]
@@ -1594,7 +1596,7 @@ bad path
             ('POST', '/v1/files', None, req),
         ])
 
-    def test_make_dir_full(self):
+    def test_make_dir_all_options(self):
         self.client.responses.append({
             "result": [{'path': '/foo/bar'}],
             'status': 'OK',
@@ -1602,14 +1604,16 @@ bad path
             'type': 'sync',
         })
         self.client.make_dir('/foo/bar', make_parents=True, permissions=0o600,
-                             user=12, group=34)
+                             user_id=12, user='bob', group_id=34, group='staff')
 
         req = {'action': 'make-dirs', 'dirs': [{
             'path': '/foo/bar',
             'make-parents': True,
             'permissions': '600',
             'user-id': 12,
+            'user': 'bob',
             'group-id': 34,
+            'group': 'staff',
         }]}
         self.assertEqual(self.client.requests, [
             ('POST', '/v1/files', None, req),

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -1155,6 +1155,8 @@ services:
                     'size': 123,
                     'permissions': '644',
                     'last-modified': '2021-01-28T14:37:04.291517768+13:00',
+                    'user-id': 12,
+                    'group-id': 34,
                 },
                 {
                     'path': '/etc/nginx',
@@ -1177,12 +1179,16 @@ services:
         self.assertEqual(infos[0].size, 123)
         self.assertEqual(infos[0].permissions, 0o644)
         self.assertEqual(infos[0].last_modified, datetime_nzdt(2021, 1, 28, 14, 37, 4, 291518))
+        self.assertEqual(infos[0].user_id, 12)
+        self.assertEqual(infos[0].group_id, 34)
         self.assertEqual(infos[1].path, '/etc/nginx')
         self.assertEqual(infos[1].name, 'nginx')
         self.assertEqual(infos[1].type, pebble.FileType.DIRECTORY)
         self.assertEqual(infos[1].size, None)
         self.assertEqual(infos[1].permissions, 0o755)
         self.assertEqual(infos[1].last_modified, datetime_nzdt(2020, 1, 1, 1, 1, 1, 0))
+        self.assertIs(infos[1].user_id, None)
+        self.assertIs(infos[1].group_id, None)
 
         self.assertEqual(self.client.requests, [
             ('GET', '/v1/files', {'action': 'list', 'path': '/etc'}, None),

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -373,7 +373,8 @@ class TestTypes(unittest.TestCase):
 
     def test_file_info_init(self):
         info = pebble.FileInfo('/etc/hosts', 'hosts', pebble.FileType.FILE, 123, 0o644,
-                               datetime_nzdt(2021, 1, 28, 14, 37, 4, 291518), 12, 34)
+                               datetime_nzdt(2021, 1, 28, 14, 37, 4, 291518),
+                               12, 'bob', 34, 'staff')
         self.assertEqual(info.path, '/etc/hosts')
         self.assertEqual(info.name, 'hosts')
         self.assertEqual(info.type, pebble.FileType.FILE)
@@ -381,7 +382,9 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(info.permissions, 0o644)
         self.assertEqual(info.last_modified, datetime_nzdt(2021, 1, 28, 14, 37, 4, 291518))
         self.assertEqual(info.user_id, 12)
+        self.assertEqual(info.user, 'bob')
         self.assertEqual(info.group_id, 34)
+        self.assertEqual(info.group, 'staff')
 
     def test_file_info_from_dict(self):
         d = {
@@ -398,17 +401,23 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(info.permissions, 0o644)
         self.assertEqual(info.last_modified, datetime_nzdt(2021, 1, 28, 14, 37, 4, 291518))
         self.assertIs(info.user_id, None)
+        self.assertIs(info.user, None)
         self.assertIs(info.group_id, None)
+        self.assertIs(info.group, None)
 
         d['type'] = 'foobar'
         d['size'] = 123
         d['user-id'] = 12
+        d['user'] = 'bob'
         d['group-id'] = 34
+        d['group'] = 'staff'
         info = pebble.FileInfo.from_dict(d)
         self.assertEqual(info.type, 'foobar')
         self.assertEqual(info.size, 123)
         self.assertEqual(info.user_id, 12)
+        self.assertEqual(info.user, 'bob')
         self.assertEqual(info.group_id, 34)
+        self.assertEqual(info.group, 'staff')
 
 
 class TestPlan(unittest.TestCase):
@@ -1404,7 +1413,9 @@ bad path
                     'permissions': '644',
                     'last-modified': '2021-01-28T14:37:04.291517768+13:00',
                     'user-id': 12,
+                    'user': 'bob',
                     'group-id': 34,
+                    'group': 'staff',
                 },
                 {
                     'path': '/etc/nginx',
@@ -1428,7 +1439,9 @@ bad path
         self.assertEqual(infos[0].permissions, 0o644)
         self.assertEqual(infos[0].last_modified, datetime_nzdt(2021, 1, 28, 14, 37, 4, 291518))
         self.assertEqual(infos[0].user_id, 12)
+        self.assertEqual(infos[0].user, 'bob')
         self.assertEqual(infos[0].group_id, 34)
+        self.assertEqual(infos[0].group, 'staff')
         self.assertEqual(infos[1].path, '/etc/nginx')
         self.assertEqual(infos[1].name, 'nginx')
         self.assertEqual(infos[1].type, pebble.FileType.DIRECTORY)
@@ -1436,7 +1449,9 @@ bad path
         self.assertEqual(infos[1].permissions, 0o755)
         self.assertEqual(infos[1].last_modified, datetime_nzdt(2020, 1, 1, 1, 1, 1, 0))
         self.assertIs(infos[1].user_id, None)
+        self.assertIs(infos[1].user, None)
         self.assertIs(infos[1].group_id, None)
+        self.assertIs(infos[1].group, None)
 
         self.assertEqual(self.client.requests, [
             ('GET', '/v1/files', {'action': 'list', 'path': '/etc'}, None),

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -1238,10 +1238,10 @@ Content-Disposition: form-data; name="response"
         self.assertEqual(str(cm.exception),
                          "expected Content-Type 'multipart/form-data', got 'ct'")
 
-        self.client.responses.append(({'Content-Type': 'multipart/form-data; boundary=X'}, b''))
+        self.client.responses.append(({'Content-Type': 'multipart/form-data'}, b''))
         with self.assertRaises(pebble.ProtocolError) as cm:
             self.client.read_file('/etc/hosts', None)
-        self.assertEqual(str(cm.exception), "invalid boundary 'X'")
+        self.assertEqual(str(cm.exception), "invalid boundary ''")
 
         self.client.responses.append((
             {'Content-Type': 'multipart/form-data; boundary=01234567890123456789012345678901'},
@@ -1495,11 +1495,11 @@ bad path
             'type': 'sync',
         })
         self.client.make_dir('/foo/bar')
-        dir_item = {
+        req = {'action': 'make-dirs', 'dirs': [{
             'path': '/foo/bar',
-        }
+        }]}
         self.assertEqual(self.client.requests, [
-            ('POST', '/v1/files', None, {'action': 'make-dirs', 'dirs': [dir_item]}),
+            ('POST', '/v1/files', None, req),
         ])
 
     def test_make_dir_full(self):
@@ -1512,15 +1512,15 @@ bad path
         self.client.make_dir('/foo/bar', make_parents=True, permissions=0o600,
                              user=12, group=34)
 
-        dir_item = {
+        req = {'action': 'make-dirs', 'dirs': [{
             'path': '/foo/bar',
             'make-parents': True,
             'permissions': '600',
             'user-id': 12,
             'group-id': 34,
-        }
+        }]}
         self.assertEqual(self.client.requests, [
-            ('POST', '/v1/files', None, {'action': 'make-dirs', 'dirs': [dir_item]}),
+            ('POST', '/v1/files', None, req),
         ])
 
     def test_make_dir_error(self):
@@ -1550,11 +1550,11 @@ bad path
             'type': 'sync',
         })
         self.client.remove_path('/boo/far')
-        dir_item = {
+        req = {'action': 'remove', 'paths': [{
             'path': '/boo/far',
-        }
+        }]}
         self.assertEqual(self.client.requests, [
-            ('POST', '/v1/files', None, {'action': 'remove', 'paths': [dir_item]}),
+            ('POST', '/v1/files', None, req),
         ])
 
     def test_remove_path_recursive(self):
@@ -1566,12 +1566,12 @@ bad path
         })
         self.client.remove_path('/boo/far', recursive=True)
 
-        dir_item = {
+        req = {'action': 'remove', 'paths': [{
             'path': '/boo/far',
             'recursive': True,
-        }
+        }]}
         self.assertEqual(self.client.requests, [
-            ('POST', '/v1/files', None, {'action': 'remove', 'paths': [dir_item]}),
+            ('POST', '/v1/files', None, req),
         ])
 
     def test_remove_path_error(self):


### PR DESCRIPTION
This PR adds Python Operator Framework support for the new Pebble files API (https://github.com/canonical/pebble/pull/25). Two things to note:

* Per the [spec](https://docs.google.com/document/d/1NPPZZB_qCwtTru-YsKkRSAb6mXJzBiE0fG3GTZnx4fM/edit#), for now we're only supporting single-file operations in the client APIs, even though the HTTP API itself supports bulk operations.
* In addition, Python's standard library doesn't have good support for streaming writing/parsing of multipart, so the current code reads the whole file into memory. However, the API is such that we can fix this at a later date without changing the `read_file` and `write_file` signatures.