### PR TITLE
Added EventBase-subclass check that snapshot/restore have been overridden if new attrs have been added

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -177,6 +177,7 @@ class EventBase(metaclass=_EventMeta):
     """The base for all the different Events.
 
     Inherit this and override 'snapshot' and 'restore' methods to build a custom event.
+    If you forget to override `snapshot` or `restore`, you will get a runtime warning.
     """
 
     # gets patched in by `Framework.restore()`, if this event is being re-emitted
@@ -248,14 +249,16 @@ class EventBase(metaclass=_EventMeta):
     def snapshot(self) -> dict:
         """Return the snapshot data that should be persisted.
 
-        Subclasses must override to save any custom state.
+        Subclasses must override to save any custom state. If you forget
+        to do so, you will get a warning.
         """
         return None
 
     def restore(self, snapshot):
         """Restore the value state from the given snapshot.
 
-        Subclasses must override to restore their custom state.
+        Subclasses must override to restore their custom state. If you forget
+        to do so, you will get a warning.
         """
         self.deferred = False
 


### PR DESCRIPTION
## Please provide the following details to expedite review (and delete this heading)
Users often forget to override `snapshot/restore` when they subclass EventBase and add some instance attributes. This can be hard to debug.
The proposed solution here is to add a subclass-instantiation-time-check that verifies that if new instance attributes are present, then `snapshot/restore` have been overridden.



## Checklist

 - [n/a] Have any types changed? If so, have the type annotations been updated?
 - [n/a] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?
 - [x] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

Added unittests in test_framework.py

## Documentation changes

We should add to the documentation that you will get a warning if you forget to override the methods.

## Bug reference

Fixes #769 

## Changelog

- Adds runtime warning if user forgot to override `EventBase.snapshot/restore`.
