### PR TITLE
Update push/make_dir docstrings with new user/user-id conflict behavior

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1034,7 +1034,7 @@ class Container:
 
     @property
     def pebble(self) -> 'pebble.Client':
-        """Return the low-level Pebble client instance for this container."""
+        """The low-level :class:`ops.pebble.Client` instance for this container."""
         return self._pebble
 
     def autostart(self):
@@ -1125,10 +1125,12 @@ class Container:
             make_dirs: If True, create parent directories if they don't exist.
             permissions: Permissions (mode) to create file with (Pebble default
                 is 0o644).
-            user_id: UID for file.
-            user: Username for file (user_id takes precedence).
-            group_id: GID for file.
-            group: Group name for file (group_id takes precedence).
+            user_id: User ID (UID) for file.
+            user: Username for file. User's UID must match user_id if both are
+                specified.
+            group_id: Group ID (GID) for file.
+            group: Group name for file. Group's GID must match group_id if
+                both are specified.
         """
         self._pebble.push(path, source, encoding=encoding, make_dirs=make_dirs,
                           permissions=permissions, user_id=user_id, user=user,
@@ -1158,10 +1160,12 @@ class Container:
             make_parents: If True, create parent directories if they don't exist.
             permissions: Permissions (mode) to create directory with (Pebble
                 default is 0o755).
-            user_id: UID for directory.
-            user: Username for directory (user_id takes precedence).
-            group_id: GID for directory.
-            group: Group name for directory (group_id takes precedence).
+            user_id: User ID (UID) for directory.
+            user: Username for directory. User's UID must match user_id if
+                both are specified.
+            group_id: Group ID (GID) for directory.
+            group: Group name for directory. Group's GID must match group_id
+                if both are specified.
         """
         self._pebble.make_dir(path, make_parents=make_parents, permissions=permissions,
                               user_id=user_id, user=user, group_id=group_id, group=group)

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -987,10 +987,12 @@ class Client:
             make_dirs: If True, create parent directories if they don't exist.
             permissions: Permissions (mode) to create file with (Pebble default
                 is 0o644).
-            user_id: UID for file.
-            user: Username for file (user_id takes precedence).
-            group_id: GID for file.
-            group: Group name for file (group_id takes precedence).
+            user_id: User ID (UID) for file.
+            user: Username for file. User's UID must match user_id if both are
+                specified.
+            group_id: Group ID (GID) for file.
+            group: Group name for file. Group's GID must match group_id if
+                both are specified.
         """
         info = self._make_auth_dict(permissions, user_id, user, group_id, group)
         info['path'] = path
@@ -1078,10 +1080,12 @@ class Client:
             make_parents: If True, create parent directories if they don't exist.
             permissions: Permissions (mode) to create directory with (Pebble
                 default is 0o755).
-            user_id: UID for directory.
-            user: Username for directory (user_id takes precedence).
-            group_id: GID for directory.
-            group: Group name for directory (group_id takes precedence).
+            user_id: User ID (UID) for directory.
+            user: Username for directory. User's UID must match user_id if
+                both are specified.
+            group_id: Group ID (GID) for directory.
+            group: Group name for directory. Group's GID must match group_id
+                if both are specified.
         """
         info = self._make_auth_dict(permissions, user_id, user, group_id, group)
         info['path'] = path


### PR DESCRIPTION
This depends on https://github.com/canonical/pebble/pull/35, so will
only actually apply for (say) Juju >= 2.9.3. But seems reasonable to
just update the docs to the latest, as it's an edge case charmers are
very likely to run into.