### PR TITLE
Remove triple backticks from ops.model docs since Sphinx doesn't like them

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1074,6 +1074,7 @@ class Container:
          raising exceptions.
 
         Example::
+
             container = self.unit.get_container("example")
             with container.is_ready() as c:
                 c.pull('/does/not/exist')
@@ -1092,6 +1093,7 @@ class Container:
         error if the container is not ready.
 
         Example::
+
             if container.is_ready():
                 do_something()
             else:

--- a/ops/model.py
+++ b/ops/model.py
@@ -1074,7 +1074,6 @@ class Container:
          raising exceptions.
 
         Example:
-            ```
             container = self.unit.get_container("example")
             with container.is_ready() as c:
                 c.pull('/does/not/exist')
@@ -1083,7 +1082,6 @@ class Container:
                 # was caught earlier
                 c.get_service("foo")
             c.completed # False
-            ```
 
             This will result in an `ERROR` log from PathError, but not a
             traceback. In addition, the block running inside the contextmanager

--- a/ops/model.py
+++ b/ops/model.py
@@ -1073,7 +1073,7 @@ class Container:
          from the underlying Pebble operations will log error messages rather than
          raising exceptions.
 
-        Example:
+        Example::
             container = self.unit.get_container("example")
             with container.is_ready() as c:
                 c.pull('/does/not/exist')
@@ -1091,8 +1091,7 @@ class Container:
         :meth:`is_ready` can also be used as a bare function, which will log an
         error if the container is not ready.
 
-        Example:
-            ```
+        Example::
             if container.is_ready():
                 do_something()
             else:


### PR DESCRIPTION
As the header, really.

Closes #599 