### PR TITLE
Extended and modified Harness storage API

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1021,6 +1021,13 @@ class StorageMapping(Mapping):
                               ' it is not present in the charm metadata').format(storage_name))
         self._backend.storage_add(storage_name, count)
 
+    def _invalidate(self, storage_name):
+        """Remove an entry from the storage map.
+
+        Not meant to be used by charm authors -- this exists mainly for testing purposes.
+        """
+        self._storage_map[storage_name] = None
+
 
 class Storage:
     """Represents a storage as defined in metadata.yaml.

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -175,9 +175,9 @@ class Harness(typing.Generic[CharmType]):
         # Checking if disks have been added
         # storage-attached events happen before install
         for storage_name in self._meta.storages:
-            if len(self._backend.storage_list(storage_name)) > 0:
-                # Storage device(s) detected, emit storage-attached event
-                storage_name = storage_name.replace('-', '_')
+            storage_name = storage_name.replace('-', '_')
+            for _ in range(len(self._backend.storage_list(storage_name))):
+                # Storage device(s) detected, emit storage-attached event(s)
                 self._charm.on[storage_name].storage_attached.emit()
         # Storage done, emit install event
         self._charm.on.install.emit()
@@ -403,7 +403,67 @@ class Harness(typing.Generic[CharmType]):
         Return:
             The storage_id created
         """
+        if storage_name not in self._meta.storages:
+            raise RuntimeError(
+                "{} not found as a valid storage key in metadata".format(storage_name))
+        if self.charm is not None and self._hooks_enabled:
+            for _ in range(count):
+                self.charm.on[storage_name].storage_attached.emit()
         return self._backend.storage_add(storage_name, count)
+
+    def detach_storage(self, storage_id: str) -> None:
+        """Detach a storage device.
+
+        The intent of this function is to simulate a "juju detach-storage" call.
+        It will trigger a storage-detaching hook if the storage unit in question exists
+        and is presently marked as attached.
+
+        Args:
+            storage_id: The full storage ID being detached, including the storage key,
+                e.g. my-storage/0.
+        """
+        if self.charm is None:
+            raise RuntimeError('Cannot detach when harness has not been started yet')
+        if self._backend._storage_detach(storage_id) and self._hooks_enabled:
+            storage_name = storage_id.split('/')[0]
+            self.charm.on[storage_name].storage_detaching.emit()
+
+    def attach_storage(self, storage_id: str) -> None:
+        """Attach a storage device.
+
+        The intent of this function is to simulate a "juju attach-storage" call.
+        It will trigger a storage-detaching hook if the storage unit in question exists
+        and is presently marked as detached.
+
+        Args:
+            storage_id: The full storage ID being detached, including the storage key,
+                e.g. my-storage/0.
+        """
+        if self.charm is None:
+            raise RuntimeError('Cannot attach when harness has not been started yet')
+        if self._backend._storage_attach(storage_id) and self._hooks_enabled:
+            storage_name = storage_id.split('/')[0]
+            self.charm.on[storage_name].storage_attached.emit()
+
+    def remove_storage(self, storage_id: str) -> None:
+        """Attach a storage device.
+
+        The intent of this function is to simulate a "juju remove-storage" call.
+        It will trigger a storage-detaching hook if the storage unit in question exists
+        and is presently marked as detached.  Additionally, it will remove the storage
+        unit from the testing backend.
+
+        Args:
+            storage_id: The full storage ID being detached, including the storage key,
+                e.g. my-storage/0.
+        """
+        storage_name = storage_id.split('/')[0]
+        if storage_name not in self._meta.storages:
+            raise RuntimeError(
+                "{} not found as a valid storage key in metadata".format(storage_name))
+        removed = self._backend._storage_remove(storage_id)
+        if self.charm is not None and self._hooks_enabled and removed:
+            self.charm.on[storage_name].storage_detaching.emit()
 
     def add_relation(self, relation_name: str, remote_app: str) -> int:
         """Declare that there is a new relation between this app and `remote_app`.
@@ -909,9 +969,7 @@ class _TestingModelBackend:
         # <ID1>: device id that is key for given storage_name
         # Initialize the _storage_list with values present on metadata.yaml
         self._storage_list = {k: {} for k in self._meta.storages}
-        # Every new storage device gets an id from the _storage_id_counter.
-        # That id is mapped back to the storage name on _storage_ids_map
-        self._storage_ids_map = {}
+        self._storage_detached = {k: set() for k in self._meta.storages}
         self._storage_id_counter = 0
         # {socket_path : _TestingPebbleClient}
         # socket_path = '/charm/containers/{container_name}/pebble.socket'
@@ -1016,24 +1074,59 @@ class _TestingModelBackend:
             self._unit_status = {'status': status, 'message': message}
 
     def storage_list(self, name):
-        return list(self._storage_list[name])
+        return list(id_ for id_ in self._storage_list[name]
+                    if id_ not in self._storage_detached[name])
 
     def storage_get(self, storage_name_id, attribute):
-        name = self._storage_ids_map[storage_name_id]
-        id = storage_name_id.split("/")[1]
-        return self._storage_list[name][id][attribute]
+        name, id_ = storage_name_id.split("/", 1)
+        try:
+            if id_ in self._storage_detached[name]:
+                raise KeyError()  # Pretend the key isn't there
+            else:
+                return self._storage_list[name][id_][attribute]
+        except KeyError:
+            raise model.ModelError(
+                'ERROR invalid value "{}/{}" for option -s: storage not found'.format(name, id_))
 
-    def storage_add(self, name, count=1):
+    def storage_add(self, name: str, count: int = 1):
         if name not in self._storage_list:
             self._storage_list[name] = {}
+        storage_id = None
         for i in range(count):
             storage_id = self._storage_id_counter
             self._storage_id_counter += 1
             self._storage_list[name][str(storage_id)] = {
-                "location": "/{}{}".format(name, i)
+                "location": "/{}/{}".format(name, storage_id)
             }
-            self._storage_ids_map['{}/{}'.format(name, storage_id)] = name
         return storage_id
+
+    def _storage_detach(self, storage_id: str):
+        # NOTE: This is an extra function for _TestingModelBackend to simulate
+        # detachment of a storage unit.  This is not present in ops.model._ModelBackend.
+        name, id_ = storage_id.split('/', 1)
+        if id_ not in self._storage_detached[name]:
+            self._storage_detached[name].add(id_)
+            return True
+        return False
+
+    def _storage_attach(self, storage_id: str):
+        # NOTE: This is an extra function for _TestingModelBackend to simulate
+        # re-attachment of a storage unit.  This is not present in
+        # ops.model._ModelBackend.
+        name, id_ = storage_id.split('/', 1)
+        if id_ in self._storage_detached[name]:
+            self._storage_detached[name].remove(id_)
+            return True
+        return False
+
+    def _storage_remove(self, storage_id: str):
+        # NOTE: This is an extra function for _TestingModelBackend to simulate
+        # full removal of a storage unit.  This is not present in
+        # ops.model._ModelBackend.
+        detached = self._storage_detach(storage_id)
+        name, id_ = storage_id.split('/', 1)
+        self._storage_list[name].pop(id_, None)
+        return detached
 
     def action_get(self):
         raise NotImplementedError(self.action_get)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -427,8 +427,8 @@ class Harness(typing.Generic[CharmType]):
         and is presently marked as attached.
 
         Args:
-            storage_id: The full storage ID being detached, including the storage key,
-                e.g. my-storage/0.
+            storage_id: The full storage ID of the storage unit being detached, including the
+                storage key, e.g. my-storage/0.
         """
         if self.charm is None:
             raise RuntimeError('cannot detach storage before Harness is initialised')
@@ -447,8 +447,8 @@ class Harness(typing.Generic[CharmType]):
         and is presently marked as detached.
 
         Args:
-            storage_id: The full storage ID being detached, including the storage key,
-                e.g. my-storage/0.
+            storage_id: The full storage ID of the storage unit being attached, including the
+                storage key, e.g. my-storage/0.
         """
         if self.charm is None:
             raise RuntimeError('cannot attach storage before Harness is initialised')
@@ -467,8 +467,8 @@ class Harness(typing.Generic[CharmType]):
         unit from the testing backend.
 
         Args:
-            storage_id: The full storage ID being detached, including the storage key,
-                e.g. my-storage/0.
+            storage_id: The full storage ID of the storage unit being removed, including the
+                storage key, e.g. my-storage/0.
         """
         storage_name, storage_index = storage_id.split('/', 1)
         storage_index = int(storage_index)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -410,6 +410,11 @@ class Harness(typing.Generic[CharmType]):
             raise RuntimeError(
                 "{} not found as a valid storage key in metadata".format(storage_name))
         storage_indices = self._backend.storage_add(storage_name, count)
+
+        # Reset associated cached value in the storage mappings.  If we don't do this,
+        # Model._storages won't return Storage objects for subsequently-added storage.
+        self._model._storages._storage_map[storage_name] = None
+
         if self.charm is not None and self._hooks_enabled:
             for storage_index in storage_indices:
                 self.charm.on[storage_name].storage_attached.emit(model.Storage(storage_name, storage_index, self._backend))

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -413,7 +413,7 @@ class Harness(typing.Generic[CharmType]):
 
         # Reset associated cached value in the storage mappings.  If we don't do this,
         # Model._storages won't return Storage objects for subsequently-added storage.
-        self._model._storages._storage_map[storage_name] = None
+        self._model._storages._invalidate(storage_name)
 
         if self.charm is not None and self._hooks_enabled:
             for storage_index in storage_indices:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -406,7 +406,7 @@ class Harness(typing.Generic[CharmType]):
         """
         if storage_name not in self._meta.storages:
             raise RuntimeError(
-                "{} not found as a valid storage key in metadata".format(storage_name))
+                "the key '{}' is not specified as a storage key in metadata".format(storage_name))
         storage_indices = self._backend.storage_add(storage_name, count)
 
         # Reset associated cached value in the storage mappings.  If we don't do this,
@@ -431,7 +431,7 @@ class Harness(typing.Generic[CharmType]):
                 e.g. my-storage/0.
         """
         if self.charm is None:
-            raise RuntimeError('Cannot detach when harness has not been started yet')
+            raise RuntimeError('cannot detach storage before Harness is initialised')
         storage_name, storage_index = storage_id.split('/', 1)
         storage_index = int(storage_index)
         if self._backend._storage_is_attached(storage_name, storage_index) and self._hooks_enabled:
@@ -451,7 +451,7 @@ class Harness(typing.Generic[CharmType]):
                 e.g. my-storage/0.
         """
         if self.charm is None:
-            raise RuntimeError('Cannot attach when harness has not been started yet')
+            raise RuntimeError('cannot attach storage before Harness is initialised')
         if self._backend._storage_attach(storage_id) and self._hooks_enabled:
             storage_name, storage_index = storage_id.split('/', 1)
             storage_index = int(storage_index)
@@ -474,7 +474,7 @@ class Harness(typing.Generic[CharmType]):
         storage_index = int(storage_index)
         if storage_name not in self._meta.storages:
             raise RuntimeError(
-                "{} not found as a valid storage key in metadata".format(storage_name))
+                "the key '{}' is not specified as a storage key in metadata".format(storage_name))
         is_attached = self._backend._storage_is_attached(storage_name, storage_index)
         if self.charm is not None and self._hooks_enabled and is_attached:
             self.charm.on[storage_name].storage_detaching.emit(

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -429,7 +429,7 @@ class Harness(typing.Generic[CharmType]):
         and is presently marked as attached.
 
         Args:
-            storage_id: The full storage ID of the storage unit being detached, including the
+            storage_id: The full storage ID of th e storage unit being detached, including the
                 storage key, e.g. my-storage/0.
         """
         if self.charm is None:
@@ -452,8 +452,6 @@ class Harness(typing.Generic[CharmType]):
             storage_id: The full storage ID of the storage unit being attached, including the
                 storage key, e.g. my-storage/0.
         """
-        if self.charm is None:
-            raise RuntimeError('cannot attach storage before Harness is initialised')
         if self._backend._storage_attach(storage_id) and self._hooks_enabled:
             storage_name, storage_index = storage_id.split('/', 1)
             storage_index = int(storage_index)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -389,7 +389,7 @@ class Harness(typing.Generic[CharmType]):
         self._relation_id_counter += 1
         return rel_id
 
-    def add_storage(self, storage_name: str, count: int = 1) -> typing.List[int]:
+    def add_storage(self, storage_name: str, count: int = 1) -> typing.List[str]:
         """Declare a new storage device attached to this unit.
 
         To have repeatable tests, each device will be initialized with
@@ -401,10 +401,7 @@ class Harness(typing.Generic[CharmType]):
             count: Number of disks being added
 
         Return:
-            A list of storage IDs, expressed as the integer component after the slash,
-            rather than the full string-based identifier.
-            For example, with storage_name="my-storage" and count=3, assuming counting
-            begins at 0, this would return [0, 1, 2].
+            A list of storage IDs, e.g. ["my-storage/1", "my-storage/2"].
         """
         if storage_name not in self._meta.storages:
             raise RuntimeError(
@@ -418,7 +415,7 @@ class Harness(typing.Generic[CharmType]):
         if self.charm is not None and self._hooks_enabled:
             for storage_index in storage_indices:
                 self.charm.on[storage_name].storage_attached.emit(model.Storage(storage_name, storage_index, self._backend))
-        return storage_indices
+        return ["{}/{}".format(storage_name, storage_index) for storage_index in storage_indices]
 
     def detach_storage(self, storage_id: str) -> None:
         """Detach a storage device.

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -179,7 +179,8 @@ class Harness(typing.Generic[CharmType]):
             storage_name = storage_name.replace('-', '_')
             for storage_index in self._backend.storage_list(storage_name):
                 # Storage device(s) detected, emit storage-attached event(s)
-                self._charm.on[storage_name].storage_attached.emit(model.Storage(storage_name, storage_index, self._backend))
+                self._charm.on[storage_name].storage_attached.emit(
+                    model.Storage(storage_name, storage_index, self._backend))
         # Storage done, emit install event
         self._charm.on.install.emit()
         # Juju itself iterates what relation to fire based on a map[int]relation, so it doesn't
@@ -414,7 +415,8 @@ class Harness(typing.Generic[CharmType]):
 
         if self.charm is not None and self._hooks_enabled:
             for storage_index in storage_indices:
-                self.charm.on[storage_name].storage_attached.emit(model.Storage(storage_name, storage_index, self._backend))
+                self.charm.on[storage_name].storage_attached.emit(
+                    model.Storage(storage_name, storage_index, self._backend))
         return ["{}/{}".format(storage_name, storage_index) for storage_index in storage_indices]
 
     def detach_storage(self, storage_id: str) -> None:
@@ -433,7 +435,8 @@ class Harness(typing.Generic[CharmType]):
         storage_name, storage_index = storage_id.split('/', 1)
         storage_index = int(storage_index)
         if self._backend._storage_is_attached(storage_name, storage_index) and self._hooks_enabled:
-            self.charm.on[storage_name].storage_detaching.emit(model.Storage(storage_name, storage_index, self._backend))
+            self.charm.on[storage_name].storage_detaching.emit(
+                model.Storage(storage_name, storage_index, self._backend))
         self._backend._storage_detach(storage_id)
 
     def attach_storage(self, storage_id: str) -> None:
@@ -452,7 +455,8 @@ class Harness(typing.Generic[CharmType]):
         if self._backend._storage_attach(storage_id) and self._hooks_enabled:
             storage_name, storage_index = storage_id.split('/', 1)
             storage_index = int(storage_index)
-            self.charm.on[storage_name].storage_attached.emit(model.Storage(storage_name, storage_index, self._backend))
+            self.charm.on[storage_name].storage_attached.emit(
+                model.Storage(storage_name, storage_index, self._backend))
 
     def remove_storage(self, storage_id: str) -> None:
         """Attach a storage device.
@@ -473,7 +477,8 @@ class Harness(typing.Generic[CharmType]):
                 "{} not found as a valid storage key in metadata".format(storage_name))
         is_attached = self._backend._storage_is_attached(storage_name, storage_index)
         if self.charm is not None and self._hooks_enabled and is_attached:
-            self.charm.on[storage_name].storage_detaching.emit(model.Storage(storage_name, storage_index, self._backend))
+            self.charm.on[storage_name].storage_detaching.emit(
+                model.Storage(storage_name, storage_index, self._backend))
         self._backend._storage_remove(storage_id)
 
     def add_relation(self, relation_name: str, remote_app: str) -> int:

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1299,13 +1299,10 @@ class TestHarness(unittest.TestCase):
             ''')
         self.addCleanup(harness.cleanup)
 
+        # We deliberately don't guard against attaching storage before the harness begins,
+        # as there are legitimate reasons to do so.
         stor_id = harness.add_storage("test")[0]
-        # This admittedly doesn't really make sense since we block pre-begin attachments; added for
-        # completeness.
-        with self.assertRaises(RuntimeError) as cm:
-            harness.attach_storage("test/{}".format(stor_id))
-        self.assertEqual(cm.exception.args[0],
-                         "cannot attach storage before Harness is initialised")
+        self.assertTrue(stor_id)
 
     def test_remove_storage_before_harness_begin(self):
         harness = Harness(StorageTester, meta='''

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1138,7 +1138,7 @@ class TestHarness(unittest.TestCase):
 
         with self.assertRaises(RuntimeError) as cm:
             harness.add_storage("test")
-        self.assertEqual(cm.exception.args[0], "test not found as a valid storage key in metadata")
+        self.assertEqual(cm.exception.args[0], "the key 'test' is not specified as a storage key in metadata")
 
     def test_add_storage_after_harness_begin(self):
         harness = Harness(StorageTester, meta='''
@@ -1235,7 +1235,7 @@ class TestHarness(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             harness.detach_storage("test/{}".format(stor_id))
         self.assertEqual(cm.exception.args[0],
-                         "Cannot detach when harness has not been started yet")
+                         "cannot detach storage before Harness is initialised")
 
     def test_attach_storage(self):
         harness = Harness(StorageTester, meta='''
@@ -1294,7 +1294,7 @@ class TestHarness(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             harness.attach_storage("test/{}".format(stor_id))
         self.assertEqual(cm.exception.args[0],
-                         "Cannot attach when harness has not been started yet")
+                         "cannot attach storage before Harness is initialised")
 
     def test_remove_storage_before_harness_begin(self):
         harness = Harness(StorageTester, meta='''
@@ -1337,7 +1337,7 @@ class TestHarness(unittest.TestCase):
         # but included for completeness.
         with self.assertRaises(RuntimeError) as cm:
             harness.remove_storage("test/0")
-        self.assertEqual(cm.exception.args[0], "test not found as a valid storage key in metadata")
+        self.assertEqual(cm.exception.args[0], "the key 'test' is not specified as a storage key in metadata")
 
     def test_remove_storage_after_harness_begin(self):
         harness = Harness(StorageTester, meta='''

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1138,7 +1138,9 @@ class TestHarness(unittest.TestCase):
 
         with self.assertRaises(RuntimeError) as cm:
             harness.add_storage("test")
-        self.assertEqual(cm.exception.args[0], "the key 'test' is not specified as a storage key in metadata")
+        self.assertEqual(
+            cm.exception.args[0],
+            "the key 'test' is not specified as a storage key in metadata")
 
     def test_add_storage_after_harness_begin(self):
         harness = Harness(StorageTester, meta='''
@@ -1337,7 +1339,9 @@ class TestHarness(unittest.TestCase):
         # but included for completeness.
         with self.assertRaises(RuntimeError) as cm:
             harness.remove_storage("test/0")
-        self.assertEqual(cm.exception.args[0], "the key 'test' is not specified as a storage key in metadata")
+        self.assertEqual(
+            cm.exception.args[0],
+            "the key 'test' is not specified as a storage key in metadata")
 
     def test_remove_storage_after_harness_begin(self):
         harness = Harness(StorageTester, meta='''

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -24,7 +24,13 @@ import unittest
 import yaml
 
 from ops import pebble
-from ops.charm import CharmBase, PebbleReadyEvent, RelationEvent
+from ops.charm import (
+    CharmBase,
+    PebbleReadyEvent,
+    RelationEvent,
+    StorageAttachedEvent,
+    StorageDetachingEvent,
+)
 from ops.framework import Object
 from ops.model import (
     ActiveStatus,
@@ -37,6 +43,24 @@ from ops.model import (
     _ModelBackend,
 )
 from ops.testing import Harness, _TestingPebbleClient
+
+
+class StorageTester(CharmBase):
+    """Record the relation-changed events."""
+
+    def __init__(self, framework):
+        super().__init__(framework)
+        self.observed_events = []
+        self.framework.observe(self.on.test_storage_attached,
+                               self._on_test_storage_attached)
+        self.framework.observe(self.on.test_storage_detaching,
+                               self._on_test_storage_detaching)
+
+    def _on_test_storage_attached(self, event):
+        self.observed_events.append(event)
+
+    def _on_test_storage_detaching(self, event):
+        self.observed_events.append(event)
 
 
 class TestHarness(unittest.TestCase):
@@ -999,7 +1023,31 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness.model.name, 'foo')
         self.assertEqual(harness.model.uuid, '96957e90-e006-11eb-ba80-0242ac130004')
 
-    def test_storage_add(self):
+    def test_add_storage_before_harness_begin(self):
+        harness = Harness(StorageTester, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            storage:
+                test:
+                    type: filesystem
+                    multiple:
+                        range: 1-3
+            ''')
+        self.addCleanup(harness.cleanup)
+
+        stor_id = harness.add_storage("test", count=3)
+        self.assertIsNotNone(stor_id)
+        self.assertIn(str(stor_id), harness._backend.storage_list("test"))
+        self.assertEqual("/test/0", harness._backend.storage_get("test/0", "location"))
+
+        harness.begin_with_initial_hooks()
+        self.assertEqual(len(harness.charm.observed_events), 3)
+        for i in range(3):
+            self.assertTrue(isinstance(harness.charm.observed_events[i], StorageAttachedEvent))
+
+    def test_add_storage_without_metadata_key_fails(self):
         harness = Harness(CharmBase, meta='''
             name: test-app
             requires:
@@ -1008,11 +1056,267 @@ class TestHarness(unittest.TestCase):
             ''')
         self.addCleanup(harness.cleanup)
 
+        with self.assertRaises(RuntimeError) as cm:
+            harness.add_storage("test")
+        self.assertEqual(cm.exception.args[0], "test not found as a valid storage key in metadata")
+
+    def test_add_storage_after_harness_begin(self):
+        harness = Harness(StorageTester, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            storage:
+                test:
+                    type: filesystem
+                    multiple:
+                        range: 1-3
+            ''')
+        self.addCleanup(harness.cleanup)
+
+        # Set up initial storage
         stor_id = harness.add_storage("test")
         self.assertIsNotNone(stor_id)
-
         self.assertIn(str(stor_id), harness._backend.storage_list("test"))
-        self.assertEqual("/test0", harness._backend.storage_get("test/0", "location"))
+        self.assertEqual("/test/0", harness._backend.storage_get("test/0", "location"))
+
+        harness.begin_with_initial_hooks()
+        self.assertEqual(len(harness.charm.observed_events), 1)
+        self.assertTrue(isinstance(harness.charm.observed_events[0], StorageAttachedEvent))
+
+        # Add additional storage
+        stor_id = harness.add_storage("test", count=3)
+        # NOTE: stor_id now reflects the 4th ID.  The 2nd and 3rd IDs are created and
+        # used, but not returned by Harness.add_storage.
+        # (Should we consider changing its return type?)
+
+        self.assertIn(str(stor_id - 2), harness._backend.storage_list("test"))
+        self.assertIn(str(stor_id - 1), harness._backend.storage_list("test"))
+        self.assertIn(str(stor_id), harness._backend.storage_list("test"))
+        self.assertEqual("/test/1", harness._backend.storage_get("test/1", "location"))
+        self.assertEqual("/test/2", harness._backend.storage_get("test/2", "location"))
+        self.assertEqual("/test/3", harness._backend.storage_get("test/3", "location"))
+        self.assertEqual(len(harness.charm.observed_events), 4)
+        for i in range(1, 4):
+            self.assertTrue(isinstance(harness.charm.observed_events[i], StorageAttachedEvent))
+
+    def test_detach_storage(self):
+        harness = Harness(StorageTester, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            storage:
+                test:
+                    type: filesystem
+            ''')
+        self.addCleanup(harness.cleanup)
+
+        # Set up initial storage
+        stor_id = harness.add_storage("test")
+        harness.begin_with_initial_hooks()
+        self.assertEqual(len(harness.charm.observed_events), 1)
+        self.assertTrue(isinstance(harness.charm.observed_events[0], StorageAttachedEvent))
+
+        # Detach storage
+        harness.detach_storage("test/{}".format(stor_id))
+        self.assertEqual(len(harness.charm.observed_events), 2)
+        self.assertTrue(isinstance(harness.charm.observed_events[1], StorageDetachingEvent))
+
+        # Verify backend functions return appropriate values.
+        # Real backend would return info only for actively attached storage units.
+        self.assertNotIn(str(stor_id), harness._backend.storage_list("test"))
+        with self.assertRaises(ModelError) as cm:
+            harness._backend.storage_get("test/0", "location")
+        # Error message modeled after output of
+        # "storage-get -s <invalid/inactive id> location" on real deployment
+        self.assertEqual(
+            cm.exception.args[0],
+            'ERROR invalid value "test/0" for option -s: storage not found')
+
+        # Retry detach
+        # Since already detached, no more hooks should fire
+        harness.detach_storage("test/{}".format(stor_id))
+        self.assertEqual(len(harness.charm.observed_events), 2)
+        self.assertTrue(isinstance(harness.charm.observed_events[1], StorageDetachingEvent))
+
+    def test_detach_storage_before_harness_begin(self):
+        harness = Harness(StorageTester, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            storage:
+                test:
+                    type: filesystem
+            ''')
+        self.addCleanup(harness.cleanup)
+
+        stor_id = harness.add_storage("test")
+        with self.assertRaises(RuntimeError) as cm:
+            harness.detach_storage("test/{}".format(stor_id))
+        self.assertEqual(cm.exception.args[0],
+                         "Cannot detach when harness has not been started yet")
+
+    # Additional test cases to cover new functionality:
+    # * Harness.attach_storage: Attaches a previously detached storage.
+    #   * Charm not yet running?  Doesn't make sense to attach storage; raise an error.
+    #   * Charm started?  fire attached hook if state is detached, change state
+
+    def test_attach_storage(self):
+        harness = Harness(StorageTester, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            storage:
+                test:
+                    type: filesystem
+            ''')
+        self.addCleanup(harness.cleanup)
+
+        # Set up initial storage
+        stor_id = harness.add_storage("test")
+        harness.begin_with_initial_hooks()
+        self.assertEqual(len(harness.charm.observed_events), 1)
+        self.assertTrue(isinstance(harness.charm.observed_events[0], StorageAttachedEvent))
+
+        # Detach storage
+        harness.detach_storage("test/{}".format(stor_id))
+        self.assertEqual(len(harness.charm.observed_events), 2)
+        self.assertTrue(isinstance(harness.charm.observed_events[1], StorageDetachingEvent))
+
+        # Re-attach storage
+        harness.attach_storage("test/{}".format(stor_id))
+        self.assertEqual(len(harness.charm.observed_events), 3)
+        self.assertTrue(isinstance(harness.charm.observed_events[2], StorageAttachedEvent))
+
+        # Verify backend functions return appropriate values.
+        # Real backend would return info only for actively attached storage units.
+        self.assertIn(str(stor_id), harness._backend.storage_list("test"))
+        self.assertEqual("/test/0", harness._backend.storage_get("test/0", "location"))
+
+        # Retry attach
+        # Since already detached, no more hooks should fire
+        harness.attach_storage("test/{}".format(stor_id))
+        self.assertEqual(len(harness.charm.observed_events), 3)
+        self.assertTrue(isinstance(harness.charm.observed_events[2], StorageAttachedEvent))
+
+    def test_attach_storage_before_harness_begin(self):
+        harness = Harness(StorageTester, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            storage:
+                test:
+                    type: filesystem
+            ''')
+        self.addCleanup(harness.cleanup)
+
+        stor_id = harness.add_storage("test")
+        # This admittedly doesn't really make sense since we block pre-begin attachments; added for
+        # completeness.
+        with self.assertRaises(RuntimeError) as cm:
+            harness.attach_storage("test/{}".format(stor_id))
+        self.assertEqual(cm.exception.args[0],
+                         "Cannot attach when harness has not been started yet")
+
+    def test_remove_storage_before_harness_begin(self):
+        harness = Harness(StorageTester, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            storage:
+                test:
+                    type: filesystem
+                    multiple:
+                        range: 1-3
+            ''')
+        self.addCleanup(harness.cleanup)
+
+        stor_id = harness.add_storage("test", count=2)
+        harness.remove_storage("test/{}".format(stor_id))
+        # Note re: delta between real behavior and Harness: Juju doesn't allow removal
+        # of the last attached storage unit while a workload is still running.  To more
+        # easily allow testing of storage removal, I am presently ignoring this detail.
+        # (Otherwise, the user would need to flag somehow that they are intentionally
+        # removing the final unit as part of a shutdown procedure, else it'd block the
+        # removal.  I'm not sure such behavior is productive.)
+
+        harness.begin_with_initial_hooks()
+        # Only one hook will fire; one won't since it was removed
+        self.assertEqual(len(harness.charm.observed_events), 1)
+        self.assertTrue(isinstance(harness.charm.observed_events[0], StorageAttachedEvent))
+
+    def test_remove_storage_without_metadata_key_fails(self):
+        harness = Harness(CharmBase, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            ''')
+        self.addCleanup(harness.cleanup)
+
+        # Doesn't really make sense since we already can't add storage which isn't in the metadata,
+        # but included for completeness.
+        with self.assertRaises(RuntimeError) as cm:
+            harness.remove_storage("test/0")
+        self.assertEqual(cm.exception.args[0], "test not found as a valid storage key in metadata")
+
+    def test_remove_storage_after_harness_begin(self):
+        harness = Harness(StorageTester, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            storage:
+                test:
+                    type: filesystem
+                    multiple:
+                        range: 1-3
+            ''')
+        self.addCleanup(harness.cleanup)
+
+        stor_id = harness.add_storage("test", count=2)
+        harness.begin_with_initial_hooks()
+        self.assertEqual(len(harness.charm.observed_events), 2)
+        self.assertTrue(isinstance(harness.charm.observed_events[0], StorageAttachedEvent))
+        self.assertTrue(isinstance(harness.charm.observed_events[1], StorageAttachedEvent))
+
+        harness.remove_storage("test/{}".format(stor_id))
+        self.assertEqual(len(harness.charm.observed_events), 3)
+        self.assertTrue(isinstance(harness.charm.observed_events[2], StorageDetachingEvent))
+
+        # stor_id will reflect the second storage unit, i.e. test/1 (integer id: 1)
+        # Since we removed the stor_id entry; I expect the other entry to remain.
+        attached_storage_ids = harness._backend.storage_list("test")
+        self.assertIn(str(stor_id - 1), attached_storage_ids)
+        self.assertNotIn(str(stor_id), attached_storage_ids)
+
+    def test_remove_detached_storage(self):
+        harness = Harness(StorageTester, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            storage:
+                test:
+                    type: filesystem
+                    multiple:
+                        range: 1-3
+            ''')
+        self.addCleanup(harness.cleanup)
+
+        stor_id = harness.add_storage("test", count=2)
+        harness.begin_with_initial_hooks()
+        harness.detach_storage("test/{}".format(stor_id))
+        harness.remove_storage("test/{}".format(stor_id))  # Already detached, so won't fire a hook
+        self.assertEqual(len(harness.charm.observed_events), 3)
+        self.assertTrue(isinstance(harness.charm.observed_events[0], StorageAttachedEvent))
+        self.assertTrue(isinstance(harness.charm.observed_events[1], StorageAttachedEvent))
+        self.assertTrue(isinstance(harness.charm.observed_events[2], StorageDetachingEvent))
 
     def test_actions_from_directory(self):
         tmp = pathlib.Path(tempfile.mkdtemp())


### PR DESCRIPTION
* Added detach, attach and remove functions to simulate storage being
  attached/detached/removed via the Juju CLI.

* Renamed some test names.

* Added firing of hooks post-Harness.begin() when appropriate Harness
  functions are called.

* Hook firing counts changed to mimic Juju behavior, e.g. if 3 storage
  units get attached (even via a single call), 3 events should be
  emitted.

* Some minor tweaks to the existing testing backend implementation for
  tracking storage state.