### PR TITLE
Reinstate reversion of add_relation_unit ValueError to warning

### DIFF
--- a/ops/_private/yaml.py
+++ b/ops/_private/yaml.py
@@ -32,6 +32,8 @@ def safe_load(stream: Union[str, TextIO]):
 def safe_dump(data: Any, *args: Any, encoding: None = None, **kwargs: Any) -> str: ...  # noqa
 @overload
 def safe_dump(data: Any, *args: Any, encoding: str = "", **kwargs: Any) -> bytes: ...  # noqa
+
+
 def safe_dump(data: Any, stream: Optional[Union[str, TextIO]] = None, **kwargs: Any  # noqa
               ) -> Union[str, bytes]:
     """Same as yaml.safe_dump, but use fast C dumper if available.

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -789,11 +789,10 @@ class Harness(Generic[CharmType]):
         self._backend._relation_data_raw[relation_id][remote_unit_name] = {}
         app = cast(model.Application, relation.app)  # should not be None since we're testing
         if not remote_unit_name.startswith(app.name):
-            raise ValueError(
+            warnings.warn(
                 'Remote unit name invalid: the remote application of {} is called {!r}; '
                 'the remote unit name should be {}/<some-number>, not {!r}.'
-                ''.format(relation_name, app.name,
-                          app.name, remote_unit_name))
+                ''.format(relation_name, app.name, app.name, remote_unit_name))
         app_and_units = self._backend._relation_app_and_units  # pyright: ReportPrivateUsage=false
         app_and_units[relation_id]["units"].append(remote_unit_name)
         # Make sure that the Model reloads the relation_list for this relation_id, as well as


### PR DESCRIPTION
This was originally coded as a ValueError exception in https://github.com/canonical/operator/pull/795/files#diff-37e8d80748bba21bb08c982f17b7879059bacc8d413b59da998a896fca18be33R713

Then downgraded to a warning in
https://github.com/canonical/operator/pull/822/files#diff-37e8d80748bba21bb08c982f17b7879059bacc8d413b59da998a896fca18be33R714

But accidentally reverted to a ValueError when types were being added: https://github.com/canonical/operator/pull/828/files#diff-37e8d80748bba21bb08c982f17b7879059bacc8d413b59da998a896fca18be33

So revert it to a warning as per #822.

