### PR TITLE
Fix _should_use_controller_storage for metadata v2 charms.

### DIFF
--- a/ops/main.py
+++ b/ops/main.py
@@ -308,7 +308,7 @@ def _should_use_controller_storage(db_path: Path, meta: ops.charm.CharmMeta) -> 
         return False
 
     # if you're not in k8s you don't need controller storage
-    if 'kubernetes' not in meta.series:
+    if 'kubernetes' not in meta.cloud:
         logger.debug("Using local storage: not a kubernetes charm")
         return False
 


### PR DESCRIPTION
This PR comprises a hack to fix _should_use_controller_storage for
metadata v2 charms.

A more complete fix relies on not yet implemented facilities in Juju
for determining the underlying cloud a charm is running on.

For now, we mirror a similar hack in Juju core, guessing that we are
on kubernetes if (and only if) this is a metadata v2 charm with a list
of containers.

We place the hack directly inside the CharmMeta class, so that we can
parse the metadata.yaml in a backwards compatible way, and don't have
to completely implement metadata v2 support.