### PR TITLE
Remove overzealous Harness.add_storage error check.

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -464,9 +464,6 @@ class Harness(typing.Generic[CharmType]):
         if storage_name not in self._meta.storages:
             raise RuntimeError(
                 "the key '{}' is not specified as a storage key in metadata".format(storage_name))
-        if not self.charm and attach:
-            msg = 'cannot run add_storage with attach=True before calling Harness.begin()'
-            raise RuntimeError(msg)
 
         storage_indices = self._backend.storage_add(storage_name, count)
 


### PR DESCRIPTION
When juju runs, storage is attached/mounted into containers before the
charm class instance is constructed - meaning that in production, charms
can access storage data inside their `__init__` functions.  In order to
allow the harness to simulate this circumstance, it must be possible to
attach storage *before* calling Harness.begin().  With that need in
mind, this error check in add_storage doesn't make sense and so is
removed here.  More details of the issue are explained in #780.

Fixes #780

## Checklist

 - [x] Have any types changed? If so, have the type annotations been updated?
 - [x] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?
 - [x] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## Documentation changes

No changes necessary.

## Changelog

This is just a small reversion of some changes we made in a prev PR this cycle.  So nothing from this should go in the release changelog.
