### PR TITLE
Proposed update to container.is_ready implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ __pycache__
 /docs/_build
 *~
 .venv
+venv
 .vscode

--- a/ops/model.py
+++ b/ops/model.py
@@ -1048,7 +1048,7 @@ class Container:
         return self._pebble
 
     def can_connect(self) -> bool:
-        """Check whether or not Pebble is ready as a simple property.
+        """Report whether the Pebble API is reachable in the container.
 
         :meth:`can_connect` returns a bool that indicates whether the Pebble API is available at
         the time the method is called. It does not guard against the Pebble API becoming

--- a/ops/model.py
+++ b/ops/model.py
@@ -1078,6 +1078,11 @@ class Container:
             # cannot be read. Both of these are a likely indicator that something is wrong.
             logger.error("Got an unexpected response from the Pebble API: %s", str(e))
             return False
+        except FileNotFoundError as e:
+            # In some cases, charm authors can attempt to hit the Pebble API before it has had the
+            # chance to create the UNIX socket in the shared volume.
+            logger.error("Could not connect to Pebble API: UNIX socket not found", str(e))
+            return False
         return True
 
     def autostart(self):

--- a/ops/model.py
+++ b/ops/model.py
@@ -1061,7 +1061,10 @@ class Container:
 
             container = self.unit.get_container("example")
             if container.can_connect():
-                c.pull('/does/not/exist')
+                try:
+                    c.pull('/does/not/exist')
+                except ProtocolError, PathError:
+                    # handle it
             else:
                 event.defer()
         """

--- a/ops/model.py
+++ b/ops/model.py
@@ -1047,12 +1047,12 @@ class Container:
         """The low-level :class:`ops.pebble.Client` instance for this container."""
         return self._pebble
 
-    def is_ready(self) -> bool:
+    def can_connect(self) -> bool:
         """Check whether or not Pebble is ready as a simple property.
 
-        :meth:`is_ready` returns a bool that indicates whether the Pebble API is available at the
-        time the method is called. It does not guard against the Pebble API becoming unavailable,
-        and should be treated as a 'point in time' status only.
+        :meth:`can_connect` returns a bool that indicates whether the Pebble API is available at
+        the time the method is called. It does not guard against the Pebble API becoming
+        unavailable, and should be treated as a 'point in time' status only.
 
         If the Pebble API later fails, serious consideration should be given as to the reason for
         this.
@@ -1060,7 +1060,7 @@ class Container:
         Example::
 
             container = self.unit.get_container("example")
-            if container.is_ready():
+            if container.can_connect():
                 c.pull('/does/not/exist')
             else:
                 event.defer()

--- a/ops/model.py
+++ b/ops/model.py
@@ -1074,17 +1074,17 @@ class Container:
             # instance that is in fact 'ready'.
             self._pebble.get_system_info()
         except pebble.ConnectionError as e:
-            logger.error("Could not connect to Pebble API: %s", e.message())
-            return False
-        except pebble.APIError as e:
-            # An API error is only raised when the Pebble API returns invalid JSON, or the response
-            # cannot be read. Both of these are a likely indicator that something is wrong.
-            logger.error("Got an unexpected response from the Pebble API: %s", str(e))
+            logger.debug("Pebble API is not ready; ConnectionError: %s", e.message())
             return False
         except FileNotFoundError as e:
             # In some cases, charm authors can attempt to hit the Pebble API before it has had the
             # chance to create the UNIX socket in the shared volume.
-            logger.error("Could not connect to Pebble API: UNIX socket not found", str(e))
+            logger.debug("Pebble API is not ready; UNIX socket not found:", str(e))
+            return False
+        except pebble.APIError as e:
+            # An API error is only raised when the Pebble API returns invalid JSON, or the response
+            # cannot be read. Both of these are a likely indicator that something is wrong.
+            logger.warning("Pebble API is not ready; APIError: %s", str(e))
             return False
         return True
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -26,17 +26,15 @@ import tempfile
 import time
 import typing
 import weakref
-
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, MutableMapping
 from pathlib import Path
-from subprocess import run, PIPE, CalledProcessError
+from subprocess import PIPE, CalledProcessError, run
 
-from ops._private import yaml
-from ops.jujuversion import JujuVersion
 import ops
 import ops.pebble as pebble
-
+from ops._private import yaml
+from ops.jujuversion import JujuVersion
 
 logger = logging.getLogger(__name__)
 
@@ -1044,7 +1042,6 @@ class Container:
     Attributes:
         name: The name of the container from metadata.yaml (eg, 'postgres').
     """
-
     def __init__(self, name, backend, pebble_client=None):
         self.name = name
 
@@ -1052,54 +1049,42 @@ class Container:
             socket_path = '/charm/containers/{}/pebble.socket'.format(name)
             pebble_client = backend.get_pebble(socket_path)
         self._pebble = pebble_client
-        self._completed = None
 
     @property
     def pebble(self) -> 'pebble.Client':
         """The low-level :class:`ops.pebble.Client` instance for this container."""
         return self._pebble
 
-    @property
-    def completed(self) -> bool:
-        """Whether or not a :meth:`is_ready` context finished successfully."""
-        return self._completed
-
-    def is_ready(self) -> '_ContainerReady':
+    def is_ready(self) -> bool:
         """Check whether or not Pebble is ready as a simple property.
 
-        :meth:`is_ready` returns a :class:_ContainerReady `contextmanager` which
-         can be used in charms to wrap :class:`Container` operations which depend
-         on the Pebble backend being available. When `is_ready` is used, exceptions
-         from the underlying Pebble operations will log error messages rather than
-         raising exceptions.
+        :meth:`is_ready` returns a bool that indicates whether the Pebble API is available at the
+        time the method is called. It does not guard against the Pebble API becoming unavailable,
+        and should be treated as a 'point in time' status only.
+
+        If the Pebble API later fails, serious consideration should be given as to the reasoning
+        for this.
 
         Example::
 
             container = self.unit.get_container("example")
-            with container.is_ready() as c:
-                c.pull('/does/not/exist')
-
-                # This point of execution will not be reached if an exception
-                # was caught earlier
-                c.get_service("foo")
-            c.completed # False
-
-            This will result in an `ERROR` log from PathError, but not a
-            traceback. In addition, the block running inside the contextmanager
-            will exit and return to the previous point of execution. Whether
-            or not the block completed successfully is available as a property
-
-        :meth:`is_ready` can also be used as a bare function, which will log an
-        error if the container is not ready.
-
-        Example::
-
             if container.is_ready():
-                do_something()
+                c.pull('/does/not/exist')
             else:
-                do_something_else()
+                event.defer()
         """
-        return _ContainerReady(self)
+        try:
+            # TODO: This call to `get_system_info` should be replaced with a call to a more
+            # appropriate endpoint that has stronger connotations of what constitutes a Pebble
+            # instance that is in fact 'ready'
+            self._pebble.get_system_info()
+        except pebble.ConnectionError as e:
+            logger.error("Could not connect to Pebble API: %s", e.message)
+            return False
+        except pebble.TimeoutError as e:
+            logger.error("Timeout when connecting to Pebble API: %s", e.message)
+            return False
+        return True
 
     def autostart(self):
         """Autostart all services marked as startup: enabled."""
@@ -1260,47 +1245,6 @@ class Container:
         self._pebble.remove_path(path, recursive=recursive)
 
 
-class _ContainerReady:
-    """Represents whether or not a container is ready as a Context Manager.
-
-    This class should not be instantiated directly, instead use :meth:`Container.is_ready`
-
-    Attributes:
-        container: A :class:`Container` object
-    """
-
-    def __init__(self, container: Container):
-        self.container = container
-
-    def __bool__(self) -> bool:
-        try:
-            # We don't care at all whether not the services are up in
-            # this case, just whether Pebble throws an error. If it doesn't,
-            # carry on with the contextmanager.
-            self.container._pebble.get_services()
-        except ErrorsWithMessage as e:
-            logger.error("Pebble is not ready! (%s) was raised due to: %s",
-                         e.name, e.message)
-            return False
-        return True
-
-    def __enter__(self) -> 'Container':
-        self.container._completed = True
-        return self.container
-
-    def __exit__(self, exc_type, e, exc_tb):
-        if exc_type in ErrorsWithMessage:
-            logger.error("(%s) was raised due to: %s", e.name, e.message)
-            self.container._completed = False
-            return True
-
-        if exc_type is pebble.ChangeError:
-            logger.error("Pebble could not apply the requested change (%s) "
-                         "due to %s", e.change, e.err)
-            self.container._completed = False
-            return True
-
-
 class ContainerMapping(Mapping):
     """Map of container names to Container objects.
 
@@ -1350,19 +1294,6 @@ class ServiceInfoMapping(Mapping):
 class ModelError(Exception):
     """Base class for exceptions raised when interacting with the Model."""
     pass
-
-
-class UnknownServiceError(Exception):
-    """Raised by :class:`Container` objects when Pebble cannot find a service.
-
-    This is done so authors can have a single catch-all exception if the service
-    cannot be found, typically due to asking for the service before
-    :meth:`Container.add_layer` has been called.
-    """
-
-
-class PebbleNotReadyError(Exception):
-    """Raised by :class:`Container` methods if the underlying Pebble socket returns an error."""
 
 
 class TooManyRelatedAppsError(ModelError):

--- a/ops/model.py
+++ b/ops/model.py
@@ -38,14 +38,6 @@ from ops.jujuversion import JujuVersion
 
 logger = logging.getLogger(__name__)
 
-ErrorsWithMessage = (
-    pebble.APIError,
-    pebble.ConnectionError,
-    pebble.PathError,
-    pebble.ProtocolError,
-    pebble.TimeoutError,
-)
-
 
 class Model:
     """Represents the Juju Model as seen from this unit.
@@ -1062,8 +1054,8 @@ class Container:
         time the method is called. It does not guard against the Pebble API becoming unavailable,
         and should be treated as a 'point in time' status only.
 
-        If the Pebble API later fails, serious consideration should be given as to the reasoning
-        for this.
+        If the Pebble API later fails, serious consideration should be given as to the reason for
+        this.
 
         Example::
 
@@ -1076,13 +1068,15 @@ class Container:
         try:
             # TODO: This call to `get_system_info` should be replaced with a call to a more
             # appropriate endpoint that has stronger connotations of what constitutes a Pebble
-            # instance that is in fact 'ready'
+            # instance that is in fact 'ready'.
             self._pebble.get_system_info()
         except pebble.ConnectionError as e:
-            logger.error("Could not connect to Pebble API: %s", e.message)
+            logger.error("Could not connect to Pebble API: %s", e.message())
             return False
-        except pebble.TimeoutError as e:
-            logger.error("Timeout when connecting to Pebble API: %s", e.message)
+        except pebble.APIError as e:
+            # An API error is only raised when the Pebble API returns invalid JSON, or the response
+            # cannot be read. Both of these are a likely indicator that something is wrong.
+            logger.error("Got an unexpected response from the Pebble API: %s", str(e))
             return False
         return True
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -816,6 +816,10 @@ containers:
         self.container.autostart()
         self.assertEqual(self.pebble.requests, [('autostart',)])
 
+    def test_get_system_info(self):
+        self.container.is_ready()
+        self.assertEqual(self.pebble.requests, [('get_system_info',)])
+
     def test_start(self):
         self.container.start('foo')
         self.container.start('foo', 'bar')
@@ -1031,18 +1035,6 @@ containers:
             ('remove_path', '/path/2', True),
         ])
 
-    def test_no_exception_with_contextmanager(self):
-        with self.assertLogs() as logs:
-            self.pebble.responses.append('dummy')
-            with self.container.is_ready() as c:
-                raise ops.pebble.ConnectionError("Some dummy message")
-        self.assertIn("was raised due to", logs.records[0].getMessage())
-        self.assertEqual(c.completed, False)
-
-    def test_exception_without_contextmanager(self):
-        with self.assertRaises(ops.pebble.ConnectionError):
-            raise ops.pebble.ConnectionError("Some dummy message")
-
     def test_bare_is_ready_call(self):
         self.pebble.responses.append('dummy')
         self.assertTrue(self.container.is_ready())
@@ -1061,6 +1053,9 @@ class MockPebbleClient:
 
     def autostart_services(self):
         self.requests.append(('autostart',))
+
+    def get_system_info(self):
+        self.requests.append(('get_system_info',))
 
     def start_services(self, service_names):
         self.requests.append(('start', service_names))

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -13,23 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import OrderedDict
-import json
 import ipaddress
+import json
 import os
 import pathlib
-from textwrap import dedent
 import unittest
+from collections import OrderedDict
+from test.test_helpers import fake_script, fake_script_calls
+from textwrap import dedent
 
-import ops.model
 import ops.charm
+import ops.model
 import ops.pebble
 import ops.testing
-from ops.charm import RelationMeta, RelationRole
-
 from ops._private import yaml
-
-from test.test_helpers import fake_script, fake_script_calls
+from ops.charm import RelationMeta, RelationRole
 
 
 class TestModel(unittest.TestCase):
@@ -817,7 +815,7 @@ containers:
         self.assertEqual(self.pebble.requests, [('autostart',)])
 
     def test_get_system_info(self):
-        self.container.is_ready()
+        self.container.can_connect()
         self.assertEqual(self.pebble.requests, [('get_system_info',)])
 
     def test_start(self):
@@ -1035,9 +1033,9 @@ containers:
             ('remove_path', '/path/2', True),
         ])
 
-    def test_bare_is_ready_call(self):
+    def test_bare_can_connect_call(self):
         self.pebble.responses.append('dummy')
-        self.assertTrue(self.container.is_ready())
+        self.assertTrue(self.container.can_connect())
 
 
 class MockPebbleBackend(ops.model._ModelBackend):


### PR DESCRIPTION
Proposed implementation for `is_ready()` as a method for checking that a given Pebble instance is 'up' and its API is reachable. The primary difference here is removal of the context manager in favour of a simpler approach. This implementation also renames `is_ready` -> `can_connect`.

The primary logic here is that checking whether the Pebble API is available should only be a point-in-time check. This change was initially implemented to catch the case where some hook (usually `config-changed`) fires before the Pebble API was up, and prevent *all the charms* from needing a big long try/except in the same place.

With this implementation, we only provide that point-in-time check, that can be used before some operation in an event handler. If the Pebble API becomes unavailable *later in the same hook*, then something *very bad* has happened, and an error bubbling up is probably the right thing.