### PR TITLE
FIX remove_path docstring to relfect current behaviour.

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1681,7 +1681,11 @@ class Client:
 
         Args:
             path: Path of the file or directory to delete from the remote system.
-            recursive: If True, recursively delete path and everything under it.
+            recursive: If True, and path is a directory recursively deletes it and
+                       everything under it.
+                       If True, and path is a file deletes it and ignore if file
+                       does not exists.
+
         """
         info = {'path': path}
         if recursive:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1682,9 +1682,9 @@ class Client:
         Args:
             path: Path of the file or directory to delete from the remote system.
             recursive: If True, and path is a directory recursively deletes it and
-                       everything under it.
-                       If True, and path is a file deletes it and ignore if file
-                       does not exists.
+                       everything under it. If the path is a file, delete the file and
+                       do nothing if the file is non-existent. Behaviourally similar 
+                       to `rm -rf <file|dir>`
 
         """
         info = {'path': path}

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1683,7 +1683,7 @@ class Client:
             path: Path of the file or directory to delete from the remote system.
             recursive: If True, and path is a directory recursively deletes it and
                        everything under it. If the path is a file, delete the file and
-                       do nothing if the file is non-existent. Behaviourally similar 
+                       do nothing if the file is non-existent. Behaviourally similar
                        to `rm -rf <file|dir>`
 
         """


### PR DESCRIPTION
The `recursive=True` argument in `remove_path` [method behaves like a `rm -rf`](https://chat.charmhub.io/charmhub/pl/rh9jykcd8tnaiex5zz8rjk9qpr) ([recursive + ignore nonexistent](https://www.man7.org/linux/man-pages/man1/rm.1.html#OPTIONS))

This PR fixes docstring to reflect current behaviour.
