### PR TITLE
Remove harcoded value for self.model_uuid

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -41,6 +41,7 @@ import random
 import signal
 import tempfile
 import typing
+import uuid
 import warnings
 from contextlib import contextmanager
 from io import BytesIO, StringIO
@@ -1091,7 +1092,7 @@ class _TestingModelBackend:
         self.unit_name = unit_name
         self.app_name = self.unit_name.split('/')[0]
         self.model_name = None
-        self.model_uuid = 'f2c1b2a6-e006-11eb-ba80-0242ac130004'
+        self.model_uuid = str(uuid.uuid4())
 
         self._harness_tmp_dir = tempfile.TemporaryDirectory(prefix='ops-harness-')
         self._calls = []

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -23,6 +23,7 @@ import sys
 import tempfile
 import textwrap
 import unittest
+import uuid
 from io import BytesIO, StringIO
 
 import pytest
@@ -2699,6 +2700,14 @@ class TestTestingModelBackend(unittest.TestCase):
         mb_methods = get_public_methods(_ModelBackend)
         backend_methods = get_public_methods(backend)
         self.assertEqual(mb_methods, backend_methods)
+
+    def test_model_uuid_is_uuid_v4(self):
+        harness = Harness(CharmBase, meta='''
+            name: test-charm
+        ''')
+        self.addCleanup(harness.cleanup)
+        backend = harness._backend
+        self.assertEqual(uuid.UUID(backend.model_uuid).version, 4)
 
     def test_status_set_get_unit(self):
         harness = Harness(CharmBase, meta='''


### PR DESCRIPTION
We changed harcoded value for `self.model_uuid` in `class _TestingModelBackend` with `str(uuid.uuid4())`.
Using a dynamically generated UUID v4 instead of a harcoded UUID v1 value mimics Juju behaviour better.

This PR fixes #779. Read this issue for further details.

## Checklist

 - [ ] Have any types changed? If so, have the type annotations been updated?
 - [ ] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?

       We want to avoid simple passthrough of model data, without contextualization, where possible.

 - [ ] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

Just run unit tests

```sh
$ tox -e unit
```

## Documentation changes

* None

## Bug reference

https://github.com/canonical/operator/issues/779

## Changelog

- Remove harcoded value for self.model_uuid in ops/testing.py
