### PR TITLE
Fix harness remove relation unit

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -555,17 +555,13 @@ class Harness(typing.Generic[CharmType]):
         relation = self._model.get_relation(relation_name, relation_id)
         unit_cache = relation.data.get(remote_unit, None)
 
-        # statements which could access cache
         # remove the unit from the list of units in the relation
-        self._backend._relation_app_and_units[relation_id][
-            "units"].remove(remote_unit_name)
-        self._backend._relation_list_map[relation_id].remove(remote_unit_name)
-        # this is required for _emit_relation_departed to pickup the changes
-        self.model._relations._invalidate(relation_name=relation.name)
+        relation.units.remove(remote_unit)
 
-        # emit the event
         self._emit_relation_departed(relation_id, remote_unit_name)
         # remove the relation data for the departed unit now that the event has happened
+        self._backend._relation_list_map[relation_id].remove(remote_unit_name)
+        self._backend._relation_app_and_units[relation_id]["units"].remove(remote_unit_name)
         self._backend._relation_data[relation_id].pop(remote_unit_name)
         self.model._relations._invalidate(relation_name=relation.name)
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -326,7 +326,7 @@ class TestHarness(unittest.TestCase):
         rel_id = harness.add_relation('db', 'postgresql')
         self.assertIsInstance(rel_id, int)
         harness.add_relation_unit(rel_id, 'postgresql/0')
-        harness.update_relation_data(rel_id, 'postgresql/0', {'db_name': 'someapp'})
+        harness.update_relation_data(rel_id, 'postgresql/0', {'foo': 'bar'})
         # Check relation and unit were created
         backend = harness._backend
         self.assertEqual(backend.relation_ids('db'), [rel_id])
@@ -336,7 +336,9 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(len(relation.units), 1)
         # Check relation data is correct
         rel_unit = harness.charm.model.get_unit('postgresql/0')
-        self.assertEqual(relation.data[rel_unit]['db_name'], 'someapp')
+        self.assertEqual(relation.data[rel_unit]['foo'], 'bar')
+        # Instruct the charm to record the relation data it sees in the list of changes
+        harness.charm.record_relation_data_on_events = True
         # Now remove unit
         harness.remove_relation_unit(rel_id, 'postgresql/0')
         # Check relation still exists
@@ -352,7 +354,11 @@ class TestHarness(unittest.TestCase):
                           'relation': 'db',
                           'data': {'app': 'postgresql',
                                    'unit': 'postgresql/0',
-                                   'relation_id': rel_id}})
+                                   'relation_id': 0,
+                                   'relation_data': {'test-app/0': {},
+                                                     'test-app': {},
+                                                     'postgresql/0': {'foo': 'bar'},
+                                                     'postgresql': {}}}})
 
     def test_removing_relation_removes_remote_app_data(self):
         # language=YAML
@@ -1896,6 +1902,10 @@ class RelationEventCharm(RecordingCharm):
 
     def __init__(self, framework):
         super().__init__(framework)
+        # When set, this instructs the charm to include a 'relation_data' field in the 'data'
+        # section of each change it logs, which allows us to test which relation data was available
+        # in each hook invocation
+        self.record_relation_data_on_events = False
 
     def observe_relation_events(self, relation_name):
         self.framework.observe(self.on[relation_name].relation_created, self._on_relation_created)
@@ -1927,9 +1937,17 @@ class RelationEventCharm(RecordingCharm):
         app_name = None
         if event.app is not None:
             app_name = event.app.name
-        self.changes.append(
-            dict(name=event_name, relation=event.relation.name,
-                 data=dict(app=app_name, unit=unit_name, relation_id=event.relation.id)))
+
+        recording = dict(name=event_name, relation=event.relation.name,
+                         data=dict(app=app_name, unit=unit_name, relation_id=event.relation.id))
+
+        if self.record_relation_data_on_events:
+            recording["data"].update({'relation_data': {
+                str(x.name): dict(event.relation.data[x])
+                for x in event.relation.data
+            }})
+
+        self.changes.append(recording)
 
 
 class ContainerEventCharm(RecordingCharm):


### PR DESCRIPTION
Fixes #638 

A minor reordering of `Harness.remove_relation_unit` to ensure that the `relation-departed` event is emitted *after* the relation cache is invalidated.