### PR TITLE
skip broken ipython version to fix CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,7 @@ passenv =
 deps =
     pytest
     ipdb
+    ipython!=8.1.0 # this version is broken and was causing failures
     logassert
     coverage[toml]
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Our CI started failing randomly on some ipython related stuff.  Internet search let me know that this has happened to other projects within the last day or so.  So skip the bad ipython version for now.