### PR TITLE
Typed `ops/testing.py`

### DIFF
--- a/ops/_private/yaml.py
+++ b/ops/_private/yaml.py
@@ -27,10 +27,12 @@ def safe_load(stream: Union[str, TextIO]):
     """Same as yaml.safe_load, but use fast C loader if available."""
     return yaml.load(stream, Loader=_safe_loader)
 
+
 @overload
 def safe_dump(data: Any, *args: Any, encoding:None =None, **kwargs: Any) -> str: ...
 @overload
 def safe_dump(data: Any, *args: Any, encoding: str = "", **kwargs: Any) -> bytes: ...
-def safe_dump(data: Any, stream: Optional[Union[str, TextIO]] = None, **kwargs: Any) -> Union[str, bytes]:
+def safe_dump(data: Any, stream: Optional[Union[str, TextIO]] = None, **kwargs: Any  # noqa
+              ) -> Union[str, bytes]:
     """Same as yaml.safe_dump, but use fast C dumper if available."""
     return yaml.dump(data, stream=stream, Dumper=_safe_dumper, **kwargs)

--- a/ops/_private/yaml.py
+++ b/ops/_private/yaml.py
@@ -29,10 +29,13 @@ def safe_load(stream: Union[str, TextIO]):
 
 
 @overload
-def safe_dump(data: Any, *args: Any, encoding:None =None, **kwargs: Any) -> str: ...
+def safe_dump(data: Any, *args: Any, encoding: None = None, **kwargs: Any) -> str: ...  # noqa
 @overload
-def safe_dump(data: Any, *args: Any, encoding: str = "", **kwargs: Any) -> bytes: ...
+def safe_dump(data: Any, *args: Any, encoding: str = "", **kwargs: Any) -> bytes: ...  # noqa
 def safe_dump(data: Any, stream: Optional[Union[str, TextIO]] = None, **kwargs: Any  # noqa
               ) -> Union[str, bytes]:
-    """Same as yaml.safe_dump, but use fast C dumper if available."""
+    """Same as yaml.safe_dump, but use fast C dumper if available.
+
+    If `encoding:str` is provided, return bytes. Else, return str.
+    """
     return yaml.dump(data, stream=stream, Dumper=_safe_dumper, **kwargs)

--- a/ops/_private/yaml.py
+++ b/ops/_private/yaml.py
@@ -14,7 +14,7 @@
 
 """Internal YAML helpers."""
 
-from typing import Any, Optional, TextIO, Union
+from typing import Any, Optional, TextIO, Union, overload
 
 import yaml
 
@@ -27,7 +27,10 @@ def safe_load(stream: Union[str, TextIO]):
     """Same as yaml.safe_load, but use fast C loader if available."""
     return yaml.load(stream, Loader=_safe_loader)
 
-
-def safe_dump(data: Any, stream: Optional[Union[str, TextIO]] = None, **kwargs):
+@overload
+def safe_dump(data: Any, *args: Any, encoding:None =None, **kwargs: Any) -> str: ...
+@overload
+def safe_dump(data: Any, *args: Any, encoding: str = "", **kwargs: Any) -> bytes: ...
+def safe_dump(data: Any, stream: Optional[Union[str, TextIO]] = None, **kwargs: Any) -> Union[str, bytes]:
     """Same as yaml.safe_dump, but use fast C dumper if available."""
     return yaml.dump(data, stream=stream, Dumper=_safe_dumper, **kwargs)

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -589,11 +589,19 @@ class Framework(Object):
         @property
         def on(self) -> 'FrameworkEvents': ...  # noqa
 
-    def __init__(self, storage: Union[SQLiteStorage, JujuStorage], charm_dir: Union[str, Path],
+    def __init__(self, storage: Union[SQLiteStorage, JujuStorage],
+                 charm_dir: Union[str, pathlib.Path],
                  meta: 'CharmMeta', model: 'Model'):
         super().__init__(self, None)
 
-        self.charm_dir = Path(charm_dir)
+        # an old, deprecated __init__ interface accepted an Optional charm_dir,
+        #  so we have to keep supporting it:
+        if charm_dir is None:
+            logger.warning('Deprecation warning: charm_dir should not be `None`')
+            self.charm_dir = None  # type: ignore
+        else:
+            self.charm_dir = pathlib.Path(charm_dir)
+
         self.meta = meta
         self.model = model
         # [(observer_path, method_name, parent_path, event_key)]

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -532,7 +532,7 @@ class PrefixedEvents:
         self._emitter = emitter
         self._prefix = key.replace("-", "_") + '_'
 
-    def __getattr__(self, name: str) -> Union['PrefixedEvents', EventSource[Any]]:
+    def __getattr__(self, name: str) -> BoundEvent[Any]:
         return getattr(self._emitter, self._prefix + name)
 
 
@@ -597,7 +597,7 @@ class Framework(Object):
         # an old, deprecated __init__ interface accepted an Optional charm_dir,
         #  so we have to keep supporting it:
         if charm_dir is None:
-            logger.warning('Deprecation warning: charm_dir should not be `None`')
+            logger.warning('Framework should not be initialized with `charm_dir` set to None.')
             self.charm_dir = None  # type: ignore
         else:
             self.charm_dir = pathlib.Path(charm_dir)

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -580,7 +580,7 @@ class Framework(Object):
     # Override properties from Object so that we can set them in __init__.
     model = None  # type: 'Model' # pyright: reportGeneralTypeIssues=false
     meta = None  # type: 'CharmMeta' # pyright: reportGeneralTypeIssues=false
-    charm_dir = None  # type: 'Path' # pyright: reportGeneralTypeIssues=false
+    charm_dir = None  # type: Path # pyright: reportGeneralTypeIssues=false
 
     # to help the type checker and IDEs:
 
@@ -589,11 +589,11 @@ class Framework(Object):
         @property
         def on(self) -> 'FrameworkEvents': ...  # noqa
 
-    def __init__(self, storage: Union[SQLiteStorage, JujuStorage], charm_dir: 'Path',
+    def __init__(self, storage: Union[SQLiteStorage, JujuStorage], charm_dir: Union[str, Path],
                  meta: 'CharmMeta', model: 'Model'):
         super().__init__(self, None)
 
-        self.charm_dir = charm_dir
+        self.charm_dir = Path(charm_dir)
         self.meta = meta
         self.model = model
         # [(observer_path, method_name, parent_path, event_key)]

--- a/ops/model.py
+++ b/ops/model.py
@@ -2226,7 +2226,7 @@ class _ModelBackend:
 
     def relation_get(self, relation_id: int, member_name: str, is_app: bool
                      ) -> '_RelationDataContent_Raw':
-        if not isinstance(is_app, bool):   # pyright:
+        if not isinstance(is_app, bool):
             raise TypeError('is_app parameter to relation_get must be a boolean')
 
         if is_app:
@@ -2247,7 +2247,7 @@ class _ModelBackend:
                 raise RelationNotFoundError() from e
             raise
 
-    def relation_set(self, relation_id: int, key: str, value: str, is_app: bool):
+    def relation_set(self, relation_id: int, key: str, value: str, is_app: bool) -> None:
         if not isinstance(is_app, bool):
             raise TypeError('is_app parameter to relation_set must be a boolean')
 
@@ -2263,7 +2263,7 @@ class _ModelBackend:
         args.extend(["--file", "-"])
 
         try:
-            content = yaml.safe_dump({key: value}, encoding='utf8')  # type: bytes
+            content = yaml.safe_dump({key: value}, encoding='utf8')
             self._run(*args, input_stream=content)
         except ModelError as e:
             if self._is_relation_not_found(e):

--- a/ops/model.py
+++ b/ops/model.py
@@ -61,9 +61,9 @@ if typing.TYPE_CHECKING:
         Client,
         ExecProcess,
         FileInfo,
+        LayerDict,
         Plan,
         ServiceInfo,
-        LayerDict,
     )
     from typing_extensions import TypedDict
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -71,7 +71,8 @@ if typing.TYPE_CHECKING:
                        Tuple['JsonObject', ...]]
 
     # a k8s spec is a mapping from names/"types" to json/yaml spec objects
-    _K8sSpec = Mapping[str, JsonObject]
+    # public since it is used in ops.testing
+    K8sSpec = Mapping[str, JsonObject]
 
     _StatusDict = TypedDict('_StatusDict', {'status': str, 'message': str})
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -63,7 +63,7 @@ if typing.TYPE_CHECKING:
         FileInfo,
         Plan,
         ServiceInfo,
-        _LayerDict,
+        LayerDict,
     )
     from typing_extensions import TypedDict
 
@@ -86,7 +86,7 @@ if typing.TYPE_CHECKING:
     _StatusDict = TypedDict('_StatusDict', {'status': str, 'message': str})
 
     # the data structure we can use to initialize pebble layers with.
-    _Layer = Union[str, _LayerDict, pebble.Layer]
+    _Layer = Union[str, LayerDict, pebble.Layer]
 
     # mapping from relation name to a list of relation objects
     _RelationMapping_Raw = Dict[str, Optional[List['Relation']]]
@@ -1219,7 +1219,7 @@ class Pod:
     def __init__(self, backend: '_ModelBackend'):
         self._backend = backend
 
-    def set_spec(self, spec: '_K8sSpec', k8s_resources: Optional['_K8sSpec'] = None):
+    def set_spec(self, spec: 'K8sSpec', k8s_resources: Optional['K8sSpec'] = None):
         """Set the specification for pods that Juju should start in kubernetes.
 
         See `juju help-tool pod-spec-set` for details of what should be passed.

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -201,11 +201,11 @@ if TYPE_CHECKING:
                           total=False)
     # public as it is accessed by ops.testing
     LayerDict = TypedDict('LayerDict',
-                           {'summary': str,
-                            'description': str,
-                            'services': Dict[str, _ServiceDict],
-                            'checks': Dict[str, _CheckDict]},
-                           total=False)
+                          {'summary': str,
+                           'description': str,
+                           'services': Dict[str, _ServiceDict],
+                           'checks': Dict[str, _CheckDict]},
+                          total=False)
 
     _Error = TypedDict('_Error',
                        {'kind': str,

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -749,7 +749,7 @@ class Plan:
 
     def to_yaml(self) -> str:
         """Return this plan's YAML representation."""
-        return yaml.safe_dump(self.to_dict())  # type: ignore
+        return yaml.safe_dump(self.to_dict())
 
     __str__ = to_yaml
 
@@ -790,8 +790,7 @@ class Layer:
 
     def to_yaml(self) -> str:
         """Convert this layer to its YAML representation."""
-        yamlstr = yaml.safe_dump(self.to_dict())  # type: ignore
-        return typing.cast(str, yamlstr)
+        return yaml.safe_dump(self.to_dict())
 
     def to_dict(self) -> 'LayerDict':
         """Convert this layer to its dict representation."""

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -199,8 +199,8 @@ if TYPE_CHECKING:
                           {'services': Dict[str, _ServiceDict],
                            'checks': Dict[str, _CheckDict]},
                           total=False)
-
-    _LayerDict = TypedDict('_LayerDict',
+    # public as it is accessed by ops.testing
+    LayerDict = TypedDict('LayerDict',
                            {'summary': str,
                             'description': str,
                             'services': Dict[str, _ServiceDict],
@@ -772,12 +772,12 @@ class Layer:
     # description: str
     # services: Mapping[str, 'Service']
 
-    def __init__(self, raw: Optional[Union[str, '_LayerDict']] = None):
+    def __init__(self, raw: Optional[Union[str, 'LayerDict']] = None):
         if isinstance(raw, str):
             d = yaml.safe_load(raw) or {}  # type: ignore # (Any 'raw' type)
         else:
             d = raw or {}
-        d = typing.cast('_LayerDict', d)
+        d = typing.cast('LayerDict', d)
 
         self.summary = d.get('summary', '')  # type: str
         self.description = d.get('description', '')  # type: str
@@ -793,7 +793,7 @@ class Layer:
         yamlstr = yaml.safe_dump(self.to_dict())  # type: ignore
         return typing.cast(str, yamlstr)
 
-    def to_dict(self) -> '_LayerDict':
+    def to_dict(self) -> 'LayerDict':
         """Convert this layer to its dict representation."""
         fields = [
             ('summary', self.summary),
@@ -802,7 +802,7 @@ class Layer:
             ('checks', {name: check.to_dict() for name, check in self.checks.items()}),
         ]
         dct = {name: value for name, value in fields if value}
-        return typing.cast('_LayerDict', dct)
+        return typing.cast('LayerDict', dct)
 
     def __repr__(self) -> str:
         return 'Layer({!r})'.format(self.to_dict())
@@ -1809,7 +1809,7 @@ class Client:
             change_id, timeout))
 
     def add_layer(
-            self, label: str, layer: Union[str, '_LayerDict', Layer], *,
+            self, label: str, layer: Union[str, 'LayerDict', Layer], *,
             combine: bool = False):
         """Dynamically add a new layer onto the Pebble configuration layers.
 

--- a/ops/storage.py
+++ b/ops/storage.py
@@ -24,7 +24,7 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Any, Callable, Generator, List, Optional, Tuple, Type, Union
 
-import yaml
+import yaml  # pyright: reportMissingModuleSource=false
 
 logger = logging.getLogger()
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -79,8 +79,9 @@ if TYPE_CHECKING:
         'description': str,
         'default': Union[str, int, float, bool]
     })
+    _StatusName = Literal['unknown', 'blocked', 'active', 'maintenance', 'waiting']
     _RawStatus = TypedDict('_RawStatus', {
-        'status': Literal['unknown', 'blocked', 'active', 'maintenance', 'waiting'],
+        'status': _StatusName,
         'message': str,
     })
     RawConfig = Dict[str, _ConfigOption]
@@ -1450,7 +1451,7 @@ class _TestingModelBackend:
         else:
             return self._unit_status
 
-    def status_set(self, status: str, message: str='', *, is_app: bool=False):
+    def status_set(self, status: '_StatusName', message: str='', *, is_app: bool=False):
         if is_app:
             self._app_status = {'status': status, 'message': message}
         else:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -46,7 +46,7 @@ from contextlib import contextmanager
 from io import BytesIO, StringIO
 from textwrap import dedent
 from typing import (TypeVar, Generic, Type, AnyStr, Iterable, Optional, Mapping,
-                    BinaryIO, TextIO, List, Union, Iterator, Tuple, Any)
+                    BinaryIO, TextIO, List, Union, Iterator, Tuple, Any, cast)
 from ops import charm, framework, model, pebble, storage
 from ops._private import yaml
 
@@ -345,7 +345,7 @@ class Harness(Generic[CharmType]):
                 charm_config = '{}'
         elif isinstance(charm_config, str):
             charm_config = dedent(charm_config)
-        charm_config = cast(ConfigRaw, yaml.safe_load(charm_config)
+        charm_config = cast(ConfigRaw, yaml.safe_load(charm_config))
         charm_config = charm_config.get('options', {})
         return {key: value.get('default', None) for key, value in charm_config.items()}
 
@@ -1121,7 +1121,7 @@ class _TestingModelBackend:
         self._config = {}
         self._is_leader = False
         self._resources_map = {}  # {resource_name: resource_content}
-        self._pod_spec = None
+        self._pod_spec = None  # type: Optional[_PodSpec]
         self._app_status = {'status': 'unknown', 'message': ''}
         self._unit_status = {'status': 'maintenance', 'message': ''}
         self._workload_version = None

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1981,12 +1981,12 @@ ChangeError: cannot perform the following tasks:
                 name=file.name,
                 type=get_pebble_file_type(file),
                 size=file.size if isinstance(file, _File) else None,
-                permissions=file.kwargs['permissions'],
+                permissions=file.kwargs.get('permissions'),
                 last_modified=file.last_modified,
-                user_id=file.kwargs['user_id'],
-                user=file.kwargs['user'],
-                group_id=file.kwargs['group_id'],
-                group=file.kwargs['group'],
+                user_id=file.kwargs.get('user_id'),
+                user=file.kwargs.get('user'),
+                group_id=file.kwargs.get('group_id'),
+                group=file.kwargs.get('group'),
             )
             for file in files
         ]

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2386,7 +2386,6 @@ class _TestingFilesystem:
         path = pathlib.PurePosixPath(path)
         parent_dir = self.get_path(path.parent)
         if not isinstance(parent_dir, _Directory):
-            # todo: or should we be casting instead?
             raise RuntimeError('cannot delete {}: parent {!r}'
                                'is not a directory'.format(path.name, parent_dir))
         del parent_dir[path.name]

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -71,7 +71,6 @@ from ops._private import yaml
 from ops.charm import CharmBase, CharmMeta, RelationRole
 from ops.model import RelationNotFoundError
 
-
 if TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -488,7 +488,7 @@ class Harness(Generic[CharmType]):
         if self._meta.resources[resource_name].type != "oci-image":
             raise RuntimeError('Resource {} is not an OCI Image'.format(resource_name))
 
-        as_yaml = yaml.safe_dump(contents)  # type: ignore  # it's a str
+        as_yaml = yaml.safe_dump(contents)
         self._backend._resources_map[resource_name] = ('contents.yaml', as_yaml)
 
     def add_resource(self, resource_name: str, content: AnyStr) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ docstring-convention = "google"
 
 [tool.pyright]
 include = ["ops/jujuversion.py", "ops/log.py", "ops/model.py", "ops/version.py",
-    "ops/__init__.py", "ops/framework.py", "opps/pebble.py"]
+    "ops/__init__.py", "ops/framework.py", "ops/pebble.py","ops/testing.py"]
 pythonVersion = "3.5" # check no python > 3.5 features are used
 pythonPlatform = "All"
 typeCheckingMode = "strict"


### PR DESCRIPTION
Typed `ops/testing.py`

And with that, ops is now officially pyright-airtight.

## Checklist

 - [x] Have any types changed? If so, have the type annotations been updated?

## QA steps

`tox -vve static`

##Changelog

- typed `ops.testing`
