### PR TITLE
Add ops.pebble module to the docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,11 @@ ops.model module
 
 .. automodule:: ops.model
 
+ops.pebble module
+-----------------
+
+.. automodule:: ops.pebble
+
 ops.testing module
 ------------------
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -1142,7 +1142,7 @@ class Container:
             path: Path of the directory to list, or path of the file to return
                 information about.
             pattern: If specified, filter the list to just the files that match,
-                for example "*.txt".
+                for example ``*.txt``.
             itself: If path refers to a directory, return information about the
                 directory itself, rather than its contents.
         """

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1052,7 +1052,7 @@ class Client:
             path: Path of the directory to list, or path of the file to return
                 information about.
             pattern: If specified, filter the list to just the files that match,
-                for example "*.txt".
+                for example ``*.txt``.
             itself: If path refers to a directory, return information about the
                 directory itself, rather than its contents.
         """

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -494,7 +494,7 @@ class Harness:
         Args:
             container_name: The simple name of the associated container
         Return:
-            The pebble.Plan for this container. You can use :meth:`pebble.Plan.to_yaml` to get
+            The pebble.Plan for this container. You can use :meth:`ops.pebble.Plan.to_yaml` to get
             a string form for the content. Will raise KeyError if no pebble client exists
             for that container name. (should only happen if container is not present in
             metadata.yaml)


### PR DESCRIPTION
This will add docs for `pebble.py` to https://ops.readthedocs.io/en/latest/

This is so I can link it from the new Discourse docs page I'm writing. Also tweak `*.txt` quoting so Sphinx doesn't interpret it as the start of an emphasis block and complain. And fix a reference in `testing.py`.