### PR TITLE
github actions: replace Python 3.{7,9} by 3.10

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.5", "3.6", "3.8", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.5", "3.6", "3.8", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17
+          go-version: "1.17"
 
       - name: Install tox
         run: pip install tox
@@ -90,4 +90,3 @@ jobs:
         env:
           RUN_REAL_PEBBLE_TESTS: 1 
           PEBBLE: /tmp/pebble 
-

--- a/.github/workflows/hello-charm-tests.yaml
+++ b/.github/workflows/hello-charm-tests.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "3.8"
 
       - name: Checkout the ${{ matrix.charm-repo }} repository
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install wheel
         run: pip install wheel
       - name: Build


### PR DESCRIPTION
There is little value added in testing 3.{7,9} because older and newer versions are tested. Furthermore, those are not part of any supported Ubuntu release.