### PR TITLE
Add storage unit tests

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -905,8 +905,7 @@ class _TestingModelBackend:
         # { "storage_name": {"<ID1>": { <other-properties> }, ... }
         # <ID1>: device id that is key for given storage_name
         # Initialize the _storage_list with values present on metadata.yaml
-        self._storage_list = \
-            {k: {} for k, v in self._meta.storages.items()}
+        self._storage_list = {k for k in self._meta.storages}
         # Every new storage device gets an id from the _storage_id_counter.
         # That id is mapped back to the storage name on _storage_ids_map
         self._storage_ids_map = {}
@@ -1014,7 +1013,7 @@ class _TestingModelBackend:
             self._unit_status = {'status': status, 'message': message}
 
     def storage_list(self, name):
-        return [id for id, props in self._storage_list[name].items()]
+        return list(self._storage_list[name])
 
     def storage_get(self, storage_name_id, attribute):
         name = self._storage_ids_map[storage_name_id]
@@ -1022,7 +1021,7 @@ class _TestingModelBackend:
         return self._storage_list[name][id][attribute]
 
     def storage_add(self, name, count=1):
-        for i in range(0, count):
+        for i in range(count):
             storage_id = self._storage_id_counter
             self._storage_id_counter += 1
             self._storage_list[name][str(storage_id)] = {


### PR DESCRIPTION
* Implements storage_add, storage_list, storage_get in testing.py backend;
* Implements add_storage to be used to write unit tests.

---

As specified in Juju documentation: https://juju.is/docs/sdk/storage
StorageAttachedEvents should be called prior to InstallEvent. That is accomplished by emitting a storage_attached events just before install on begin_with_initial_hooks:

```
        for storage_name in self._meta.storages:
            if len(self._backend.storage_list(storage_name)) > 0:
                storage_name = storage_name.replace('-', '_')
                self._charm.on[storage_name].storage_attached.emit()
        # Storage done, emit install event
        self._charm.on.install.emit()
```

---

Examples:
The user can run add_storage to attach a number of disks to the charm unit.

```
...
        harness.add_storage("data", count=2)
        harness.update_config({
             ...
        })
        self.harness.begin_with_initial_hooks()
```

Fixes #263