### PR TITLE
Add semantic_version to setup.py so pip will properly resolve the deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ version = {!r}
             # "Operating System :: Microsoft :: Windows",
         ],
         python_requires='>=3.5',
-        install_requires=["PyYAML"],
+        install_requires=["PyYAML", "semantic_version"],
     )
 
 finally:


### PR DESCRIPTION
No longer will users have to add `semantic_version` themselves because it's required as part of `ops.relation`.

Closes #561 