### PR TITLE
Test observe(decorated-method)

### DIFF
--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -97,6 +97,7 @@ class TestCharm(unittest.TestCase):
 
     def test_observe_decorated_method(self):
         events = []
+
         def dec(fn):
             @functools.wraps(fn)
             def wrapper(charm, evt):


### PR DESCRIPTION
Someone had some issues applying a decorator to an event handler, solution was: use functools.wrap.
Felt like a good idea to add a test for it to help catch regressions.