### PR TITLE
Implement send-signal for harness

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3097,27 +3097,27 @@ services:
         # Foo is now started, but Bar is not
 
         # Send a valid signal to a running service
-        client.send_signal("SIGHUP", "foo")
+        client.send_signal("SIGINT", "foo")
 
         # Send a valid signal but omit service name
         with self.assertRaises(TypeError):
-            client.send_signal("SIGHUP")
+            client.send_signal("SIGINT")
 
         # Send an invalid signal to a running service
         with self.assertRaises(pebble.APIError):
-            client.send_signal("sighup", "foo")
+            client.send_signal("sigint", "foo")
 
         # Send a valid signal to a stopped service
         with self.assertRaises(pebble.APIError):
-            client.send_signal("SIGHUP", "bar")
+            client.send_signal("SIGINT", "bar")
 
         # Send a valid signal to a non-existing service
         with self.assertRaises(pebble.APIError):
-            client.send_signal("SIGHUP", "baz")
+            client.send_signal("SIGINT", "baz")
 
         # Send a valid signal to a multiple services, one of which is not running
         with self.assertRaises(pebble.APIError):
-            client.send_signal("SIGHUP", "foo", "bar")
+            client.send_signal("SIGINT", "foo", "bar")
 
 
 # For testing file-ops of the pebble client.  This is refactored into a

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -17,6 +17,7 @@ import inspect
 import io
 import os
 import pathlib
+import platform
 import shutil
 import sys
 import tempfile
@@ -52,6 +53,8 @@ from ops.testing import (
     _MockFilesystem,
     _TestingPebbleClient,
 )
+
+is_linux = platform.system() == 'Linux'
 
 
 class StorageTester(CharmBase):
@@ -3080,6 +3083,7 @@ services:
         self.assertEqual(pebble.ServiceStartup.ENABLED, foo_info.startup)
         self.assertEqual(pebble.ServiceStatus.ACTIVE, foo_info.current)
 
+    @unittest.skipUnless(is_linux, 'Pebble runs on Linux')
     def test_send_signal(self):
         client = self.get_testing_client()
         client.add_layer('foo', '''\


### PR DESCRIPTION
This PR implements `send_signal` for the test harness.

Apart from error handling, this is implemented as a no-op.

Without this change, unit tests would have to include a mock for every test:

```python
@patch("ops.testing._TestingPebbleClient.send_signal")
```