### PR TITLE
begin_with_initial_hooks now sets post install status correctly

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -186,12 +186,6 @@ class Harness(typing.Generic[CharmType]):
                     model.Storage(storage_name, storage_index, self._backend))
         # Storage done, emit install event
         self._charm.on.install.emit()
-        # If the install hook does not set a unit status, the Juju controller will switch
-        # the unit status from "Maintenance" to "Unknown". See gh#726
-        post_install_status = self._backend.status_get()
-        if post_install_status.get("status") == "maintenance":
-            if not post_install_status.get("message"):
-                self._backend.status_set("unknown", "", is_app=False)
         # Juju itself iterates what relation to fire based on a map[int]relation, so it doesn't
         # guarantee a stable ordering between relation events. It *does* give a stable ordering
         # of joined units for a given relation.
@@ -221,6 +215,11 @@ class Harness(typing.Generic[CharmType]):
             self._charm.on.leader_settings_changed.emit()
         self._charm.on.config_changed.emit()
         self._charm.on.start.emit()
+        # If the initial hooks do not set a unit status, the Juju controller will switch
+        # the unit status from "Maintenance" to "Unknown". See gh#726
+        post_setup_sts = self._backend.status_get()
+        if post_setup_sts.get("status") == "maintenance" and not post_setup_sts.get("message"):
+            self._backend.status_set("unknown", "", is_app=False)
         all_ids = list(self._backend._relation_names.items())
         random.shuffle(all_ids)
         for rel_id, rel_name in all_ids:

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2258,6 +2258,48 @@ class TestHarness(unittest.TestCase):
             b_first = [a_first[2], a_first[3], a_first[0], a_first[1]]
             self.assertEqual(changes, b_first)
 
+    def test_begin_with_initial_hooks_unknown_status(self):
+        # Verify that a charm that does not set a status in the install hook will have an
+        # unknown status in the harness.
+        harness = Harness(RecordingCharm, meta='''
+            name: test-app
+            ''', config='''
+          options:
+                foo:
+                    description: a config option
+                    type: string
+            ''')
+        self.addCleanup(harness.cleanup)
+        backend = harness._backend
+        harness.begin_with_initial_hooks()
+
+        self.assertEqual(
+            backend.status_get(is_app=False),
+            {'status': 'unknown', 'message': ''})
+
+        self.assertEqual(
+            backend.status_get(is_app=True),
+            {'status': 'unknown', 'message': ''})
+
+    def test_begin_with_initial_hooks_install_sets_status(self):
+        harness = Harness(RecordingCharm, meta='''
+            name: test-app
+            ''', config='''
+            options:
+                set_status:
+                    description: a config option
+                    type: boolean
+
+            ''')
+        self.addCleanup(harness.cleanup)
+        backend = harness._backend
+        harness.update_config(key_values={"set_status": True})
+        harness.begin_with_initial_hooks()
+
+        self.assertEqual(
+            backend.status_get(is_app=False),
+            {'status': 'maintenance', 'message': 'Status set on install'})
+
     def test_get_pebble_container_plan(self):
         harness = Harness(CharmBase, meta='''
             name: test-app
@@ -2387,6 +2429,8 @@ class RecordingCharm(CharmBase):
         return changes
 
     def _on_install(self, _):
+        if self.config.get('set_status'):
+            self.unit.status = MaintenanceStatus("Status set on install")
         self.changes.append(dict(name='install'))
 
     def _on_start(self, _):


### PR DESCRIPTION
Change the behavior of the begin_with_initial_hooks test fixture to
better reflect the behavior of production Juju.

Specifically, after the fixture runs the install hook, we check unit
status. If the status is "maintenance" with an empty message, we
assume that the install hook did not set a status, and set the unit's
status to Unknown.

Resolves #726