### PR TITLE
Add storage details to StorageEvents

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -451,8 +451,10 @@ class StorageEvent(HookEvent):
         storage_name = snapshot.get("storage_name")
         storage_id = snapshot.get("storage_id")
         storage_location = snapshot.get("storage_location")
+        print(storage_name)
+        print(storage_id)
 
-        if storage_name and storage_id:
+        if storage_name and storage_id is not None:
             self.storage = next(
                 (s for s in self.framework.model.storages[storage_name] if s.id == storage_id),
                 None,)

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -440,6 +440,7 @@ class StorageEvent(HookEvent):
         if isinstance(self.storage, model.Storage):
             snapshot["storage_name"] = self.storage.name
             snapshot["storage_id"] = self.storage.id
+            snapshot["storage_location"] = str(self.storage.location)
         return snapshot
 
     def restore(self, snapshot: dict) -> None:
@@ -449,11 +450,13 @@ class StorageEvent(HookEvent):
         """
         storage_name = snapshot.get("storage_name")
         storage_id = snapshot.get("storage_id")
+        storage_location = snapshot.get("storage_location")
 
         if storage_name and storage_id:
             self.storage = next(
                 (s for s in self.framework.model.storages[storage_name] if s.id == storage_id),
                 None,)
+            self.storage.location = storage_location
 
 
 class StorageAttachedEvent(StorageEvent):

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -426,6 +426,35 @@ class StorageEvent(HookEvent):
     of :class:`StorageEvent`.
     """
 
+    def __init__(self, handle, storage):
+        super().__init__(handle)
+        self.storage = storage
+
+    def snapshot(self) -> dict:
+        """Used by the framework to serialize the event to disk.
+
+        Not meant to be called by charm code.
+        """
+        snapshot = {}
+
+        if isinstance(self.storage, model.Storage):
+            snapshot["storage_name"] = self.storage.name
+            snapshot["storage_id"] = self.storage.id
+        return snapshot
+
+    def restore(self, snapshot: dict) -> None:
+        """Used by the framework to deserialize the event from disk.
+
+        Not meant to be called by charm code.
+        """
+        storage_name = snapshot.get("storage_name")
+        storage_id = snapshot.get("storage_id")
+
+        if storage_name and storage_id:
+            self.storage = next(
+                (s for s in self.framework.model.storages[storage_name] if s.id == storage_id),
+                None,)
+
 
 class StorageAttachedEvent(StorageEvent):
     """Event triggered when new storage becomes available.

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -451,8 +451,6 @@ class StorageEvent(HookEvent):
         storage_name = snapshot.get("storage_name")
         storage_id = snapshot.get("storage_id")
         storage_location = snapshot.get("storage_location")
-        print(storage_name)
-        print(storage_id)
 
         if storage_name and storage_id is not None:
             self.storage = next(

--- a/ops/main.py
+++ b/ops/main.py
@@ -151,22 +151,21 @@ def _get_event_args(charm, bound_event):
         container = model.unit.get_container(workload_name)
         return [container], {}
     elif issubclass(event_type, ops.charm.StorageEvent):
-        storage_info = model._backend._run("storage-get", return_output=True, use_json=True)
         storage_id = os.environ.get("JUJU_STORAGE_ID", "")
-
         if storage_id:
             storage_name = storage_id.split("/")[0]
         else:
             # Before JUJU_STORAGE_ID exists
-            storage_name = bound_event.event_kind.split('_storage', 1)[0]
+            storage_name = bound_event.event_kind.split("_", 1)[0]
 
         storages = model.storages[storage_name]
+        id, storage_location = model._backend._storage_event_details()
         if len(storages) == 1:
             storage = storages[0]
-            storage.location = storage_info["location"]
         else:
             # If there's more than one value, pick the right one. We'll realize the key on lookup
-            storage = next((s for s in storages if s.location == storage_info["location"]), None)
+            storage = next((s for s in storages if s.id == id), None)
+        storage.location = storage_location
         return [storage], {}
     elif issubclass(event_type, ops.charm.RelationEvent):
         relation_name = os.environ['JUJU_RELATION']

--- a/ops/model.py
+++ b/ops/model.py
@@ -1037,7 +1037,7 @@ class Storage:
         self._location = None
 
     @property
-    def location(self) -> typing.Union[Path, str]:
+    def location(self) -> Path:
         """Return the location of the storage."""
         if self._location is None:
             raw = self._backend.storage_get('{}/{}'.format(self.name, self.id), "location")

--- a/ops/model.py
+++ b/ops/model.py
@@ -1010,22 +1010,6 @@ class StorageMapping(Mapping):
                 storage_list.append(Storage(storage_name, storage_id, self._backend))
         return storage_list
 
-    def get_by_name_and_location(self, storage_name: str, location: str) -> "Storage":
-        """Looks up an entry by the location.
-
-        :class:`Storage` objects do not necessarily have any unique identifiers
-        which can resolve to the informaiton returned by `storage-get` when a storage
-        is attached or detached, which returns only the location and type. A lookup
-        here allows for :class:`Model``.storages`:meth:`get_by_location` to aggregate
-        lookups in a single place.
-        """
-        # Force population of the lookup table if it isn't initialized
-        for val in self.__getitem__(storage_name):
-            if val.location == location:
-                return val
-        raise ModelError("Cannot find storage by location {!r}: no storage with the given "
-                         "location found".format(location))
-
     def request(self, storage_name: str, count: int = 1):
         """Requests new storage instances of a given name.
 
@@ -1053,12 +1037,21 @@ class Storage:
         self._location = None
 
     @property
-    def location(self):
+    def location(self) -> typing.Union[Path, str]:
         """Return the location of the storage."""
         if self._location is None:
             raw = self._backend.storage_get('{}/{}'.format(self.name, self.id), "location")
             self._location = Path(raw)
         return self._location
+
+    @location.setter
+    def location(self, location: str) -> None:
+        """Sets the location for use in events.
+
+        For :class:`StorageAttachedEvent` and :class:`StorageDetachingEvent` in case
+        the actual details are gone from Juju by the time of a dynamic lookup.
+        """
+        self._location = location
 
 
 class Container:

--- a/ops/model.py
+++ b/ops/model.py
@@ -1008,6 +1008,22 @@ class StorageMapping(Mapping):
                 storage_list.append(Storage(storage_name, storage_id, self._backend))
         return storage_list
 
+    def get_by_name_and_location(self, storage_name: str, location: str) -> "Storage":
+        """Looks up an entry by the location.
+
+        :class:`Storage` objects do not necessarily have any unique identifiers
+        which can resolve to the informaiton returned by `storage-get` when a storage
+        is attached or detached, which returns only the location and type. A lookup
+        here allows for :class:`Model``.storages`:meth:`get_by_location` to aggregate
+        lookups in a single place.
+        """
+        # Force population of the lookup table if it isn't initialized
+        for val in self.__getitem__(storage_name):
+            if val.location == location:
+                return val
+        raise ModelError("Cannot find storage by location {!r}: no storage with the given "
+                         "location found".format(location))
+
     def request(self, storage_name: str, count: int = 1):
         """Requests new storage instances of a given name.
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -1051,7 +1051,7 @@ class Storage:
         For :class:`StorageAttachedEvent` and :class:`StorageDetachingEvent` in case
         the actual details are gone from Juju by the time of a dynamic lookup.
         """
-        self._location = location
+        self._location = Path(location)
 
 
 class Container:
@@ -1675,6 +1675,20 @@ class _ModelBackend:
     def storage_list(self, name):
         return [int(s.split('/')[1]) for s in self._run('storage-list', name,
                                                         return_output=True, use_json=True)]
+
+    def _storage_event_details(self) -> typing.Tuple[int, str]:
+        output = self._run('storage-get', '--help', return_output=True)
+
+        # Match the entire string at once instead of going line by line
+        matcher = re.compile(
+            r'.*^-s\s+\(=\s+(?P<storage_key>.*?)\)\s*?$',
+            re.MULTILINE | re.DOTALL
+        )
+        key = matcher.match(output).groupdict()["storage_key"]
+
+        id = int(key.split("/")[1])
+        location = self.storage_get(key, "location")
+        return id, location
 
     def storage_get(self, storage_name_id, attribute):
         return self._run('storage-get', '-s', storage_name_id, attribute,

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -188,7 +188,7 @@ peers:
 
             def _on_stor1_attach(self, event):
                 self.seen.append(type(event).__name__)
-                this.assertEqual(str(event.storage.location), "/var/srv/stor1/0")
+                this.assertEqual(event.storage.location, Path("/var/srv/stor1/0"))
 
             def _on_stor2_detach(self, event):
                 self.seen.append(type(event).__name__)

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -247,10 +247,10 @@ storage:
 
         charm = MyCharm(self.create_framework())
 
-        charm.on['stor1'].storage_attached.emit(Storage("stor1", 0, None))
-        charm.on['stor2'].storage_detaching.emit(Storage("stor2", 0, None))
-        charm.on['stor3'].storage_attached.emit(Storage("stor3", 0, None))
-        charm.on['stor-4'].storage_attached.emit(Storage("stor-4", 0, None))
+        charm.on['stor1'].storage_attached.emit(Storage("stor1", 0, charm.model._backend))
+        charm.on['stor2'].storage_detaching.emit(Storage("stor2", 0, charm.model._backend))
+        charm.on['stor3'].storage_attached.emit(Storage("stor3", 0, charm.model._backend))
+        charm.on['stor-4'].storage_attached.emit(Storage("stor-4", 0, charm.model._backend))
 
         self.assertEqual(charm.seen, [
             'StorageAttachedEvent',

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -710,6 +710,26 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
         event_file = self.JUJU_CHARM_DIR / rel_path
         # Note that sys.executable is used to make sure we are using the same
         # interpreter for the child process to support virtual environments.
+        fake_script(
+            self,
+            "storage-get",
+            """
+            if [ "$1" = --format=json ]; then
+                echo '{"type": "filesystem", "location": "/var/srv/disks/0"}'
+            elif [ "$2" = disks/0 ]; then
+                echo '"/var/srv/disks/0"'
+            else
+                exit 0
+            fi
+            """,
+        )
+        fake_script(
+            self,
+            "storage-list",
+            """
+            echo '["disks/0"]'
+            """,
+        )
         subprocess.run(
             [sys.executable, str(event_file)],
             check=True, env=env, cwd=str(self.JUJU_CHARM_DIR))
@@ -960,6 +980,26 @@ class TestMainWithDispatch(_TestMainWithDispatch, unittest.TestCase):
         env['JUJU_DISPATCH_PATH'] = str(rel_path)
         env['JUJU_VERSION'] = '2.8.0'
         dispatch = self.JUJU_CHARM_DIR / 'dispatch'
+        fake_script(
+            self,
+            "storage-get",
+            """
+            if [ "$1" = --format=json ]; then
+                echo '{"type": "filesystem", "location": "/var/srv/disks/0"}'
+            elif [ "$2" = disks/0 ]; then
+                echo '"/var/srv/disks/0"'
+            else
+                exit 0
+            fi
+            """,
+        )
+        fake_script(
+            self,
+            "storage-list",
+            """
+            echo '["disks/0"]'
+            """,
+        )
         subprocess.run(
             [sys.executable, str(dispatch)],
             # stdout=self.stdout,
@@ -990,6 +1030,26 @@ class TestMainWithDispatchAsScript(_TestMainWithDispatch, unittest.TestCase):
     def _call_event(self, rel_path, env):
         env['JUJU_DISPATCH_PATH'] = str(rel_path)
         env['JUJU_VERSION'] = '2.8.0'
+        fake_script(
+            self,
+            "storage-get",
+            """
+            if [ "$1" = --format=json ]; then
+                echo '{"type": "filesystem", "location": "/var/srv/disks/0"}'
+            elif [ "$2" = disks/0 ]; then
+                echo '"/var/srv/disks/0"'
+            else
+                exit 0
+            fi
+            """,
+        )
+        fake_script(
+            self,
+            "storage-list",
+            """
+            echo '["disks/0"]'
+            """,
+        )
         dispatch = (self.JUJU_CHARM_DIR / 'dispatch').with_suffix(self.suffix)
         subprocess.check_call([str(dispatch)], env=env, cwd=str(self.JUJU_CHARM_DIR))
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -714,12 +714,32 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
             self,
             "storage-get",
             """
-            if [ "$1" = --format=json ]; then
-                echo '{"type": "filesystem", "location": "/var/srv/disks/0"}'
-            elif [ "$2" = disks/0 ]; then
-                echo '"/var/srv/disks/0"'
+            if [ "$1" = "-s" ]; then
+                id=${2#*/}
+                key=${2%/*}
+                echo "\\"/var/srv/${key}/${id}\\"" # NOQA: test_quote_backslashes
+            elif [ "$1" = '--help' ]; then
+                printf '%s\\n' \\
+                'Usage: storage-get [options] [<key>]' \\
+                '   ' \\
+                'Summary:' \\
+                'print information for storage instance with specified id' \\
+                '   ' \\
+                'Options:' \\
+                '--format  (= smart)' \\
+                '    Specify output format (json|smart|yaml)' \\
+                '-o, --output (= "")' \\
+                '    Specify an output file' \\
+                '-s  (= test-stor/0)' \\
+                '    specify a storage instance by id' \\
+                '   ' \\
+                'Details:' \\
+                'When no <key> is supplied, all keys values are printed.'
             else
-                exit 0
+                # Return the same path for all disks since `storage-get`
+                # on attach and detach takes no parameters and is not
+                # deterministically faked with fake_script
+                exit 1
             fi
             """,
         )
@@ -984,12 +1004,32 @@ class TestMainWithDispatch(_TestMainWithDispatch, unittest.TestCase):
             self,
             "storage-get",
             """
-            if [ "$1" = --format=json ]; then
-                echo '{"type": "filesystem", "location": "/var/srv/disks/0"}'
-            elif [ "$2" = disks/0 ]; then
-                echo '"/var/srv/disks/0"'
+            if [ "$1" = "-s" ]; then
+                id=${2#*/}
+                key=${2%/*}
+                echo "\\"/var/srv/${key}/${id}\\"" # NOQA: test_quote_backslashes
+            elif [ "$1" = '--help' ]; then
+                printf '%s\\n' \\
+                'Usage: storage-get [options] [<key>]' \\
+                '   ' \\
+                'Summary:' \\
+                'print information for storage instance with specified id' \\
+                '   ' \\
+                'Options:' \\
+                '--format  (= smart)' \\
+                '    Specify output format (json|smart|yaml)' \\
+                '-o, --output (= "")' \\
+                '    Specify an output file' \\
+                '-s  (= test-stor/0)' \\
+                '    specify a storage instance by id' \\
+                '   ' \\
+                'Details:' \\
+                'When no <key> is supplied, all keys values are printed.'
             else
-                exit 0
+                # Return the same path for all disks since `storage-get`
+                # on attach and detach takes no parameters and is not
+                # deterministically faked with fake_script
+                exit 1
             fi
             """,
         )
@@ -1034,12 +1074,32 @@ class TestMainWithDispatchAsScript(_TestMainWithDispatch, unittest.TestCase):
             self,
             "storage-get",
             """
-            if [ "$1" = --format=json ]; then
-                echo '{"type": "filesystem", "location": "/var/srv/disks/0"}'
-            elif [ "$2" = disks/0 ]; then
-                echo '"/var/srv/disks/0"'
+            if [ "$1" = "-s" ]; then
+                id=${2#*/}
+                key=${2%/*}
+                echo "\\"/var/srv/${key}/${id}\\"" # NOQA: test_quote_backslashes
+            elif [ "$1" = '--help' ]; then
+                printf '%s\\n' \\
+                'Usage: storage-get [options] [<key>]' \\
+                '   ' \\
+                'Summary:' \\
+                'print information for storage instance with specified id' \\
+                '   ' \\
+                'Options:' \\
+                '--format  (= smart)' \\
+                '    Specify output format (json|smart|yaml)' \\
+                '-o, --output (= "")' \\
+                '    Specify an output file' \\
+                '-s  (= test-stor/0)' \\
+                '    specify a storage instance by id' \\
+                '   ' \\
+                'Details:' \\
+                'When no <key> is supplied, all keys values are printed.'
             else
-                exit 0
+                # Return the same path for all disks since `storage-get`
+                # on attach and detach takes no parameters and is not
+                # deterministically faked with fake_script
+                exit 1
             fi
             """,
         )


### PR DESCRIPTION
When any storage event fires, look up the appropriate Storage
object and attach it to the event. Since `juju storage-get` on
any attach or detach will return the type and location without
any additional arguments, it's necessary to iterate through the
list of known storages until we find the location for the appropriate
object.

Once we find it, we can operate by Storage.name and Storage.id for
restoring/deserializing the snapshot data, and further lookups are
not necessary.

Closes #571 