### PR TITLE
Fix docstring

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -688,7 +688,7 @@ class Harness(typing.Generic[CharmType]):
 
         Args:
             relation_id: The integer relation identifier (as returned by add_relation).
-            remote_unit_name: A string representing the remote unit that is being added.
+            remote_unit_name: A string representing the remote unit that is being removed.
 
         Raises:
             KeyError: if relation_id or remote_unit_name is not valid


### PR DESCRIPTION
Small change to a docstring I noticed while doing unit tests. Seems like `remove_relation_unit()` was copied from `add_relation_unit()` and the args weren't updated.