### PR TITLE
fix observer type hint

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -26,6 +26,7 @@ import pdb
 import re
 import sys
 import types
+import typing
 import weakref
 
 from ops import charm
@@ -640,7 +641,7 @@ class Framework(Object):
         """Discard a persistent snapshot."""
         self._storage.drop_snapshot(handle.path)
 
-    def observe(self, bound_event: BoundEvent, observer: types.MethodType):
+    def observe(self, bound_event: BoundEvent, observer: typing.Callable[[EventBase], None]):
         """Register observer to be called when bound_event is emitted.
 
         The bound_event is generally provided as an attribute of the object that emits

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -641,7 +641,7 @@ class Framework(Object):
         """Discard a persistent snapshot."""
         self._storage.drop_snapshot(handle.path)
 
-    def observe(self, bound_event: BoundEvent, observer: typing.Callable[[EventBase], None]):
+    def observe(self, bound_event: BoundEvent, observer: typing.Callable[[typing.Any], None]):
         """Register observer to be called when bound_event is emitted.
 
         The bound_event is generally provided as an attribute of the object that emits


### PR DESCRIPTION
This PR addresses a repeating mypy error for observer:
```
lib/charms/alertmanager_k8s/v0/alertmanager_dispatch.py:149: error: Argument 2 to "observe" of "Framework" has incompatible type "Callable[[RelationChangedEvent], Any]"; expected
"MethodType"  [arg-type]
                self.charm.on[self.name].relation_changed, self._on_relation_changed
                                                           ^
lib/charms/alertmanager_k8s/v0/alertmanager_dispatch.py:153: error: Argument 2 to "observe" of "Framework" has incompatible type "Callable[[Any], Any]"; expected "MethodType"  [arg-type]
                self._on_relation_departed,
                ^
```

The mypy errors go away if you either
1. run mypy without `--check-untyped-defs` ([playground](https://mypy-play.net/?mypy=0.800&python=3.5&flags=check-untyped-defs&gist=c01b11ed64f19090c0e24928261dc2c2)); or
2. change ops type hint
