### PR TITLE
Doc tweak: clarify what Container.get_plan actually returns

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 -r ../requirements.txt
 
-sphinx==3.*
+sphinx
 sphinx_rtd_theme
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -1488,7 +1488,12 @@ class Container:
         self._pebble.add_layer(label, layer, combine=combine)
 
     def get_plan(self) -> 'Plan':
-        """Get the current effective pebble configuration."""
+        """Get the combined Pebble configuration.
+
+        This will immediately reflect changes from any previous
+        :meth:`add_layer` calls, regardless of whether :meth:`replan` or
+        :meth:`restart` have been called.
+        """
         return self._pebble.get_plan()
 
     def get_services(self, *service_names: str) -> '_ServiceInfoMapping':


### PR DESCRIPTION
This doc tweaks is to clarify for https://github.com/canonical/operator/issues/863

Note that the Sphinx change is because 3.x no longer installs on recent Python versions. I updated this to fix doc build on Python 3.10.x. Due to changes in the typing module in Python 3.10.x and how Sphinx was doing a version test using version > (3, 10), doc building was broken with an ImportError when import Sphinx on Python 3.10.x (I'm using Python 3.10.6, for example). See: sphinx-doc/sphinx@8b2031c ... So just use the latest version of Sphinx for now.

Fixes #863
