### PR TITLE
Add Container.isdir and Container.exists helpers

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1270,6 +1270,26 @@ class Container:
         """
         return self._pebble.list_files(path, pattern=pattern, itself=itself)
 
+    def exists(self, path: str) -> bool:
+        """Return true if the path exists on the container filesystem."""
+        try:
+            self._pebble.list_files(path, itself=True)
+        except pebble.APIError as err:
+            if err.code == 404:
+                return False
+            raise err
+        return True
+
+    def isdir(self, path: str) -> bool:
+        """Return true if a directory exists at the given path on the container filesystem."""
+        try:
+            files = self._pebble.list_files(path, itself=True)
+        except pebble.APIError as err:
+            if err.code == 404:
+                return False
+            raise err
+        return files[0].type == pebble.FileType.DIRECTORY
+
     def make_dir(
             self, path: str, *, make_parents: bool = False, permissions: int = None,
             user_id: int = None, user: str = None, group_id: int = None, group: str = None):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1646,6 +1646,33 @@ class TestHarness(unittest.TestCase):
         self.assertFalse(path.parent.exists())
         self.assertFalse(path.parent.parent.exists())
 
+    def test_container_isdir_and_exists(self):
+        harness = Harness(CharmBase, meta='''
+            name: test-app
+            containers:
+              foo:
+                resource: foo-image
+            ''')
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        c = harness.model.unit.containers['foo']
+
+        dir_path = '/tmp/foo/dir'
+        file_path = '/tmp/foo/file'
+
+        self.assertFalse(c.isdir(dir_path))
+        self.assertFalse(c.exists(dir_path))
+        self.assertFalse(c.isdir(file_path))
+        self.assertFalse(c.exists(file_path))
+
+        c.make_dir(dir_path, make_parents=True)
+        c.push(file_path, 'data')
+
+        self.assertTrue(c.isdir(dir_path))
+        self.assertTrue(c.exists(dir_path))
+        self.assertFalse(c.isdir(file_path))
+        self.assertTrue(c.exists(file_path))
+
     def test_add_oci_resource_custom(self):
         harness = Harness(CharmBase, meta='''
             name: test-app


### PR DESCRIPTION
These are common file io patterns that previously required a fair bit of
boilerplate for users to accomplish.

Before:

```python
try:
    f = container.list_files(path, itself=True)[0]
    isdir = f.type == pebble.FileType.DIRECTORY
except pebble.APIError as err:
    if err.code == 404:
        isdir = False
    raise err
```

After:

```python
container.isdir(path)
```

Similar pattern for `exists`.

@mmanciop 