### PR TITLE
Add user/group fields to Service (layer configuration)

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -503,6 +503,10 @@ class Service:
         self.before = list(raw.get('before', []))
         self.requires = list(raw.get('requires', []))
         self.environment = dict(raw.get('environment', {}))
+        self.user = raw.get('user', '')
+        self.user_id = raw.get('user-id')
+        self.group = raw.get('group', '')
+        self.group_id = raw.get('group-id')
 
     def to_dict(self) -> typing.Dict:
         """Convert this service object to its dict representation."""
@@ -516,6 +520,10 @@ class Service:
             ('before', self.before),
             ('requires', self.requires),
             ('environment', self.environment),
+            ('user', self.user),
+            ('user-id', self.user_id),
+            ('group', self.group),
+            ('group-id', self.group_id),
         ]
         return {name: value for name, value in fields if value}
 

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -512,7 +512,11 @@ services:
     environment:
       ENV1: value1
       ENV2: value2
+    group: staff
+    group-id: 2000
     summary: Bar
+    user: bob
+    user-id: 1000
   foo:
     command: echo foo
     summary: Foo
@@ -529,6 +533,10 @@ summary: Sum Mary
         self.assertEqual(s.services['bar'].command, 'echo bar')
         self.assertEqual(s.services['bar'].environment,
                          {'ENV1': 'value1', 'ENV2': 'value2'})
+        self.assertEqual(s.services['bar'].user, 'bob')
+        self.assertEqual(s.services['bar'].user_id, 1000)
+        self.assertEqual(s.services['bar'].group, 'staff')
+        self.assertEqual(s.services['bar'].group_id, 2000)
 
         self.assertEqual(s.to_yaml(), yaml)
         self.assertEqual(str(s), yaml)
@@ -546,6 +554,10 @@ class TestService(unittest.TestCase):
         self.assertEqual(service.before, [])
         self.assertEqual(service.requires, [])
         self.assertEqual(service.environment, {})
+        self.assertEqual(service.user, '')
+        self.assertIs(service.user_id, None)
+        self.assertEqual(service.group, '')
+        self.assertIs(service.group_id, None)
         self.assertEqual(service.to_dict(), {})
 
     def test_name_only(self):
@@ -566,6 +578,10 @@ class TestService(unittest.TestCase):
             'before': ['b1', 'b2'],
             'requires': ['r1', 'r2'],
             'environment': {'k1': 'v1', 'k2': 'v2'},
+            'user': 'bob',
+            'user-id': 1000,
+            'group': 'staff',
+            'group-id': 2000,
         }
         s = pebble.Service('Name 2', d)
         self.assertEqual(s.name, 'Name 2')
@@ -577,6 +593,10 @@ class TestService(unittest.TestCase):
         self.assertEqual(s.before, ['b1', 'b2'])
         self.assertEqual(s.requires, ['r1', 'r2'])
         self.assertEqual(s.environment, {'k1': 'v1', 'k2': 'v2'})
+        self.assertEqual(s.user, 'bob')
+        self.assertEqual(s.user_id, 1000)
+        self.assertEqual(s.group, 'staff')
+        self.assertEqual(s.group_id, 2000)
 
         self.assertEqual(s.to_dict(), d)
 


### PR DESCRIPTION
This adds up the new user, user-id, group, group-id fields added in https://github.com/canonical/pebble/pull/35 to the Layer.services dict, allowing you to pass a dict object to `add_layer` with those fields in it (without this change you have to specify the layer as a raw YAML string).