### PR TITLE
Fix incorrect kwarg handling in testing backend storage_list

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -1027,6 +1027,7 @@ class BoundStoredState:
         @property
         def _data(self) -> StoredStateData:  # noqa
             pass  # pyright: reportGeneralTypeIssues=false
+
         @property  # noqa
         def _attr_name(self) -> str:  # noqa
             pass  # pyright: reportGeneralTypeIssues=false

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -524,10 +524,6 @@ class Harness(typing.Generic[CharmType]):
 
         storage_indices = self._backend.storage_add(storage_name, count)
 
-        # Reset associated cached value in the storage mappings.  If we don't do this,
-        # Model._storages won't return Storage objects for subsequently-added storage.
-        self._model._storages._invalidate(storage_name)
-
         ids = []
         for storage_index in storage_indices:
             s = model.Storage(storage_name, storage_index, self._backend)
@@ -573,6 +569,10 @@ class Harness(typing.Generic[CharmType]):
             return  # don't need to run hook callback
 
         storage_name, storage_index = storage_id.split('/', 1)
+
+        # Reset associated cached value in the storage mappings.  If we don't do this,
+        # Model._storages won't return Storage objects for subsequently-added storage.
+        self._model._storages._invalidate(storage_name)
 
         storage_index = int(storage_index)
         self.charm.on[storage_name].storage_attached.emit(
@@ -1433,7 +1433,7 @@ class _TestingModelBackend:
             include_detached: True to include unattached storage mounts as well.
         """
         return list(index for index in self._storage_list[name]
-                    if all or self._storage_is_attached(name, index))
+                    if include_detached or self._storage_is_attached(name, index))
 
     def storage_get(self, storage_name_id, attribute):
         name, index = storage_name_id.split("/", 1)

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1416,6 +1416,23 @@ class TestHarness(unittest.TestCase):
         want = str(pathlib.PurePath('test', '0'))
         self.assertEqual(want, harness._backend.storage_get("test/0", "location")[-6:])
 
+    def test_add_storage_not_attached_default(self):
+        harness = Harness(CharmBase, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            storage:
+                test:
+                    type: filesystem
+            ''')
+        self.addCleanup(harness.cleanup)
+
+        harness.add_storage('test')
+        harness.begin()
+        assert len(harness.model.storages['test']) == 0, \
+            'storage should start in detached state and be excluded from storage listing'
+
     def test_add_storage_without_metadata_key_fails(self):
         harness = Harness(CharmBase, meta='''
             name: test-app


### PR DESCRIPTION
storage_list in the testing backend was erroneously using "all" instead
of "include_detached" - in its list comprehension to accumulate
active/attached storage entries.  We didn't get an error before since
"all" is a python builtin :-/  Correcting this also unveiled another
error where we weren't invalidating the stale storages list/cache in the
model when attaching a new storage - which showed up as failed snapshot
loading for storage events.  The cache invalidation code was moved from
Harness.add_storage to Harness.attach_storage where it belongs.

Fixes #819

## QA steps

See #819 for error details.

## Changelog

*Please include a bulleted list of items here, suitable for inclusion in a release changelog.*

- Fixed bug where currently-detached storage entries could show up erroneously in test harness operations.
