### PR TITLE
Parse revision|version into CharmMeta

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -748,7 +748,6 @@ class CharmMeta:
         self.subordinate = raw.get('subordinate', False)
         self.min_juju_version = raw.get('min-juju-version')
         self.revision = versions.get('revision', '')
-        self.version = versions.get('version', '')
         self.requires = {name: RelationMeta(RelationRole.requires, name, rel)
                          for name, rel in raw.get('requires', {}).items()}
         self.provides = {name: RelationMeta(RelationRole.provides, name, rel)

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -733,7 +733,7 @@ class CharmMeta:
 
     """
 
-    def __init__(self, raw: dict = {}, actions_raw: dict = {}):
+    def __init__(self, raw: dict = {}, actions_raw: dict = {}, versions: dict = {}):
         self.name = raw.get('name', '')
         self.summary = raw.get('summary', '')
         self.description = raw.get('description', '')
@@ -747,6 +747,8 @@ class CharmMeta:
         self.series = raw.get('series', [])
         self.subordinate = raw.get('subordinate', False)
         self.min_juju_version = raw.get('min-juju-version')
+        self.revision = versions.get('revision', '')
+        self.version = versions.get('version', '')
         self.requires = {name: RelationMeta(RelationRole.requires, name, rel)
                          for name, rel in raw.get('requires', {}).items()}
         self.provides = {name: RelationMeta(RelationRole.provides, name, rel)
@@ -774,13 +776,15 @@ class CharmMeta:
     @classmethod
     def from_yaml(
             cls, metadata: typing.Union[str, typing.TextIO],
-            actions: typing.Optional[typing.Union[str, typing.TextIO]] = None):
+            actions: typing.Optional[typing.Union[str, typing.TextIO]] = None,
+            versions: typing.Optional[typing.Dict] = None):
         """Instantiate a CharmMeta from a YAML description of metadata.yaml.
 
         Args:
             metadata: A YAML description of charm metadata (name, relations, etc.)
                 This can be a simple string, or a file-like object. (passed to `yaml.safe_load`).
             actions: YAML description of Actions for this charm (eg actions.yaml)
+            versions: a dict describing the version and revision
         """
         meta = yaml.safe_load(metadata)
         raw_actions = {}
@@ -788,7 +792,8 @@ class CharmMeta:
             raw_actions = yaml.safe_load(actions)
             if raw_actions is None:
                 raw_actions = {}
-        return cls(meta, raw_actions)
+        raw_versions = versions or {}
+        return cls(meta, raw_actions, raw_versions)
 
 
 class RelationRole(enum.Enum):

--- a/ops/main.py
+++ b/ops/main.py
@@ -369,9 +369,21 @@ def main(charm_class: typing.Type[ops.charm.CharmBase], use_juju_for_storage: bo
     else:
         actions_metadata = None
 
+    versions_meta = {}
+    revision_file = charm_dir / 'revision'
+    if revision_file.exists():
+        versions_meta.update({
+            "revision": revision_file.read_text()
+        })
+    version_file = charm_dir / 'version'
+    if version_file.exists():
+        versions_meta.update({
+            "version": version_file.read_text()
+        })
+
     if not yaml.__with_libyaml__:
         logger.debug('yaml does not have libyaml extensions, using slower pure Python yaml loader')
-    meta = ops.charm.CharmMeta.from_yaml(metadata, actions_metadata)
+    meta = ops.charm.CharmMeta.from_yaml(metadata, actions_metadata, versions=versions_meta)
     model = ops.model.Model(meta, model_backend)
 
     charm_state_path = charm_dir / CHARM_STATE_FILE

--- a/ops/main.py
+++ b/ops/main.py
@@ -375,11 +375,6 @@ def main(charm_class: typing.Type[ops.charm.CharmBase], use_juju_for_storage: bo
         versions_meta.update({
             "revision": revision_file.read_text()
         })
-    version_file = charm_dir / 'version'
-    if version_file.exists():
-        versions_meta.update({
-            "version": version_file.read_text()
-        })
 
     if not yaml.__with_libyaml__:
         logger.debug('yaml does not have libyaml extensions, using slower pure Python yaml loader')

--- a/ops/model.py
+++ b/ops/model.py
@@ -199,6 +199,9 @@ class Application:
 
     def __init__(self, name, meta, backend, cache):
         self.name = name
+        # test_testing passes a dict in directly, but in case 'revision' is not set on `meta` in
+        # other cases, return the default here
+        self.revision = meta.revision if hasattr(meta, 'revision') else ""
         self._backend = backend
         self._cache = cache
         self._is_our_app = self.name == self._backend.app_name

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -484,6 +484,10 @@ class Harness(typing.Generic[CharmType]):
     def add_relation(self, relation_name: str, remote_app: str) -> int:
         """Declare that there is a new relation between this app and `remote_app`.
 
+        This function creates a relation with an application and will trigger a relation-created
+        hook. To relate units (and trigger relation-joined and relation-changed hooks), you should
+        also call :meth:`.add_relation_unit`.
+
         Args:
             relation_name: The relation on Charm that is being related to
             remote_app: The name of the application that is being related to

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -485,12 +485,21 @@ containers:
 name: k8s-charm
 """,
                                    versions={
-                                       "version": "1.2.3",
                                        "revision": "987",
                                    }
                                    )
-        self.assertEqual(meta.version, "1.2.3")
         self.assertEqual(meta.revision, "987")
+
+        class MyCharm(CharmBase):
+
+            def __init__(self, *args):
+                super().__init__(*args)
+
+        model = Model(meta, _ModelBackend('local/0'))
+        framework = Framework(SQLiteStorage(':memory:'), self.tmpdir, meta, model)
+        self.addCleanup(framework.close)
+        charm = MyCharm(framework)
+        self.assertEqual(charm.app.revision, "987")
 
     def test_containers_storage(self):
         meta = CharmMeta.from_yaml("""

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -480,6 +480,18 @@ containers:
         self.assertEqual(meta.containers['test1'].name, 'test1')
         self.assertEqual(meta.containers['test2'].name, 'test2')
 
+    def test_versions(self):
+        meta = CharmMeta.from_yaml("""
+name: k8s-charm
+""",
+                                   versions={
+                                       "version": "1.2.3",
+                                       "revision": "987",
+                                   }
+                                   )
+        self.assertEqual(meta.version, "1.2.3")
+        self.assertEqual(meta.revision, "987")
+
     def test_containers_storage(self):
         meta = CharmMeta.from_yaml("""
 name: k8s-charm


### PR DESCRIPTION
Operator Framework does not currently do anything with `version`
(which no longer appears to be automatically generated by
`charmcraft` anyway) or `revision`, which is always present when
Juju deploys, even if it's `0` for a locally-built charm.

Expose these in `CharmMeta` so authors can use it to
`set_workload_version` based on `charm.meta` information if desired,
or otherwise perform labeling/checking on metrics labels or other
data.