### PR TITLE
Make Stored[Dict|List|Set] behave like the objects they pretend to be

### DIFF
--- a/ops/_private/json.py
+++ b/ops/_private/json.py
@@ -1,0 +1,33 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# autopep8 hates monkeypatching
+# autopep8: off
+# flake8: noqa
+
+"""Internal JSON helpers."""
+
+from json import JSONEncoder
+
+# Monkeypatch so Stored[Dict|List|Set] can be serialized
+
+
+def _storedstate_workaround(self, obj):
+    return getattr(obj.__class__, "to_json", _storedstate_workaround.default)(obj)
+
+
+_storedstate_workaround.default = JSONEncoder().default
+JSONEncoder.default = _storedstate_workaround
+
+from json import *

--- a/ops/_private/json.py
+++ b/ops/_private/json.py
@@ -20,11 +20,16 @@
 
 from json import JSONEncoder
 
+# Explicitly import to avoid circular ImportErrors
+import ops.framework
+
 # Monkeypatch so Stored[Dict|List|Set] can be serialized
 
 
 def _storedstate_workaround(self, obj):
-    return getattr(obj.__class__, "to_json", _storedstate_workaround.default)(obj)
+    if isinstance(obj, (ops.framework.StoredDict, ops.framework.StoredList)):
+        return getattr(obj.__class__, "to_json")(obj)
+    return _storedstate_workaround.default(obj)
 
 
 _storedstate_workaround.default = JSONEncoder().default

--- a/ops/_private/json.py
+++ b/ops/_private/json.py
@@ -28,7 +28,7 @@ import ops.framework
 
 def _storedstate_workaround(self, obj):
     if isinstance(obj, (ops.framework.StoredDict, ops.framework.StoredList)):
-        return getattr(obj.__class__, "to_json")(obj)
+        return obj.to_json()
     return _storedstate_workaround.default(obj)
 
 

--- a/ops/_private/yaml.py
+++ b/ops/_private/yaml.py
@@ -12,21 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# autopep8 hates monkeypatching
+# autopep8: off
+# flake8: noqa
+
 """Internal YAML helpers."""
 
-import yaml
+import yaml as pyyaml
 
 
 # Use C speedups if available
-_safe_loader = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
-_safe_dumper = getattr(yaml, 'CSafeDumper', yaml.SafeDumper)
+_safe_loader = getattr(pyyaml, "CSafeLoader", pyyaml.SafeLoader)
+_safe_dumper = getattr(pyyaml, "CSafeDumper", pyyaml.SafeDumper)
 
 
 def safe_load(stream):
     """Same as yaml.safe_load, but use fast C loader if available."""
-    return yaml.load(stream, Loader=_safe_loader)
+    return pyyaml.load(stream, Loader=_safe_loader)
 
 
 def safe_dump(data, stream=None, **kwargs):
     """Same as yaml.safe_dump, but use fast C dumper if available."""
-    return yaml.dump(data, stream=stream, Dumper=_safe_dumper, **kwargs)
+    return pyyaml.dump(data, stream=stream, Dumper=_safe_dumper, **kwargs)
+
+
+pyyaml.safe_load = safe_load
+pyyaml.safe_dump = safe_dump
+
+del safe_load, safe_dump
+from yaml import *

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -1060,7 +1060,7 @@ class StoredDict(collections.abc.MutableMapping):
 
     def to_json(self) -> str:
         """Return a JSON representation of the underlying object."""
-        return json.dumps(dict(self._under))
+        return json.dumps(dict(self._under), sort_keys=True)
 
     __repr__ = _wrapped_repr
 
@@ -1157,7 +1157,7 @@ class StoredList(collections.abc.MutableSequence):
 
     def to_json(self) -> str:
         """Return a JSON representation of the underlying object."""
-        return json.dumps(list(self._under))
+        return json.dumps(list(self._under), sort_keys=True)
 
     __repr__ = _wrapped_repr
 

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -29,6 +29,8 @@ import types
 import weakref
 
 from ops import charm
+from ops._private import json
+from ops._private import yaml
 from ops.storage import (
     NoSnapshotError,
     SQLiteStorage,
@@ -1051,10 +1053,25 @@ class StoredDict(collections.abc.MutableMapping):
             return self._under == other._under
         elif isinstance(other, collections.abc.Mapping):
             return self._under == other
+        elif isinstance(other, dict):
+            return dict(self._under) == other
         else:
             return NotImplemented
 
+    def to_json(self) -> str:
+        """Return a JSON representation of the underlying object."""
+        return json.dumps(dict(self._under))
+
     __repr__ = _wrapped_repr
+
+
+def _stored_dict_representer(dumper, data):
+    return dumper.represent_dict(
+        data._under
+    )
+
+
+yaml.add_representer(StoredDict, _stored_dict_representer)
 
 
 class StoredList(collections.abc.MutableSequence):
@@ -1093,6 +1110,8 @@ class StoredList(collections.abc.MutableSequence):
             return self._under == other._under
         elif isinstance(other, collections.abc.Sequence):
             return self._under == other
+        elif isinstance(other, list):
+            return list(self._under) == other
         else:
             return NotImplemented
 
@@ -1101,6 +1120,8 @@ class StoredList(collections.abc.MutableSequence):
             return self._under < other._under
         elif isinstance(other, collections.abc.Sequence):
             return self._under < other
+        elif isinstance(other, list):
+            return list(self._under) < other
         else:
             return NotImplemented
 
@@ -1109,6 +1130,8 @@ class StoredList(collections.abc.MutableSequence):
             return self._under <= other._under
         elif isinstance(other, collections.abc.Sequence):
             return self._under <= other
+        elif isinstance(other, list):
+            return list(self._under) <= other
         else:
             return NotImplemented
 
@@ -1117,6 +1140,8 @@ class StoredList(collections.abc.MutableSequence):
             return self._under > other._under
         elif isinstance(other, collections.abc.Sequence):
             return self._under > other
+        elif isinstance(other, list):
+            return list(self._under) > other
         else:
             return NotImplemented
 
@@ -1125,10 +1150,25 @@ class StoredList(collections.abc.MutableSequence):
             return self._under >= other._under
         elif isinstance(other, collections.abc.Sequence):
             return self._under >= other
+        elif isinstance(other, list):
+            return list(self._under) >= other
         else:
             return NotImplemented
 
+    def to_json(self) -> str:
+        """Return a JSON representation of the underlying object."""
+        return json.dumps(list(self._under))
+
     __repr__ = _wrapped_repr
+
+
+def _stored_list_representer(dumper, data):
+    return dumper.represent_list(
+        data._under
+    )
+
+
+yaml.add_representer(StoredList, _stored_list_representer)
 
 
 class StoredSet(collections.abc.MutableSet):
@@ -1179,6 +1219,8 @@ class StoredSet(collections.abc.MutableSet):
             return self._under <= other._under
         elif isinstance(other, collections.abc.Set):
             return self._under <= other
+        elif isinstance(other, set):
+            return self._under <= other
         else:
             return NotImplemented
 
@@ -1187,6 +1229,8 @@ class StoredSet(collections.abc.MutableSet):
             return self._under >= other._under
         elif isinstance(other, collections.abc.Set):
             return self._under >= other
+        elif isinstance(other, set):
+            return self._under >= other
         else:
             return NotImplemented
 
@@ -1194,6 +1238,8 @@ class StoredSet(collections.abc.MutableSet):
         if isinstance(other, StoredSet):
             return self._under == other._under
         elif isinstance(other, collections.abc.Set):
+            return self._under == other
+        elif isinstance(other, set):
             return self._under == other
         else:
             return NotImplemented

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -909,7 +909,7 @@ class TestStoredState(BaseTestCase):
     def test_stored_dict_json(self):
         self.assertEqual(stdlib_json.dumps(StoredDict(None, {})), '"{}"')
         self.assertEqual(stdlib_json.dumps(
-            StoredDict(None, {"a": 1, "b": 2})),
+            StoredDict(None, {"a": 1, "b": 2}), sort_keys=True),
             '"{\\"a\\": 1, \\"b\\": 2}"' # NOQA
         )
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -25,6 +25,9 @@ import unittest
 from unittest.mock import patch
 from pathlib import Path
 
+import json as stdlib_json
+import yaml as stdlib_yaml
+
 import logassert
 
 from ops import charm
@@ -46,6 +49,7 @@ from ops.framework import (
     StoredState,
     StoredStateData,
 )
+from ops._private import yaml
 from ops.storage import NoSnapshotError, SQLiteStorage
 from test.test_helpers import fake_script, BaseTestCase
 
@@ -894,9 +898,36 @@ class TestStoredState(BaseTestCase):
         self.assertEqual(repr(StoredDict(None, {})), "ops.framework.StoredDict()")
         self.assertEqual(repr(StoredDict(None, {"a": 1})), "ops.framework.StoredDict({'a': 1})")
 
+    def test_stored_dict_equality(self):
+        self.assertEqual(StoredDict(None, {}), {})
+        self.assertEqual(StoredDict(None, {"a": 1}), {"a": 1})
+
+    def test_stored_dict_yaml(self):
+        self.assertEqual(stdlib_yaml.dump(StoredDict(None, {})), '{}\n')
+        self.assertEqual(stdlib_yaml.dump(StoredDict(None, {"a": 1, "b": 2})), 'a: 1\nb: 2\n')
+
+    def test_stored_dict_json(self):
+        self.assertEqual(stdlib_json.dumps(StoredDict(None, {})), '"{}"')
+        self.assertEqual(stdlib_json.dumps(
+            StoredDict(None, {"a": 1, "b": 2})),
+            '"{\\"a\\": 1, \\"b\\": 2}"' # NOQA
+        )
+
     def test_stored_list_repr(self):
         self.assertEqual(repr(StoredList(None, [])), "ops.framework.StoredList()")
         self.assertEqual(repr(StoredList(None, [1, 2, 3])), 'ops.framework.StoredList([1, 2, 3])')
+
+    def test_stored_list_equality(self):
+        self.assertEqual(StoredList(None, []), [])
+        self.assertEqual(StoredList(None, [1, 2, 3]), [1, 2, 3])
+
+    def test_stored_list_yaml(self):
+        self.assertEqual(stdlib_yaml.dump(StoredList(None, [])), '[]\n')
+        self.assertEqual(stdlib_yaml.dump(StoredList(None, [1, 2, 3])), '- 1\n- 2\n- 3\n')
+
+    def test_stored_list_json(self):
+        self.assertEqual(stdlib_json.dumps(StoredList(None, [])), '"[]"')
+        self.assertEqual(stdlib_json.dumps(StoredList(None, [1, 2, 3])), '"[1, 2, 3]"')
 
     def test_stored_set_repr(self):
         self.assertEqual(repr(StoredSet(None, set())), 'ops.framework.StoredSet()')

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -909,7 +909,7 @@ class TestStoredState(BaseTestCase):
     def test_stored_dict_json(self):
         self.assertEqual(stdlib_json.dumps(StoredDict(None, {})), '"{}"')
         self.assertEqual(stdlib_json.dumps(
-            StoredDict(None, {"a": 1, "b": 2}), sort_keys=True),
+            StoredDict(None, {"a": 1, "b": 2})),
             '"{\\"a\\": 1, \\"b\\": 2}"' # NOQA
         )
 


### PR DESCRIPTION
Monkeypatch yaml and json so they can be dumped without casting, and add equality operators for the types in _under so they can be compared without casting all over the place.

Yes, monkeypatching is ugly, and I'm not a fan of it, but forcing Charm authors to cast objects over and over again to make a `StoredDict` behave like a `dict` is a terrible experience.

Closes #527 