### PR TITLE
add abort method to Framework

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -669,6 +669,14 @@ class Framework(Object):
             sys.breakpointhook = self.breakpoint
         return old_breakpointhook
 
+    def abort(self):
+        """Abort the execution of the framework and exit."""
+        try:
+            self.commit()
+        finally:
+            self.close()
+        sys.exit(0)
+
     def close(self):
         """Close the underlying backends."""
         self._storage.close()

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -669,12 +669,11 @@ class Framework(Object):
             sys.breakpointhook = self.breakpoint
         return old_breakpointhook
 
-    def abort(self):
-        """Abort the execution of the framework and exit."""
-        try:
+    def exit(self, commit: bool = True):
+        """Stop the execution of the framework and exit."""
+        if commit:
             self.commit()
-        finally:
-            self.close()
+
         sys.exit(0)
 
     def close(self):


### PR DESCRIPTION
Not sure that this will be sufficient to gracefully exit from the framework, but would like to initialize the discussion

## Bug reference
Closes #839 

## Changelog

- add `abort` method to `Framework`
