### PR TITLE
Add reinitialize_charm to harness

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -199,7 +199,6 @@ class Harness(typing.Generic[CharmType]):
         if self._charm is None:
             raise RuntimeError('cannot call the upgrade method before begin')
 
-
         # Reinitialize the charm-under-test
         self._charm.on.stop.emit()
         self._framework = framework.Framework(

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -187,6 +187,15 @@ class Harness(typing.Generic[CharmType]):
         TestCharm.__name__ = self._charm_cls.__name__
         self._charm = TestCharm(self._framework)
 
+    def reinitialize_charm(self) -> None:
+        if self._charm is None:
+            raise RuntimeError('cannot call the reinitialize_charm method before begin')
+
+        self._framework = framework.Framework(
+            self._storage, self._charm_dir, self._meta, self._model)
+        self._charm = None
+        self.begin()
+
     def upgrade(self) -> None:
         """Simulate a charm upgrade.
 
@@ -199,22 +208,8 @@ class Harness(typing.Generic[CharmType]):
         if self._charm is None:
             raise RuntimeError('cannot call the upgrade method before begin')
 
-        # Reinitialize the charm-under-test
         self._charm.on.stop.emit()
-        self._framework = framework.Framework(
-            self._storage, self._charm_dir, self._meta, self._model)
-        self._charm = None
-
-        # self.framework._objects.pop(self._charm.__class__.__name__)
-        # to_remove = []
-        # for key in self.framework._objects:
-        #     if key.startswith(self._charm.__class__.__name__ + "/"):
-        #         to_remove.append(key)
-        # for key in to_remove:
-        #     self.framework._objects.pop(key)
-        # self.framework._observers = []
-
-        self.begin()
+        self.reinitialize_charm()
         self._charm.on.upgrade_charm.emit()
         self._charm.on.config_changed.emit()
         if not self._backend._is_leader:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -199,7 +199,23 @@ class Harness(typing.Generic[CharmType]):
         if self._charm is None:
             raise RuntimeError('cannot call the upgrade method before begin')
 
+
+        # Reinitialize the charm-under-test
         self._charm.on.stop.emit()
+        self._framework = framework.Framework(
+            self._storage, self._charm_dir, self._meta, self._model)
+        self._charm = None
+
+        # self.framework._objects.pop(self._charm.__class__.__name__)
+        # to_remove = []
+        # for key in self.framework._objects:
+        #     if key.startswith(self._charm.__class__.__name__ + "/"):
+        #         to_remove.append(key)
+        # for key in to_remove:
+        #     self.framework._objects.pop(key)
+        # self.framework._observers = []
+
+        self.begin()
         self._charm.on.upgrade_charm.emit()
         self._charm.on.config_changed.emit()
         if not self._backend._is_leader:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -188,6 +188,7 @@ class Harness(typing.Generic[CharmType]):
         self._charm = TestCharm(self._framework)
 
     def reinitialize_charm(self) -> None:
+        """Re-initialize the charm under test."""
         if self._charm is None:
             raise RuntimeError('cannot call the reinitialize_charm method before begin')
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -187,6 +187,25 @@ class Harness(typing.Generic[CharmType]):
         TestCharm.__name__ = self._charm_cls.__name__
         self._charm = TestCharm(self._framework)
 
+    def upgrade(self) -> None:
+        """Simulate a charm upgrade.
+
+        This triggers stop, upgrade-charm, config-changed, leader_settings_changed and start hooks.
+        This does NOT trigger a pebble-ready hook (use :meth:`.container_pebble_ready` for that).
+
+        Before calling :meth:`upgrade`, a Charm instance must exist, so you must call
+        :meth:`.begin` or :meth:`.begin_with_initial_hooks` first.
+        """
+        if self._charm is None:
+            raise RuntimeError('cannot call the upgrade method before begin')
+
+        self._charm.on.stop.emit()
+        self._charm.on.upgrade_charm.emit()
+        self._charm.on.config_changed.emit()
+        if not self._backend._is_leader:
+            self._charm.on.leader_settings_changed.emit()
+        self._charm.on.start.emit()
+
     def begin_with_initial_hooks(self) -> None:
         """Called when you want the Harness to fire the same hooks that Juju would fire at startup.
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -197,26 +197,6 @@ class Harness(typing.Generic[CharmType]):
         self._charm = None
         self.begin()
 
-    def upgrade(self) -> None:
-        """Simulate a charm upgrade.
-
-        This triggers stop, upgrade-charm, config-changed, leader_settings_changed and start hooks.
-        This does NOT trigger a pebble-ready hook (use :meth:`.container_pebble_ready` for that).
-
-        Before calling :meth:`upgrade`, a Charm instance must exist, so you must call
-        :meth:`.begin` or :meth:`.begin_with_initial_hooks` first.
-        """
-        if self._charm is None:
-            raise RuntimeError('cannot call the upgrade method before begin')
-
-        self._charm.on.stop.emit()
-        self.reinitialize_charm()
-        self._charm.on.upgrade_charm.emit()
-        self._charm.on.config_changed.emit()
-        if not self._backend._is_leader:
-            self._charm.on.leader_settings_changed.emit()
-        self._charm.on.start.emit()
-
     def begin_with_initial_hooks(self) -> None:
         """Called when you want the Harness to fire the same hooks that Juju would fire at startup.
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2401,12 +2401,16 @@ class TestHarness(unittest.TestCase):
         self.addCleanup(harness.cleanup)
         harness.set_leader(True)
         harness.begin_with_initial_hooks()
-        harness.charm.changes = []  # Clean up records to have a fresh count for `upgrade`
+
+        # The "stop" record is going to be dropped after charm re-init inside the upgrade method,
+        # so holding on to the charm to assert later
+        dying_charm = harness.charm
         harness.upgrade()
+
+        self.assertEqual(dying_charm.changes[-1], {'name': 'stop'})
         self.assertEqual(
             harness.charm.changes,
             [
-                # {'name': 'stop'},  # the "stop" record is dropped due to charm reinit on upgrade
                 {'name': 'upgrade-charm'},
                 {'name': 'config-changed', 'data': {}},
                 {'name': 'start'},
@@ -2418,12 +2422,10 @@ class TestHarness(unittest.TestCase):
         self.addCleanup(harness.cleanup)
         harness.set_leader(False)
         harness.begin_with_initial_hooks()
-        harness.charm.changes = []  # Clean up records to have a fresh count for `upgrade`
         harness.upgrade()
         self.assertEqual(
             harness.charm.changes,
             [
-                # {'name': 'stop'},  # the "stop" record is dropped due to charm reinit on upgrade
                 {'name': 'upgrade-charm'},
                 {'name': 'config-changed', 'data': {}},
                 {'name': 'leader-settings-changed'},
@@ -2447,12 +2449,10 @@ class TestHarness(unittest.TestCase):
         harness.set_leader()
         harness.add_relation('peer', 'test-app')
         harness.begin_with_initial_hooks()
-        harness.charm.changes = []  # Clean up records to have a fresh count for `upgrade`
         harness.upgrade()
         self.assertEqual(
             harness.charm.changes,
             [
-                # {'name': 'stop'},  # the "stop" record is dropped due to charm reinit on upgrade
                 {'name': 'upgrade-charm'},
                 {'name': 'config-changed', 'data': {}},
                 {'name': 'start'},
@@ -2478,12 +2478,10 @@ class TestHarness(unittest.TestCase):
         harness.update_relation_data(rel_id, 'postgresql/0', {'new': 'data'})
         harness.update_relation_data(rel_id, 'postgresql', {'app': 'data'})
         harness.begin_with_initial_hooks()
-        harness.charm.changes = []  # Clean up records to have a fresh count for `upgrade`
         harness.upgrade()
         self.assertEqual(
             harness.charm.changes,
             [
-                # {'name': 'stop'},  # the "stop" record is dropped due to charm reinit on upgrade
                 {'name': 'upgrade-charm'},
                 {'name': 'config-changed', 'data': {}},
                 {'name': 'start'},
@@ -2515,12 +2513,10 @@ class TestHarness(unittest.TestCase):
         harness.add_relation_unit(rel_id, 'postgresql/0')
         harness.add_relation_unit(rel_id, 'postgresql/1')
         harness.begin_with_initial_hooks()
-        harness.charm.changes = []  # Clean up records to have a fresh count for `upgrade`
         harness.upgrade()
         self.assertEqual(
             harness.charm.changes,
             [
-                # {'name': 'stop'},  # the "stop" record is dropped due to charm reinit on upgrade
                 {'name': 'upgrade-charm'},
                 {'name': 'config-changed', 'data': {}},
                 {'name': 'start'},

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2519,17 +2519,6 @@ class TestHarness(unittest.TestCase):
             ]
         )
 
-    def test_upgrade_unknown_status(self):
-        """Unknown status should remain unknown across an upgrade."""
-        harness = Harness(RecordingCharm, meta='''name: test-app''')
-        self.addCleanup(harness.cleanup)
-        backend = harness._backend
-        harness.begin_with_initial_hooks()
-
-        self.assertEqual(backend.status_get(is_app=False), {'status': 'unknown', 'message': ''})
-        harness.upgrade()
-        self.assertEqual(backend.status_get(is_app=False), {'status': 'unknown', 'message': ''})
-
     def test_get_pebble_container_plan(self):
         harness = Harness(CharmBase, meta='''
             name: test-app

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2406,7 +2406,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(
             harness.charm.changes,
             [
-                {'name': 'stop'},
+                # {'name': 'stop'},  # the "stop" record is dropped due to charm reinit on upgrade
                 {'name': 'upgrade-charm'},
                 {'name': 'config-changed', 'data': {}},
                 {'name': 'start'},
@@ -2423,7 +2423,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(
             harness.charm.changes,
             [
-                {'name': 'stop'},
+                # {'name': 'stop'},  # the "stop" record is dropped due to charm reinit on upgrade
                 {'name': 'upgrade-charm'},
                 {'name': 'config-changed', 'data': {}},
                 {'name': 'leader-settings-changed'},
@@ -2452,7 +2452,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(
             harness.charm.changes,
             [
-                {'name': 'stop'},
+                # {'name': 'stop'},  # the "stop" record is dropped due to charm reinit on upgrade
                 {'name': 'upgrade-charm'},
                 {'name': 'config-changed', 'data': {}},
                 {'name': 'start'},
@@ -2482,7 +2482,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(
             harness.charm.changes,
             [
-                {'name': 'stop'},
+                # {'name': 'stop'},  # the "stop" record is dropped due to charm reinit on upgrade
                 {'name': 'upgrade-charm'},
                 {'name': 'config-changed', 'data': {}},
                 {'name': 'start'},
@@ -2512,7 +2512,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(
             harness.charm.changes,
             [
-                {'name': 'stop'},
+                # {'name': 'stop'},  # the "stop" record is dropped due to charm reinit on upgrade
                 {'name': 'upgrade-charm'},
                 {'name': 'config-changed', 'data': {}},
                 {'name': 'start'},

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2519,6 +2519,22 @@ class TestHarness(unittest.TestCase):
             ]
         )
 
+    def test_upgrade_status_consistency(self):
+        """The upgrade sequence itself shouldn't change the status."""
+        harness = Harness(RecordingCharm, meta='''name: test-app''')
+        self.addCleanup(harness.cleanup)
+        backend = harness._backend
+        harness.begin_with_initial_hooks()
+
+        unit_status_before = backend.status_get(is_app=False)
+        app_status_before = backend.status_get(is_app=True)
+        harness.upgrade()
+        unit_status_after = backend.status_get(is_app=False)
+        app_status_after = backend.status_get(is_app=True)
+
+        self.assertEqual(unit_status_before, unit_status_after)
+        self.assertEqual(app_status_before, app_status_after)
+
     def test_get_pebble_container_plan(self):
         harness = Harness(CharmBase, meta='''
             name: test-app


### PR DESCRIPTION
This PR adds a convenience method to harness for simulating a charm upgrade ([example](https://github.com/canonical/prometheus-k8s-operator/blob/7ae9e8fe139323463bc40e68d91d96cde29c0caf/tests/unit/test_remote_write.py#L271)).

Manually emitting `upgrade_charm` could probably be enough to cover most of the need, but having all the correct events emitted in the correct order makes it easier to choose unit tests over integration tests where possible.