### PR TITLE
remove_path succeeds even if path does not exist

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1546,7 +1546,11 @@ ChangeError: cannot perform the following tasks:
             )
 
     def remove_path(self, path: str, *, recursive: bool = False):
-        file_or_dir = self._fs.get_path(path)
+        try:
+            file_or_dir = self._fs.get_path(path)
+        except FileNotFoundError:
+            return
+
         if isinstance(file_or_dir, _Directory) and len(file_or_dir) > 0 and not recursive:
             raise pebble.PathError(
                 'generic-file-error', 'cannot remove non-empty directory without recursive=True')

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1549,7 +1549,10 @@ ChangeError: cannot perform the following tasks:
         try:
             file_or_dir = self._fs.get_path(path)
         except FileNotFoundError:
-            return
+            if recursive:
+                return
+            raise pebble.PathError(
+                'generic-file-error', 'cannot remove non-existing path without recursive=True')
 
         if isinstance(file_or_dir, _Directory) and len(file_or_dir) > 0 and not recursive:
             raise pebble.PathError(

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1550,9 +1550,10 @@ ChangeError: cannot perform the following tasks:
             file_or_dir = self._fs.get_path(path)
         except FileNotFoundError:
             if recursive:
+                # Pebble doesn't give not-found error when recursive is specified
                 return
             raise pebble.PathError(
-                'generic-file-error', 'cannot remove non-existing path without recursive=True')
+                'not-found', 'remove {}: no such file or directory'.format(path))
 
         if isinstance(file_or_dir, _Directory) and len(file_or_dir) > 0 and not recursive:
             raise pebble.PathError(

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3260,7 +3260,7 @@ class _PebbleStorageAPIsTestMixin:
         # Remove non-existent path, recursive=False: error
         with self.assertRaises(pebble.PathError) as cm:
             client.remove_path(self.prefix + '/dir/does/not/exist/asdf', recursive=False)
-        self.assertEqual(cm.exception.kind, 'generic-file-error')
+        self.assertEqual(cm.exception.kind, 'not-found')
 
         # Remove non-existent path, recursive=True: succeeds
         client.remove_path(self.prefix + '/dir/does/not/exist/asdf', recursive=True)

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3257,8 +3257,10 @@ class _PebbleStorageAPIsTestMixin:
         # Remove non-empty directory, recursive=True: succeeds (and removes child objects)
         client.remove_path(self.prefix + '/dir', recursive=True)
 
-        # Remove non-existent path, recursive=False: succeeds
-        client.remove_path(self.prefix + '/dir/does/not/exist/asdf', recursive=False)
+        # Remove non-existent path, recursive=False: error
+        with self.assertRaises(pebble.PathError) as cm:
+            client.remove_path(self.prefix + '/dir/does/not/exist/asdf', recursive=False)
+        self.assertEqual(cm.exception.kind, 'generic-file-error')
 
         # Remove non-existent path, recursive=True: succeeds
         client.remove_path(self.prefix + '/dir/does/not/exist/asdf', recursive=True)

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3257,10 +3257,10 @@ class _PebbleStorageAPIsTestMixin:
         # Remove non-empty directory, recursive=True: succeeds (and removes child objects)
         client.remove_path(self.prefix + '/dir', recursive=True)
 
-        # Removing non-existent path, recursive=False: succeeds
+        # Remove non-existent path, recursive=False: succeeds
         client.remove_path(self.prefix + '/dir/does/not/exist/asdf', recursive=False)
 
-        # Removing non-existent path, recursive=True: succeeds
+        # Remove non-existent path, recursive=True: succeeds
         client.remove_path(self.prefix + '/dir/does/not/exist/asdf', recursive=True)
 
     # Other notes:

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3257,10 +3257,11 @@ class _PebbleStorageAPIsTestMixin:
         # Remove non-empty directory, recursive=True: succeeds (and removes child objects)
         client.remove_path(self.prefix + '/dir', recursive=True)
 
-        # Deliberately ignoring a few cases right now, as the behavior for these may
-        # change based upon discussions:
-        # * Removing non-existent path, recursive=False: currently does error
-        # * Removing non-existent path, recursive=True: currently does not error
+        # Removing non-existent path, recursive=False: succeeds
+        client.remove_path(self.prefix + '/dir/does/not/exist/asdf', recursive=False)
+
+        # Removing non-existent path, recursive=True: succeeds
+        client.remove_path(self.prefix + '/dir/does/not/exist/asdf', recursive=True)
 
     # Other notes:
     # * Parent directories created via push(make_dirs=True) default to root:root ownership


### PR DESCRIPTION
This PR modifies the harness's `remove_path` to succeed even if path does not exist.
Per comment by @benhoyt in #676, this matches pebble's behavior.

Fixes #676.