### PR TITLE
add tox config for real pebble tests

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,82 @@
+
+# Setting up a Dev Environment
+
+To work in the framework itself you will need Python >= 3.5. Linting, testing,
+and docs automation is performed using
+[`tox`](https://tox.readthedocs.io/en/latest/) which you should install.
+For improved performance on the tests, ensure that you have PyYAML
+installed with the correct extensions:
+
+```sh
+apt-get install libyaml-dev
+pip install --force-reinstall --no-cache-dir pyyaml
+```
+
+# Testing
+
+The following are likely to be useful during development:
+
+```sh
+# Run linting and unit tests
+tox
+
+# Run tests, specifying whole suite or specific files
+tox -e unit
+tox -e unit test/test_charm.py
+
+# Format the code using isort
+tox -e fmt
+
+# Generate a local copy of the Sphinx docs in docs/_build
+tox -e docs
+
+# run only tests matching a certain pattern
+tox -e unit -- -k <pattern>
+```
+
+For more in depth debugging, you can enter any of `tox`'s created virtualenvs
+provided they have been run at least once and do fun things - e.g. run
+`pytest` directly:
+
+```sh
+# Enter the linting virtualenv
+source .tox/lint/bin/activate
+
+...
+
+# Enter the unit testing virtualenv and run tests
+source .tox/unit/bin/activate
+pytest
+...
+
+```
+
+## Pebble Tests
+
+The framework has some tests that interact with a real/live pebble server.  To
+run these tests, you must have (pebble)[https://github.com/canonical/pebble]
+installed and available in your path.  If you have the Go toolchain installed,
+you can run `go install github.com/canonical/pebble@latest`.  This will
+install pebble to `$GOBIN` if it is set or `$HOME/go/bin` otherwise.  Add
+`$GOBIN` to your path (e.g. `export PATH=$PATH:$GOBIN` or `export
+PATH=$PATH:$HOME/go/bin` in your `.bashrc`) and you are ready to run the real
+pebble tests:
+
+```sh
+tox -e pebble
+```
+
+To do this even more manually, you could start the pebble server yourself:
+
+```sh
+export PEBBLE=$HOME/pebble
+export RUN_REAL_PEBBLE_TESTS=1
+pebble run --create-dirs &>pebble.log &
+
+# Then
+tox -e unit -- -k RealPebble
+# or
+source .tox/unit/bin/activate
+pytest -v -k RealPebble
+```
+

--- a/README.md
+++ b/README.md
@@ -127,41 +127,5 @@ You can deep dive into the [API docs] if that's your thing.
 
 ## Operator Framework development
 
-To work in the framework itself you will need Python >= 3.5. Linting, testing, and docs automation
-is performed using [`tox`](https://tox.readthedocs.io/en/latest/).
+See [HACKING.md](HACKING.md) for details on dev environments, testing, etc.
 
-The following are likely to be useful during development:
-
-```sh
-# Run linting and unit tests
-tox
-
-# Run tests, specifying whole suite or specific files
-tox -e unit
-tox -e unit test/test_charm.py
-
-# Format the code using isort
-tox -e fmt
-
-# Generate a local copy of the Sphinx docs in docs/_build
-tox -e docs
-```
-
-For more in depth debugging, you can enter any of `tox`'s created virtualenvs
-provided they have been run at least once:
-
-```sh
-# Enter the unit testing virtualenv
-source .tox/unit/bin/activate
-
-# Enter the linting virtualenv
-source .tox/lint/bin/activate
-```
-
-For improved performance on the tests, ensure that you have PyYAML
-installed with the correct extensions:
-
-```sh
-apt-get install libyaml-dev
-pip install --force-reinstall --no-cache-dir pyyaml
-```

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2551,6 +2551,7 @@ class _TestingPebbleClientMixin:
         return backend.get_pebble('/custom/socket/path')
 
 
+# For testing non file ops of the pebble testing client.
 class TestTestingPebbleClient(unittest.TestCase, _TestingPebbleClientMixin):
 
     def test_methods_match_pebble_client(self):
@@ -3053,6 +3054,9 @@ services:
         self.assertEqual(pebble.ServiceStatus.ACTIVE, foo_info.current)
 
 
+# For testing file-ops of the pebble client.  This is refactored into a
+# separate mixin so we can run these tests against both the mock client as
+# well as a real pebble server instance.
 class _PebbleStorageAPIsTestMixin:
     # Override this in classes using this mixin.
     # This should be set to any non-empty path, but without a trailing /.

--- a/tox.ini
+++ b/tox.ini
@@ -68,3 +68,18 @@ deps =
 commands =
     coverage run --source={[vars]src_path} -m pytest -v --tb native {posargs} 
     coverage report
+
+[testenv:pebble]
+description = Run real pebble tests
+allowlist_externals = pebble
+                      mkdir
+                      bash
+setenv =
+  PEBBLE=/tmp/pebble
+  RUN_REAL_PEBBLE_TESTS=1
+deps =
+    pytest
+    logassert
+    -r{toxinidir}/requirements.txt
+commands =
+    bash -c "(pebble run --create-dirs &>/dev/null & ) ; sleep 1; pytest -v --tb native -k RealPebble {posargs} ; killall -y 3m pebble"


### PR DESCRIPTION
Make sure the pebble binary is in your path and run `tox -e pebble`.  This should help facilitate smoother ops dev iteration.