### PR TITLE
Fix test_lib on Python 3.8.10 due to importlib relative path changes

### DIFF
--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -123,9 +123,10 @@ class TestLibFinder(TestCase):
 
         _mklib(tmpcwd, "foo", "bar").write_text("")
 
+        paths = _flatten(ops.lib._find_all_specs(dirs))
         self.assertEqual(
-            _flatten(ops.lib._find_all_specs(dirs)),
-            [os.path.join('.', 'foo', 'opslib', 'bar')])
+            [os.path.relpath(p) for p in paths],
+            [os.path.join('foo', 'opslib', 'bar')])
 
     def test_bogus_topdir(self):
         """Check that having one bogus dir in sys.path doesn't cause the finder to abort."""


### PR DESCRIPTION
Now that GitHub Actions is on Python 3.8.10, test_lib.test_cwd fails.
This is due to Python 3.8.10 changing (fixing?) importlib to resolves
relative paths when creating module spec objects from file locations.

This change should work on both 3.8.9 and 3.8.10.

See:
* https://docs.python.org/release/3.8.10/whatsnew/changelog.html#core-and-builtins
* https://bugs.python.org/issue43105