### PR TITLE
Make Container.restart() semantics operate more like system services

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1118,7 +1118,9 @@ class Container:
         if not service_names:
             raise TypeError('restart expected at least 1 argument, got 0')
 
-        self._pebble.stop_services(service_names)
+        for svc in self.get_services(service_names):
+            if svc.is_running():
+                self._pebble.stop_services(svc.name)
         self._pebble.start_services(service_names)
 
     def stop(self, *service_names: str):


### PR DESCRIPTION
Check whether the services are running before stopping them so we don't hit `pebble.ChangeError` if they're stopped, and the semantics are more familiar to anyone who may expect it to behave like systemd/sysvinit/etc.