### PR TITLE
Add utility to get hashes for resources

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -14,6 +14,7 @@
 
 """Representations of Juju's model, application, unit, and other entities."""
 import datetime
+import hashlib
 import ipaddress
 import json
 import logging
@@ -1218,6 +1219,16 @@ class Resources:
         if self._paths[name] is None:
             self._paths[name] = Path(self._backend.resource_get(name))
         return typing.cast(Path, self._paths[name])
+
+    def sha256digest(self, name: str) -> bytes:
+        """Get the sha256 hash of a resource."""
+        sha256 = hashlib.sha256()
+        with self.fetch(name).open('rb') as resource:
+            chunk = resource.read(4096)
+            while chunk:
+                sha256.update(chunk)
+                chunk = resource.read(4096)
+        return sha256.digest()
 
 
 class Pod:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import datetime
+import hashlib
 import ipaddress
 import json
 import os
@@ -679,6 +680,15 @@ class TestModel(unittest.TestCase):
 
         self.assertEqual(self.harness.model.resources.fetch('foo').name, 'foo.txt')
         self.assertEqual(self.harness.model.resources.fetch('bar').name, 'bar.txt')
+
+    def test_resources_sha256(self):
+        contents = 'foo contents\n'
+        self.harness.add_resource('foo', contents)
+        hash = hashlib.sha256()
+        hash.update(bytes(contents, 'ascii'))
+        self.assertEqual(
+            self.harness.model.resources.sha256digest('foo'), hash.digest()
+        )
 
     def test_resources_immutable(self):
         with self.assertRaises(AttributeError):


### PR DESCRIPTION
Add an utility method to get sha256 hashes from resources.

Charms often need to detect whether a resource has been upgraded. One popular way to do so is via comparing hashes; this patch provides a helper to calculate such a hash

## Checklist

None of these are applicable:

 - [ ] Have any types changed? If so, have the type annotations been updated?
 - [ ] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?
 - [ ] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

*Please replace with how we can verify that the change works.*

- Patch comes with a unit test

## Documentation changes

*Please replace with any notes about how it affects current user workflow, CLI, or API.*

- No current user worklow changes

## Changelog

*Please include a bulleted list of items here, suitable for inclusion in a release changelog.*

- *Add an utility to calculate hashes from resources*

