### PR TITLE
Add a method to set planned unit count in the testing harness.

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -822,9 +822,9 @@ class Harness(typing.Generic[CharmType]):
         application. E.g., this number will be the number of peers this unit has, plus one, as we
         count our own unit in the total.
 
-        At the time of this writing (2021/11), a change to the return from planned_units will not
-        generate an event. Typically, a charm author would check planned units during a config or
-        install hook, or after receiving a peer relation joined event.
+        A change to the return from planned_units will not generate an event. Typically, a charm author
+        would check planned units during a config or install hook, or after receiving a peer relation
+        joined event.
         """
         self._backend._planned_units = num_units
 
@@ -1094,13 +1094,12 @@ class _TestingModelBackend:
         return client
 
     def planned_units(self):
-        """Simulate processing the return from goal-state into a count of planned units.
+        """Simulate fetching the number of planned application units from the model.
 
         If self._planned_units is None, then we simulate what the Juju controller will do, which is
-        to report the number of peers, plus one (we include this unit in the count).
-
-        For testing purposes, a charm author can set self._planned_units explicitly by calling
-        "Harness.set_planned_units".
+        to report the number of peers, plus one (we include this unit in the count). This can be
+        overridden for testing purposes: a charm author can set the number of planned units 
+        explicitly by calling `Harness.set_planned_units`
         """
         if isinstance(self._planned_units, int):
             return self._planned_units

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -831,6 +831,16 @@ class Harness(typing.Generic[CharmType]):
             raise TypeError("num_units must be 0 or a positive integer.")
         self._backend._planned_units = num_units
 
+    def reset_planned_units(self):
+        """Reset the planned units override.
+
+        This allows the harness to fall through to the built in methods that will try to
+        guess at a value for planned units, based on the number of peer relations that
+        have been setup in the testing harness.
+
+        """
+        self._backend._planned_units = None
+
     def _get_backend_calls(self, reset: bool = True) -> list:
         """Return the calls that we have made to the TestingModelBackend.
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -822,10 +822,13 @@ class Harness(typing.Generic[CharmType]):
         application. E.g., this number will be the number of peers this unit has, plus one, as we
         count our own unit in the total.
 
-        A change to the return from planned_units will not generate an event. Typically, a charm author
-        would check planned units during a config or install hook, or after receiving a peer relation
-        joined event.
+        A change to the return from planned_units will not generate an event. Typically, a charm
+        author would check planned units during a config or install hook, or after receiving a peer
+        relation joined event.
+
         """
+        if num_units < 0:
+            raise TypeError("num_units must be 0 or a positive integer.")
         self._backend._planned_units = num_units
 
     def _get_backend_calls(self, reset: bool = True) -> list:
@@ -1098,10 +1101,10 @@ class _TestingModelBackend:
 
         If self._planned_units is None, then we simulate what the Juju controller will do, which is
         to report the number of peers, plus one (we include this unit in the count). This can be
-        overridden for testing purposes: a charm author can set the number of planned units 
+        overridden for testing purposes: a charm author can set the number of planned units
         explicitly by calling `Harness.set_planned_units`
         """
-        if isinstance(self._planned_units, int):
+        if self._planned_units is not None:
             return self._planned_units
 
         units = []

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -827,8 +827,8 @@ class TestApplication(unittest.TestCase):
 
         When a charm author writes a test that explicitly calls set_planned_units, we assume that
         their intent is to override the calculated return value. Often, this will be because the
-        charm author is composing a charm without peer relations, and the harness's count of planned
-        units, which is based on the number of peer relations, will not be accurate.
+        charm author is composing a charm without peer relations, and the harness's count of
+        planned units, which is based on the number of peer relations, will not be accurate.
         """
         peer_id = self.peer_rel_id
 
@@ -841,7 +841,7 @@ class TestApplication(unittest.TestCase):
 
         # Verify that we can clear the override.
         self.harness.reset_planned_units()
-        self.assertEqual(self.app.planned_units(), 3)
+        self.assertEqual(self.app.planned_units(), 4)  # self + 3 peers
 
 
 class TestContainers(unittest.TestCase):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -827,7 +827,7 @@ class TestApplication(unittest.TestCase):
 
         When a charm author writes a test that explicitly calls set_planned_units, we assume that
         their intent is to override the calculated return value. Often, this will be because the
-        charm author is composing a charm without peer relations, and the harness' count of planned
+        charm author is composing a charm without peer relations, and the harness's count of planned
         units, which is based on the number of peer relations, will not be accurate.
         """
         peer_id = self.peer_rel_id

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -839,6 +839,10 @@ class TestApplication(unittest.TestCase):
 
         self.assertEqual(self.app.planned_units(), 10)
 
+        # Verify that we can clear the override.
+        self.harness.reset_planned_units()
+        self.assertEqual(self.app.planned_units(), 3)
+
 
 class TestContainers(unittest.TestCase):
     def setUp(self):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -796,6 +796,17 @@ class TestApplication(unittest.TestCase):
 
         self.assertEqual(self.app.planned_units(), 3)
 
+    def test_planned_units_user_set(self):
+
+        self.harness.set_planned_units(1)
+        self.assertEqual(self.app.planned_units(), 1)
+
+        self.harness.set_planned_units(2)
+        self.assertEqual(self.app.planned_units(), 2)
+
+        self.harness.set_planned_units(100)
+        self.assertEqual(self.app.planned_units(), 100)
+
 
 class TestContainers(unittest.TestCase):
     def setUp(self):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -807,6 +807,38 @@ class TestApplication(unittest.TestCase):
         self.harness.set_planned_units(100)
         self.assertEqual(self.app.planned_units(), 100)
 
+    def test_planned_units_garbage_values(self):
+        # Planned units should be a positive integer, or zero.
+        with self.assertRaises(TypeError):
+            self.harness.set_planned_units(-1)
+        # Verify that we didn't set our value before raising the error.
+        self.assertTrue(self.harness._backend._planned_units is None)
+        # Verify that we still get the default value back from .planned_units.
+        self.assertEqual(self.app.planned_units(), 1)
+
+        with self.assertRaises(TypeError):
+            self.harness.set_planned_units("foo")
+
+        with self.assertRaises(TypeError):
+            self.harness.set_planned_units(-3423000102312321090)
+
+    def test_planned_units_override(self):
+        """Verify that we override the calculated value of planned_units when we set it manually.
+
+        When a charm author writes a test that explicitly calls set_planned_units, we assume that
+        their intent is to override the calculated return value. Often, this will be because the
+        charm author is composing a charm without peer relations, and the harness' count of planned
+        units, which is based on the number of peer relations, will not be accurate.
+        """
+        peer_id = self.peer_rel_id
+
+        self.harness.set_planned_units(10)
+        self.harness.add_relation_unit(peer_id, 'myapp/1')
+        self.harness.add_relation_unit(peer_id, 'myapp/2')
+        self.harness.add_relation_unit(peer_id, 'myapp/3')
+
+        self.assertEqual(self.app.planned_units(), 10)
+
 
 class TestContainers(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Closes gh#636

In many cases, someone testing code that calls planned units will not
want to make calls to the harness to setup virtual peer units. This PR
provides a nice, relatively clean way to set the return from planned
units (and only the return from planned units) in the harness backend.