### PR TITLE
Edited test charm to support metadata v2, drop untested v1 fields

### DIFF
--- a/test/charms/test_main/metadata.yaml
+++ b/test/charms/test_main/metadata.yaml
@@ -2,13 +2,11 @@ name: main
 summary: A charm used for testing the basic operation of the entrypoint code.
 maintainer: Dmitrii Shcherbakov <dmitrii.shcherbakov@canonical.com>
 description: A charm used for testing the basic operation of the entrypoint code.
-tags:
-    - misc
-series:
-    - bionic
-    - cosmic
-    - disco
-min-juju-version: 2.7.1
+bases:
+  - name: ubuntu
+    channel: focal
+    architectures:
+      - amd64
 provides:
     db:
         interface: db


### PR DESCRIPTION
Removed deprecated fields.

Added new required `bases` field.

Testing and verifying bases is left for a separate PR, adding bases
support. (If we desire to do so -- bases are not necessarily a runtime
concern per the discussion in the metadata v2 spec.)