### PR TITLE
Harness.container_pebble_ready

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -492,7 +492,7 @@ class Harness:
         """Return the current Plan that pebble is executing for the given container.
 
         Args:
-            container_name: The simple name of the associated container
+            container_name: The simple name of t/he associated container
         Return:
             The pebble.Plan for this container. You can use :meth:`pebble.Plan.to_yaml` to get
             a string form for the content. Will raise KeyError if no pebble client exists
@@ -504,6 +504,16 @@ class Harness:
         if client is None:
             raise KeyError('no known pebble client for container "{}"'.format(container_name))
         return client.get_plan()
+
+    def container_pebble_ready(self, container_name: str):
+        """Fire the pebble_ready hook for the associated container.
+
+        This will do nothing if the begin() has not been called.
+        """
+        if self.charm is None:
+            return
+        container = self.model.unit.get_container(container_name)
+        self.charm.on[container_name].pebble_ready.emit(container)
 
     def get_workload_version(self) -> str:
         """Read the workload version that was set by the unit."""

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -492,7 +492,7 @@ class Harness:
         """Return the current Plan that pebble is executing for the given container.
 
         Args:
-            container_name: The simple name of t/he associated container
+            container_name: The simple name of the associated container
         Return:
             The pebble.Plan for this container. You can use :meth:`pebble.Plan.to_yaml` to get
             a string form for the content. Will raise KeyError if no pebble client exists


### PR DESCRIPTION
This adds an easier syntax to triggering a PebbleReadyEvent.

Specifically you have to grab a container object as a parameter to the event, which isn't terribly awkward but enough that it is cleaner to just have a simple "container_ready_event('name')" rather than going via a roundabout method.

