### PR TITLE
Better error for relation data access in relation-broken events

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -716,9 +716,8 @@ class TestModel(unittest.TestCase):
         self.assertEqual(model.storages.keys(), meta.storages.keys())
         self.assertIn('disks', model.storages)
 
-        with self.assertRaises(KeyError) as cm:
+        with pytest.raises(KeyError, match='Did you mean'):
             model.storages['does-not-exist']
-        assert 'Did you mean' in str(cm.exception)
 
         test_cases = {
             0: {'name': 'disks', 'location': pathlib.Path('/var/srv/disks/0')},
@@ -1889,18 +1888,6 @@ class TestModelBackend(unittest.TestCase):
         if self._backend is None:
             self._backend = ops.model._ModelBackend('myapp/0')
         return self._backend
-
-    def test_relation_get_when_broken(self):
-        # No is_app provided.
-        os.environ['JUJU_REMOTE_APP'] = ''
-        os.environ['JUJU_RELATION_ID'] = 'foo:1'
-
-        # Invalid types for is_app.
-        self.backend._hook_is_running = 'foo_relation_broken'
-
-        with self.assertRaises(RuntimeError) as cm:
-            self.backend.relation_get(1, 'foo', is_app=False)
-        assert 'remote-side relation data cannot be accessed' in str(cm.exception)
 
     def test_relation_get_set_is_app_arg(self):
         # No is_app provided.

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1896,6 +1896,23 @@ class TestModelBackend(unittest.TestCase):
             self._backend = ops.model._ModelBackend('myapp/0')
         return self._backend
 
+    def test_relation_get_when_broken(self):
+        # No is_app provided.
+        os.environ['JUJU_REMOTE_APP'] = ''
+        os.environ['JUJU_RELATION_ID'] = 'foo:1'
+
+        # Invalid types for is_app.
+        self.backend._hook_is_running = 'foo_relation_broken'
+        try:
+            self.backend.relation_get(1, 'foo', is_app=False)
+        except RuntimeError as err:
+            assert 'remote-side relation data cannot be accessed' in str(err), \
+                'got wrong exception'
+        except Exception:
+            assert False, 'got wrong exception type'
+        else:
+            assert False, 'expected exception not raised'
+
     def test_relation_get_set_is_app_arg(self):
         # No is_app provided.
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Fixes #693.

## Changelog

- Fixes a bug during relation-broken events where an Application instance was created with an empty app name; also provides better errors when remote relation data is accessed in this circumstance.
