### PR TITLE
Use Storage.index instead of deprecated Storage.id

### DIFF
--- a/ops/main.py
+++ b/ops/main.py
@@ -170,12 +170,12 @@ def _get_event_args(charm: 'CharmBase',
             storage_name = "-".join(bound_event.event_kind.split("_")[:-2])
 
         storages = model.storages[storage_name]
-        id, storage_location = model._backend._storage_event_details()
+        index, storage_location = model._backend._storage_event_details()
         if len(storages) == 1:
             storage = storages[0]
         else:
             # If there's more than one value, pick the right one. We'll realize the key on lookup
-            storage = next((s for s in storages if s.id == id), None)
+            storage = next((s for s in storages if s.index == index), None)
         storage = cast(Union[ops.storage.JujuStorage, ops.storage.SQLiteStorage], storage)
         storage.location = storage_location  # type: ignore
         return [storage], {}

--- a/ops/model.py
+++ b/ops/model.py
@@ -2392,9 +2392,9 @@ class _ModelBackend:
             raise RuntimeError('unable to find storage key in {output!r}'.format(output=output))
         key = match.groupdict()["storage_key"]
 
-        id = int(key.split("/")[1])
+        index = int(key.split("/")[1])
         location = self.storage_get(key, "location")
-        return id, location
+        return index, location
 
     def storage_get(self, storage_name_id: str, attribute: str) -> str:
         if not len(attribute) > 0:  # assume it's an empty string.


### PR DESCRIPTION
The Storage.id attributes was deprecated in PR #734, but this usage of it wasn't updated, so we were getting WARNING logs about it.

I've tested this code path locally by changing the `echo '["disks/0"]'` in `test_main.py:TestMainWithNoDispatch` to `echo '["disks/0", "disks/1]'`.

Fixes #853
