### PR TITLE
Fix for container.restart in older versions of Pebble

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1135,9 +1135,9 @@ class Container:
             if e.code != 400:
                 raise e
             # support old Pebble instances that don't support the "restart" action
-            for svc in self.get_services(service_names):
+            for svc in self.get_services(*service_names).values():
                 if svc.is_running():
-                    self._pebble.stop_services(svc.name)
+                    self._pebble.stop_services((*[svc.name],))
             self._pebble.start_services(service_names)
 
     def stop(self, *service_names: str):


### PR DESCRIPTION
Related to #647 - slight change to method of restarting services within containers for older versions of Pebble.

Without this change, the following error occurs when trying to restart a service:

```
Traceback (most recent call last):
  File "./src/charm.py", line 350, in <module>
    main(MongoDBCharm, use_juju_for_storage=True)
  File "/var/lib/juju/agents/unit-mongodb-k8s-0/charm/venv/ops/main.py", line 408, in main
    _emit_charm_event(charm, dispatcher.event_name)
  File "/var/lib/juju/agents/unit-mongodb-k8s-0/charm/venv/ops/main.py", line 142, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-mongodb-k8s-0/charm/venv/ops/framework.py", line 275, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-mongodb-k8s-0/charm/venv/ops/framework.py", line 735, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-mongodb-k8s-0/charm/venv/ops/framework.py", line 782, in _reemit
    custom_handler(event)
  File "./src/charm.py", line 118, in _on_start
    self._on_update_status(event)
  File "./src/charm.py", line 162, in _on_update_status
    container.restart("mongodb")
  File "/var/lib/juju/agents/unit-mongodb-k8s-0/charm/venv/ops/model.py", line 1138, in restart
    for svc in self.get_services(service_names):
  File "/var/lib/juju/agents/unit-mongodb-k8s-0/charm/venv/ops/model.py", line 1179, in get_services
    services = self._pebble.get_services(service_names)
  File "/var/lib/juju/agents/unit-mongodb-k8s-0/charm/venv/ops/pebble.py", line 1398, in get_services
    query = {'names': ','.join(names)}
```

This change actually just restores existing behaviour.