### PR TITLE
Add storage attribute to StorageEvent docstring (#764)

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -612,6 +612,9 @@ class StorageEvent(HookEvent):
     charms can define several different types of storage that are
     allocated from Juju. Changes in state of storage trigger sub-types
     of :class:`StorageEvent`.
+
+    Attributes:
+        storage: The :class:`~ops.model.Storage` instance this event is about.
     """
 
     def __init__(self, handle: 'Handle', storage: 'Storage'):


### PR DESCRIPTION
## Documentation changes

Add storage attribute to StorageEvent docstring to fix sphinx documentation.

## Changelog

- Add storage attribute to StorageEvent docstring (#764)
