### PR TITLE
Documented and checked ActionEvent.set_results with "Stdout" key

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -204,6 +204,16 @@ class ActionEvent(EventBase):
             Note that the resulting keys must start and end with lowercase
             alphanumeric, and can only contain lowercase alphanumeric, hyphens
             and periods.
+
+            If any exceptions occur whilst the action is being handled, juju will
+            gather any stdout/stderr data (and the return code) and inject them into the
+            results object. Thus, the results object might contain the following keys,
+            additionally to those specified by the charm code:
+             - Stdout
+             - Stderr
+             - Stdout-encoding
+             - Stderr-encoding
+             - ReturnCode
         """
         self.framework.model._backend.action_set(results)   # pyright: reportPrivateUsage=false
 

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -189,7 +189,6 @@ class ActionEvent(EventBase):
     def set_results(self, results: '_SerializedData'):
         """Report the result of the action.
 
-
         Args:
             results: The result of the action as a Dict
             Juju eventually only accepts a str:str mapping, so we will attempt

--- a/ops/model.py
+++ b/ops/model.py
@@ -2102,6 +2102,10 @@ def _format_action_result_dict(input: Dict[str, 'JsonObject'],
 
     for key, value in input.items():
         # Ensure the key is of a valid format, and raise a ValueError if not
+        if not isinstance(key, str):
+            # technically a type error, but for consistency with the
+            # other exceptions raised on key validation...
+            raise ValueError('invalid key {!r}; must be a string'.format(key))
         if not _ACTION_RESULT_KEY_REGEX.match(key):
             raise ValueError("key '{!r}' is invalid: must be similar to 'key', 'some-key2', or "
                              "'some.key'".format(key))

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -430,7 +430,15 @@ start:
   description: "Start the unit."
 ''')
 
-    def _test_action_events(self, cmd_type):
+    def _setup_test_action(self):
+        os.environ['JUJU_ACTION_NAME'] = 'foo-bar'
+        fake_script(self, 'action-get', """echo '{"foo-name": "name", "silent": true}'""")
+        fake_script(self, 'action-set', "")
+        fake_script(self, 'action-log', "")
+        fake_script(self, 'action-fail', "")
+        self.meta = self._get_action_test_meta()
+
+    def test_action_events(self):
 
         class MyCharm(CharmBase):
 
@@ -448,13 +456,7 @@ start:
             def _on_start_action(self, event):
                 pass
 
-        fake_script(self, cmd_type + '-get', """echo '{"foo-name": "name", "silent": true}'""")
-        fake_script(self, cmd_type + '-set', "")
-        fake_script(self, cmd_type + '-log', "")
-        fake_script(self, cmd_type + '-fail', "")
-        self.meta = self._get_action_test_meta()
-
-        os.environ['JUJU_{}_NAME'.format(cmd_type.upper())] = 'foo-bar'
+        self._setup_test_action()
         framework = self.create_framework()
         charm = MyCharm(framework)
 
@@ -465,10 +467,10 @@ start:
         charm.on.foo_bar_action.emit()
         self.assertEqual(charm.seen_action_params, {"foo-name": "name", "silent": True})
         self.assertEqual(fake_script_calls(self), [
-            [cmd_type + '-get', '--format=json'],
-            [cmd_type + '-log', "test-log"],
-            [cmd_type + '-set', "res=val with spaces"],
-            [cmd_type + '-fail', "test-fail"],
+            ['action-get', '--format=json'],
+            ['action-log', "test-log"],
+            ['action-set', "res=val with spaces"],
+            ['action-fail', "test-fail"],
         ])
 
         # Make sure that action events that do not match the current context are
@@ -476,8 +478,32 @@ start:
         with self.assertRaises(RuntimeError):
             charm.on.start_action.emit()
 
-    def test_action_events(self):
-        self._test_action_events('action')
+    def test_invalid_action_results(self):
+
+        class MyCharm(CharmBase):
+
+            def __init__(self, *args):
+                super().__init__(*args)
+                self.res = {}
+                framework.observe(self.on.foo_bar_action, self._on_foo_bar_action)
+
+            def _on_foo_bar_action(self, event):
+                event.set_results(self.res)
+
+        self._setup_test_action()
+        framework = self.create_framework()
+        charm = MyCharm(framework)
+
+        for bad_res in (
+                {'a': {'b': 'c'}, 'a.b': 'c'},
+                {'a': {'B': 'c'}},
+                {'a': {(1, 2): 'c'}},
+                {'a': {None: 'c'}},
+                {'aBc': 'd'}):
+            charm.res = bad_res
+
+            with self.assertRaises(ValueError):
+                charm.on.foo_bar_action.emit()
 
     def _test_action_event_defer_fails(self, cmd_type):
 


### PR DESCRIPTION
Stderr output emitted during an action hook execution gets injected in an action's results by juju.
- documented this in the ActionEvent docstring
- added a check that users don't manually set_results to anything containing "Stdout", because it will either be overridden or override juju's or break something, not sure which one but either way, it ain't good.

## Checklist
 - [x] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

Added test for the new error condition.

## Documentation changes

We should make this clear in the ActionEvent-related documentation.
Already updated: https://discourse.charmhub.io/t/action-name-action-event/6466

## Changelog

*Please include a bulleted list of items here, suitable for inclusion in a release changelog.*

- Added check that `ActionEvent.set_results` will fail if the results contain the 'special' juju key "Stdout"
