### PR TITLE
Upkeep: Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,15 +15,12 @@ basepython = python3
 setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
   PYTHONBREAKPOINT=ipdb.set_trace
+  PY_COLORS=1
 passenv =
   PYTHONPATH
   HOME
   PATH
-  CHARM_BUILD_DIR
   MODEL_SETTINGS
-  HTTP_PROXY
-  HTTPS_PROXY
-  NO_PROXY
 
 [testenv:docs]
 description = Build the Sphinx docs


### PR DESCRIPTION
Make the test output more colourful in CI, and remove some environment variables from the list of those to explicitly passthrough that are automatically passed through.