### PR TITLE
Fix legacy service restart by restoring #588

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1133,7 +1133,9 @@ class Container:
             if e.code != 400:
                 raise e
             # support old Pebble instances that don't support the "restart" action
-            self._pebble.stop_services(service_names)
+            for svc in self.get_services(service_names):
+                if svc.is_running():
+                    self._pebble.stop_services(svc.name)
             self._pebble.start_services(service_names)
 
     def stop(self, *service_names: str):


### PR DESCRIPTION
#580 accidentally dropped changes from #588. This PR restores those changes to preserve legacy behaviour of restart on old pebbles.