### PR TITLE
Make test CLI show error type for clarity

### DIFF
--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -178,10 +178,10 @@ def main():
         else:
             raise AssertionError("shouldn't happen")
     except pebble.APIError as e:
-        print('{} {}: {}'.format(e.code, e.status, e.message), file=sys.stderr)
+        print('APIError: {} {}: {}'.format(e.code, e.status, e.message), file=sys.stderr)
         sys.exit(1)
     except pebble.ConnectionError as e:
-        print('cannot connect to socket {!r}: {}'.format(socket_path, e),
+        print('ConnectionError: cannot connect to socket {!r}: {}'.format(socket_path, e),
               file=sys.stderr)
         sys.exit(1)
     except pebble.ChangeError as e:


### PR DESCRIPTION
This is just a tiny tweak to the Pebble test CLI to clarify that the `pebble.APIError` it's displaying isn't a raw HTTP error, but a pebble-wrapped one. See related discussion on #514.