### PR TITLE
Address storage testing quirks

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -121,3 +121,5 @@ This will trigger an automatic build for the Python package and publish it to Py
 See [.github/workflows/publish.yml](https://github.com/canonical/operator/blob/main/.github/workflows/publish.yml) for details. (Note that the versions in publish.yml refer to versions of the github actions, not the versions of the Operator Framework.)
 
 You can troubleshoot errors on the [Actions Tab](https://github.com/canonical/operator/actions).
+
+Announce the release on discourse.

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -445,7 +445,7 @@ class Harness(typing.Generic[CharmType]):
         return rel_id
 
     def add_storage(self, storage_name: str, count: int = 1,
-                    attach: bool = False) -> typing.List[str]:
+                    *, attach: bool = False) -> typing.List[str]:
         """Create a new storage device and attach it to this unit.
 
         To have repeatable tests, each device will be initialized with

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -227,11 +227,9 @@ class Harness(typing.Generic[CharmType]):
         # Checking if disks have been added
         # storage-attached events happen before install
         for storage_name in self._meta.storages:
-            for storage_index in self._backend.storage_list(storage_name):
-                storage_name = storage_name.replace('-', '_')
-                # Storage device(s) detected, emit storage-attached event(s)
-                self._charm.on[storage_name].storage_attached.emit(
-                    model.Storage(storage_name, storage_index, self._backend))
+            for storage_index in self._backend.storage_list(storage_name, include_detached=True):
+                s = model.Storage(storage_name, storage_index, self._backend)
+                self.attach_storage(s.full_id)
         # Storage done, emit install event
         self._charm.on.install.emit()
         # Juju itself iterates what relation to fire based on a map[int]relation, so it doesn't
@@ -446,16 +444,19 @@ class Harness(typing.Generic[CharmType]):
         self._relation_id_counter += 1
         return rel_id
 
-    def add_storage(self, storage_name: str, count: int = 1) -> typing.List[str]:
-        """Declare a new storage device attached to this unit.
+    def add_storage(self, storage_name: str, count: int = 1,
+                    attach: bool = False) -> typing.List[str]:
+        """Create a new storage device and attach it to this unit.
 
         To have repeatable tests, each device will be initialized with
-        location set to /<storage_name>N, where N is the counter and
-        will be a number from [0,total_num_disks-1]
+        location set to /[tmpdir]/<storage_name>N, where N is the counter and
+        will be a number from [0,total_num_disks-1].
 
         Args:
             storage_name: The storage backend name on the Charm
             count: Number of disks being added
+            attach: True to also attach the storage mount and emit storage-attached if
+                harness.begin() has been called.
 
         Return:
             A list of storage IDs, e.g. ["my-storage/1", "my-storage/2"].
@@ -463,6 +464,10 @@ class Harness(typing.Generic[CharmType]):
         if storage_name not in self._meta.storages:
             raise RuntimeError(
                 "the key '{}' is not specified as a storage key in metadata".format(storage_name))
+        if not self.charm and attach:
+            msg = 'cannot run add_storage with attach=True before calling Harness.begin()'
+            raise RuntimeError(msg)
+
         storage_indices = self._backend.storage_add(storage_name, count)
 
         # Reset associated cached value in the storage mappings.  If we don't do this,
@@ -473,8 +478,8 @@ class Harness(typing.Generic[CharmType]):
         for storage_index in storage_indices:
             s = model.Storage(storage_name, storage_index, self._backend)
             ids.append(s.full_id)
-            if self.charm is not None and self._hooks_enabled:
-                self.charm.on[storage_name].storage_attached.emit(s)
+            if attach:
+                self.attach_storage(s.full_id)
         return ids
 
     def detach_storage(self, storage_id: str) -> None:
@@ -508,11 +513,16 @@ class Harness(typing.Generic[CharmType]):
             storage_id: The full storage ID of the storage unit being attached, including the
                 storage key, e.g. my-storage/0.
         """
-        if self._backend._storage_attach(storage_id) and self._hooks_enabled:
-            storage_name, storage_index = storage_id.split('/', 1)
-            storage_index = int(storage_index)
-            self.charm.on[storage_name].storage_attached.emit(
-                model.Storage(storage_name, storage_index, self._backend))
+        if not self._backend._storage_attach(storage_id):
+            return  # storage was already attached
+        if not self.charm or not self._hooks_enabled:
+            return  # don't need to run hook callback
+
+        storage_name, storage_index = storage_id.split('/', 1)
+
+        storage_index = int(storage_index)
+        self.charm.on[storage_name].storage_attached.emit(
+            model.Storage(storage_name, storage_index, self._backend))
 
     def remove_storage(self, storage_id: str) -> None:
         """Detach a storage device.
@@ -1106,7 +1116,7 @@ class _TestingModelBackend:
         # Initialize the _storage_list with values present on metadata.yaml
         self._storage_list = {k: {} for k in self._meta.storages}
 
-        self._storage_detached = {k: set() for k in self._meta.storages}
+        self._storage_attached = {k: set() for k in self._meta.storages}
         self._storage_index_counter = 0
         # {container_name : _TestingPebbleClient}
         self._pebble_clients = {}  # type: {str: _TestingPebbleClient}
@@ -1258,15 +1268,21 @@ class _TestingModelBackend:
         else:
             self._unit_status = {'status': status, 'message': message}
 
-    def storage_list(self, name):
+    def storage_list(self, name: str, include_detached: bool = False):
+        """Returns a list of all attached storage mounts for the given storage name.
+
+        Args:
+            name: name (i.e. from metadata.yaml).
+            include_detached: True to include unattached storage mounts as well.
+        """
         return list(index for index in self._storage_list[name]
-                    if self._storage_is_attached(name, index))
+                    if all or self._storage_is_attached(name, index))
 
     def storage_get(self, storage_name_id, attribute):
         name, index = storage_name_id.split("/", 1)
         index = int(index)
         try:
-            if index in self._storage_detached[name]:
+            if index not in self._storage_attached[name]:
                 raise KeyError()  # Pretend the key isn't there
             else:
                 return self._storage_list[name][index][attribute]
@@ -1300,9 +1316,10 @@ class _TestingModelBackend:
             client._fs.remove_mount(name)
 
         if self._storage_is_attached(name, index):
-            self._storage_detached[name].add(index)
+            self._storage_attached[name].remove(index)
 
     def _storage_attach(self, storage_id: str):
+        """Mark the named storage_id as attached and return True if it was previously detached."""
         # NOTE: This is an extra function for _TestingModelBackend to simulate
         # re-attachment of a storage unit.  This is not present in
         # ops.model._ModelBackend.
@@ -1317,12 +1334,12 @@ class _TestingModelBackend:
 
         index = int(index)
         if not self._storage_is_attached(name, index):
-            self._storage_detached[name].remove(index)
+            self._storage_attached[name].add(index)
             return True
         return False
 
     def _storage_is_attached(self, storage_name, storage_index):
-        return storage_index not in self._storage_detached[storage_name]
+        return storage_index in self._storage_attached[storage_name]
 
     def _storage_remove(self, storage_id: str):
         # NOTE: This is an extra function for _TestingModelBackend to simulate


### PR DESCRIPTION
Note that in its current form, this does change the behavior of harness.add_storage in a way that could break users' tests.  I am curious to see how widespread or not any breakage will be before deciding on details for the best way to not break users.

* Changes Harness.storage_add to not mark storage as attached by default unless explicitly told to via kwarg attach=True

* Updates add_storage and begin_with_initial_hooks to use attach_storage method rather than manually emitting storage_attached events.

* Minor doc comment tweaks and housekeeping.

Fixes #750

## Checklist

 - [x] Have any types changed? If so, have the type annotations been updated?
 - [x] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?

       We want to avoid simple passthrough of model data, without contextualization, where possible.

 - [x] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## Changelog

- storage_add and begin_with_initial_hooks only emit storage-attached events if storage is actually market attached internally (was inconsistent before).

- Provides more direct control over when/whether to attach storage mounts.
