### PR TITLE
Add Model.topology to provide labels for observability

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1403,6 +1403,7 @@ class _TestingModelBackend:
         if self._resource_dir is not None:
             self._resource_dir.cleanup()
             self._resource_dir = None
+        self._harness_tmp_dir.cleanup()
 
     def _get_resource_dir(self) -> pathlib.Path:
         if self._resource_dir is None:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -942,6 +942,19 @@ class TestModel(unittest.TestCase):
     def assertBackendCalls(self, expected, *, reset=True):  # noqa: N802
         self.assertEqual(expected, self.harness._get_backend_calls(reset=reset))
 
+    def test_topology(self):
+        meta = ops.charm.CharmMeta()
+        meta.name = 'foo/0'
+        model = ops.model.Model(meta, ops.model._ModelBackend('myapp/0'))
+        topo = model.topology
+        assert topo == {
+            'application': 'myapp',
+            'charm_name': 'foo/0',
+            'model': model.name,
+            'model_uuid': model.uuid,
+            'unit': 'myapp/0'
+        }
+
 
 class PushPullCase:
     """Test case for table-driven tests."""


### PR DESCRIPTION
Lots of charm code relies on https://github.com/canonical/prometheus-k8s-operator/blob/main/lib/charms/observability_libs/v0/juju_topology.py to extract a 'juju topology' object, providing a way to uniquely identify (in a human-readable manner) a unit across your juju deployments.

This PR adds to Model a `topology` property exposing the same data from native ops code.

## Checklist

 - [y] Have any types changed? If so, have the type annotations been updated?
 - [y] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?
 - [n/a] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

Added a test verifying the API.

## Documentation changes
None necessary.

## Changelog

*Please include a bulleted list of items here, suitable for inclusion in a release changelog.*

- Added Model.topology to expose juju topology information to uniquely identify the current unit.