### PR TITLE
Allow network-get to return hostnames where previously IPaddr were expected

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -84,7 +84,7 @@ if typing.TYPE_CHECKING:
     _RelationsMeta_Raw = Dict[str, ops.charm.RelationMeta]
     # mapping from container name to container metadata
     _ContainerMeta_Raw = Dict[str, ops.charm.ContainerMeta]
-    _IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+    _NetworkAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address, str]
     _Network = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
 
     _ServiceInfoMapping = Mapping[str, pebble.ServiceInfo]
@@ -687,6 +687,17 @@ class Binding:
         return self._network
 
 
+def _cast_network_address(raw: str) -> '_NetworkAddress':
+    # fields marked as network addresses need not be IPs; they could be
+    # hostnames that juju failed to resolve. In that case, we'll log a
+    # debug message and leave it as-is.
+    try:
+        return ipaddress.ip_address(raw)
+    except ValueError:
+        logger.debug("could not cast {} to IPv4/v6 address".format(raw))
+        return raw
+
+
 class Network:
     """Network space details.
 
@@ -720,15 +731,15 @@ class Network:
             if addrs is not None:
                 for address_info in addrs:
                     self.interfaces.append(NetworkInterface(interface_name, address_info))
-        self.ingress_addresses = []  # type: List[_IPAddress]
+        self.ingress_addresses = []  # type: List[_NetworkAddress]
         for address in network_info.get('ingress-addresses', []):
-            self.ingress_addresses.append(ipaddress.ip_address(address))
+            self.ingress_addresses.append(_cast_network_address(address))
         self.egress_subnets = []  # type: List[_Network]
         for subnet in network_info.get('egress-subnets', []):
             self.egress_subnets.append(ipaddress.ip_network(subnet))
 
     @property
-    def bind_address(self) -> Optional['_IPAddress']:
+    def bind_address(self) -> Optional['_NetworkAddress']:
         """A single address that your application should bind() to.
 
         For the common case where there is a single answer. This represents a single
@@ -741,7 +752,7 @@ class Network:
             return None
 
     @property
-    def ingress_address(self):
+    def ingress_address(self) -> Optional['_NetworkAddress']:
         """The address other applications should use to connect to your unit.
 
         Due to things like public/private addresses, NAT and tunneling, the address you bind()
@@ -777,8 +788,8 @@ class NetworkInterface:
             address = address_info.get('address')
 
         # The value field may be empty.
-        address_ = ipaddress.ip_address(address) if address else None
-        self.address = address_  # type: Optional[_IPAddress]
+        address_ = _cast_network_address(address) if address else None
+        self.address = address_  # type: Optional[_NetworkAddress]
         cidr = address_info.get('cidr')  # type: str
         # The cidr field may be empty, see LP: #1864102.
         if cidr:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1765,7 +1765,6 @@ class TestModelBindings(unittest.TestCase):
             self.assertEqual(binding.network.interfaces[i].address, ipaddress.ip_address(address))
             self.assertEqual(binding.network.interfaces[i].subnet, ipaddress.ip_network(subnet))
 
-
     def test_invalid_keys(self):
         # Basic validation for passing invalid keys.
         for name in (object, 0):
@@ -1913,9 +1912,11 @@ class TestModelBindings(unittest.TestCase):
         self.assertEqual(binding.network.egress_subnets, [])
 
     def test_unresolved_ingress_addresses(self):
+        # sometimes juju fails to resolve an url to an IP, in which case
+        # ingress-addresses will be the 'raw' url instead of an IP.
         network_data = json.dumps({
             'ingress-addresses': [
-               'foo.bar.baz.com'
+                'foo.bar.baz.com'
             ],
         })
         fake_script(self, 'network-get',

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1755,6 +1755,17 @@ class TestModelBindings(unittest.TestCase):
             self.assertEqual(binding.network.interfaces[i].address, ipaddress.ip_address(address))
             self.assertEqual(binding.network.interfaces[i].subnet, ipaddress.ip_network(subnet))
 
+        for (i, (name, address, subnet)) in enumerate([
+                ('lo', '192.0.2.2', '192.0.2.0/24'),
+                ('lo', 'dead:beef::1', 'dead:beef::/64'),
+                ('tun', '192.0.3.3', '192.0.3.3/32'),
+                ('tun', '2001:db8::3', '2001:db8::3/128'),
+                ('tun', 'fe80::1:1', 'fe80::/64')]):
+            self.assertEqual(binding.network.interfaces[i].name, name)
+            self.assertEqual(binding.network.interfaces[i].address, ipaddress.ip_address(address))
+            self.assertEqual(binding.network.interfaces[i].subnet, ipaddress.ip_network(subnet))
+
+
     def test_invalid_keys(self):
         # Basic validation for passing invalid keys.
         for name in (object, 0):
@@ -1900,6 +1911,18 @@ class TestModelBindings(unittest.TestCase):
         binding_name = 'db0'
         binding = self.model.get_binding(self.model.get_relation(binding_name))
         self.assertEqual(binding.network.egress_subnets, [])
+
+    def test_unresolved_ingress_addresses(self):
+        network_data = json.dumps({
+            'ingress-addresses': [
+               'foo.bar.baz.com'
+            ],
+        })
+        fake_script(self, 'network-get',
+                    '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(network_data))
+        binding_name = 'db0'
+        binding = self.model.get_binding(self.model.get_relation(binding_name))
+        self.assertEqual(binding.network.ingress_addresses, ['foo.bar.baz.com'])
 
 
 class TestModelBackend(unittest.TestCase):


### PR DESCRIPTION
Fixes #818

## Checklist

 - [x] Have any types changed? If so, have the type annotations been updated?
 - [x] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

There are no tests for network object properties; ~~we probably should add some~~ --> I added some.

## Documentation changes

We should document somewhere that if juju fails to resolve a hostname, some network-get fields will not be IPs but the 'raw' hostname itself.

## Changelog

- OF won't break if hook tools return hostnames where IPs were previously expected.
