### PR TITLE
Decode stderr from _run() from bytes to str

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.5", "3.6", "3.8", "3.10"]
+        python-version: ["3.8", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.5", "3.6", "3.8", "3.10"]
+        python-version: ["3.8", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/ops/model.py
+++ b/ops/model.py
@@ -2181,7 +2181,7 @@ class _ModelBackend:
             # so this needs to be coerced into the right type
             result = typing.cast('CompletedProcess[bytes]', result)
         except CalledProcessError as e:
-            raise ModelError(e.stderr)
+            raise ModelError(e.stderr.decode('utf-8').strip())
         if return_output:
             if result.stdout is None:
                 return ''

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -949,6 +949,14 @@ class TestModel(unittest.TestCase):
     def assertBackendCalls(self, expected, *, reset=True):  # noqa: N802
         self.assertEqual(expected, self.harness._get_backend_calls(reset=reset))
 
+    def test_run_error(self):
+        model = ops.model.Model(ops.charm.CharmMeta(), ops.model._ModelBackend('myapp/0'))
+        fake_script(self, 'status-get', """echo 'ERROR cannot get status' >&2; exit 1""")
+        with self.assertRaises(ops.model.ModelError) as cm:
+            _ = model.unit.status.message
+        self.assertEqual(str(cm.exception), 'ERROR cannot get status')
+        self.assertEqual(cm.exception.args[0], 'ERROR cannot get status')
+
 
 class PushPullCase:
     """Test case for table-driven tests."""


### PR DESCRIPTION
This changes the relatively awkward exception output from this:

```
Traceback (most recent call last):
  ...
ops.model.ModelError: b'ERROR an error\n'
```

To this:

```
Traceback (most recent call last):
  ...
ops.model.ModelError: ERROR an error
```

This is similar to how we already decode the stdout output in the `return_output` block below.