### PR TITLE
Typing framework.py

### DIFF
--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -40,5 +40,5 @@ Full developer documentation is available at https://juju.is/docs/sdk.
 """
 
 # Import here the bare minimum to break the circular import between modules
-from . import charm  # noqa: F401 (imported but unused)
-from .version import version as __version__  # noqa: F401 (imported but unused)
+from . import charm  # type: ignore # noqa
+from .version import version as __version__  # type: ignore # noqa

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -18,6 +18,7 @@ import enum
 import os
 import pathlib
 import typing
+from typing import TYPE_CHECKING
 
 from ops import model
 from ops._private import yaml
@@ -669,8 +670,12 @@ class CharmBase(Object):
 
     # note that without the #: below, sphinx will copy the whole of CharmEvents
     # docstring inline which is less than ideal.
-    #: Used to set up event handlers; see :class:`CharmEvents`.
+    # Used to set up event handlers; see :class:`CharmEvents`.
     on = CharmEvents()
+    if TYPE_CHECKING:
+        # to help the type checker and IDEs:
+        @property
+        def on(self) -> CharmEvents: ... # noqa
 
     def __init__(self, framework: Framework, key: typing.Optional = None):
         super().__init__(framework, None)

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -461,16 +461,11 @@ class ObjectEvents(Object):
     """Convenience type to allow defining .on attributes at class level."""
 
     handle_kind = "on"
-    if TYPE_CHECKING:
-        # to help the type checker and IDEs:
-        @property
-        def _cache(self) -> weakref.WeakKeyDictionary[Object, 'ObjectEvents']: ...  # noqa
 
     def __init__(self, parent: Optional[Object] = None, key: Optional[str] = None):
         if parent is not None:
             super().__init__(parent, key)
-        else:
-            self._cache = weakref.WeakKeyDictionary()  # noqa
+        self._cache = weakref.WeakKeyDictionary()  # type: weakref.WeakKeyDictionary[Object, 'ObjectEvents']  # noqa
 
     def __get__(self, emitter: Object, emitter_type: 'Type[Object]'):
         if emitter is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,4 @@ pythonVersion = "3.5" # check no python > 3.5 features are used
 pythonPlatform = "All"
 typeCheckingMode = "strict"
 reportIncompatibleMethodOverride = false
+reportImportCycles = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,8 @@ per-file-ignores = ["test/*:D100,D101,D102,D103,D104"]
 docstring-convention = "google"
 
 [tool.pyright]
-exclude = ["ops/_vendor", ".git", "__pycache__", ".tox", "build", "test",
-    "ops/lib", "ops/_private", "dist", "*.egg_info", "venv", "ops/charm.py",
-    "ops/framework.py", "ops/main.py", "ops/pebble.py",
-    "ops/testing.py", "ops/__init__.py"]
+include = ["ops/jujuversion.py", "ops/log.py", "ops/model.py", "ops/version.py",
+    "ops/__init__.py", "ops/framework.py"]
 pythonVersion = "3.5" # check no python > 3.5 features are used
 pythonPlatform = "All"
 typeCheckingMode = "strict"


### PR DESCRIPTION
Added typing for ops/framework.py

Notes for reviewers:
- I had to touch __init__.py because the newly added 'from ops.model import...' (Even if guarded by an if TYPE_CHECKING...) made the import tree circular. There is no other solution (short of refactoring the whole project): https://github.com/microsoft/pylance-release/issues/531
- I had to touch charm.py to prevent CharmBase.on to be incorrectly predicted to be of type ObjectEvents (instead of CharmEvents). This is because of the `@property`-based approach I chose for typing Object.on (data descriptors are messy when it comes to typing...). If someone can think of a better solution, I'm all ears.
I think this workaround will become unnecessary with python 3.6+, where we can declare variable types without assigning them.

## Checklist

 - [x ] Have any types changed? If so, have the type annotations been updated?
 - [n/a] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?
 - [n/a] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

static tox env run now includes framework

```sh
tox -vve static
```

## Changelog

- Added types to ops.framework.py, which means that proojects importing ops can now in turn rely on them to statically check their code. Also, users will get improved in-IDE code completion and linting.
