### PR TITLE
check that container.start() and .stop() have at least 1 service name

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1043,10 +1043,14 @@ class Container:
 
     def start(self, *service_names: str):
         """Start given service(s) by name."""
+        if not service_names:
+            raise TypeError('start expected at least 1 argument, got 0')
         self._pebble.start_services(service_names)
 
     def stop(self, *service_names: str):
         """Stop given service(s) by name."""
+        if not service_names:
+            raise TypeError('stop expected at least 1 argument, got 0')
         self._pebble.stop_services(service_names)
 
     # TODO(benhoyt) - should be: layer: typing.Union[str, typing.Dict, 'pebble.Layer'],

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -824,6 +824,10 @@ containers:
             ('start', ('foo', 'bar')),
         ])
 
+    def test_start_no_arguments(self):
+        with self.assertRaises(TypeError):
+            self.container.start()
+
     def test_stop(self):
         self.container.stop('foo')
         self.container.stop('foo', 'bar')
@@ -831,6 +835,10 @@ containers:
             ('stop', ('foo',)),
             ('stop', ('foo', 'bar')),
         ])
+
+    def test_stop_no_arguments(self):
+        with self.assertRaises(TypeError):
+            self.container.stop()
 
     def test_type_errors(self):
         meta = ops.charm.CharmMeta.from_yaml("""


### PR DESCRIPTION
It's a coding mistake not to specify at least one, so raise a TypeError if this happens.

Fixes #555