### PR TITLE
pass missing make_dirs arg

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1514,7 +1514,7 @@ class _MockFilesystem:
             dir_ = self.get_path(path_obj.parent)
         except FileNotFoundError:
             if make_dirs:
-                dir_ = self.create_dir(str(path_obj.parent))
+                dir_ = self.create_dir(str(path_obj.parent), make_parents=make_dirs)
                 # NOTE: other parameters (e.g. ownership, permissions) only get applied to the
                 # final directory.
                 # (At the time of writing, Pebble defaults to the specified permissions and

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3035,7 +3035,7 @@ class TestMockFilesystem(unittest.TestCase):
         self.assertEqual(cm.exception.args[0], '/etc')
 
     def test_create_file_succeeds_if_parent_dir_doesnt_exist_when_make_dirs_true(self):
-        f = self.fs.create_file('/test/subdir/testfile', "foo", make_dirs=True)
+        self.fs.create_file('/test/subdir/testfile', "foo", make_dirs=True)
         with self.fs.open('/test/subdir/testfile') as infile:
             self.assertEqual(infile.read(), 'foo')
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3029,6 +3029,16 @@ class TestMockFilesystem(unittest.TestCase):
         with self.assertRaises(NonAbsolutePathError):
             self.fs.create_dir("noslash")
 
+    def test_create_file_fails_if_parent_dir_doesnt_exist(self):
+        with self.assertRaises(FileNotFoundError) as cm:
+            self.fs.create_file('/etc/passwd', "foo")
+        self.assertEqual(cm.exception.args[0], '/etc')
+
+    def test_create_file_succeeds_if_parent_dir_doesnt_exist_when_make_dirs_true(self):
+        f = self.fs.create_file('/test/subdir/testfile', "foo", make_dirs=True)
+        with self.fs.open('/test/subdir/testfile') as infile:
+            self.assertEqual(infile.read(), 'foo')
+
     def test_create_file_from_str(self):
         self.fs.create_file('/test', "foo")
         with self.fs.open('/test') as infile:


### PR DESCRIPTION
#645 added harness support for filesystem operations such as push/pull.
A call to `create_dir` in the original implementation omitted the `make_dirs` args, which failed `container.push` when parent dirs did not exist.
This bug became visible only when the nesting level was higher than 1.