### PR TITLE
test harness: remove units via a copy rather than in-place

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -424,7 +424,7 @@ class Harness(typing.Generic[CharmType]):
         except KeyError as e:
             raise model.RelationNotFoundError from e
 
-        for unit_name in self._backend._relation_list_map[relation_id]:
+        for unit_name in sorted(self._backend._relation_list_map[relation_id], reverse=True):
             self.remove_relation_unit(relation_id, unit_name)
 
         self._emit_relation_broken(relation_name, relation_id, remote_app)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -424,7 +424,7 @@ class Harness(typing.Generic[CharmType]):
         except KeyError as e:
             raise model.RelationNotFoundError from e
 
-        for unit_name in sorted(self._backend._relation_list_map[relation_id], reverse=True):
+        for unit_name in self._backend._relation_list_map[relation_id].copy():
             self.remove_relation_unit(relation_id, unit_name)
 
         self._emit_relation_broken(relation_name, relation_id, remote_app)


### PR DESCRIPTION
when units are removed out-of-order things break (some unit data bags are not removed).
with `sorted(..., reverse=True)` it works.
Tested with: https://github.com/canonical/alertmanager-operator/pull/24/commits/52b1f6944ec03b61a61548fdab611fe2b1f1486e