### PR TITLE
Adjust the behaviour of the create_dir function in the fake Pebble FS

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1488,7 +1488,12 @@ class _MockFilesystem:
         if token not in current_dir:
             current_dir = current_dir.create_dir(token, **kwargs)
         else:
-            raise FileExistsError(str(current_dir.path / token))
+            # If 'make_parents' is specified, behave like 'mkdir -p' and ignore if the dir already
+            # exists.
+            if make_parents:
+                current_dir = _Directory(current_dir.path / token)
+            else:
+                raise FileExistsError(str(current_dir.path / token))
         return current_dir
 
     def create_file(

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3002,6 +3002,12 @@ class TestMockFilesystem(unittest.TestCase):
             self.fs.create_dir('/etc')
         self.assertEqual(cm.exception.args[0], '/etc')
 
+    def test_makedir_succeeds_if_already_exists_when_make_parents_true(self):
+        d1 = self.fs.create_dir('/etc')
+        d2 = self.fs.create_dir('/etc', make_parents=True)
+        self.assertEqual(d1.path, d2.path)
+        self.assertEqual(d1.name, d2.name)
+
     def test_makedir_fails_if_parent_dir_doesnt_exist(self):
         with self.assertRaises(FileNotFoundError) as cm:
             self.fs.create_dir('/etc/init.d')


### PR DESCRIPTION
In the current implementation of the fake pebble filesystem in harness, the following would fail:

```python
client.make_dir("/mydir")
client.make_dir("/mydir", make_parents=True)
```

With a `FileExistsError`. This PR corrects that, and makes the fake FS behave like a real Pebble Files API (and more like `mkdir -p`), and ignores when a folder already exists if `make_parents` is specified.