### PR TITLE
Added a very basic smoke test. Run it with `tox -e smoke`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ venv
 .vscode
 .coverage
 /.tox
+
+# Smoke test artifacts
+*.tar.gz
+*.charm
+test/charms/test_smoke/requirements.txt

--- a/test/charms/test_smoke/README.md
+++ b/test/charms/test_smoke/README.md
@@ -6,4 +6,6 @@ A simple test charm for running smoke tests.
 
 ## Usage
 
-Run `tox -e smoke` in the root directory of this repository to build and deploy this charm.
+Make sure that you are on a box with charmcraft and juju installed, and that you are connected to a "machine" controller, such as a local lxd cloud. 
+
+Then, from the root directory of this repository, execute `tox -e smoke` to build and deploy this charm.

--- a/test/charms/test_smoke/README.md
+++ b/test/charms/test_smoke/README.md
@@ -1,0 +1,9 @@
+# smoke
+
+## Description
+
+A simple test charm for running smoke tests.
+
+## Usage
+
+Run `tox -e smoke` in the root directory of this repository to build and deploy this charm.

--- a/test/charms/test_smoke/charmcraft.yaml
+++ b/test/charms/test_smoke/charmcraft.yaml
@@ -1,0 +1,22 @@
+# Learn more about charmcraft.yaml configuration at:
+# https://juju.is/docs/sdk/charmcraft-config
+type: "charm"
+bases:
+  - build-on:
+    - name: "ubuntu"
+      channel: "20.04"
+    run-on:
+    - name: "ubuntu"
+      channel: "20.04"
+  - build-on:
+    - name: "ubuntu"
+      channel: "18.04"
+    run-on:
+    - name: "ubuntu"
+      channel: "18.04"
+  - build-on:
+    - name: "ubuntu"
+      channel: "16.04"
+    run-on:
+    - name: "ubuntu"
+      channel: "16.04"

--- a/test/charms/test_smoke/config.yaml
+++ b/test/charms/test_smoke/config.yaml
@@ -1,10 +1,4 @@
-# Copyright 2022 Penelope Valentine Gale
+# Copyright 2022 Canonical
 # See LICENSE file for licensing details.
-#
-# TEMPLATE-TODO: change this example to suit your needs.
-# If you don't need a config, you can remove the file entirely.
-# It ties in to the example _on_config_changed handler in src/charm.py
-#
-# Learn more about config at: https://juju.is/docs/sdk/config
 
 options: {}

--- a/test/charms/test_smoke/config.yaml
+++ b/test/charms/test_smoke/config.yaml
@@ -1,0 +1,10 @@
+# Copyright 2022 Penelope Valentine Gale
+# See LICENSE file for licensing details.
+#
+# TEMPLATE-TODO: change this example to suit your needs.
+# If you don't need a config, you can remove the file entirely.
+# It ties in to the example _on_config_changed handler in src/charm.py
+#
+# Learn more about config at: https://juju.is/docs/sdk/config
+
+options: {}

--- a/test/charms/test_smoke/config.yaml
+++ b/test/charms/test_smoke/config.yaml
@@ -1,4 +1,0 @@
-# Copyright 2022 Canonical
-# See LICENSE file for licensing details.
-
-options: {}

--- a/test/charms/test_smoke/metadata.yaml
+++ b/test/charms/test_smoke/metadata.yaml
@@ -1,0 +1,12 @@
+# Copyright 2022 Penelope Valentine Gale
+# See LICENSE file for licensing details.
+
+# For a complete list of supported options, see:
+# https://juju.is/docs/sdk/metadata-reference
+name: smoke
+display-name: |
+  smoke
+description: |
+  smoke test charm
+summary: |
+  basic minimal charm for running smoke tests

--- a/test/charms/test_smoke/src/charm.py
+++ b/test/charms/test_smoke/src/charm.py
@@ -1,8 +1,18 @@
 #!/usr/bin/env python3
-# Copyright 2022 Penelope Valentine Gale
-# See LICENSE file for licensing details.
 #
-# Learn more at: https://juju.is/docs/sdk
+# Copyright 2022 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Charm the service.
 
@@ -30,6 +40,7 @@ class SmokeCharm(CharmBase):
 
     def _on_install(self, event):
         self.unit.status = ActiveStatus()
+
 
 if __name__ == "__main__":
     main(SmokeCharm)

--- a/test/charms/test_smoke/src/charm.py
+++ b/test/charms/test_smoke/src/charm.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright 2022 Penelope Valentine Gale
+# See LICENSE file for licensing details.
+#
+# Learn more at: https://juju.is/docs/sdk
+
+"""Charm the service.
+
+Refer to the following post for a quick-start guide that will help you
+develop a new k8s charm using the Operator Framework:
+
+    https://discourse.charmhub.io/t/4208
+"""
+
+import logging
+
+from ops.charm import CharmBase
+from ops.main import main
+from ops.model import ActiveStatus
+
+logger = logging.getLogger(__name__)
+
+
+class SmokeCharm(CharmBase):
+    """Charm the service."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.framework.observe(self.on.install, self._on_install)
+
+    def _on_install(self, event):
+        self.unit.status = ActiveStatus()
+
+if __name__ == "__main__":
+    main(SmokeCharm)

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -1,0 +1,42 @@
+# Copyright 2022 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Learn more about testing at: https://juju.is/docs/sdk/testing
+
+import logging
+from pathlib import Path
+
+from pytest_operator.plugin import OpsTest
+
+
+logger = logging.getLogger(__name__)
+
+
+CURRENT_CHANNEL = '20.04'  # Focal
+
+
+async def test_smoke(ops_test: OpsTest):
+    # Verify that we can deploy charms from supported series.
+
+    # Build the charm. (We just build it for focal -- it *should* work to deploy it on
+    # older versions of Juju.)
+    charm = await ops_test.build_charm("./test/charms/test_smoke/")
+
+    for series in ['focal', 'bionic', 'xenial']:
+        app = await ops_test.model.deploy(
+            charm, series=series, application_name="{}-smoke".format(series))
+        await ops_test.model.wait_for_idle(timeout=600)
+
+        assert app.status == "active", "Series {} failed with '{}' status".format(
+            series, app.status)

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -15,10 +15,8 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import logging
-from pathlib import Path
 
 from pytest_operator.plugin import OpsTest
-
 
 logger = logging.getLogger(__name__)
 

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -21,9 +21,6 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 
 
-CURRENT_CHANNEL = '20.04'  # Focal
-
-
 async def test_smoke(ops_test: OpsTest):
     # Verify that we can deploy charms from supported series.
 

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,8 @@ deps =
     coverage[toml]
     -r{toxinidir}/requirements.txt
 commands =
-    coverage run --source={[vars]src_path} -m pytest -v --tb native {posargs}
+    coverage run --source={[vars]src_path} \
+             -m pytest --ignore={[vars]tst_path}smoke -v --tb native {posargs} 
     coverage report
 
 [testenv:pebble]

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ commands =
 
 [testenv:unit]
 description = Run unit tests
-passenv = 
+passenv =
     RUN_REAL_PEBBLE_TESTS
     PEBBLE
 deps =
@@ -74,7 +74,7 @@ deps =
     coverage[toml]
     -r{toxinidir}/requirements.txt
 commands =
-    coverage run --source={[vars]src_path} -m pytest -v --tb native {posargs} 
+    coverage run --source={[vars]src_path} -m pytest -v --tb native {posargs}
     coverage report
 
 [testenv:pebble]
@@ -91,3 +91,21 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     bash -c "umask 0; (pebble run --http=':4000' --create-dirs &>/dev/null & ) ; sleep 1; pytest -v --tb native -k RealPebble {posargs} ; killall -y 3m pebble"
+
+[testenv:smoke]
+description = Run a smoke test against a Juju controller.
+whitelist_externals = juju
+                      charmcraft
+                      bash
+deps =
+    pytest
+    pytest-operator
+commands =
+    # Build a source tarball for ops, and drop it into the root directory of the smoke test charm.
+    bash -c 'rm -vf ./test/charms/test_smoke/*.tar.gz  # Cleanup old builds'
+    python {toxinidir}/setup.py sdist --dist-dir={toxinidir}/test/charms/test_smoke/
+    # Inject the tarball into the smoke test charm's requirements.
+    bash -c 'echo "./$(ls -1 ./test/charms/test_smoke/ | grep tar.gz)" > ./test/charms/test_smoke/requirements.txt'
+
+    # Run our smoke tests (this will build the charm, then run the tests).
+    pytest -v --tb native --log-cli-level=INFO -s {posargs} {toxinidir}/test/smoke/


### PR DESCRIPTION
This PR adds a smoke test will build a new "smoke" charm in test/charms/test_smoke.
The test will attempt to deploy xenial, bionic and focal versions of the charm.

## Checklist

 - [N] Have any types changed? If so, have the type annotations been updated?
 - [N/A] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?

       We want to avoid simple passthrough of model data, without contextualization, where possible.

 - [Y] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

Make sure that you are on a box with charmcraft and juju installed, and that you are connected to a "machine" controller, such as a local lxd cloud. Then run:

```sh
tox -e smoke
```

## Documentation changes

* This adds a step to the release process. Right now, it's a manual step: run `tox -e smoke` before releasing a version of ops.

## Bug reference

* This would have caught https://github.com/canonical/operator/issues/798

## Changelog
- Adds smoke test charm to test/charms dir.
- Adds tox smoke env that builds and deploys the charm.

## Notes
There are a few wonky things about this, including how we inject the current ops package, and the fact that we test with just the focal version of the charm. Future versions of this smoke test should clear those wonky bits up, as well as add automation.


