### PR TITLE
[WIP] track config history

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -15,6 +15,7 @@
 """Base objects for the Charm, events and metadata."""
 
 import enum
+import logging
 import os
 import pathlib
 import typing
@@ -22,6 +23,8 @@ import typing
 from ops import model
 from ops._private import yaml
 from ops.framework import EventBase, EventSource, Framework, Object, ObjectEvents
+
+logger = logging.getLogger(__name__)
 
 
 class HookEvent(EventBase):

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ version = {!r}
             # "Operating System :: Microsoft :: Windows",
         ],
         python_requires='>=3.5',
-        install_requires=["PyYAML"],
+        install_requires=["PyYAML", "memory_profiler"],
         package_data={'ops': ['py.typed']},
     )
 


### PR DESCRIPTION
These changes will provide the ability to track the history of specific keys from the charm config.


Example how it could be used.
```python
class Charm(CharmBase):
  def __init__(*args):
    super().__init__(*args)
    self.framework.observe(self.on.config_changed, self._on_config_changed)
    self.framework.tacked(["key-1", "key-2"])

  def _on_config_changed(self, _):
    self.framework.tack["key-1"][-1]  # get the last value 
```

These changes were tested with [`memory_profile`](https://github.com/pythonprofilers/memory_profiler) and [charm-history-overheat](https://github.com/r-f-g/charm-history-overheat/tree/ops-tacked-test).
```python
# NOTE (rgildein): this part is for test purpose
import time
from functools import wraps
from memory_profiler import profile


def track(func):
    @wraps(wrapped=func)
    def wrapper(self, *args, **kwargs):
        with open("tracking-history.log", "a+") as file:
            start = time.time()
            file.write(f"### track history={self.model.config['history']}\n")
            result = profile(func=func, stream=file, precision=4)(self, *args, **kwargs)
            file.write(f"### finished {time.time()-start:.3f}s\n")
            return result

    return wrapper
# END

...
    @track
    def commit(self):
```
The [results](https://pastebin.canonical.com/p/rG8SbkK5Vk/).