### PR TITLE
added config backend to simulate more closely juju's own

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1111,10 +1111,6 @@ class _TestingConfig(dict):
         # this is only called by the harness itself
         # we don't do real serialization/deserialization, but we do check that the value
         # has the expected type.
-        if type(value) not in self._supported_types.values():
-            raise RuntimeError('cannot set {} to {}; type {} is not '
-                               'supported by juju'.format(key, value, type(value)))
-
         option = self._spec.get('options', {}).get(key)
         if not option:
             raise RuntimeError('Unknown config option {}; '

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -58,7 +58,7 @@ class TestModel(unittest.TestCase):
             bar:
                 type: int
             qux:
-                type: bool
+                type: boolean
         ''')
         self.addCleanup(self.harness.cleanup)
         self.relation_id_db0 = self.harness.add_relation('db0', 'db')

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -993,7 +993,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(viewer.changes, [{'initial': 'data'}])
 
     def test_empty_config_raises(self):
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(TypeError):
             Harness(RecordingCharm, config='')
 
     def test_update_config(self):
@@ -1033,12 +1033,66 @@ class TestHarness(unittest.TestCase):
         with self.assertRaises(ValueError):
             harness.update_config(key_values={'nonexistent': 'foo'})
 
+    def test_update_config_bad_type(self):
+        harness = Harness(RecordingCharm, config='''
+            options:
+                a:
+                    description: a config option
+                    type: boolean
+                    default: false
+            ''')
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        with self.assertRaises(RuntimeError):
+            # cannot cast to bool
+            harness.update_config(key_values={'a': 'foo'})
+
+        with self.assertRaises(RuntimeError):
+            # cannot cast to float
+            harness.update_config(key_values={'a': 42.42})
+
+        with self.assertRaises(RuntimeError):
+            # cannot cast to int
+            harness.update_config(key_values={'a': 42})
+
+        # can cast to bool!
+        harness.update_config(key_values={'a': False})
+
+    def test_bad_config_option_type(self):
+        with self.assertRaises(RuntimeError):
+            Harness(RecordingCharm, config='''
+                options:
+                    a:
+                        description: a config option
+                        type: gibberish
+                        default: False
+                ''')
+
+    def test_no_config_option_type(self):
+        with self.assertRaises(RuntimeError):
+            Harness(RecordingCharm, config='''
+                options:
+                    a:
+                        description: a config option
+                        default: False
+                ''')
+
+    def test_uncastable_config_option_type(self):
+        with self.assertRaises(RuntimeError):
+            Harness(RecordingCharm, config='''
+                options:
+                    a:
+                        description: a config option
+                        type: boolean
+                        default: peek-a-bool!
+                ''')
+
     def test_update_config_unset_boolean(self):
         harness = Harness(RecordingCharm, config='''
             options:
                 a:
                     description: a config option
-                    type: bool
+                    type: boolean
                     default: False
             ''')
         self.addCleanup(harness.cleanup)
@@ -1249,8 +1303,8 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness.model.config['opt_float'], 1.0)
         self.assertIsInstance(harness.model.config['opt_float'], float)
         self.assertFalse('opt_null' in harness.model.config)
-        self.assertIsNone(harness._defaults['opt_null'])
-        self.assertIsNone(harness._defaults['opt_no_default'])
+        self.assertIsNone(harness._backend._config._defaults['opt_null'])
+        self.assertIsNone(harness._backend._config._defaults['opt_no_default'])
 
     def test_set_model_name(self):
         harness = Harness(CharmBase, meta='''


### PR DESCRIPTION
As I was working on #786 I realized also config is not as strict as juju config is. This PR brings the harness' behaviour in line.
From now on, the harness will complain if you try and set a non-existing config key, if you try and set a config key to a value that doesn't match its desired type.

## Checklist

 - [ x ] Have any types changed? If so, have the type annotations been updated?
 - [ x ] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?
 - [ x ] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

Added itests for all changed behaviours.

## Changelog

- The harness is now more strict in the way it manages config.
- Unittests will catch charm code attempting to mutate config (in naive ways).