### PR TITLE
Fix Container.restart() accidentally operating on strings, add a testcase

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1118,7 +1118,7 @@ class Container:
         if not service_names:
             raise TypeError('restart expected at least 1 argument, got 0')
 
-        for svc in self.get_services(service_names):
+        for svc in self.get_services(*service_names).values():
             if svc.is_running():
                 self._pebble.stop_services(svc.name)
         self._pebble.start_services(service_names)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -827,6 +827,24 @@ containers:
     def test_start_no_arguments(self):
         with self.assertRaises(TypeError):
             self.container.start()
+    
+    def test_restart(self):
+        two_services = [
+            self._make_service('foo', 'enabled', 'active'),
+            self._make_service('bar', 'disabled', 'inactive'),
+        ]
+        self.pebble.responses.append(two_services)
+        self.container.restart('foo')
+        self.pebble.responses.append(two_services)
+        self.container.restart('foo', 'bar')
+        self.assertEqual(self.pebble.requests, [
+            ('get_services', ('foo',)),
+            ('stop', 'foo'),
+            ('start', ('foo',)),
+            ('get_services', ('foo','bar')),
+            ('stop', 'foo'),
+            ('start', ('foo','bar',)),
+        ])
 
     def test_stop(self):
         self.container.stop('foo')

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -827,7 +827,7 @@ containers:
     def test_start_no_arguments(self):
         with self.assertRaises(TypeError):
             self.container.start()
-    
+
     def test_restart(self):
         two_services = [
             self._make_service('foo', 'enabled', 'active'),
@@ -841,9 +841,9 @@ containers:
             ('get_services', ('foo',)),
             ('stop', 'foo'),
             ('start', ('foo',)),
-            ('get_services', ('foo','bar')),
+            ('get_services', ('foo', 'bar')),
             ('stop', 'foo'),
-            ('start', ('foo','bar',)),
+            ('start', ('foo', 'bar',)),
         ])
 
     def test_stop(self):


### PR DESCRIPTION
My fault for writing patches first thing in the morning and not adding a test...