### PR TITLE
Added further documentation to define_event function in framework.py #830

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -484,6 +484,14 @@ class ObjectEvents(Object):
 
         event_type: a type of the event to define.
 
+        ops uses a labeling system to track and reconstruct events between hook
+        executions (each time a hook runs, the Juju Agent invokes a fresh
+        instance of ops; there is no ops process that persists on the host
+        between hooks).
+        Having duplicate Python objects creates duplicate labels, which
+        increases the risk of ops running the "wrong" code after
+        something has been deferred.
+
         """
         prefix = 'unable to define an event with event_kind that '
         if not event_kind.isidentifier():

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -484,14 +484,15 @@ class ObjectEvents(Object):
 
         event_type: a type of the event to define.
 
-        ops uses a labeling system to track and reconstruct events between hook
-        executions (each time a hook runs, the Juju Agent invokes a fresh
-        instance of ops; there is no ops process that persists on the host
-        between hooks).
-        Having duplicate Python objects creates duplicate labels, which
-        increases the risk of ops running the "wrong" code after
-        something has been deferred.
-
+        Note that attempting to define the same event kind more than once will
+        raise a 'overlaps with existing type' runtime error. Ops uses a
+        labeling system to track and reconstruct events between hook executions
+        (each time a hook runs, the Juju Agent invokes a fresh instance of ops;
+        there is no ops process that persists on the host between hooks).
+        Having duplicate Python objects creates duplicate labels. Overwriting a
+        previously created label means that only the latter code path will be
+        ran when the current event, if it does get deferred, is reemitted. This
+        is usually not what is desired, and is error-prone and ambigous.
         """
         prefix = 'unable to define an event with event_kind that '
         if not event_kind.isidentifier():

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -491,7 +491,7 @@ class ObjectEvents(Object):
         there is no ops process that persists on the host between hooks).
         Having duplicate Python objects creates duplicate labels. Overwriting a
         previously created label means that only the latter code path will be
-        ran when the current event, if it does get deferred, is reemitted. This
+        run when the current event, if it does get deferred, is reemitted. This
         is usually not what is desired, and is error-prone and ambigous.
         """
         prefix = 'unable to define an event with event_kind that '


### PR DESCRIPTION
What is being changed: framework.py
Description: Adding more documentation to the function `define_event` as per issue #830 

## Checklist

 - [x] (none) Have any types changed? If so, have the type annotations been updated?
 - [x] (none) If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?

       We want to avoid simple passthrough of model data, without contextualization, where possible.

 - [x] (na) Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

Documentation update only.

## Documentation changes

Documentation updated.

## Bug reference

#830 -> #824

## Changelog

- Documentation has been added to `define_event`,  to further elaborate its functionality and purpose.
