### PR TITLE
Use --file for relation-set; avoid shell argument length limits

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -2042,7 +2042,7 @@ class _ModelBackend:
 
             # pyright infers the first match when argument overloading/unpacking is used,
             # so this needs to be coerced into the right type
-            result = typing.cast(CompletedProcess[bytes], result)
+            result = typing.cast('CompletedProcess[bytes]', result)
         except CalledProcessError as e:
             raise ModelError(e.stderr)
         if return_output:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1969,17 +1969,17 @@ class TestModelBackend(unittest.TestCase):
             lambda: fake_script(self, 'relation-set', 'echo fooerror >&2 ; exit 1'),
             lambda: self.backend.relation_set(3, 'foo', 'bar', is_app=False),
             ops.model.ModelError,
-            [['relation-set', '-r', '3', 'foo=bar']],
+            [['relation-set', '-r', '3', '--file', '-']],
         ), (
             lambda: fake_script(self, 'relation-set', 'echo {} >&2 ; exit 2'.format(err_msg)),
             lambda: self.backend.relation_set(3, 'foo', 'bar', is_app=False),
             ops.model.RelationNotFoundError,
-            [['relation-set', '-r', '3', 'foo=bar']],
+            [['relation-set', '-r', '3', '--file', '-']],
         ), (
             lambda: None,
             lambda: self.backend.relation_set(3, 'foo', 'bar', is_app=True),
             ops.model.RelationNotFoundError,
-            [['relation-set', '-r', '3', 'foo=bar', '--app']],
+            [['relation-set', '-r', '3', '--app', '--file', '-']],
         ), (
             lambda: fake_script(self, 'relation-get', 'echo fooerror >&2 ; exit 1'),
             lambda: self.backend.relation_get(3, 'remote/0', is_app=False),
@@ -2027,15 +2027,25 @@ class TestModelBackend(unittest.TestCase):
     def test_relation_set_juju_version_quirks(self):
         self.addCleanup(os.environ.pop, 'JUJU_VERSION', None)
 
-        fake_script(self, 'relation-set', 'exit 0')
-
         # on 2.7.0+, things proceed as expected
         for v in ['2.8.0', '2.7.0']:
             with self.subTest(v):
-                os.environ['JUJU_VERSION'] = v
-                self.backend.relation_set(1, 'foo', 'bar', is_app=True)
-                calls = [' '.join(i) for i in fake_script_calls(self, clear=True)]
-                self.assertEqual(calls, ['relation-set -r 1 foo=bar --app'])
+                t = tempfile.NamedTemporaryFile()
+                try:
+                    fake_script(self, 'relation-set', dedent("""
+                        cat >> {}
+                        """).format(pathlib.Path(t.name).as_posix()))
+                    os.environ['JUJU_VERSION'] = v
+                    self.backend.relation_set(1, 'foo', 'bar', is_app=True)
+                    calls = [' '.join(i) for i in fake_script_calls(self, clear=True)]
+                    self.assertEqual(calls, ['relation-set -r 1 --app --file -'])
+                    t.seek(0)
+                    content = t.read()
+                finally:
+                    t.close()
+                self.assertEqual(content.decode('utf-8'), dedent("""\
+                    foo: bar
+                    """))
 
         # before 2.7.0, it just fails always (no --app support)
         os.environ['JUJU_VERSION'] = '2.6.9'


### PR DESCRIPTION
## Please provide the following details to expedite review (and delete this heading)

In some cases, the value of any given relation data key may be too long to set within the boundaries of the maximum argument length of `subprocess` and/or shell invocation. Charm authors interact with this by setting `MutableMapping` data, and it is not obvious to authors that this maps back to a bare k:v set on the commandline, until the data exceeds some limit and an `OSError` appears in the logs on a `RelationEvent`.

Deferring to file-based input is already done for `state-set`. Match that pattern.

Closes #801 
## Checklist

 - [ ] Have any types changed? If so, have the type annotations been updated?
 - [ ] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?

       We want to avoid simple passthrough of model data, without contextualization, where possible.

 - [ ] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

*Please replace with how we can verify that the change works.*

This modifies all `relation-set` operations, so integration tests cover it, though it can certainly be tested manually also with any operation on relation data.

## Documentation changes

No change to workflow or API, and this part of the backend doesn't need doc changes.

## Changelog

*Please include a bulleted list of items here, suitable for inclusion in a release changelog.*

- Use --file for relation-set, so we avoid shell argument length limits
