### PR TITLE
Update minimum Python version from 3.5 to 3.8

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,6 +1,6 @@
 # Setting up a Dev Environment
 
-To work in the framework itself you will need Python >= 3.5. Linting, testing,
+To work in the framework itself you will need Python >= 3.8. Linting, testing,
 and docs automation is performed using
 [`tox`](https://tox.readthedocs.io/en/latest/) which you should install.
 For improved performance on the tests, ensure that you have PyYAML

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ is to feel natural for somebody used to coding in Python, and reasonably easy to
 who is not a pythonista.
 
 The dependencies of the operator framework are kept as minimal as possible; currently that's Python
-3.5 or greater, and `PyYAML` (both are included by default in Ubuntu's cloud images from 16.04 on).
+3.8 or greater, and `PyYAML` (both are included by default in Ubuntu's cloud images from 20.04 on).
 
 For a brief intro on how to get started, check out the
 [Hello, World!](https://juju.is/docs/sdk/hello-world) section of the documentation!

--- a/ops/model.py
+++ b/ops/model.py
@@ -2544,9 +2544,10 @@ class _ModelBackend:
         self._hook_is_running = ''
 
     def _run(self, *args: str, return_output: bool = False,
-             use_json: bool = False, input_stream: Optional[bytes] = None
+             use_json: bool = False, input_stream: Optional[str] = None
              ) -> Union[str, 'JsonObject', None]:
-        kwargs = dict(stdout=PIPE, stderr=PIPE, check=True)  # type: Dict[str, Any]
+        kwargs = dict(stdout=PIPE, stderr=PIPE, check=True,
+                      encoding='utf-8')  # type: Dict[str, Any]
         if input_stream:
             kwargs.update({"input": input_stream})
         which_cmd = shutil.which(args[0])
@@ -2567,7 +2568,7 @@ class _ModelBackend:
             if result.stdout is None:
                 return ''
             else:
-                text = result.stdout.decode('utf8')
+                text = typing.cast(str, result.stdout)
                 if use_json:
                     return json.loads(text)
                 else:
@@ -2664,7 +2665,7 @@ class _ModelBackend:
         args.extend(["--file", "-"])
 
         try:
-            content = yaml.safe_dump({key: value}, encoding='utf8')
+            content = yaml.safe_dump({key: value})
             self._run(*args, input_stream=content)
         except ModelError as e:
             if self._is_relation_not_found(e):

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -693,13 +693,16 @@ class Layer:
 
     The format of this is documented at
     https://github.com/canonical/pebble/#layer-specification.
-
-    Attributes:
-        summary: A summary of the purpose of this layer
-        description: A long form description of this layer
-        services: A mapping of name to :class:`Service` defined by this layer
-        checks: A mapping of check to :class:`Check` defined by this layer
     """
+
+    #: Summary of the purpose of this layer.
+    summary: str
+    #: Long-form description of this layer.
+    description: str
+    #: Mapping of name to :class:`Service` defined by this layer.
+    services: Dict[str, 'Service']
+    #: Mapping of check to :class:`Check` defined by this layer.
+    checks: Dict[str, 'Check']
 
     def __init__(self, raw: Optional[Union[str, 'LayerDict']] = None):
         if isinstance(raw, str):
@@ -708,14 +711,12 @@ class Layer:
             d = raw or {}
         d = typing.cast('LayerDict', d)
 
-        self.summary = d.get('summary', '')  # type: str
-        self.description = d.get('description', '')  # type: str
+        self.summary = d.get('summary', '')
+        self.description = d.get('description', '')
         self.services = {name: Service(name, service)
-                         for name, service in d.get('services', {}).items()
-                         }  # type: Dict[str, Service]
+                         for name, service in d.get('services', {}).items()}
         self.checks = {name: Check(name, check)
-                       for name, check in d.get('checks', {}).items()
-                       }  # type: Dict[str, Check]
+                       for name, check in d.get('checks', {}).items()}
 
     def to_yaml(self) -> str:
         """Convert this layer to its YAML representation."""

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -36,7 +36,6 @@ import sys
 import tempfile
 import threading
 import time
-import types
 import typing
 import urllib.error
 import urllib.parse
@@ -267,17 +266,6 @@ def _format_timeout(timeout: float) -> str:
     as accepted by the Pebble API (which uses Go's time.ParseDuration).
     """
     return '{:.3f}s'.format(timeout)
-
-
-def _json_loads(s: '_StrOrBytes') -> Dict[Any, Any]:
-    """Like json.loads(), but handle str or bytes.
-
-    This is needed because an HTTP response's read() method returns bytes on
-    Python 3.5, and json.load doesn't handle bytes.
-    """
-    if isinstance(s, bytes):
-        s = s.decode('utf-8')
-    return json.loads(s)
 
 
 def _start_thread(target: Callable[..., Any], *args: Any, **kwargs: Any) -> threading.Thread:
@@ -712,11 +700,6 @@ class Layer:
         services: A mapping of name to :class:`Service` defined by this layer
         checks: A mapping of check to :class:`Check` defined by this layer
     """
-
-    # This is how you do type annotations, but it is not supported by Python 3.5
-    # summary: str
-    # description: str
-    # services: Mapping[str, 'Service']
 
     def __init__(self, raw: Optional[Union[str, 'LayerDict']] = None):
         if isinstance(raw, str):
@@ -1459,7 +1442,7 @@ class Client:
 
         response = self._request_raw(method, path, query, headers, data)
         self._ensure_content_type(response.headers, 'application/json')
-        raw_resp = _json_loads(response.read())  # type: Dict[str, Any]
+        raw_resp = json.loads(response.read())  # type: Dict[str, Any]
         return raw_resp
 
     @staticmethod
@@ -1485,11 +1468,6 @@ class Client:
         if query:
             url = url + '?' + urllib.parse.urlencode(query, doseq=True)
 
-        # python 3.5 urllib requests require their data to be a bytes object -
-        # generators won't work.
-        if sys.version_info[:2] < (3, 6) and isinstance(data, types.GeneratorType):
-            data = b''.join(data)
-
         if headers is None:
             headers = {}
         request = urllib.request.Request(url, method=method, data=data, headers=headers)
@@ -1500,7 +1478,7 @@ class Client:
             code = e.code
             status = e.reason
             try:
-                body = _json_loads(e.read())  # type: Dict[str, Any]
+                body = json.loads(e.read())  # type: Dict[str, Any]
                 message = body['result']['message']  # type: str
             except (IOError, ValueError, KeyError) as e2:
                 # Will only happen on read error or if Pebble sends invalid JSON.
@@ -1920,7 +1898,7 @@ class Client:
         }
         response = self._request_raw('POST', '/v1/files', None, headers, data)
         self._ensure_content_type(response.headers, 'application/json')
-        resp = _json_loads(response.read())
+        resp = json.loads(response.read())
         # we need to cast the Dict[Any, Any] to _FilesResponse
         self._raise_on_path_error(typing.cast('_FilesResponse', resp), path)
 

--- a/ops/storage.py
+++ b/ops/storage.py
@@ -372,7 +372,7 @@ class _JujuStorageBackend:
             CalledProcessError: if 'state-get' returns an error code.
         """
         # We don't capture stderr here so it can end up in debug logs.
-        p = _run(["state-get", key], stdout=subprocess.PIPE, check=True, universal_newlines=True)
+        p = _run(["state-get", key], stdout=subprocess.PIPE, check=True, encoding='utf-8')
         if p.stdout == '' or p.stdout == '\n':
             raise KeyError(key)
         return yaml.load(p.stdout, Loader=_SimpleLoader)  # type: ignore

--- a/ops/storage.py
+++ b/ops/storage.py
@@ -45,7 +45,7 @@ def _run(args: List[str], **kw: Any):
     cmd = shutil.which(args[0])  # type: Optional[str]
     if cmd is None:
         raise FileNotFoundError(args[0])
-    return subprocess.run([cmd, *args[1:]], **kw)
+    return subprocess.run([cmd, *args[1:]], encoding='utf-8', **kw)
 
 
 class SQLiteStorage:
@@ -358,7 +358,8 @@ class _JujuStorageBackend:
         # have the same default style.
         encoded_value = yaml.dump(value, Dumper=_SimpleDumper, default_flow_style=None)
         content = yaml.dump(
-            {key: encoded_value}, encoding='utf8', default_style='|',
+            {key: encoded_value},
+            default_style='|',
             default_flow_style=False,
             Dumper=_SimpleDumper)
         _run(["state-set", "--file", "-"], input=content, check=True)
@@ -372,7 +373,7 @@ class _JujuStorageBackend:
             CalledProcessError: if 'state-get' returns an error code.
         """
         # We don't capture stderr here so it can end up in debug logs.
-        p = _run(["state-get", key], stdout=subprocess.PIPE, check=True, encoding='utf-8')
+        p = _run(["state-get", key], stdout=subprocess.PIPE, check=True)
         if p.stdout == '' or p.stdout == '\n':
             raise KeyError(key)
         return yaml.load(p.stdout, Loader=_SimpleLoader)  # type: ignore

--- a/ops/version.py
+++ b/ops/version.py
@@ -36,11 +36,12 @@ def _get_version():
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 cwd=p,
-                check=True)
+                check=True,
+                encoding='utf-8')
         except Exception:
             pass
         else:
-            version = proc.stdout.strip().decode('utf8')
+            version = proc.stdout.strip()
             if '-' in version:
                 # version will look like <tag>-<#commits>-g<hex>[-dirty]
                 # in terms of PEP 440, the tag we'll make sure is a 'public version identifier';

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,7 @@ def _get_version() -> str:
 version = _get_version()
 version_path = Path("ops/version.py")
 version_backup = Path("ops/version.py~")
-if version_backup.exists():
-    # unlink(missing_ok=True) is a 3.8-ish
-    version_backup.unlink()
+version_backup.unlink(missing_ok=True)
 version_path.rename(version_backup)
 try:
     with version_path.open("wt", encoding="utf8") as fh:
@@ -77,7 +75,7 @@ version = {!r}
             # include Windows once we're running tests there also
             # "Operating System :: Microsoft :: Windows",
         ],
-        python_requires='>=3.5',
+        python_requires='>=3.8',
         install_requires=["PyYAML"],
         package_data={'ops': ['py.typed']},
     )

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -21,7 +21,6 @@ import re
 import shutil
 import sys
 import tempfile
-import unittest
 from pathlib import Path
 from test.test_helpers import BaseTestCase, fake_script
 from unittest.mock import patch
@@ -547,7 +546,7 @@ class TestFramework(BaseTestCase):
             class OtherEvents(ObjectEvents):
                 foo = event
         self.assertEqual(
-            str(cm.exception),
+            str(cm.exception.__cause__),
             "EventSource(MyEvent) reused as MyEvents.foo and OtherEvents.foo")
 
         with self.assertRaises(RuntimeError) as cm:
@@ -555,7 +554,7 @@ class TestFramework(BaseTestCase):
                 on = MyEvents()
                 bar = event
         self.assertEqual(
-            str(cm.exception),
+            str(cm.exception.__cause__),
             "EventSource(MyEvent) reused as MyEvents.foo and MyNotifier.bar")
 
     def test_reemit_ignores_unknown_event_type(self):
@@ -1545,7 +1544,6 @@ class BreakpointTests(BaseTestCase):
             framework.breakpoint()
             self.assertEqual(fake_stderr.getvalue(), _BREAKPOINT_WELCOME_MESSAGE)
 
-    @unittest.skipIf(sys.version_info < (3, 7), "no breakpoint builtin for Python < 3.7")
     def test_breakpoint_builtin_sanity(self, fake_stderr):
         # this just checks that calling breakpoint() works as expected
         # nothing really framework-dependent
@@ -1555,12 +1553,11 @@ class BreakpointTests(BaseTestCase):
 
         with patch('pdb.Pdb.set_trace') as mock:
             this_frame = inspect.currentframe()
-            breakpoint()        # noqa: F821 ('undefined name' in <3.7)
+            breakpoint()
 
         self.assertEqual(mock.call_count, 1)
         self.assertEqual(mock.call_args, ((this_frame,), {}))
 
-    @unittest.skipIf(sys.version_info < (3, 7), "no sys.breakpointhook for Python < 3.7")
     def test_builtin_breakpoint_hooked(self, fake_stderr):
         # Verify that the proper hook is set.
         with patch.dict(os.environ, {'JUJU_DEBUG_AT': 'all'}):
@@ -1568,10 +1565,9 @@ class BreakpointTests(BaseTestCase):
         old_breakpointhook = framework.set_breakpointhook()
         self.addCleanup(setattr, sys, 'breakpointhook', old_breakpointhook)
         with patch('pdb.Pdb.set_trace') as mock:
-            breakpoint()        # noqa: F821 ('undefined name' in <3.7)
+            breakpoint()
         self.assertEqual(mock.call_count, 1)
 
-    @unittest.skipIf(sys.version_info < (3, 7), "no breakpoint builtin for Python < 3.7")
     def test_breakpoint_builtin_unset(self, fake_stderr):
         # if no JUJU_DEBUG_AT, no call to pdb is done
         with patch.dict(os.environ):
@@ -1581,7 +1577,7 @@ class BreakpointTests(BaseTestCase):
         self.addCleanup(setattr, sys, 'breakpointhook', old_breakpointhook)
 
         with patch('pdb.Pdb.set_trace') as mock:
-            breakpoint()        # noqa: F821 ('undefined name' in <3.7)
+            breakpoint()
 
         self.assertEqual(mock.call_count, 0)
 

--- a/test/test_infra.py
+++ b/test/test_infra.py
@@ -72,16 +72,12 @@ class InfrastructureTests(unittest.TestCase):
             self.fail("Please add copyright headers to the following files:\n" + "\n".join(issues))
 
     def _run_setup(self, *args):
-        # from 3.6 we could just use encoding="utf8" here, but 3.5
-        # doesn't expose that and instead defaults to the wrong thing
         proc = subprocess.run(
             (sys.executable, 'setup.py') + args,
             stdout=subprocess.PIPE,
-            check=True)
-        out = proc.stdout.strip().decode("utf8")
-        if os.linesep != '\n':
-            out = out.replace(os.linesep, '\n')
-        return out
+            check=True,
+            encoding='utf-8')
+        return proc.stdout.strip()
 
     def test_setup_version(self):
         setup_version = self._run_setup('--version')

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -105,7 +105,6 @@ class EventSpec:
 @patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class CharmInitTestCase(unittest.TestCase):
 
-    @unittest.skipIf(sys.version_info < (3, 7), "no breakpoint builtin for Python < 3.7")
     @patch('sys.stderr', new_callable=io.StringIO)
     def test_breakpoint(self, fake_stderr):
         class MyCharm(CharmBase):
@@ -113,19 +112,18 @@ class CharmInitTestCase(unittest.TestCase):
         self._check(MyCharm, extra_environ={'JUJU_DEBUG_AT': 'all'})
 
         with patch('pdb.Pdb.set_trace') as mock:
-            breakpoint()        # noqa: F821 ('undefined name' in <3.7)
+            breakpoint()
 
         self.assertEqual(mock.call_count, 1)
         self.assertIn('Starting pdb to debug charm operator', fake_stderr.getvalue())
 
-    @unittest.skipIf(sys.version_info < (3, 7), "no breakpoint builtin for Python < 3.7")
     def test_no_debug_breakpoint(self):
         class MyCharm(CharmBase):
             pass
         self._check(MyCharm, extra_environ={'JUJU_DEBUG_AT': ''})
 
         with patch('pdb.Pdb.set_trace') as mock:
-            breakpoint()        # noqa: F821 ('undefined name' in <3.7)
+            breakpoint()
 
         self.assertEqual(mock.call_count, 0)
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -941,6 +941,14 @@ class TestModel(unittest.TestCase):
     def assertBackendCalls(self, expected, *, reset=True):  # noqa: N802
         self.assertEqual(expected, self.harness._get_backend_calls(reset=reset))
 
+    def test_run_error(self):
+        model = ops.model.Model(ops.charm.CharmMeta(), ops.model._ModelBackend('myapp/0'))
+        fake_script(self, 'status-get', """echo 'ERROR cannot get status' >&2; exit 1""")
+        with self.assertRaises(ops.model.ModelError) as cm:
+            _ = model.unit.status.message
+        self.assertEqual(str(cm.exception), 'ERROR cannot get status\n')
+        self.assertEqual(cm.exception.args[0], 'ERROR cannot get status\n')
+
 
 class PushPullCase:
     """Test case for table-driven tests."""

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -18,7 +18,6 @@ import ipaddress
 import json
 import os
 import pathlib
-import sys
 import tempfile
 import types
 import unittest
@@ -301,14 +300,12 @@ class TestModel(unittest.TestCase):
         # this will fire more backend calls
         with self.harness._event_context('foo_event'):
             data_repr = repr(rel_db1.data)
-        # the CountEqual and weird (and brittle) splitting is to accommodate python 3.5
-        # TODO: switch to assertEqual when we drop 3.5
-        self.assertCountEqual(
-            data_repr[1:-1].split(', '),
-            ["<ops.model.Unit myapp/0>: {}",
-             "<ops.model.Application myapp>: <n/a>",
-             "<ops.model.Unit remoteapp1/0>: {'host': 'remoteapp1/0'}",
-             "<ops.model.Application remoteapp1>: {'secret': 'cafedeadbeef'}"])
+        self.assertEqual(
+            data_repr,
+            ('{<ops.model.Unit myapp/0>: {}, '
+             '<ops.model.Application myapp>: <n/a>, '
+             "<ops.model.Unit remoteapp1/0>: {'host': 'remoteapp1/0'}, "
+             "<ops.model.Application remoteapp1>: {'secret': 'cafedeadbeef'}}"))
 
     def test_relation_data_modify_our(self):
         relation_id = self.harness.add_relation('db1', 'remoteapp1')
@@ -597,13 +594,7 @@ class TestModel(unittest.TestCase):
                 ('relation_get', 1, 'remoteapp1/0', False),
                 ('is_leader',),
                 ('relation_get', 1, 'remoteapp1', True)]
-            # in < 3.5 dicts are unsorted
-            major, minor, *_ = sys.version_info
-            if (major, minor) > (3, 5):
-                self.assertBackendCalls(expected_backend_calls)
-            else:
-                backend_calls = set(self.harness._get_backend_calls())
-                self.assertEqual(backend_calls, set(expected_backend_calls))
+            self.assertBackendCalls(expected_backend_calls)
 
     def test_relation_no_units(self):
         self.harness.add_relation('db1', 'remoteapp1')

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -2260,9 +2260,8 @@ class TestModelBackend(unittest.TestCase):
                     content = t.read()
                 finally:
                     t.close()
-                self.assertEqual(content.decode('utf-8'), dedent("""\
-                    foo: bar
-                    """))
+                decoded = content.decode('utf-8').replace('\r\n', '\n')
+                self.assertEqual(decoded, 'foo: bar\n')
 
         # before 2.7.0, it just fails always (no --app support)
         os.environ['JUJU_VERSION'] = '2.6.9'

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -3258,7 +3258,7 @@ class TestRealPebble(unittest.TestCase):
         with self.assertRaises(urllib.error.HTTPError) as cm:
             self._get_health()
         self.assertEqual(cm.exception.code, 502)
-        health = pebble._json_loads(cm.exception.read())
+        health = json.loads(cm.exception.read())
         self.assertEqual(health, {
             'result': {'healthy': False},
             'status': 'Bad Gateway',
@@ -3277,7 +3277,7 @@ class TestRealPebble(unittest.TestCase):
 
     def _get_health(self):
         f = urllib.request.urlopen('http://localhost:4000/v1/health')
-        return pebble._json_loads(f.read())
+        return json.loads(f.read())
 
     def test_exec_wait(self):
         process = self.client.exec(['true'])

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -396,20 +396,16 @@ class TestJujuStateBackend(BaseTestCase):
         self.assertEqual(list(outer.keys()), [key])
         inner = yaml.load(outer[key], Loader=storage._SimpleLoader)
         self.assertEqual(complex_val, inner)
-        if sys.version_info >= (3, 6):
-            # In Python 3.5 dicts are not ordered by default, and PyYAML only
-            # iterates the dict. So we read and assert the content is valid,
-            # but we don't assert the serialized form.
-            self.assertEqual(content.decode('utf-8'), dedent("""\
-                "Class[foo]/_stored": |
-                  foo: 2
-                  3: [1, 2, '3']
-                  four: !!set {2: null, 3: null}
-                  five: {a: 2, b: 3.0}
-                  six: !!python/tuple [a, b]
-                  seven: !!binary |
-                    MTIzNA==
-                """))
+        self.assertEqual(content.decode('utf-8'), dedent("""\
+            "Class[foo]/_stored": |
+              foo: 2
+              3: [1, 2, '3']
+              four: !!set {2: null, 3: null}
+              five: {a: 2, b: 3.0}
+              six: !!python/tuple [a, b]
+              seven: !!binary |
+                MTIzNA==
+            """))
         # Note that the content is yaml in a string, embedded inside YAML to declare the Key:
         # Value of where to store the entry.
         fake_script(self, 'state-get', dedent("""


### PR DESCRIPTION
* Update references to the minimum Python version from 3.5 to 3.8
* Update setup.py `python_requires` version to 3.8
* Get rid of `framework._Metaclass` hack and use `__set_name__` instead
* Use `subprocess.run()`'s encoding argument now that we can
* Remove `pebble._json_loads()` now that `json.loads()` handles bytes
* `Pathlib.path.unlink()`'s "missing_ok" keyword argument
* Remove need for `unittest.skipIf` for Python < 3.7
* Couple of test tweaks now that dicts are ordered (as of Python 3.6)

Also added `test_run_error` from #868 (which is superceded by this PR).

**NOTE: This is a first pass, "minimum viable product" only.** In a subsequent release (2.1) I plan to do a full pass, updating everything to f-strings, variable type annotations, and so on.