### PR TITLE
We standardized on Google style doc strings.

### DIFF
--- a/ops/log.py
+++ b/ops/log.py
@@ -42,8 +42,9 @@ def setup_root_logging(model_backend, debug=False):
 
       logging.getLogger().setLevel(logging.INFO)
 
-    model_backend -- a ModelBackend to use for juju-log
-    debug -- if True, write logs to stderr as well as to juju-log.
+    Args:
+        model_backend: a ModelBackend to use for juju-log
+        debug: if True, write logs to stderr as well as to juju-log.
     """
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)

--- a/ops/main.py
+++ b/ops/main.py
@@ -64,9 +64,10 @@ def _get_charm_dir():
 def _create_event_link(charm, bound_event, link_to):
     """Create a symlink for a particular event.
 
-    charm -- A charm object.
-    bound_event -- An event for which to create a symlink.
-    link_to -- What the event link should point to
+    Args:
+        charm: A charm object.
+        bound_event: An event for which to create a symlink.
+        link_to: What the event link should point to
     """
     if issubclass(bound_event.event_type, ops.charm.HookEvent):
         event_dir = charm.framework.charm_dir / 'hooks'
@@ -104,8 +105,9 @@ def _setup_event_links(charm_dir, charm):
     which is determined by inspecting symlinks provided by the charm
     author at hooks/install or hooks/start.
 
-    charm_dir -- A root directory of the charm.
-    charm -- An instance of the Charm class.
+    Args:
+        charm_dir: A root directory of the charm.
+        charm: An instance of the Charm class.
 
     """
     # XXX: on windows this function does not accomplish what it wants to:
@@ -123,8 +125,9 @@ def _setup_event_links(charm_dir, charm):
 def _emit_charm_event(charm, event_name):
     """Emits a charm event based on a Juju event name.
 
-    charm -- A charm instance to emit an event from.
-    event_name -- A Juju event name to emit on a charm.
+    Args:
+        charm: A charm instance to emit an event from.
+        event_name: A Juju event name to emit on a charm.
     """
     event_to_emit = None
     try:


### PR DESCRIPTION
It seems there were a few functions that still used a different format. This should bring them all into a standard pattern. (At least I don't see any other functions with '--' style arguments.)
