### PR TITLE
expose the departing unit on RelationDeparted events

### DIFF
--- a/ops/main.py
+++ b/ops/main.py
@@ -146,6 +146,7 @@ def _get_event_args(charm, bound_event):
     event_type = bound_event.event_type
     model = charm.framework.model
 
+    relation = None
     if issubclass(event_type, ops.charm.WorkloadEvent):
         workload_name = os.environ['JUJU_WORKLOAD_NAME']
         container = model.unit.get_container(workload_name)
@@ -172,22 +173,26 @@ def _get_event_args(charm, bound_event):
         relation_name = os.environ['JUJU_RELATION']
         relation_id = int(os.environ['JUJU_RELATION_ID'].split(':')[-1])
         relation = model.get_relation(relation_name, relation_id)
-    else:
-        relation = None
 
     remote_app_name = os.environ.get('JUJU_REMOTE_APP', '')
     remote_unit_name = os.environ.get('JUJU_REMOTE_UNIT', '')
-    if remote_app_name or remote_unit_name:
-        if not remote_app_name:
-            if '/' not in remote_unit_name:
-                raise RuntimeError('invalid remote unit name: {}'.format(remote_unit_name))
-            remote_app_name = remote_unit_name.split('/')[0]
-        args = [relation, model.get_app(remote_app_name)]
-        if remote_unit_name:
-            args.append(model.get_unit(remote_unit_name))
-        return args, {}
-    elif relation:
-        return [relation], {}
+    departing_unit_name = os.environ.get('JUJU_DEPATING_UNIT', '')
+
+    if not remote_app_name and remote_unit_name:
+        if '/' not in remote_unit_name:
+            raise RuntimeError('invalid remote unit name: {}'.format(remote_unit_name))
+        remote_app_name = remote_unit_name.split('/')[0]
+
+    kwargs = {}
+    if remote_app_name:
+        kwargs['app'] = model.get_app(remote_app_name)
+    if remote_unit_name:
+        kwargs['unit'] = model.get_unit(remote_unit_name)
+    if departing_unit_name:
+        kwargs['departing_unit'] = model.get_unit(departing_unit_name)
+
+    if relation:
+        return [relation], kwargs
     return [], {}
 
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -84,13 +84,14 @@ class SymlinkTargetError(Exception):
 class EventSpec:
     def __init__(self, event_type, event_name, env_var=None,
                  relation_id=None, remote_app=None, remote_unit=None,
-                 model_name=None, set_in_env=None, workload_name=None):
+                 model_name=None, set_in_env=None, workload_name=None, departing_unit=None):
         self.event_type = event_type
         self.event_name = event_name
         self.env_var = env_var
         self.relation_id = relation_id
         self.remote_app = remote_app
         self.remote_unit = remote_unit
+        self.departing_unit = departing_unit
         self.model_name = model_name
         self.set_in_env = set_in_env
         self.workload_name = workload_name
@@ -382,8 +383,12 @@ class _TestMain(abc.ABC):
             remote_unit = event_spec.remote_unit
             if remote_unit is None:
                 remote_unit = ''
-
             env['JUJU_REMOTE_UNIT'] = remote_unit
+
+            departing_unit = event_spec.departing_unit
+            if departing_unit is None:
+                departing_unit = ''
+            env['JUJU_DEPARTING_UNIT'] = departing_unit
         else:
             env.update({
                 'JUJU_REMOTE_UNIT': '',
@@ -486,11 +491,12 @@ class _TestMain(abc.ABC):
         ), (
             EventSpec(RelationDepartedEvent, 'mon_relation_departed',
                       relation_id=2,
-                      remote_app='remote', remote_unit='remote/0'),
+                      remote_app='remote', remote_unit='remote/0', departing_unit='remote/42'),
             {'relation_name': 'mon',
              'relation_id': 2,
              'app_name': 'remote',
-             'unit_name': 'remote/0'},
+             'unit_name': 'remote/0',
+             'departing_unit_name': 'remote/42'},
         ), (
             EventSpec(RelationBrokenEvent, 'ha_relation_broken',
                       relation_id=3),
@@ -516,11 +522,13 @@ class _TestMain(abc.ABC):
         ), (
             EventSpec(RelationDepartedEvent, 'mon_relation_departed',
                       relation_id=2,
-                      remote_unit='remote/0'),
+                      remote_unit='remote/0',
+                      departing_unit='remote/42'),
             {'relation_name': 'mon',
              'relation_id': 2,
              'app_name': 'remote',
-             'unit_name': 'remote/0'},
+             'unit_name': 'remote/0',
+             'departing_unit_name': 'remote/42'},
         ), (
             EventSpec(ActionEvent, 'start_action',
                       env_var='JUJU_ACTION_NAME'),


### PR DESCRIPTION
I refactored a bit of the _get_event_args func logic.  I'd appreciate
some review focus on that to make sure I didn't subtley change/break
behavior.

Fixes #707