### PR TITLE
Remove check for existing event on define_event

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -476,11 +476,14 @@ class ObjectEvents(Object):
     def define_event(cls, event_kind: str, event_type: 'Type[EventBase]'):
         """Define an event on this type at runtime.
 
+        If `event_kind` has been previously defined,
+        it will be overwritten with this one.
+
         cls: a type to define an event on.
 
         event_kind: an attribute name that will be used to access the
-                    event. Must be a valid python identifier, not be a keyword
-                    or an existing attribute.
+                    event. Must be a valid python identifier,
+                    and not be a keyword.
 
         event_type: a type of the event to define.
 
@@ -490,12 +493,6 @@ class ObjectEvents(Object):
             raise RuntimeError(prefix + 'is not a valid python identifier: ' + event_kind)
         elif keyword.iskeyword(event_kind):
             raise RuntimeError(prefix + 'is a python keyword: ' + event_kind)
-        try:
-            getattr(cls, event_kind)
-            raise RuntimeError(
-                prefix + 'overlaps with an existing type {} attribute: {}'.format(cls, event_kind))
-        except AttributeError:
-            pass
 
         event_descriptor = EventSource(event_type)
         event_descriptor._set_name(cls, event_kind)  # noqa

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -675,6 +675,9 @@ class TestFramework(BaseTestCase):
         class MyFoo(EventBase):
             pass
 
+        class MyFoo2(EventBase):
+            pass
+
         class MyBar(EventBase):
             pass
 
@@ -707,9 +710,11 @@ class TestFramework(BaseTestCase):
         with self.assertRaises(RuntimeError):
             pub.on_a.define_event("None", NoneEvent)
 
-        # Try to override an existing attribute.
-        with self.assertRaises(RuntimeError):
-            pub.on_a.define_event("foo", MyFoo)
+        # Try to override an existing attribute;
+        # Weird asserts because isinstance doesn't seem to like this case.
+        self.assertEqual(pub.on_a.foo.event_type.__class__, MyFoo.__class__)
+        pub.on_a.define_event("foo", MyFoo2)
+        self.assertEqual(pub.on_a.foo.event_type.__class__, MyFoo2.__class__)
 
     def test_event_key_roundtrip(self):
         class MyEvent(EventBase):


### PR DESCRIPTION
This check feels arbitrary, and causes issues in cases where
code that defines an event is somehow unavoidable called more than once.

This check was originally introduced in 41b8081,
without an explanation of why it was a bad thing
for an event to override an existing event.

## Checklist

 - [x] (no change) Have any types changed? If so, have the type annotations been updated?
 - [x] (no change) If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?

       We want to avoid simple passthrough of model data, without contextualization, where possible.

 - [x] (na) Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

Unit test updates are included, but the general gist is:

1. try to define an event with the same name as an already defined event
2. verify that there are no raised errors, and that the new event has replaced the old event

## Documentation changes

docstrings updated

## Bug reference

Motivation for this pull request: https://review.opendev.org/c/openstack/charm-ops-sunbeam/+/855308/comments/d1e6dbf8_02df450a

## Changelog

- `define_event` no longer raises an error on overriding existing events.
