### PR TITLE
reinitialize charm on event in harness

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -640,6 +640,22 @@ class Framework(Object):
         self._juju_debug_at = (set(x.strip() for x in debug_at.split(','))
                                if debug_at else set())  # type: Set[str]
 
+    def _clear_all_state(self):
+        """Clear the state.
+
+        Allows testing environments to clean the framework up and instantiate the
+        same Object (Handle, specifically) multiple times.
+        """
+        if self.model._backend._hook_is_running:  # type: ignore # noqa
+            raise RuntimeError('You should not do this while a hook is running. '
+                               'This method is for testing only.')
+
+        self._objects.clear()
+        self._observers.clear()
+        self._observer.clear()
+        self._type_registry.clear()
+        self._type_known.clear()
+
     def set_breakpointhook(self):
         """Hook into sys.breakpointhook so the builtin breakpoint() works as expected.
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -207,7 +207,7 @@ class Harness(typing.Generic[CharmType]):
         evt.emit(*args, **kwargs)
 
     def _reinitialize_charm(self):
-        self._framework._forget(self.charm)
+        self._framework._clear_all_state()  # type:ignore # noqa
         self._charm = None
         self.begin()
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -63,6 +63,11 @@ from ops.testing import (
 
 is_linux = platform.system() == 'Linux'
 
+# fixme: setting this to true breaks plenty of our own tests
+#  because of all the event recording hackiness we do.
+#  see esp. StorageTester.observed_events and RecordingCharm.changes
+testing.REINITIALIZE_CHARM_ON_EVENT = False
+
 
 class SetLeaderErrorTester(CharmBase):
     """Sets peer relation data inside leader-elected."""
@@ -4325,7 +4330,7 @@ class TestReinitializeCharmOnEvent(unittest.TestCase):
 
         # mapping from ID to instances
         initial_charm_instance = self.harness.charm
-        charm_ids = {id(initial_charm_instance)}
+        charm_instances = [initial_charm_instance]
 
         # we test with all events that are easy to mock, i.e. no args/kwargs.
         bound_events = (
@@ -4341,9 +4346,9 @@ class TestReinitializeCharmOnEvent(unittest.TestCase):
         for i, evt in enumerate(bound_events):
             with self.subTest(name=str(evt)):
                 self.harness.emit_event(evt)
-                new_charm_id = id(self.harness.charm)
-                self.assertNotIn(new_charm_id, charm_ids)
-                charm_ids.add(new_charm_id)
+                new_charm_instance = self.harness.charm
+                self.assertNotIn(new_charm_instance, charm_instances)
+                charm_instances.append(new_charm_instance)
 
     def test_not_reinitialize(self):
         testing.REINITIALIZE_CHARM_ON_EVENT = False


### PR DESCRIPTION
Extended the Harness with an opt-in feature to reinitialize the charm on every event.

## Documentation changes

This will likely have a moderate impact on user tests. It might reveal some bugs (which is good!), but it might also give some false negatives where people wrote tests (as we did too) using mock charms that attached state to the instance.

We need to communicate very clearly the scope of this change, and give time to adapt.
We should also probably add some api to hook into the harness' emit_event for recording purposes.

## Bug reference

Bug: #736 
Prior art: #758 

## Changelog

- added an opt-in feature (to become default in the future) to reinitialize the charm every time the harness fires an event on it.
