### PR TITLE
track can_connect state for mock pebble clients

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -22,6 +22,7 @@ import random
 import signal
 import tempfile
 import typing
+import warnings
 from contextlib import contextmanager
 from io import BytesIO, StringIO
 from textwrap import dedent
@@ -100,6 +101,31 @@ class Harness(typing.Generic[CharmType]):
         self._defaults = self._load_config_defaults(config)
         self._update_config(key_values=self._defaults)
 
+    def set_can_connect(self, container: typing.Union[str, model.Container], val: bool):
+        """Change the simulated can_connect status of a container's underlying pebble client.
+
+        simulate_can_connect must be called prior to using this.
+        """
+        if isinstance(container, str):
+            container = self.model.unit.get_container(container)
+        self._backend._set_can_connect(container._pebble, val)
+
+    def simulate_can_connect(self):
+        """Activate Container.can_connect simulation.
+
+        This sets all containers' can_connect states to False and causes the
+        testing with the harness to model and track can_connect state for
+        containers accurately.  This means that calls that require
+        communication with the container API (e.g. Container.push,
+        Container.get_plan, Container.add_layer, etc.) will only succeed if
+        Container.can_connect() returns True and will raise exceptions
+        otherwise.  can_connect state evolves automatically to track with
+        events associated with container state, (e.g. calling
+        container_pebble_ready).  Once activated, can_connect state for
+        containers can also be manually controlled using set_can_connect.
+        """
+        self._backend._sim_can_connect()
+
     @property
     def charm(self) -> CharmType:
         """Return the instance of the charm class that was passed to __init__.
@@ -128,6 +154,14 @@ class Harness(typing.Generic[CharmType]):
         if self._charm is not None:
             raise RuntimeError('cannot call the begin method on the harness more than once')
 
+        # TODO: If/when we decide to allow breaking changes for a release,
+        # insert a self.simulate_can_connect() here to track container
+        # can_connect state correctly by default. And remove the warning
+        # message below.  This warning was added 2022-03-22
+        if not self._backend._simulate_can_connect:
+            warnings.warn(
+                'Please call Harness.simulate_can_connect prior to calling Harness.begin.')
+
         # The Framework adds attributes to class objects for events, etc. As such, we can't re-use
         # the original class against multiple Frameworks. So create a locally defined class
         # and register it.
@@ -153,7 +187,10 @@ class Harness(typing.Generic[CharmType]):
         hooks. Based on what relations have been defined before you called begin().
         Note that all of these are fired before returning control to the test suite, so if you
         want to introspect what happens at each step, you need to fire them directly
-        (eg Charm.on.install.emit()).
+        (eg Charm.on.install.emit()).  In your hook callback functions, you should not assume that
+        workload containers are active; guard such code with checks to Container.can_connect().
+        You are encouraged to test this by calling simulate_can_connect() before calling this
+        function.
 
         To use this with all the normal hooks, you should instantiate the harness, setup any
         relations that you want active when the charm starts, and then call this method.
@@ -176,6 +213,7 @@ class Harness(typing.Generic[CharmType]):
             # To be fired.
         """
         self.begin()
+
         # Checking if disks have been added
         # storage-attached events happen before install
         for storage_name in self._meta.storages:
@@ -718,11 +756,16 @@ class Harness(typing.Generic[CharmType]):
     def container_pebble_ready(self, container_name: str):
         """Fire the pebble_ready hook for the associated container.
 
-        This will do nothing if the begin() has not been called.
+        This will do nothing if the begin() has not been called.  If
+        simulate_can_connect has been called, this will switch the given
+        container's can_connect state to True before the hook
+        function is called.
         """
         if self.charm is None:
             return
         container = self.model.unit.get_container(container_name)
+        if self._backend._simulate_can_connect:
+            self.set_can_connect(container, True)
         self.charm.on[container_name].pebble_ready.emit(container)
 
     def get_workload_version(self) -> str:
@@ -1049,7 +1092,28 @@ class _TestingModelBackend:
         # {socket_path : _TestingPebbleClient}
         # socket_path = '/charm/containers/{container_name}/pebble.socket'
         self._pebble_clients = {}  # type: {str: _TestingPebbleClient}
+        self._pebble_clients_can_connect = {}  # type: {_TestingPebbleClient: bool}
+        self._simulate_can_connect = False
         self._planned_units = None
+
+    def _sim_can_connect(self):
+        """Activates Container.can_connect state simulation."""
+        self._simulate_can_connect = True
+        for client in self._pebble_clients_can_connect:
+            self._pebble_clients_can_connect[client] = False
+
+    def _can_connect(self, pebble_client) -> bool:
+        """Returns whether the mock client is active and can support API calls with no errors."""
+        return self._pebble_clients_can_connect[pebble_client]
+
+    def _set_can_connect(self, pebble_client, val):
+        """Manually sets the can_connect state for the given mock client."""
+        if not self._simulate_can_connect:
+            raise RuntimeError('simulate_can_connect must be called before using set_can_connect')
+        if pebble_client not in self._pebble_clients_can_connect:
+            msg = 'cannot set can_connect for the client - are you running a "real" pebble test?'
+            raise RuntimeError(msg)
+        self._pebble_clients_can_connect[pebble_client] = val
 
     def _cleanup(self):
         if self._resource_dir is not None:
@@ -1239,6 +1303,7 @@ class _TestingModelBackend:
         if client is None:
             client = _TestingPebbleClient(self)
             self._pebble_clients[socket_path] = client
+        self._pebble_clients_can_connect[client] = not self._simulate_can_connect
         return client
 
     def planned_units(self):
@@ -1280,9 +1345,15 @@ class _TestingPebbleClient:
         # Has a service been started/stopped?
         self._service_status = {}
         self._fs = _MockFilesystem()
+        self._backend = backend
+
+    def _check_connection(self):
+        if not self._backend._can_connect(self):
+            raise pebble.ConnectionError('cannot connect to pebble')
 
     def get_system_info(self) -> pebble.SystemInfo:
-        return pebble.SystemInfo(version="1.0.0")
+        self._check_connection()
+        return pebble.SystemInfo(version='1.0.0')
 
     def get_warnings(
             self, select: pebble.WarningState = pebble.WarningState.PENDING,
@@ -1304,6 +1375,7 @@ class _TestingPebbleClient:
         raise NotImplementedError(self.abort_change)
 
     def autostart_services(self, timeout: float = 30.0, delay: float = 0.1) -> pebble.ChangeID:
+        self._check_connection()
         for name, service in self._render_services().items():
             # TODO: jam 2021-04-20 This feels awkward that Service.startup might be a string or
             #  might be an enum. Probably should make Service.startup a property rather than an
@@ -1326,6 +1398,8 @@ class _TestingPebbleClient:
         if isinstance(services, str):
             raise TypeError('start_services should take a list of names, not just "{}"'.format(
                 services))
+
+        self._check_connection()
 
         # Note: jam 2021-04-20 We don't implement ChangeID, but the default caller of this is
         # Container.start() which currently ignores the return value
@@ -1358,6 +1432,9 @@ cannot perform the following tasks:
         if isinstance(services, str):
             raise TypeError('stop_services should take a list of names, not just "{}"'.format(
                 services))
+
+        self._check_connection()
+
         # TODO: handle invalid names
         # Note: jam 2021-04-20 We don't implement ChangeID, but the default caller of this is
         # Container.stop() which currently ignores the return value
@@ -1386,6 +1463,9 @@ ChangeError: cannot perform the following tasks:
         if isinstance(services, str):
             raise TypeError('restart_services should take a list of names, not just "{}"'.format(
                 services))
+
+        self._check_connection()
+
         # TODO: handle invalid names
         # Note: jam 2021-04-20 We don't implement ChangeID, but the default caller of this is
         # Container.restart() which currently ignores the return value
@@ -1418,6 +1498,9 @@ ChangeError: cannot perform the following tasks:
         else:
             raise TypeError('layer must be str, dict, or pebble.Layer, not {}'.format(
                 type(layer).__name__))
+
+        self._check_connection()
+
         if label in self._layers:
             # TODO: jam 2021-04-19 These should not be RuntimeErrors but should be proper error
             #  types. https://github.com/canonical/operator/issues/514
@@ -1451,6 +1534,7 @@ ChangeError: cannot perform the following tasks:
         return services
 
     def get_plan(self) -> pebble.Plan:
+        self._check_connection()
         plan = pebble.Plan('{}')
         services = self._render_services()
         if not services:
@@ -1463,6 +1547,8 @@ ChangeError: cannot perform the following tasks:
         if isinstance(names, str):
             raise TypeError('start_services should take a list of names, not just "{}"'.format(
                 names))
+
+        self._check_connection()
         services = self._render_services()
         infos = []
         if names is None:
@@ -1487,12 +1573,14 @@ ChangeError: cannot perform the following tasks:
 
     def pull(self, path: str, *, encoding: str = 'utf-8') -> typing.Union[typing.BinaryIO,
                                                                           typing.TextIO]:
+        self._check_connection()
         return self._fs.open(path, encoding=encoding)
 
     def push(
             self, path: str, source: typing.Union[bytes, str, typing.BinaryIO, typing.TextIO], *,
             encoding: str = 'utf-8', make_dirs: bool = False, permissions: int = None,
             user_id: int = None, user: str = None, group_id: int = None, group: str = None):
+        self._check_connection()
         if permissions is not None and not (0 <= permissions <= 0o777):
             raise pebble.PathError(
                 'generic-file-error',
@@ -1512,6 +1600,7 @@ ChangeError: cannot perform the following tasks:
 
     def list_files(self, path: str, *, pattern: str = None,
                    itself: bool = False) -> typing.List[pebble.FileInfo]:
+        self._check_connection()
         try:
             files = [self._fs.get_path(path)]
         except FileNotFoundError:
@@ -1552,6 +1641,7 @@ ChangeError: cannot perform the following tasks:
     def make_dir(
             self, path: str, *, make_parents: bool = False, permissions: int = None,
             user_id: int = None, user: str = None, group_id: int = None, group: str = None):
+        self._check_connection()
         if permissions is not None and not (0 <= permissions <= 0o777):
             raise pebble.PathError(
                 'generic-file-error',
@@ -1574,6 +1664,7 @@ ChangeError: cannot perform the following tasks:
             )
 
     def remove_path(self, path: str, *, recursive: bool = False):
+        self._check_connection()
         try:
             file_or_dir = self._fs.get_path(path)
         except FileNotFoundError:
@@ -1594,6 +1685,7 @@ ChangeError: cannot perform the following tasks:
     def send_signal(self, sig: typing.Union[int, str], *service_names: str):
         if not service_names:
             raise TypeError('send_signal expected at least 1 service name, got 0')
+        self._check_connection()
 
         # Convert signal to str
         if isinstance(sig, int):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -27,6 +27,7 @@ from io import BytesIO, StringIO
 
 import yaml
 
+import ops.testing
 from ops import pebble
 from ops.charm import (
     CharmBase,
@@ -116,25 +117,38 @@ class TestHarness(unittest.TestCase):
             ''')
         self.addCleanup(harness.cleanup)
 
+        self.assertRaises(RuntimeError, harness.set_can_connect, 'foo', False)
+
+        harness.begin()
+        c = harness.model.unit.get_container('foo')
+        self.assertTrue(c.can_connect())
+
+    def test_simulate_can_connect(self):
+        ops.testing.SIMULATE_CAN_CONNECT = True
+        harness = Harness(CharmBase, meta='''
+            name: test-app
+            containers:
+              foo:
+                resource: foo-image
+            ''')
+        self.addCleanup(harness.cleanup)
+
         harness.begin()
         c = harness.model.unit.get_container('foo')
 
-        self.assertRaises(RuntimeError, harness.set_can_connect, 'foo', False)
-        self.assertTrue(c.can_connect())
-
-        harness.simulate_can_connect()
         self.assertFalse(c.can_connect())
+        self.assertRaises(pebble.ConnectionError, c.get_plan)
 
         harness.set_can_connect('foo', True)
         self.assertTrue(c.can_connect())
 
         harness.set_can_connect('foo', False)
         self.assertFalse(c.can_connect())
-        self.assertRaises(pebble.ConnectionError, c.get_plan)
 
         harness.container_pebble_ready('foo')
         self.assertTrue(c.can_connect())
         c.get_plan()
+        ops.testing.SIMULATE_CAN_CONNECT = False
 
     def test_add_relation_and_unit(self):
         harness = Harness(CharmBase, meta='''


### PR DESCRIPTION
This introduces tracking of can_connect state for containers/pebble-clients in the test harness.  Container.can_connect uses the PebbleClient.get_system_info function to determine connectability.  I've added a _check_connection call to every mock client method (including get_system_info) that consults the testing backend for whether or not pebble is "available" to connect to. It raises a ConnectionError if we are simulating can_connect=False.

By default, can_connect is true for all containers - this is to help not break tests in other charms.  Calling harness.begin() causes can_connect to become false for all containers.  And calling harness.container_pebble_ready automatically switches can_connect to true before running the hook code.

I suspect introducing a change like this will break a lot of tests - probably not good.  Perhaps I should change harness.begin() to not set can_connect to false unless something like harness.simulate_can_connect() has been called.  On the other hand, dumping this change as implemented may help shake out bugs in charm code. Thoughts?

Fixes #691.