### PR TITLE
Check whether Pebble is ready before 

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1055,7 +1055,21 @@ class Container:
 
     @contextmanager
     def is_ready(self) -> None:
-        """Check whether or not Pebble is ready as a simple property."""
+        """Check whether or not Pebble is ready as a simple property.
+
+        :meth:`is_ready` implements a `contextmanager` which can be used in charms
+        to wrap :class:`Container` operations which depend on the Pebble backend
+        being available. When `is_ready` is used, exceptions from the underlying
+        Pebble operations will log error messages rather than raising exceptions.
+
+        Example:
+            container = self.unit.get_container("example")
+
+            with container.is_ready():
+                container.pull('/does/not/exist')
+                # This will result in an `ERROR` log from PathError, but not a backtrace
+
+        """
         try:
             # We don't care at all whether not the services are up in
             # this case, jsut whether Pebble throws an error. If it doesn't,

--- a/ops/model.py
+++ b/ops/model.py
@@ -1045,6 +1045,17 @@ class Container:
         """The low-level :class:`ops.pebble.Client` instance for this container."""
         return self._pebble
 
+    @property
+    def ready(self) -> bool:
+        """Check whether or not Pebble is ready as a simple property"""
+        try:
+            # We don't<F12> care at all whether not the services are up in
+            # this case, jsut whether Pebble throws an error
+            services = self._pebble.get_services()
+            return True
+        except pebble.ConnectionError:
+            return False
+
     def autostart(self):
         """Autostart all services marked as startup: enabled."""
         self._pebble.autostart_services()
@@ -1119,6 +1130,9 @@ class Container:
             objects decoded according to the specified encoding, or bytes if
             encoding is None.
         """
+        if not self.ready:
+            return
+
         return self._pebble.pull(path, encoding=encoding)
 
     def push(
@@ -1144,6 +1158,9 @@ class Container:
             group: Group name for file. Group's GID must match group_id if
                 both are specified.
         """
+        if not self.ready:
+            return
+
         self._pebble.push(path, source, encoding=encoding, make_dirs=make_dirs,
                           permissions=permissions, user_id=user_id, user=user,
                           group_id=group_id, group=group)
@@ -1160,6 +1177,9 @@ class Container:
             itself: If path refers to a directory, return information about the
                 directory itself, rather than its contents.
         """
+        if not self.ready:
+            return
+
         return self._pebble.list_files(path, pattern=pattern, itself=itself)
 
     def make_dir(
@@ -1189,6 +1209,9 @@ class Container:
             path: Path of the file or directory to delete from the remote system.
             recursive: If True, recursively delete path and everything under it.
         """
+        if not self.ready:
+            return
+
         self._pebble.remove_path(path, recursive=recursive)
 
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -125,6 +125,17 @@ def _json_loads(s: typing.Union[str, bytes]) -> typing.Dict:
 class Error(Exception):
     """Base class of most errors raised by the Pebble client."""
 
+    def __repr__(self):
+        return '<{}.{} {}>'.format(type(self).__module__, type(self).__name__, self.args)
+
+    def name(self):
+        """Return a string representation of the model plus class."""
+        return '<{}.{}>'.format(type(self).__module__, type(self).__name__)
+
+    def message(self):
+        """Return the message passed as an argument."""
+        return self.args[0]
+
 
 class TimeoutError(TimeoutError, Error):
     """Raised when a polling timeout occurs."""

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1016,13 +1016,18 @@ containers:
     def test_no_exception_with_contextmanager(self):
         with self.assertLogs() as logs:
             self.pebble.responses.append('dummy')
-            with self.container.is_ready():
+            with self.container.is_ready() as c:
                 raise ops.pebble.ConnectionError("Some dummy message")
         self.assertIn("was raised due to", logs.records[0].getMessage())
+        self.assertEqual(c.completed, False)
 
     def test_exception_without_contextmanager(self):
         with self.assertRaises(ops.pebble.ConnectionError):
             raise ops.pebble.ConnectionError("Some dummy message")
+
+    def test_bare_is_ready_call(self):
+        self.pebble.responses.append('dummy')
+        self.assertTrue(self.container.is_ready())
 
 
 class MockPebbleBackend(ops.model._ModelBackend):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -20,7 +20,6 @@ import os
 import pathlib
 from textwrap import dedent
 import unittest
-from unittest.mock import patch
 
 import ops.model
 import ops.charm
@@ -28,18 +27,9 @@ import ops.pebble
 import ops.testing
 from ops.charm import RelationMeta, RelationRole
 
-
 from ops._private import yaml
 
 from test.test_helpers import fake_script, fake_script_calls
-
-
-def service_builder():
-    return [ops.pebble.ServiceInfo.from_dict({
-        'name': "test",
-        'startup': "enabled",
-        'current': ops.pebble.ServiceStatus.ACTIVE
-    })]
 
 
 class TestModel(unittest.TestCase):
@@ -827,43 +817,24 @@ containers:
         self.assertEqual(self.pebble.requests, [('autostart',)])
 
     def test_start(self):
-        with patch('test.test_model.MockPebbleClient.get_services',
-                   side_effect=service_builder
-                   ):
-            self.container.start('foo')
-            self.container.start('foo', 'bar')
-            self.assertEqual(self.pebble.requests, [
-                ('start', ('foo',)),
-                ('start', ('foo', 'bar')),
-            ])
+        self.container.start('foo')
+        self.container.start('foo', 'bar')
+        self.assertEqual(self.pebble.requests, [
+            ('start', ('foo',)),
+            ('start', ('foo', 'bar')),
+        ])
 
     def test_start_no_arguments(self):
         with self.assertRaises(TypeError):
             self.container.start()
 
     def test_stop(self):
-        with patch('test.test_model.MockPebbleClient.get_services',
-                   side_effect=service_builder
-                   ):
-            self.container.stop('foo')
-            self.container.stop('foo', 'bar')
-            self.assertEqual(self.pebble.requests, [
-                ('stop', ('foo',)),
-                ('stop', ('foo', 'bar')),
-            ])
-
-    def test_restart(self):
-        with patch('test.test_model.MockPebbleClient.get_services',
-                   side_effect=service_builder
-                   ):
-            self.container.restart('foo')
-            self.container.restart('foo', 'bar')
-            self.assertEqual(self.pebble.requests, [
-                ('stop', ('foo',)),
-                ('start', ('foo',)),
-                ('stop', ('foo', 'bar')),
-                ('start', ('foo', 'bar')),
-            ])
+        self.container.stop('foo')
+        self.container.stop('foo', 'bar')
+        self.assertEqual(self.pebble.requests, [
+            ('stop', ('foo',)),
+            ('stop', ('foo', 'bar')),
+        ])
 
     def test_stop_no_arguments(self):
         with self.assertRaises(TypeError):
@@ -881,17 +852,11 @@ containers:
         model = ops.model.Model(meta, backend)
         container = model.unit.containers['c1']
 
-        with patch('ops.model.Container.ready',
-                   side_effect=True
-                   ):
-            with self.assertRaises(TypeError):
-                container.start(['foo'])
+        with self.assertRaises(TypeError):
+            container.start(['foo'])
 
-        with patch('ops.model.Container.ready',
-                   side_effect=True
-                   ):
-            with self.assertRaises(TypeError):
-                container.stop(['foo'])
+        with self.assertRaises(TypeError):
+            container.stop(['foo'])
 
     def test_add_layer(self):
         self.container.add_layer('a', 'summary: str\n')
@@ -923,160 +888,141 @@ containers:
             {'name': name, 'startup': startup, 'current': current})
 
     def test_get_services(self):
-        with patch('ops.model.Container.ready',
-                   side_effect=True
-                   ):
-            two_services = [
-                self._make_service('s1', 'enabled', 'active'),
-                self._make_service('s2', 'disabled', 'inactive'),
-            ]
-            self.pebble.responses.append(two_services)
-            services = self.container.get_services()
-            self.assertEqual(len(services), 2)
-            self.assertEqual(set(services), {'s1', 's2'})
-            self.assertEqual(services['s1'].name, 's1')
-            self.assertEqual(services['s1'].startup, ops.pebble.ServiceStartup.ENABLED)
-            self.assertEqual(services['s1'].current, ops.pebble.ServiceStatus.ACTIVE)
-            self.assertEqual(services['s2'].name, 's2')
-            self.assertEqual(services['s2'].startup, ops.pebble.ServiceStartup.DISABLED)
-            self.assertEqual(services['s2'].current, ops.pebble.ServiceStatus.INACTIVE)
+        two_services = [
+            self._make_service('s1', 'enabled', 'active'),
+            self._make_service('s2', 'disabled', 'inactive'),
+        ]
+        self.pebble.responses.append(two_services)
+        services = self.container.get_services()
+        self.assertEqual(len(services), 2)
+        self.assertEqual(set(services), {'s1', 's2'})
+        self.assertEqual(services['s1'].name, 's1')
+        self.assertEqual(services['s1'].startup, ops.pebble.ServiceStartup.ENABLED)
+        self.assertEqual(services['s1'].current, ops.pebble.ServiceStatus.ACTIVE)
+        self.assertEqual(services['s2'].name, 's2')
+        self.assertEqual(services['s2'].startup, ops.pebble.ServiceStartup.DISABLED)
+        self.assertEqual(services['s2'].current, ops.pebble.ServiceStatus.INACTIVE)
 
-            self.pebble.responses.append(two_services)
-            services = self.container.get_services('s1', 's2')
-            self.assertEqual(len(services), 2)
-            self.assertEqual(set(services), {'s1', 's2'})
-            self.assertEqual(services['s1'].name, 's1')
-            self.assertEqual(services['s1'].startup, ops.pebble.ServiceStartup.ENABLED)
-            self.assertEqual(services['s1'].current, ops.pebble.ServiceStatus.ACTIVE)
-            self.assertEqual(services['s2'].name, 's2')
-            self.assertEqual(services['s2'].startup, ops.pebble.ServiceStartup.DISABLED)
-            self.assertEqual(services['s2'].current, ops.pebble.ServiceStatus.INACTIVE)
+        self.pebble.responses.append(two_services)
+        services = self.container.get_services('s1', 's2')
+        self.assertEqual(len(services), 2)
+        self.assertEqual(set(services), {'s1', 's2'})
+        self.assertEqual(services['s1'].name, 's1')
+        self.assertEqual(services['s1'].startup, ops.pebble.ServiceStartup.ENABLED)
+        self.assertEqual(services['s1'].current, ops.pebble.ServiceStatus.ACTIVE)
+        self.assertEqual(services['s2'].name, 's2')
+        self.assertEqual(services['s2'].startup, ops.pebble.ServiceStartup.DISABLED)
+        self.assertEqual(services['s2'].current, ops.pebble.ServiceStatus.INACTIVE)
 
-            self.assertEqual(self.pebble.requests, [
-                ('get_services', ()),
-                ('get_services', ('s1', 's2')),
-            ])
+        self.assertEqual(self.pebble.requests, [
+            ('get_services', ()),
+            ('get_services', ('s1', 's2')),
+        ])
 
     def test_get_service(self):
-        with patch('ops.model.Container.ready',
-                   side_effect=True
-                   ):
-            # Single service returned successfully
-            self.pebble.responses.append([self._make_service('s1', 'enabled', 'active')])
-            s = self.container.get_service('s1')
-            self.assertEqual(self.pebble.requests, [('get_services', ('s1', ))])
-            self.assertEqual(s.name, 's1')
-            self.assertEqual(s.startup, ops.pebble.ServiceStartup.ENABLED)
-            self.assertEqual(s.current, ops.pebble.ServiceStatus.ACTIVE)
+        # Single service returned successfully
+        self.pebble.responses.append([self._make_service('s1', 'enabled', 'active')])
+        s = self.container.get_service('s1')
+        self.assertEqual(self.pebble.requests, [('get_services', ('s1', ))])
+        self.assertEqual(s.name, 's1')
+        self.assertEqual(s.startup, ops.pebble.ServiceStartup.ENABLED)
+        self.assertEqual(s.current, ops.pebble.ServiceStatus.ACTIVE)
 
-            # If Pebble returns no services, should be a ModelError
-            self.pebble.responses.append([])
-            with self.assertRaises(ops.model.UnknownServiceError) as cm:
-                self.container.get_service('s2')
-            self.assertIn("service 's2' not found", str(cm.exception))
+        # If Pebble returns no services, should be a ModelError
+        self.pebble.responses.append([])
+        with self.assertRaises(ops.model.ModelError) as cm:
+            self.container.get_service('s2')
+        self.assertEqual(str(cm.exception), "service 's2' not found")
 
-            # If Pebble returns more than one service, RuntimeError is raised
-            self.pebble.responses.append([
-                self._make_service('s1', 'enabled', 'active'),
-                self._make_service('s2', 'disabled', 'inactive'),
-            ])
-            with self.assertRaises(RuntimeError):
-                self.container.get_service('s1')
-
-    def test_container_not_ready_if_pebble_is_down(self):
-        with patch('test.test_model.MockPebbleClient.get_services',
-                   side_effect=ops.pebble.ConnectionError("Pebble is dead")
-                   ):
-            # with unittest.mock.patch('')
-            # If the service is not running, the container is not ready yet
-            self.assertEqual(self.container.ready, False)
+        # If Pebble returns more than one service, RuntimeError is raised
+        self.pebble.responses.append([
+            self._make_service('s1', 'enabled', 'active'),
+            self._make_service('s2', 'disabled', 'inactive'),
+        ])
+        with self.assertRaises(RuntimeError):
+            self.container.get_service('s1')
 
     def test_pull(self):
-        with patch('test.test_model.MockPebbleClient.get_services',
-                   side_effect=service_builder
-                   ):
-            self.pebble.responses.append('dummy1')
-            got = self.container.pull('/path/1')
-            self.assertEqual(got, 'dummy1')
-            self.assertEqual(self.pebble.requests, [
-                ('pull', '/path/1', 'utf-8'),
-            ])
-            self.pebble.requests = []
+        self.pebble.responses.append('dummy1')
+        got = self.container.pull('/path/1')
+        self.assertEqual(got, 'dummy1')
+        self.assertEqual(self.pebble.requests, [
+            ('pull', '/path/1', 'utf-8'),
+        ])
+        self.pebble.requests = []
 
-            self.pebble.responses.append(b'dummy2')
-            got = self.container.pull('/path/2', encoding=None)
-            self.assertEqual(got, b'dummy2')
-            self.assertEqual(self.pebble.requests, [
-                ('pull', '/path/2', None),
-            ])
+        self.pebble.responses.append(b'dummy2')
+        got = self.container.pull('/path/2', encoding=None)
+        self.assertEqual(got, b'dummy2')
+        self.assertEqual(self.pebble.requests, [
+            ('pull', '/path/2', None),
+        ])
 
     def test_push(self):
-        with patch('test.test_model.MockPebbleClient.get_services',
-                   side_effect=service_builder
-                   ):
-            self.container.push('/path/1', 'content1')
-            self.assertEqual(self.pebble.requests, [
-                ('push', '/path/1', 'content1', 'utf-8', False, None,
-                 None, None, None, None),
-            ])
-            self.pebble.requests = []
+        self.container.push('/path/1', 'content1')
+        self.assertEqual(self.pebble.requests, [
+            ('push', '/path/1', 'content1', 'utf-8', False, None,
+             None, None, None, None),
+        ])
+        self.pebble.requests = []
 
-            self.container.push('/path/2', b'content2', encoding=None, make_dirs=True,
-                                permissions=0o600, user_id=12, user='bob', group_id=34,
-                                group='staff')
-            self.assertEqual(self.pebble.requests, [
-                ('push', '/path/2', b'content2', None, True, 0o600, 12, 'bob', 34, 'staff'),
-            ])
+        self.container.push('/path/2', b'content2', encoding=None, make_dirs=True,
+                            permissions=0o600, user_id=12, user='bob', group_id=34, group='staff')
+        self.assertEqual(self.pebble.requests, [
+            ('push', '/path/2', b'content2', None, True, 0o600, 12, 'bob', 34, 'staff'),
+        ])
 
     def test_list_files(self):
-        with patch('test.test_model.MockPebbleClient.get_services',
-                   side_effect=service_builder
-                   ):
-            self.pebble.responses.append('dummy1')
-            ret = self.container.list_files('/path/1')
-            self.assertEqual(ret, 'dummy1')
-            self.assertEqual(self.pebble.requests, [
-                ('list_files', '/path/1', None, False),
-            ])
-            self.pebble.requests = []
+        self.pebble.responses.append('dummy1')
+        ret = self.container.list_files('/path/1')
+        self.assertEqual(ret, 'dummy1')
+        self.assertEqual(self.pebble.requests, [
+            ('list_files', '/path/1', None, False),
+        ])
+        self.pebble.requests = []
 
-            self.pebble.responses.append('dummy2')
-            ret = self.container.list_files('/path/2', pattern='*.txt', itself=True)
-            self.assertEqual(ret, 'dummy2')
-            self.assertEqual(self.pebble.requests, [
-                ('list_files', '/path/2', '*.txt', True),
-            ])
+        self.pebble.responses.append('dummy2')
+        ret = self.container.list_files('/path/2', pattern='*.txt', itself=True)
+        self.assertEqual(ret, 'dummy2')
+        self.assertEqual(self.pebble.requests, [
+            ('list_files', '/path/2', '*.txt', True),
+        ])
 
     def test_make_dir(self):
-        with patch('test.test_model.MockPebbleClient.get_services',
-                   side_effect=service_builder
-                   ):
-            self.container.make_dir('/path/1')
-            self.assertEqual(self.pebble.requests, [
-                ('make_dir', '/path/1', False, None, None, None, None, None),
-            ])
-            self.pebble.requests = []
+        self.container.make_dir('/path/1')
+        self.assertEqual(self.pebble.requests, [
+            ('make_dir', '/path/1', False, None, None, None, None, None),
+        ])
+        self.pebble.requests = []
 
-            self.container.make_dir('/path/2', make_parents=True, permissions=0o700,
-                                    user_id=12, user='bob', group_id=34, group='staff')
-            self.assertEqual(self.pebble.requests, [
-                ('make_dir', '/path/2', True, 0o700, 12, 'bob', 34, 'staff'),
-            ])
+        self.container.make_dir('/path/2', make_parents=True, permissions=0o700,
+                                user_id=12, user='bob', group_id=34, group='staff')
+        self.assertEqual(self.pebble.requests, [
+            ('make_dir', '/path/2', True, 0o700, 12, 'bob', 34, 'staff'),
+        ])
 
     def test_remove_path(self):
-        with patch('test.test_model.MockPebbleClient.get_services',
-                   side_effect=service_builder
-                   ):
-            self.container.remove_path('/path/1')
-            self.assertEqual(self.pebble.requests, [
-                ('remove_path', '/path/1', False),
-            ])
-            self.pebble.requests = []
+        self.container.remove_path('/path/1')
+        self.assertEqual(self.pebble.requests, [
+            ('remove_path', '/path/1', False),
+        ])
+        self.pebble.requests = []
 
-            self.container.remove_path('/path/2', recursive=True)
-            self.assertEqual(self.pebble.requests, [
-                ('remove_path', '/path/2', True),
-            ])
+        self.container.remove_path('/path/2', recursive=True)
+        self.assertEqual(self.pebble.requests, [
+            ('remove_path', '/path/2', True),
+        ])
+
+    def test_no_exception_with_contextmanager(self):
+        with self.assertLogs() as logs:
+            self.pebble.responses.append('dummy')
+            with self.container.is_ready():
+                raise ops.pebble.ConnectionError("Some dummy message")
+        self.assertIn("was raised due to", logs.records[0].getMessage())
+
+    def test_exception_without_contextmanager(self):
+        with self.assertRaises(ops.pebble.ConnectionError):
+            raise ops.pebble.ConnectionError("Some dummy message")
 
 
 class MockPebbleBackend(ops.model._ModelBackend):


### PR DESCRIPTION
Try to get a list of services from `Container`. If we get a `ConnectionError`, return False. This is a first-pass towards a better workflow for catching common errors when writing charms and Pebble is not ready yet (or is not ready again)
    
Since there are almost no operations we can actually perform if Pebble returns a `ConnectionError`, check for it first and log it if that's the case to give a hint to Charm authors in case they forget to check.
    
This required some extra test mocking due to the way `MockPebbleClient` is implemented.

Add a .ready property to Model.Container to see if Pebble is usable
        
Closes #553
