### PR TITLE
Update ReadTheDocs build to use Python 3.8 instead of 3.5

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,6 @@
 version: 2                      # required
 formats: []                     # i.e. no extra formats (for now)
 python:
-  version: "3.5"
+  version: "3.8"
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
Our docs are broken due to the codebase now using 3.6 or 3.8 syntax features, and that breaks the docs generation on ReadTheDocs due to the version being fixed to 3.5 -- there's no content at all under any of the sections.