### PR TITLE
Add .copy() to Stored<type> objects

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -1097,6 +1097,19 @@ class StoredList(collections.abc.MutableSequence):
         self._under.append(value)
         self._stored_data.dirty = True
 
+    def as_list(self) -> typing.List:
+        """Return a copy of the backing data as a list.
+
+        Any list copy in Python other than copy.deepcopy() still references the
+        original, including .copy(), some_list[:], list(some_list), and so on. `as_list`
+        matches this behavior.
+        """
+        return list(self._under)
+
+    def copy(self) -> 'StoredList':
+        """Returns a copy of the object."""
+        return StoredList(self._stored_data, self._under.copy())
+
     def __eq__(self, other):
         if isinstance(other, StoredList):
             return self._under == other._under
@@ -1162,6 +1175,14 @@ class StoredSet(collections.abc.MutableSet):
         """
         self._under.discard(key)
         self._stored_data.dirty = True
+
+    def as_set(self) -> typing.Set:
+        """Return a copy of the backing data as a set."""
+        return set(self._under)
+
+    def copy(self) -> 'StoredSet':
+        """Returns a copy of the object."""
+        return StoredSet(self._stored_data, self._under.copy())
 
     def __contains__(self, key):
         return key in self._under

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -26,6 +26,7 @@ import pdb
 import re
 import sys
 import types
+import typing
 import weakref
 
 from ops import charm
@@ -1053,6 +1054,10 @@ class StoredDict(collections.abc.MutableMapping):
             return self._under == other
         else:
             return NotImplemented
+
+    def copy(self) -> typing.Dict:
+        """Return a copy of the backing data as a dict."""
+        return dict(self._under)
 
     __repr__ = _wrapped_repr
 

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -1055,9 +1055,13 @@ class StoredDict(collections.abc.MutableMapping):
         else:
             return NotImplemented
 
-    def copy(self) -> typing.Dict:
+    def as_dict(self) -> typing.Dict:
         """Return a copy of the backing data as a dict."""
         return dict(self._under)
+
+    def copy(self) -> 'StoredDict':
+        """Returns a copy of the object."""
+        return StoredDict(self._stored_data, self._under.copy())
 
     __repr__ = _wrapped_repr
 

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -1059,9 +1059,9 @@ class StoredDict(collections.abc.MutableMapping):
         """Return a copy of the backing data as a dict."""
         return dict(self._under)
 
-    def copy(self) -> 'StoredDict':
-        """Returns a copy of the object."""
-        return StoredDict(self._stored_data, self._under.copy())
+    def copy(self) -> typing.Dict:
+        """Returns a copy of the backing `dict` as a deep copy dict."""
+        return dict(self._under)
 
     __repr__ = _wrapped_repr
 
@@ -1106,9 +1106,14 @@ class StoredList(collections.abc.MutableSequence):
         """
         return list(self._under)
 
-    def copy(self) -> 'StoredList':
-        """Returns a copy of the object."""
-        return StoredList(self._stored_data, self._under.copy())
+    def copy(self) -> typing.List:
+        """Returns a copy of the backing `list` as a deep copy.
+
+        Any list copy in Python other than copy.deepcopy() still references the
+        original, including .copy(), some_list[:], list(some_list), and so on. `as_list`
+        matches this behavior.
+        """
+        return list(self._under)
 
     def __eq__(self, other):
         if isinstance(other, StoredList):
@@ -1181,8 +1186,8 @@ class StoredSet(collections.abc.MutableSet):
         return set(self._under)
 
     def copy(self) -> 'StoredSet':
-        """Returns a copy of the object."""
-        return StoredSet(self._stored_data, self._under.copy())
+        """Returns a copy of the backing `set`."""
+        return set(self._under)
 
     def __contains__(self, key):
         return key in self._under

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -1055,10 +1055,6 @@ class StoredDict(collections.abc.MutableMapping):
         else:
             return NotImplemented
 
-    def as_dict(self) -> typing.Dict:
-        """Return a copy of the backing data as a dict."""
-        return dict(self._under)
-
     def copy(self) -> typing.Dict:
         """Returns a copy of the backing `dict` as a deep copy dict."""
         return dict(self._under)
@@ -1097,17 +1093,8 @@ class StoredList(collections.abc.MutableSequence):
         self._under.append(value)
         self._stored_data.dirty = True
 
-    def as_list(self) -> typing.List:
-        """Return a copy of the backing data as a list.
-
-        Any list copy in Python other than copy.deepcopy() still references the
-        original, including .copy(), some_list[:], list(some_list), and so on. `as_list`
-        matches this behavior.
-        """
-        return list(self._under)
-
     def copy(self) -> typing.List:
-        """Returns a copy of the backing `list` as a deep copy.
+        """Returns a copy of the backing `list`.
 
         Any list copy in Python other than copy.deepcopy() still references the
         original, including .copy(), some_list[:], list(some_list), and so on. `as_list`
@@ -1180,10 +1167,6 @@ class StoredSet(collections.abc.MutableSet):
         """
         self._under.discard(key)
         self._stored_data.dirty = True
-
-    def as_set(self) -> typing.Set:
-        """Return a copy of the backing data as a set."""
-        return set(self._under)
 
     def copy(self) -> 'StoredSet':
         """Returns a copy of the backing `set`."""

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -898,7 +898,7 @@ class TestStoredState(BaseTestCase):
         sd = StoredDict(None, {"a": 1})
         self.assertEqual(sd.copy(), sd)
 
-    def test_stored_dict_copyreferences_original(self):
+    def test_stored_dict_copy_references_original(self):
         class TempStorage(object):
             dirty = False
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -908,7 +908,7 @@ class TestStoredState(BaseTestCase):
 
         self.assertEqual(copy["a"], 1)
         self.assertNotIn("b", copy)
-        
+
         copy["b"] = 456
         self.assertNotEqual(sd["b"], copy["b"])
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -935,9 +935,38 @@ class TestStoredState(BaseTestCase):
         self.assertEqual(repr(StoredList(None, [])), "ops.framework.StoredList()")
         self.assertEqual(repr(StoredList(None, [1, 2, 3])), 'ops.framework.StoredList([1, 2, 3])')
 
+    def test_stored_list_copy(self):
+        sl = StoredList(None, [1, "a"])
+        self.assertEqual(sl.copy(), sl)
+
+    def test_stored_list_copy_references_original(self):
+        class TempStorage(object):
+            dirty = False
+
+        sl = StoredList(TempStorage, [1, 2, [3, 4]])
+        copy = sl.copy()
+
+        sl[0] = 2
+        copy[0] = 3
+        self.assertEqual(2, sl[0])
+        self.assertEqual(3, copy[0])
+
+        sl[2][0] = 5
+        self.assertEqual(5, copy[2][0])
+
+    def test_stored_list_as_list(self):
+        self.assertEqual(StoredList(None, [1]).as_list(), [1])
+
     def test_stored_set_repr(self):
         self.assertEqual(repr(StoredSet(None, set())), 'ops.framework.StoredSet()')
         self.assertEqual(repr(StoredSet(None, {1})), 'ops.framework.StoredSet({1})')
+
+    def test_stored_set_copy(self):
+        ss = StoredSet(None, {1})
+        self.assertEqual(ss.copy(), {1})
+
+    def test_stored_list_as_set(self):
+        self.assertEqual(StoredSet(None, {1}).as_set(), {1})
 
     def test_basic_state_storage(self):
         class SomeObject(Object):

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -898,20 +898,20 @@ class TestStoredState(BaseTestCase):
         sd = StoredDict(None, {"a": 1})
         self.assertEqual(sd.copy(), sd)
 
-    def test_stored_dict_copy_references_original(self):
+    def test_stored_dict_copy_does_not_reference_original(self):
         class TempStorage(object):
             dirty = False
-
-        sd = StoredDict(TempStorage, {"a": 1, "b": {"c": 2}})
-        copy = sd.copy()
+        sd = StoredDict(TempStorage(), {"a": 1})
+        copy = sd.as_dict()
 
         sd["a"] = 2
-        copy["a"] = 3
-        self.assertEqual(2, sd["a"])
-        self.assertEqual(3, copy["a"])
+        sd["b"] = 123
 
-        sd["b"]["c"] = 4
-        self.assertEqual(4, copy["b"]["c"])
+        self.assertEqual(copy["a"], 1)
+        self.assertNotIn("b", copy)
+
+        copy["b"] = 456
+        self.assertNotEqual(sd["b"], copy["b"])
 
     def test_stored_dict_as_dict(self):
         self.assertEqual(StoredDict(None, {"a": 1}).as_dict(), {"a": 1})

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -894,6 +894,9 @@ class TestStoredState(BaseTestCase):
         self.assertEqual(repr(StoredDict(None, {})), "ops.framework.StoredDict()")
         self.assertEqual(repr(StoredDict(None, {"a": 1})), "ops.framework.StoredDict({'a': 1})")
 
+    def test_stored_dict_copy(self):
+        self.assertEqual(StoredDict(None, {"a": 1}).copy(), {"a": 1})
+
     def test_stored_list_repr(self):
         self.assertEqual(repr(StoredList(None, [])), "ops.framework.StoredList()")
         self.assertEqual(repr(StoredList(None, [1, 2, 3])), 'ops.framework.StoredList([1, 2, 3])')

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -902,25 +902,7 @@ class TestStoredState(BaseTestCase):
         class TempStorage(object):
             dirty = False
         sd = StoredDict(TempStorage(), {"a": 1})
-        copy = sd.as_dict()
-
-        sd["a"] = 2
-        sd["b"] = 123
-
-        self.assertEqual(copy["a"], 1)
-        self.assertNotIn("b", copy)
-
-        copy["b"] = 456
-        self.assertNotEqual(sd["b"], copy["b"])
-
-    def test_stored_dict_as_dict(self):
-        self.assertEqual(StoredDict(None, {"a": 1}).as_dict(), {"a": 1})
-
-    def test_stored_dict_as_dict_does_not_reference_original(self):
-        class TempStorage(object):
-            dirty = False
-        sd = StoredDict(TempStorage(), {"a": 1})
-        copy = sd.as_dict()
+        copy = sd.copy()
 
         sd["a"] = 2
         sd["b"] = 123
@@ -954,9 +936,6 @@ class TestStoredState(BaseTestCase):
         sl[2][0] = 5
         self.assertEqual(5, copy[2][0])
 
-    def test_stored_list_as_list(self):
-        self.assertEqual(StoredList(None, [1]).as_list(), [1])
-
     def test_stored_set_repr(self):
         self.assertEqual(repr(StoredSet(None, set())), 'ops.framework.StoredSet()')
         self.assertEqual(repr(StoredSet(None, {1})), 'ops.framework.StoredSet({1})')
@@ -964,9 +943,6 @@ class TestStoredState(BaseTestCase):
     def test_stored_set_copy(self):
         ss = StoredSet(None, {1})
         self.assertEqual(ss.copy(), {1})
-
-    def test_stored_list_as_set(self):
-        self.assertEqual(StoredSet(None, {1}).as_set(), {1})
 
     def test_basic_state_storage(self):
         class SomeObject(Object):

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -897,6 +897,21 @@ class TestStoredState(BaseTestCase):
     def test_stored_dict_copy(self):
         self.assertEqual(StoredDict(None, {"a": 1}).copy(), {"a": 1})
 
+    def test_stored_dict_copy_does_not_reference_original(self):
+        class TempStorage(object):
+            dirty = False
+        sd = StoredDict(TempStorage(), {"a": 1})
+        copy = sd.copy()
+
+        sd["a"] = 2
+        sd["b"] = 123
+
+        self.assertEqual(copy["a"], 1)
+        self.assertNotIn("b", copy)
+        
+        copy["b"] = 456
+        self.assertNotEqual(sd["b"], copy["b"])
+
     def test_stored_list_repr(self):
         self.assertEqual(repr(StoredList(None, [])), "ops.framework.StoredList()")
         self.assertEqual(repr(StoredList(None, [1, 2, 3])), 'ops.framework.StoredList([1, 2, 3])')

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -895,13 +895,32 @@ class TestStoredState(BaseTestCase):
         self.assertEqual(repr(StoredDict(None, {"a": 1})), "ops.framework.StoredDict({'a': 1})")
 
     def test_stored_dict_copy(self):
-        self.assertEqual(StoredDict(None, {"a": 1}).copy(), {"a": 1})
+        sd = StoredDict(None, {"a": 1})
+        self.assertEqual(sd.copy(), sd)
 
-    def test_stored_dict_copy_does_not_reference_original(self):
+    def test_stored_dict_copyreferences_original(self):
+        class TempStorage(object):
+            dirty = False
+
+        sd = StoredDict(TempStorage, {"a": 1, "b": {"c": 2}})
+        copy = sd.copy()
+
+        sd["a"] = 2
+        copy["a"] = 3
+        self.assertEqual(2, sd["a"])
+        self.assertEqual(3, copy["a"])
+
+        sd["b"]["c"] = 4
+        self.assertEqual(4, copy["b"]["c"])
+
+    def test_stored_dict_as_dict(self):
+        self.assertEqual(StoredDict(None, {"a": 1}).as_dict(), {"a": 1})
+
+    def test_stored_dict_as_dict_does_not_reference_original(self):
         class TempStorage(object):
             dirty = False
         sd = StoredDict(TempStorage(), {"a": 1})
-        copy = sd.copy()
+        copy = sd.as_dict()
 
         sd["a"] = 2
         sd["b"] = 123


### PR DESCRIPTION
Simply enough, convert `StoredDict._under` to a `dict` and pass it back. Without a complete re-implementation of the thorny parts of the "real" `dict.copy()`, we get slightly different behavior, but also avoid the sometimes-confusing changes in referenced objects