### PR TITLE
downgrade breaking-change exception to just a warning

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -1047,6 +1047,11 @@ class BoundStoredState:
 
         parent.framework.observe(parent.framework.on.commit, self._data.on_commit)  # type: ignore
 
+    if TYPE_CHECKING:
+        @typing.overload
+        def __getattr__(self, key: Literal['on']) -> ObjectEvents:
+            pass
+
     def __getattr__(self, key: str) -> Union['_StorableType', 'StoredObject', ObjectEvents]:
         # "on" is the only reserved key that can't be used in the data map.
         if key == "on":
@@ -1055,7 +1060,7 @@ class BoundStoredState:
             raise AttributeError("attribute '{}' is not stored".format(key))
         return _wrap_stored(self._data, self._data[key])
 
-    def __setattr__(self, key: str, value: '_StoredObject'):
+    def __setattr__(self, key: str, value: Union['_StorableType', '_StoredObject']):
         if key == "on":
             raise AttributeError("attribute 'on' is reserved and cannot be set")
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -709,12 +709,13 @@ class Harness(typing.Generic[CharmType]):
         relation_name = self._backend._relation_names[relation_id]
         relation = self._model.get_relation(relation_name, relation_id)
         self._backend._relation_data_raw[relation_id][remote_unit_name] = {}
+
         if not remote_unit_name.startswith(relation.app.name):
-            raise ValueError(
+            warnings.warn(
                 'Remote unit name invalid: the remote application of {} is called {!r}; '
                 'the remote unit name should be {}/<some-number>, not {!r}.'
-                ''.format(relation_name, relation.app.name,
-                          relation.app.name, remote_unit_name))
+                ''.format(relation_name, relation.app.name, relation.app.name, remote_unit_name))
+
         self._backend._relation_app_and_units[relation_id]["units"].append(remote_unit_name)
         # Make sure that the Model reloads the relation_list for this relation_id, as well as
         # reloading the relation data for this unit.

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1336,7 +1336,7 @@ class _TestingModelBackend:
 
     def relation_get(self, relation_id, member_name, is_app):
         if 'relation_broken' in self._hook_is_running and not self.relation_remote_app_name(
-                relation_id):
+                relation_id) and member_name != self.app_name and member_name != self.unit_name:
             # TODO: if juju gets fixed to set JUJU_REMOTE_APP for this case, then we may opt to
             # allow charms to read/get that (stale) relation data.
             # See https://bugs.launchpad.net/juju/+bug/1960934


### PR DESCRIPTION
This harness error check was added in #795.  It raises on a usually
benign sloppy naming of units by charm developers when writing tests.
In order to avoid breaking CI/tests for other charms, this should be
downgraded to a warning only. Notably, this change does/did cause
breakage in some data platform and observability charms - so it isn't
just a theoretical problem.  We are working to add some more charm tests to our CI - which is what originally caught this in #776.

## Changelog

Nothing for the changelog - we are basically rolling back an intra-release change.
