### PR TITLE
Pebble testing

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -17,7 +17,7 @@
 For a command-line interface for local testing, see test/pebble_cli.py.
 """
 
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Dict, Iterable, List, Mapping, Optional, Union
 import datetime
 import enum
 import http.client
@@ -426,7 +426,16 @@ class Layer:
 
     The format of this is not documented, but is captured in code here:
     https://github.com/canonical/pebble/blob/master/internal/plan/plan.go
+
+    Attributes:
+        summary: A summary of the purpose of this layer
+        description: A long form description of this layer
+        services: A mapping of name: :class:`Service` defined by this layer
     """
+
+    summary: str
+    description: str
+    services: Mapping[str, 'Service']
 
     def __init__(self, raw: Union[str, Dict] = None):
         if isinstance(raw, str):

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -426,11 +426,9 @@ class Plan:
         """
         return self._services
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
         """Convert this plan to its dict representation."""
-        as_dicts = {}
-        for name, service in self._services.items():
-            as_dicts[name] = service.to_dict()
+        as_dicts = {name: service.to_dict() for name, service in self._services.items()}
         if not as_dicts:
             return {}
         return {
@@ -475,7 +473,7 @@ class Layer:
         """Convert this layer to its YAML representation."""
         return yaml.safe_dump(self.to_dict())
 
-    def to_dict(self) -> typing.Dict:
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
         """Convert this layer to its dict representation."""
         fields = [
             ('summary', self.summary),

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -456,9 +456,10 @@ class Layer:
         services: A mapping of name: :class:`Service` defined by this layer
     """
 
-    summary: str
-    description: str
-    services: typing.Mapping[str, 'Service']
+    # This is how you do type annotations, but it is not supported by Python 3.5
+    # summary: str
+    # description: str
+    # services: typing.Mapping[str, 'Service']
 
     def __init__(self, raw: typing.Union[str, typing.Dict] = None):
         if isinstance(raw, str):

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -403,9 +403,20 @@ class Plan:
         """
         return self._services
 
+    def to_dict(self) -> dict:
+        """Convert this plan to its dict representation."""
+        as_dicts = {}
+        for name, service in self._services.items():
+            as_dicts[name] = service.to_dict()
+        if not as_dicts:
+            return {}
+        return {
+            'services': as_dicts,
+        }
+
     def to_yaml(self) -> str:
         """Return this plan's YAML representation."""
-        return self._raw
+        return yaml.safe_dump(self.to_dict())
 
     __str__ = to_yaml
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1043,12 +1043,14 @@ ChangeError: cannot perform the following tasks:
                 raise RuntimeError('400 Bad Request: layer "{}" already exists'.format(label))
             layer = self._layers[label]
             for name, service in layer_obj.services.items():
+                # 'override' is actually single quoted in the real error, but
+                # it shouldn't be, hopefully that gets cleaned up.
                 if not service.override:
-                    raise RuntimeError("500 Internal Server Error: layer \"{}\" must define"
-                                       "'override' for service \"{}\"".format(label, name))
+                    raise RuntimeError('500 Internal Server Error: layer "{}" must define'
+                                       '"override" for service "{}"'.format(label, name))
                 if service.override not in ('merge', 'replace'):
-                    raise RuntimeError("500 Internal Server Error: layer \"{}\" has invalid "
-                                       "'override' value on service \"{}\"".format(label, name))
+                    raise RuntimeError('500 Internal Server Error: layer "{}" has invalid '
+                                       '"override" value on service "{}"'.format(label, name))
                 if service.override != 'replace':
                     raise RuntimeError(
                         'override: "{}" unsupported for layer "{}" service "{}"'.format(

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1084,11 +1084,14 @@ ChangeError: cannot perform the following tasks:
         If names is specified, only fetch the service status for the services
         named.
         """
-        if names is not None:
-            raise NotImplementedError("passing a list of names to get_services not implemented")
+        if isinstance(names, str):
+            raise TypeError('start_services should take a list of names, not just "{}"'.format(
+                names))
         services = self._render_services()
         infos = []
-        for name in sorted(services.keys()):
+        if names is None:
+            names = sorted(services.keys())
+        for name in sorted(names):
             service = services[name]
             status = self._service_status.get(name, pebble.ServiceStatus.INACTIVE)
             if service.startup == '':

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1092,7 +1092,12 @@ ChangeError: cannot perform the following tasks:
         if names is None:
             names = sorted(services.keys())
         for name in sorted(names):
-            service = services[name]
+            try:
+                service = services[name]
+            except KeyError:
+                # in pebble, it just returns "nothing matched" if there are 0 matches,
+                # but it ignores services it doesn't recognize
+                continue
             status = self._service_status.get(name, pebble.ServiceStatus.INACTIVE)
             if service.startup == '':
                 startup = pebble.ServiceStartup.DISABLED

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1015,8 +1015,7 @@ ChangeError: cannot perform the following tasks:
 
     def add_layer(
             self, label: str, layer: typing.Union[str, dict, pebble.Layer], *,
-            combine: bool = False,
-    ):
+            combine: bool = False):
         """Dynamically add a new layer onto the Pebble configuration layers.
 
         If combine is False (the default), append the new layer as the top

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -27,6 +27,8 @@ import ops.pebble
 import ops.testing
 from ops.charm import RelationMeta, RelationRole
 
+from ops._private import yaml
+
 from test.test_helpers import fake_script, fake_script_calls
 
 
@@ -870,7 +872,7 @@ containers:
         plan = self.container.get_plan()
         self.assertEqual(self.pebble.requests, [('get_plan',)])
         self.assertIsInstance(plan, ops.pebble.Plan)
-        self.assertEqual(plan.to_yaml(), plan_yaml)
+        self.assertEqual(plan.to_yaml(), yaml.safe_dump(yaml.safe_load(plan_yaml)))
 
     @staticmethod
     def _make_service(name, startup, current):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1117,7 +1117,7 @@ class TestModelBindings(unittest.TestCase):
                     'interface-name': '',
                     'addresses': [
                         {
-                            'hostname':  '',
+                            'hostname': '',
                             'value': '10.1.89.35',
                             'cidr': ''
                         }

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -21,6 +21,7 @@ import sys
 
 import ops.pebble as pebble
 import test.fake_pebble as fake_pebble
+from ops._private import yaml
 
 
 # Ensure unittest diffs don't get truncated like "[17 chars]"
@@ -359,14 +360,22 @@ class TestPlan(unittest.TestCase):
             plan.services = {}
 
     def test_yaml(self):
+        # Starting with nothing, we get the empty result
         plan = pebble.Plan('')
-        self.assertEqual(plan.to_yaml(), '')
-        self.assertEqual(str(plan), '')
+        self.assertEqual(plan.to_yaml(), '{}\n')
+        self.assertEqual(str(plan), '{}\n')
 
-        yaml = 'services:\n foo:\n  override: replace\n  command: echo foo'
-        plan = pebble.Plan(yaml)
-        self.assertEqual(plan.to_yaml(), yaml)
-        self.assertEqual(str(plan), yaml)
+        # With a service, we return validated yaml content.
+        raw = '''\
+services:
+ foo:
+  override: replace
+  command: echo foo
+'''
+        plan = pebble.Plan(raw)
+        reformed = yaml.safe_dump(yaml.safe_load(raw))
+        self.assertEqual(plan.to_yaml(), reformed)
+        self.assertEqual(str(plan), reformed)
 
 
 class TestLayer(unittest.TestCase):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1392,8 +1392,6 @@ class TestHarness(unittest.TestCase):
         harness.begin()
         initial_plan = harness.get_container_pebble_plan('foo')
         self.assertEqual(initial_plan.to_yaml(), '{}\n')
-        # this may become a different error
-        self.assertIsNone(harness.get_container_pebble_plan('unknown'))
         container = harness.model.unit.get_container('foo')
         container.pebble.add_layer('test-ab', '''\
 summary: test-layer
@@ -1422,6 +1420,20 @@ services:
 ''')
         harness_plan = harness.get_container_pebble_plan('foo')
         self.assertEqual(harness_plan.to_yaml(), plan.to_yaml())
+
+    def test_get_pebble_container_plan_unknown(self):
+        harness = Harness(CharmBase, meta='''
+            name: test-app
+            containers:
+              foo:
+                resource: foo-image
+            ''')
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        with self.assertRaises(KeyError):
+            harness.get_container_pebble_plan('unknown')
+        plan = harness.get_container_pebble_plan('foo')
+        self.assertEqual(plan.to_yaml(), "{}\n")
 
 
 class DBRelationChangedHelper(Object):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1945,10 +1945,12 @@ services:
         # Default when not specified is DISABLED
         self.assertEqual(pebble.ServiceStartup.DISABLED, bar_info.startup)
         self.assertEqual(pebble.ServiceStatus.INACTIVE, bar_info.current)
+        self.assertFalse(bar_info.is_running())
         foo_info = infos[1]
         self.assertEqual('foo', foo_info.name)
         self.assertEqual(pebble.ServiceStartup.ENABLED, foo_info.startup)
         self.assertEqual(pebble.ServiceStatus.INACTIVE, foo_info.current)
+        self.assertFalse(foo_info.is_running())
 
     def test_get_services_autostart(self):
         client = self.get_testing_client()
@@ -1971,10 +1973,12 @@ services:
         # Default when not specified is DISABLED
         self.assertEqual(pebble.ServiceStartup.DISABLED, bar_info.startup)
         self.assertEqual(pebble.ServiceStatus.INACTIVE, bar_info.current)
+        self.assertFalse(bar_info.is_running())
         foo_info = infos[1]
         self.assertEqual('foo', foo_info.name)
         self.assertEqual(pebble.ServiceStartup.ENABLED, foo_info.startup)
         self.assertEqual(pebble.ServiceStatus.ACTIVE, foo_info.current)
+        self.assertTrue(foo_info.is_running())
 
     def test_get_services_start_stop(self):
         client = self.get_testing_client()

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -38,7 +38,10 @@ from ops.model import (
     RelationNotFoundError,
     _ModelBackend,
 )
-from ops.testing import Harness
+from ops.testing import (
+    Harness,
+    _TestingPebbleClient,
+)
 
 
 class TestHarness(unittest.TestCase):
@@ -1636,6 +1639,19 @@ class TestTestingModelBackend(unittest.TestCase):
         self.assertIs(backend.relation_remote_app_name(7), None)
 
     def test_get_pebble_methods(self):
+        harness = Harness(CharmBase, meta='''
+            name: test-app
+            ''')
+        self.addCleanup(harness.cleanup)
+        backend = harness._backend
+
+        client = backend.get_pebble('/custom/socket/path')
+        self.assertIsInstance(client, _TestingPebbleClient)
+
+
+class TestTestingPebbleClient(unittest.TestCase):
+
+    def test_methods_match_pebble_client(self):
         harness = Harness(CharmBase, meta='''
             name: test-app
             ''')

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2051,6 +2051,25 @@ services:
         self.assertEqual(pebble.ServiceStartup.ENABLED, foo_info.startup)
         self.assertEqual(pebble.ServiceStatus.INACTIVE, foo_info.current)
 
+    def test_get_services_unknown(self):
+        client = self.get_testing_client()
+        client.add_layer('foo', '''\
+summary: foo
+services:
+  foo:
+    summary: Foo
+    startup: enabled
+    command: '/bin/echo foo'
+  bar:
+    summary: Bar
+    command: '/bin/echo bar'
+''')
+        # This doesn't seem to be an error at the moment.
+        # pebble_cli.py service just returns an empty list
+        # pebble service unknown says "No matching services" (but exits 0)
+        infos = client.get_services(['unknown'])
+        self.assertEqual(infos, [])
+
     def test_invalid_start_service(self):
         client = self.get_testing_client()
         # TODO: jam 2021-04-20 This should become a better error

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1922,11 +1922,6 @@ services:
 
     def test_get_services_none(self):
         client = self.get_testing_client()
-        serviceInfo = client.get_services()
-        self.assertEqual([], serviceInfo)
-
-    def test_get_services_none(self):
-        client = self.get_testing_client()
         service_info = client.get_services()
         self.assertEqual([], service_info)
 


### PR DESCRIPTION
Fixes #488 

This implements a fairly primitive pebble backend for the testing Harness. It allows you to publish layers and read what the overall plan is.
It only supports `override: replace` directives, and doesn't yet support `override:merge`. But for the straightforward cases of asking pebble to track a layer and start some services, you have the opportunity to set that up with the testing Harness, and assert that you have the right plan when you are done.

