### PR TITLE
Make the storage harness work when metadata keys have hyphens

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -178,8 +178,8 @@ class Harness(typing.Generic[CharmType]):
         # Checking if disks have been added
         # storage-attached events happen before install
         for storage_name in self._meta.storages:
-            storage_name = storage_name.replace('-', '_')
             for storage_index in self._backend.storage_list(storage_name):
+                storage_name = storage_name.replace('-', '_')
                 # Storage device(s) detected, emit storage-attached event(s)
                 self._charm.on[storage_name].storage_attached.emit(
                     model.Storage(storage_name, storage_index, self._backend))


### PR DESCRIPTION
Don't replace '-' with '_' until after we find the index. This is
essentially an off-by-one error which prevents any storage key
which uses hyphens from being looked up, and causes a difference
in behavior between actual charm behavior and harness behavior.

Add a small helper to the tests and an additional test to verify
that it works.