### PR TITLE
Harness: add test for an empty config file

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -291,7 +291,7 @@ class Harness(typing.Generic[CharmType]):
                 charm_config = '{}'
         elif isinstance(charm_config, str):
             charm_config = dedent(charm_config)
-        charm_config = yaml.safe_load(charm_config) or {}
+        charm_config = yaml.safe_load(charm_config)
         charm_config = charm_config.get('options', {})
         return {key: value.get('default', None) for key, value in charm_config.items()}
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -291,7 +291,7 @@ class Harness(typing.Generic[CharmType]):
                 charm_config = '{}'
         elif isinstance(charm_config, str):
             charm_config = dedent(charm_config)
-        charm_config = yaml.safe_load(charm_config)
+        charm_config = yaml.safe_load(charm_config) or {}
         charm_config = charm_config.get('options', {})
         return {key: value.get('default', None) for key, value in charm_config.items()}
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -885,10 +885,11 @@ class TestHarness(unittest.TestCase):
         harness.update_relation_data(rel_id, 'postgresql/0', {'initial': 'data'})
         self.assertEqual(viewer.changes, [{'initial': 'data'}])
 
-    def test_empty_config_behaves_the_same_as_none(self):
+    def test_empty_config_raises(self):
         harness = Harness(RecordingCharm, config='')
         self.addCleanup(harness.cleanup)
-        harness.begin()
+        with self.assertRaises(AttributeError):
+            harness.begin()
 
     def test_update_config(self):
         harness = Harness(RecordingCharm, config='''

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -885,6 +885,11 @@ class TestHarness(unittest.TestCase):
         harness.update_relation_data(rel_id, 'postgresql/0', {'initial': 'data'})
         self.assertEqual(viewer.changes, [{'initial': 'data'}])
 
+    def test_empty_config_behaves_the_same_as_none(self):
+        harness = Harness(RecordingCharm, config='')
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+
     def test_update_config(self):
         harness = Harness(RecordingCharm, config='''
             options:

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -886,10 +886,8 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(viewer.changes, [{'initial': 'data'}])
 
     def test_empty_config_raises(self):
-        harness = Harness(RecordingCharm, config='')
-        self.addCleanup(harness.cleanup)
         with self.assertRaises(AttributeError):
-            harness.begin()
+            Harness(RecordingCharm, config='')
 
     def test_update_config(self):
         harness = Harness(RecordingCharm, config='''


### PR DESCRIPTION
~~Attempting to run unit tests with an empty config file errors out with:~~

```
ops/testing.py", line 294, in _load_config_defaults
    charm_config = charm_config.get('options', {})
AttributeError: 'NoneType' object has no attribute 'get'
```

~~because `yaml.safe_load` returns a None (instead of an empty dict).~~

Attempting to run unit tests with an empty config file errors out, as expected (cf. #618):
https://github.com/juju/charm/blob/965348bad4ccc62f5bcca591fdbbe03a7de02e4e/config.go#L100

This PR adds a unit test to that effect.

Closes #617 