### PR TITLE
Include departing unit info for harness-initiated events

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -725,7 +725,7 @@ class Harness(typing.Generic[CharmType]):
             unit = self.model.get_unit(unit_name)
         else:
             raise ValueError('Invalid Unit Name')
-        self._charm.on[rel_name].relation_departed.emit(relation, app, unit)
+        self._charm.on[rel_name].relation_departed.emit(relation, app, unit, unit_name)
 
     def get_relation_data(self, relation_id: int, app_or_unit: AppUnitOrName) -> typing.Mapping:
         """Get the relation data bucket for a single app or unit in a given relation.

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -34,6 +34,7 @@ from ops import pebble
 from ops.charm import (
     CharmBase,
     PebbleReadyEvent,
+    RelationDepartedEvent,
     RelationEvent,
     StorageAttachedEvent,
     StorageDetachingEvent,
@@ -369,6 +370,7 @@ class TestHarness(unittest.TestCase):
                           'relation': 'db',
                           'data': {'app': 'postgresql',
                                    'unit': 'postgresql/0',
+                                   'departing_unit': 'postgresql/0',
                                    'relation_id': 0}})
         self.assertEqual(changes[1],
                          {'name': 'relation-broken',
@@ -422,6 +424,7 @@ class TestHarness(unittest.TestCase):
                           'relation': 'db',
                           'data': {'app': 'postgresql',
                                    'unit': 'postgresql/1',
+                                   'departing_unit': 'postgresql/1',
                                    'relation_id': rel_id_2}})
         self.assertEqual(changes[1],
                          {'name': 'relation-broken',
@@ -495,6 +498,7 @@ class TestHarness(unittest.TestCase):
                           'relation': 'db',
                           'data': {'app': 'postgresql',
                                    'unit': 'postgresql/0',
+                                   'departing_unit': 'postgresql/0',
                                    'relation_id': 0,
                                    'relation_data': {'test-app/0': {},
                                                      'test-app': {},
@@ -598,6 +602,7 @@ class TestHarness(unittest.TestCase):
                           'relation': 'db',
                           'data': {'app': 'postgresql',
                                    'unit': 'postgresql/0',
+                                   'departing_unit': 'postgresql/0',
                                    'relation_id': rel_id}})
 
     def test_removing_relation_unit_does_not_remove_other_unit_and_data(self):
@@ -643,6 +648,7 @@ class TestHarness(unittest.TestCase):
                           'relation': 'db',
                           'data': {'app': 'postgresql',
                                    'unit': 'postgresql/1',
+                                   'departing_unit': 'postgresql/1',
                                    'relation_id': rel_id}})
 
     def test_relation_events(self):
@@ -2635,8 +2641,11 @@ class RelationEventCharm(RecordingCharm):
         if event.app is not None:
             app_name = event.app.name
 
-        recording = dict(name=event_name, relation=event.relation.name,
-                         data=dict(app=app_name, unit=unit_name, relation_id=event.relation.id))
+        data = dict(app=app_name, unit=unit_name, relation_id=event.relation.id)
+        if isinstance(event, RelationDepartedEvent):
+            data['departing_unit'] = event.departing_unit.name
+
+        recording = dict(name=event_name, relation=event.relation.name, data=data)
 
         if self.record_relation_data_on_events:
             recording["data"].update({'relation_data': {


### PR DESCRIPTION
When we added the departing_unit attribute to relation departed events,
I neglected to add that attribute to the corresponding events we emit
from the harness.  This fixes that and includes a test.

## Checklist

 - [x] Have any types changed? If so, have the type annotations been updated?
 - [x] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?

       We want to avoid simple passthrough of model data, without contextualization, where possible.

 - [x] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

*Please replace with how we can verify that the change works.*

```sh
QA steps here
```

## Changelog

* Fixed the test harness to include departing unit information in relation-departed events consistent with the production environment.
