### PR TITLE
Fix storage events with multiple hyphens

### DIFF
--- a/ops/main.py
+++ b/ops/main.py
@@ -155,8 +155,9 @@ def _get_event_args(charm, bound_event):
         if storage_id:
             storage_name = storage_id.split("/")[0]
         else:
-            # Before JUJU_STORAGE_ID exists
-            storage_name = bound_event.event_kind.split("_", 1)[0]
+            # Before JUJU_STORAGE_ID exists, take the event name as
+            # <storage_name>_storage_<attached|detached> and replace it with <storage_name<
+            storage_name = "-".join(bound_event.event_kind.split("_")[:-2])
 
         storages = model.storages[storage_name]
         id, storage_location = model._backend._storage_event_details()

--- a/ops/main.py
+++ b/ops/main.py
@@ -156,7 +156,7 @@ def _get_event_args(charm, bound_event):
             storage_name = storage_id.split("/")[0]
         else:
             # Before JUJU_STORAGE_ID exists, take the event name as
-            # <storage_name>_storage_<attached|detached> and replace it with <storage_name<
+            # <storage_name>_storage_<attached|detached> and replace it with <storage_name>
             storage_name = "-".join(bound_event.event_kind.split("_")[:-2])
 
         storages = model.storages[storage_name]

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -217,6 +217,10 @@ storage:
     multiple:
       range: 2-
     type: filesystem
+  stor-multiple-dashes:
+    multiple:
+      range: 2-
+    type: filesystem
 ''')
 
         fake_script(
@@ -271,6 +275,7 @@ storage:
         charm.on['stor2'].storage_detaching.emit(Storage("stor2", 0, charm.model._backend))
         charm.on['stor3'].storage_attached.emit(Storage("stor3", 0, charm.model._backend))
         charm.on['stor-4'].storage_attached.emit(Storage("stor-4", 0, charm.model._backend))
+        charm.on['stor-multiple-dashes'].storage_attached.emit(Storage("stor-multiple-dashes", 0, charm.model._backend))
 
         self.assertEqual(charm.seen, [
             'StorageAttachedEvent',

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -275,7 +275,8 @@ storage:
         charm.on['stor2'].storage_detaching.emit(Storage("stor2", 0, charm.model._backend))
         charm.on['stor3'].storage_attached.emit(Storage("stor3", 0, charm.model._backend))
         charm.on['stor-4'].storage_attached.emit(Storage("stor-4", 0, charm.model._backend))
-        charm.on['stor-multiple-dashes'].storage_attached.emit(Storage("stor-multiple-dashes", 0, charm.model._backend))
+        charm.on['stor-multiple-dashes'].storage_attached.emit(
+            Storage("stor-multiple-dashes", 0, charm.model._backend))
 
         self.assertEqual(charm.seen, [
             'StorageAttachedEvent',


### PR DESCRIPTION
Don't throw exceptions if storage names have multiple hyphens. 

Closes #662 