### PR TITLE
Make Harness more strict in validating relation data contents (on write)

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -47,7 +47,6 @@ from contextlib import contextmanager
 from io import BytesIO, StringIO
 from textwrap import dedent
 
-import ops.model
 from ops import charm, framework, model, pebble, storage
 from ops._private import yaml
 
@@ -650,7 +649,8 @@ class Harness(typing.Generic[CharmType]):
             None
         """
         self._backend._relation_list_map[relation_id].append(remote_unit_name)
-        self._backend._relation_data[relation_id][remote_unit_name] = {}
+        rel_data = self._backend._relation_data
+        rel_data[relation_id][remote_unit_name] = _TestingRelationDataContents()
         # TODO: jam 2020-08-03 This is where we could assert that the unit name matches the
         #  application name (eg you don't have a relation to 'foo' but add units of 'bar/0'
         self._backend._relation_app_and_units[relation_id]["units"].append(remote_unit_name)

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -30,7 +30,7 @@ import pytest
 import yaml
 
 import ops.testing
-from ops import pebble, model
+from ops import model, pebble
 from ops.charm import (
     CharmBase,
     PebbleReadyEvent,


### PR DESCRIPTION
Brings the harness in line with the behaviour of RelationDataContents: key/value pairs MUST be of type str:str. Else: ModelError.
The harness is with this PR more 'correct' than ops itself, because while I was writing out this code I found  #785. So ops allows you to write Any:str to relation data. Ops forces you to do str:str.
Once #785 is merged, ops will also enforce str:str and the harness will be at the same level.

## Checklist

 - [ x ] Have any types changed? If so, have the type annotations been updated?
 - [ x ] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?
 - [ x ] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

Added integration tests for this bug.

## Documentation changes

I believe the docs already make it clear that config keys must be strings.

## Changelog

- Fixed bug with relations data contents seemingly supporting arbitrary type-keys and silently 'forgetting' them.
