### PR TITLE
Attempt to fix model.py for Python 3.5.2 (default on Xenial)

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1049,8 +1049,10 @@ class Container:
         """Stop given service(s) by name."""
         self._pebble.stop_services(service_names)
 
-    def add_layer(self, label: str, layer: typing.Union[str, typing.Dict, 'pebble.Layer'], *,
-                  combine: bool = False):
+    # TODO(benhoyt) - should be: layer: typing.Union[str, typing.Dict, 'pebble.Layer'],
+    # but this breaks on Python 3.5.2 (the default on Xenial). See:
+    # https://github.com/canonical/operator/issues/517
+    def add_layer(self, label: str, layer, *, combine: bool = False):
         """Dynamically add a new layer onto the Pebble configuration layers.
 
         Args:


### PR DESCRIPTION
This is annoying, but Python 3.5.2 (but not the 3.5.10 version we're testing against in CI) seem to fail with an obscure typing.py problem due to the `pebble.Layer` type annotation -- see #517. Just remove the type annotation and add a comment for now. The comment in the docstring still mentions the three types, so it's not a big deal to drop this.

Fixes #517