### PR TITLE
Implement a basic update method on BoundStoredState

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -917,6 +917,16 @@ class BoundStoredState:
             if k not in self._data:
                 self._data[k] = v
 
+    def update(self, **kwargs):
+        """Set the value of any given set of keys.
+
+        Example::
+
+            self._stored.update(foo="bar", baz="qux")
+        """
+        for k, v in kwargs.items():
+            self._data[k] = v
+
 
 class StoredState:
     """A class used to store data the charm needs persisted across invocations.

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -1481,6 +1481,32 @@ class TestStoredState(BaseTestCase):
         # TODO: jam 2020-01-30 is there a clean way to tell that
         #       parent._stored._data.dirty is False?
 
+    def test_update(self):
+        framework = self.create_framework()
+
+        class StatefulObject(Object):
+            _stored = StoredState()
+        parent = StatefulObject(framework, 'key')
+
+        # Check updating a single key, not yet set
+        parent._stored.update(foo="bar")
+        self.assertEqual(parent._stored.foo, "bar")
+        parent._stored.update(foo="baz")
+
+        # Set some defaults, ensure the update method overrides them
+        parent._stored.set_default(operator=True, framework=False)
+        self.assertEqual(parent._stored.operator, True)
+        parent._stored.update(operator=False)
+        self.assertEqual(parent._stored.operator, False)
+
+        # Check updating multiple items
+        parent._stored.update(operator=True, framework=True)
+        self.assertEqual(parent._stored.operator, True)
+        self.assertEqual(parent._stored.framework, True)
+        parent._stored.update(foo="qux", operator=False)
+        self.assertEqual(parent._stored.operator, False)
+        self.assertEqual(parent._stored.foo, "qux")
+
 
 class GenericObserver(Object):
     """Generic observer for the tests."""


### PR DESCRIPTION
Implements a basic `update` method on `BoundStoredState`.

Example usage:

```python
self._stored.update(foo="bar", baz="quz", great_feature=True)
```

Fixes #388 