### PR TITLE
conformed list_files behaviour on failure with pebble's

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1500,8 +1500,7 @@ ChangeError: cannot perform the following tasks:
         except FileNotFoundError as e:
             # conform with the real pebble api
             raise pebble.APIError(
-                body={}, message=str(e),
-                code=404, status='Not Found')
+                body={}, code=404, status='Not Found', message=str(e))
 
         if not itself:
             try:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1495,7 +1495,14 @@ ChangeError: cannot perform the following tasks:
 
     def list_files(self, path: str, *, pattern: str = None,
                    itself: bool = False) -> typing.List[pebble.FileInfo]:
-        files = [self._fs.get_path(path)]
+        try:
+            files = [self._fs.get_path(path)]
+        except FileNotFoundError as e:
+            # conform with the real pebble api
+            raise pebble.APIError(
+                body={}, message=str(e),
+                code=404, status='Not Found')
+
         if not itself:
             try:
                 files = self._fs.list_dir(path)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1497,7 +1497,7 @@ ChangeError: cannot perform the following tasks:
                    itself: bool = False) -> typing.List[pebble.FileInfo]:
         try:
             files = [self._fs.get_path(path)]
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             # conform with the real pebble api
             raise pebble.APIError(
                 body={}, code=404, status='Not Found',

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1500,7 +1500,8 @@ ChangeError: cannot perform the following tasks:
         except FileNotFoundError as e:
             # conform with the real pebble api
             raise pebble.APIError(
-                body={}, code=404, status='Not Found', message=str(e))
+                body={}, code=404, status='Not Found',
+                message="open {}: no such file or directory".format(path))
 
         if not itself:
             try:

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -26,6 +26,7 @@ from io import BytesIO, StringIO
 
 import yaml
 
+import ops.pebble
 from ops import pebble
 from ops.charm import (
     CharmBase,
@@ -3054,6 +3055,7 @@ services:
 
 
 class _PebbleStorageAPIsTestMixin:
+    client: ops.pebble.Client
 
     # Override this in classes using this mixin.
     # This should be set to any non-empty path, but without a trailing /.
@@ -3169,6 +3171,14 @@ class _PebbleStorageAPIsTestMixin:
         with self.assertRaises(pebble.PathError) as cm:
             client.push('file', '')
         self.assertEqual(cm.exception.kind, 'generic-file-error')
+
+    def test_list_files_not_found_raises(self):
+        client = self.client
+        with self.assertRaises(pebble.APIError) as cm:
+            client.list_files("/not/existing/file/")
+        self.assertEqual(cm.exception.code, 404)
+        self.assertEqual(cm.exception.status, 'Not Found')
+        self.assertEqual(cm.exception.message, '/not')
 
     def test_list_directory_object_itself(self):
         client = self.client

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3175,7 +3175,8 @@ class _PebbleStorageAPIsTestMixin:
             client.list_files("/not/existing/file/")
         self.assertEqual(cm.exception.code, 404)
         self.assertEqual(cm.exception.status, 'Not Found')
-        self.assertEqual(cm.exception.message, '/not')
+        self.assertEqual(cm.exception.message, 'open /not/existing/file/: no '
+                                               'such file or directory')
 
     def test_list_directory_object_itself(self):
         client = self.client

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3055,8 +3055,6 @@ services:
 
 
 class _PebbleStorageAPIsTestMixin:
-    client: ops.pebble.Client
-
     # Override this in classes using this mixin.
     # This should be set to any non-empty path, but without a trailing /.
     prefix = None

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -26,7 +26,6 @@ from io import BytesIO, StringIO
 
 import yaml
 
-import ops.pebble
 from ops import pebble
 from ops.charm import (
     CharmBase,


### PR DESCRIPTION
Ensured that an APIError is raised instead of FileNotFoundError on list_files('/not/existing/path'); 

Fixes #679


