### PR TITLE
Rename read_content/write_content to pull/push; use file-like objects

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1091,31 +1091,35 @@ class Container:
             raise RuntimeError('expected 1 service, got {}'.format(len(services)))
         return services[service_name]
 
-    def read_content(self, path: str, *, encoding: str = 'utf-8') -> typing.Union[bytes, str]:
-        """Read a file's content from the remote system to a string.
+    def pull(self, path: str, *, encoding: str = 'utf-8') -> typing.Union[typing.BinaryIO,
+                                                                          typing.TextIO]:
+        """Read a file's content from the remote system.
 
         Args:
             path: Path of the file to read from the remote system.
-            encoding: Encoding to use for decoding file's bytes to a text string
-                (or None to return raw bytes).
+            encoding: Encoding to use for decoding the file's bytes to str,
+                or None to specify no decoding.
 
         Returns:
-            File's content, decoded and returned as str if encoding is not None,
-            or returned as raw bytes if encoding is None.
+            A readable file-like object, whose read() method will return str
+            objects decoded according to the specified encoding, or bytes if
+            encoding is None.
         """
-        return self._pebble.read_content(path, encoding=encoding)
+        return self._pebble.pull(path, encoding=encoding)
 
-    def write_content(
-            self, path: str, content: typing.Union[bytes, str], *, encoding: str = 'utf-8',
-            make_dirs: bool = False, permissions: int = None, user_id: int = None,
-            user: str = None, group_id: int = None, group: str = None):
+    def push(
+            self, path: str, source: typing.Union[bytes, str, typing.BinaryIO, typing.TextIO], *,
+            encoding: str = 'utf-8', make_dirs: bool = False, permissions: int = None,
+            user_id: int = None, user: str = None, group_id: int = None, group: str = None):
         """Write content to a given file path on the remote system.
 
         Args:
             path: Path of the file to write to on the remote system.
-            content: Content to write (str or bytes).
-            encoding: Encoding to use for encoding content str to bytes.
-                Ignored if content is bytes.
+            source: Source of data to write. This is either a concrete str or
+                bytes instance, or a readable file-like object.
+            encoding: Encoding to use for encoding source str to bytes, or
+                strings read from source if it is a TextIO type. Ignored if
+                source is bytes or BinaryIO.
             make_dirs: If True, create parent directories if they don't exist.
             permissions: Permissions (mode) to create file with (Pebble default
                 is 0o644).
@@ -1124,9 +1128,9 @@ class Container:
             group_id: GID for file.
             group: Group name for file (group_id takes precedence).
         """
-        self._pebble.write_content(path, content, encoding=encoding, make_dirs=make_dirs,
-                                   permissions=permissions, user_id=user_id, user=user,
-                                   group_id=group_id, group=group)
+        self._pebble.push(path, source, encoding=encoding, make_dirs=make_dirs,
+                          permissions=permissions, user_id=user_id, user=user,
+                          group_id=group_id, group=group)
 
     def list_files(self, path: str, *, pattern: str = None,
                    itself: bool = False) -> typing.List['pebble.FileInfo']:

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -147,7 +147,7 @@ def main():
         elif args.command == 'plan':
             result = client.get_plan().to_yaml()
         elif args.command == 'pull':
-            content = client.read_content(args.remote_path, encoding=None)
+            content = client.pull(args.remote_path, encoding=None).read()
             if args.local_path != '-':
                 with open(args.local_path, 'wb') as f:
                     f.write(content)
@@ -157,11 +157,10 @@ def main():
                 return
         elif args.command == 'push':
             with open(args.local_path, 'rb') as f:
-                content = f.read()
-            client.write_content(
-                args.remote_path, content, make_dirs=args.dirs,
-                permissions=int(args.mode, 8) if args.mode is not None else None,
-                user=args.user, group=args.group)
+                client.push(
+                    args.remote_path, f, make_dirs=args.dirs,
+                    permissions=int(args.mode, 8) if args.mode is not None else None,
+                    user=args.user, group=args.group)
             result = 'wrote {} to remote file {}'.format(args.local_path, args.remote_path)
         elif args.command == 'rm':
             client.remove_path(args.path, recursive=bool(args.recursive))

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -932,35 +932,34 @@ containers:
         with self.assertRaises(RuntimeError):
             self.container.get_service('s1')
 
-    def test_read_content(self):
-        self.pebble.responses.append('content1')
-        got = self.container.read_content('/path/1')
-        self.assertEqual(got, 'content1')
+    def test_pull(self):
+        self.pebble.responses.append('dummy1')
+        got = self.container.pull('/path/1')
+        self.assertEqual(got, 'dummy1')
         self.assertEqual(self.pebble.requests, [
-            ('read_content', '/path/1', 'utf-8'),
+            ('pull', '/path/1', 'utf-8'),
         ])
         self.pebble.requests = []
 
-        self.pebble.responses.append(b'content2')
-        got = self.container.read_content('/path/2', encoding=None)
-        self.assertEqual(got, b'content2')
+        self.pebble.responses.append(b'dummy2')
+        got = self.container.pull('/path/2', encoding=None)
+        self.assertEqual(got, b'dummy2')
         self.assertEqual(self.pebble.requests, [
-            ('read_content', '/path/2', None),
+            ('pull', '/path/2', None),
         ])
 
-    def test_write_content(self):
-        self.container.write_content('/path/1', 'content1')
+    def test_push(self):
+        self.container.push('/path/1', 'content1')
         self.assertEqual(self.pebble.requests, [
-            ('write_content', '/path/1', 'content1', 'utf-8', False, None,
+            ('push', '/path/1', 'content1', 'utf-8', False, None,
              None, None, None, None),
         ])
         self.pebble.requests = []
 
-        self.container.write_content('/path/2', b'content2', encoding=None, make_dirs=True,
-                                     permissions=0o600, user_id=12, user='bob', group_id=34,
-                                     group='staff')
+        self.container.push('/path/2', b'content2', encoding=None, make_dirs=True,
+                            permissions=0o600, user_id=12, user='bob', group_id=34, group='staff')
         self.assertEqual(self.pebble.requests, [
-            ('write_content', '/path/2', b'content2', None, True, 0o600, 12, 'bob', 34, 'staff'),
+            ('push', '/path/2', b'content2', None, True, 0o600, 12, 'bob', 34, 'staff'),
         ])
 
     def test_list_files(self):
@@ -1040,13 +1039,13 @@ class MockPebbleClient:
         self.requests.append(('get_services', names))
         return self.responses.pop(0)
 
-    def read_content(self, path, *, encoding='utf-8'):
-        self.requests.append(('read_content', path, encoding))
+    def pull(self, path, *, encoding='utf-8'):
+        self.requests.append(('pull', path, encoding))
         return self.responses.pop(0)
 
-    def write_content(self, path, content, *, encoding='utf-8', make_dirs=False, permissions=None,
-                      user_id=None, user=None, group_id=None, group=None):
-        self.requests.append(('write_content', path, content, encoding, make_dirs, permissions,
+    def push(self, path, source, *, encoding='utf-8', make_dirs=False, permissions=None,
+             user_id=None, user=None, group_id=None, group=None):
+        self.requests.append(('push', path, source, encoding, make_dirs, permissions,
                               user_id, user, group_id, group))
 
     def list_files(self, path, *, pattern=None, itself=False):


### PR DESCRIPTION
This updates the name and signature so we get that right now, but doesn't change the implementation, which still reads the whole thing into memory. We'll address that later.

Fixes #512.