### PR TITLE
Improved error message for invalid storage key usage

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1139,6 +1139,10 @@ class StorageMapping(Mapping[str, List['Storage']]):
         return iter(self._storage_map)
 
     def __getitem__(self, storage_name: str) -> List['Storage']:
+        if storage_name not in self._storage_map:
+            meant = ', or '.join(['{!r}'.format(k) for k in self._storage_map.keys()])
+            raise KeyError(
+                'Storage {!r} not found. Did you mean {}?'.format(storage_name, meant))
         storage_list = self._storage_map[storage_name]
         if storage_list is None:
             storage_list = self._storage_map[storage_name] = []

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -690,7 +690,6 @@ class TestModel(unittest.TestCase):
         self.assertBackendCalls([])
 
     def test_storage(self):
-        # TODO: (jam) 2020-05-07 Harness doesn't yet expose storage-get issue #263
         meta = ops.charm.CharmMeta()
         meta.storages = {'disks': None, 'data': None}
         model = ops.model.Model(meta, ops.model._ModelBackend('myapp/0'))
@@ -716,6 +715,13 @@ class TestModel(unittest.TestCase):
         self.assertEqual(len(model.storages), 2)
         self.assertEqual(model.storages.keys(), meta.storages.keys())
         self.assertIn('disks', model.storages)
+        try:
+            model.storages['does-not-exist']
+        except KeyError as err:
+            assert 'Did you mean' in str(err), 'got wrong error message'
+        except Exception as err:
+            assert False, 'got wrong exception type: ' + str(err)
+
         test_cases = {
             0: {'name': 'disks', 'location': pathlib.Path('/var/srv/disks/0')},
             1: {'name': 'disks', 'location': pathlib.Path('/var/srv/disks/1')},


### PR DESCRIPTION
Just trying to be more helpful to users.  Pretty self explanitory.

## Checklist

 - [x] Have any types changed? If so, have the type annotations been updated?
 - [x] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?

       We want to avoid simple passthrough of model data, without contextualization, where possible.

 - [x] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## Bug reference

@sed-i had this idea [on discourse](https://discourse.charmhub.io/t/operator-framework-1-5-0/6533/2)

## Changelog

- Incorrect storage access (via model.storages) now provides a more helpful message - e.g. "Did you mean x, or y?".
