### PR TITLE
Adjust the ops.model.Resources.fetch method to throw a NameError

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -954,7 +954,7 @@ class Resources:
         on disk, otherwise it raises a ModelError.
         """
         if name not in self._paths:
-            raise RuntimeError('invalid resource name: {}'.format(name))
+            raise ModelError('invalid resource name: {}'.format(name))
         if self._paths[name] is None:
             self._paths[name] = Path(self._backend.resource_get(name))
         return self._paths[name]

--- a/ops/model.py
+++ b/ops/model.py
@@ -951,10 +951,10 @@ class Resources:
         """Fetch the resource from the controller or store.
 
         If successfully fetched, this returns a Path object to where the resource is stored
-        on disk, otherwise it raises a ModelError.
+        on disk, otherwise it raises a NameError.
         """
         if name not in self._paths:
-            raise ModelError('invalid resource name: {}'.format(name))
+            raise NameError('invalid resource name: {}'.format(name))
         if self._paths[name] is None:
             self._paths[name] = Path(self._backend.resource_get(name))
         return self._paths[name]

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -490,7 +490,7 @@ class TestModel(unittest.TestCase):
         self.harness.add_resource('foo', 'foo contents\n')
         self.harness.add_resource('bar', '')
 
-        with self.assertRaises(ops.model.ModelError):
+        with self.assertRaises(NameError):
             self.harness.model.resources.fetch('qux')
 
         self.assertEqual(self.harness.model.resources.fetch('foo').name, 'foo.txt')

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -490,7 +490,7 @@ class TestModel(unittest.TestCase):
         self.harness.add_resource('foo', 'foo contents\n')
         self.harness.add_resource('bar', '')
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ops.model.ModelError):
             self.harness.model.resources.fetch('qux')
 
         self.assertEqual(self.harness.model.resources.fetch('foo').name, 'foo.txt')


### PR DESCRIPTION
Fixes #660 

The docstring about `ops.model.Resources.fetch` states that a `ModelError` is thrown when a path to the resource cannot be found on disk. The current implementation raises a `RuntimeError`. Either the docstring or the code need changing, and I think throwing a `ModelError` is appropriate.

Update: changed to `NameError` after review feedback