### PR TITLE
Add real pebble tests to our CI

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -65,8 +65,15 @@ jobs:
         run: go install github.com/canonical/pebble/cmd/pebble@latest
 
       - name: Start Pebble
-        run: umask 0 && PEBBLE=/tmp/pebble $HOME/go/bin/pebble run --create-dirs &
+        run: |
+          umask 0
+          $HOME/go/bin/pebble run --create-dirs &
+        env:
+          PEBBLE: /tmp/pebble
 
       - name: Run Real pebble tests
-        run: RUN_REAL_PEBBLE_TESTS=1 PEBBLE=/tmp/pebble tox -e unit -- -k RealPebble
+        run: tox -e unit -- -k RealPebble
+        env:
+          RUN_REAL_PEBBLE_TESTS: 1 
+          PEBBLE: /tmp/pebble 
 

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -37,3 +37,36 @@ jobs:
 
       - name: Run unit tests
         run: tox -e unit
+
+  test-real-pebble:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up Go 1.17
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.17
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Install Pebble
+        run: go install github.com/canonical/pebble/cmd/pebble@latest
+
+      - name: Start Pebble
+        run: PEBBLE=/tmp/pebble $HOME/go/bin/pebble run --create-dirs &
+
+      - name: Run Real pebble tests
+        run: RUN_REAL_PEBBLE_TESTS=1 PEBBLE=/tmp/pebble tox -e unit -- -k RealPebble
+

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -65,7 +65,7 @@ jobs:
         run: go install github.com/canonical/pebble/cmd/pebble@latest
 
       - name: Start Pebble
-        run: PEBBLE=/tmp/pebble $HOME/go/bin/pebble run --create-dirs &
+        run: umask 0 && PEBBLE=/tmp/pebble $HOME/go/bin/pebble run --create-dirs &
 
       - name: Run Real pebble tests
         run: RUN_REAL_PEBBLE_TESTS=1 PEBBLE=/tmp/pebble tox -e unit -- -k RealPebble

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -35,6 +35,7 @@ import socket
 import sys
 import threading
 import time
+import types
 import typing
 import urllib.error
 import urllib.parse
@@ -1135,6 +1136,11 @@ class Client:
         url = self.base_url + path
         if query:
             url = url + '?' + urllib.parse.urlencode(query)
+
+        # python 3.5 urllib requests require their data to be a bytes object -
+        # generators won't work.
+        if sys.version_info[:2] < (3, 6) and isinstance(data, types.GeneratorType):
+            data = b''.join(data)
 
         if headers is None:
             headers = {}

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1501,7 +1501,7 @@ ChangeError: cannot perform the following tasks:
             # conform with the real pebble api
             raise pebble.APIError(
                 body={}, code=404, status='Not Found',
-                message="open {}: no such file or directory".format(path))
+                message="stat {}: no such file or directory".format(path))
 
         if not itself:
             try:

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3175,7 +3175,7 @@ class _PebbleStorageAPIsTestMixin:
             client.list_files("/not/existing/file/")
         self.assertEqual(cm.exception.code, 404)
         self.assertEqual(cm.exception.status, 'Not Found')
-        self.assertEqual(cm.exception.message, 'open /not/existing/file/: no '
+        self.assertEqual(cm.exception.message, 'stat /not/existing/file/: no '
                                                'such file or directory')
 
     def test_list_directory_object_itself(self):

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,9 @@ commands =
 
 [testenv:unit]
 description = Run unit tests
+passenv = 
+    RUN_REAL_PEBBLE_TESTS
+    PEBBLE
 deps =
     pytest
     ipdb


### PR DESCRIPTION
This adds a real pebble tests step to all our workflow permutations.  After running the regular unit tests, it builds and starts the latest pebble and then runs the real pebble tests in the framework.  This exercise caught a couple of small bugs lying dormant that I have included fixes for.