### PR TITLE
Remove Windows support

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.10"]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ software component that can be shared.
 
 This project extends the operator pattern to enable
 [charmed operators](https://juju.is/universal-operators), not just for Kubernetes but also
-operators for traditional Linux or Windows application management.
+operators for traditional Linux application management.
 
 Operators use a [Charmed Operator Lifecycle Manager
 (Charmed OLM)](https://juju.is/operator-lifecycle-manager) to coordinate their work in a cluster.

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -25,10 +25,10 @@ knowledge from experts in a software component that can be shared.
 
 The Charmed Operator Framework extends the "operator pattern" to enable Charmed
 Operators, packaged as and often referred to as "charms". Charms are not just
-for Kubernetes but also operators for traditional Linux or Windows application
-management. Operators use an Operator Lifecycle Manager (OLM), like Juju, to
-coordinate their work in a cluster. The system uses Golang for concurrent event
-processing under the hood, but enables the operators to be written in Python.
+for Kubernetes but also operators for traditional Linux application management.
+Operators use an Operator Lifecycle Manager (OLM), like Juju, to coordinate
+their work in a cluster. The system uses Golang for concurrent event processing
+under the hood, but enables the operators to be written in Python.
 
 Operators should do one thing and do it well. Each operator drives a single
 application or service and can be composed with other operators to deliver a

--- a/ops/main.py
+++ b/ops/main.py
@@ -117,11 +117,6 @@ def _setup_event_links(charm_dir: Path, charm: 'CharmBase'):
         charm: An instance of the Charm class.
 
     """
-    # XXX: on windows this function does not accomplish what it wants to:
-    #      it creates symlinks with no extension pointing to a .py
-    #      and Juju only knows how to handle .exe, .bat, .cmd, and .ps1
-    #      so it does its job, but does not accomplish anything as the
-    #      hooks aren't 'callable'.
     link_to = os.path.realpath(os.environ.get("JUJU_DISPATCH_PATH", sys.argv[0]))
     for bound_event in charm.on.events().values():
         # Only events that originate from Juju need symlinks.

--- a/ops/model.py
+++ b/ops/model.py
@@ -2039,9 +2039,6 @@ class Container:
             dest_dir: Remote destination directory inside which the source dir/files will be
                 placed.  This must be an absolute path.
         """
-        if os.name == 'nt':
-            raise RuntimeError('Container.push_path is not supported on Windows-based systems')
-
         if hasattr(source_path, '__iter__') and not isinstance(source_path, str):
             source_paths = typing.cast(Iterable[StrOrPath], source_path)
         else:
@@ -2122,9 +2119,6 @@ class Container:
             dest_dir: Local destination directory inside which the source dir/files will be
                 placed.
         """
-        if os.name == 'nt':
-            raise RuntimeError('Container.pull_path is not supported on Windows-based systems')
-
         if hasattr(source_path, '__iter__') and not isinstance(source_path, str):
             source_paths = typing.cast(Iterable[StrOrPath], source_path)
         else:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1855,14 +1855,6 @@ class Client:
 
         f = parser.get_file(path, encoding)
 
-        # The opened file remains usable after removing/unlinking on posix
-        # platforms until it is closed.  This prevents callers from
-        # interacting with it on disk.  But e.g. Windows doesn't allow
-        # removing opened files, and so we use the tempfile lib's
-        # helper class to auto-delete on close/gc for us.
-        if os.name != 'posix' or sys.platform == 'cygwin':
-            return tempfile._TemporaryFileWrapper(  # type: ignore
-                f, f.name, delete=True)  # type: ignore
         parser.remove_files()
         return f
 
@@ -2247,9 +2239,6 @@ class Client:
 
         if stdin is not None:
             if _has_fileno(stdin):
-                if sys.platform == 'win32':
-                    raise NotImplementedError('file-based stdin not supported on Windows')
-
                 # Create a pipe so _reader_to_websocket can select() on the
                 # reader as well as this cancel_reader; when we write anything
                 # to cancel_writer it'll trigger the select and end the thread.

--- a/setup.py
+++ b/setup.py
@@ -69,13 +69,10 @@ version = {!r}
             "Programming Language :: Python :: 3",
             "License :: OSI Approved :: Apache Software License",
             "Development Status :: 4 - Beta",
-
             "Intended Audience :: Developers",
             "Intended Audience :: System Administrators",
             "Operating System :: MacOS :: MacOS X",
             "Operating System :: POSIX :: Linux",
-            # include Windows once we're running tests there also
-            # "Operating System :: Microsoft :: Windows",
         ],
         python_requires='>=3.5',
         install_requires=["PyYAML"],

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -17,7 +17,6 @@ import importlib.util
 import io
 import logging
 import os
-import platform
 import shutil
 import subprocess
 import sys
@@ -62,8 +61,6 @@ from ops.storage import SQLiteStorage
 from ops.version import version
 
 from .test_helpers import fake_script, fake_script_calls
-
-is_windows = platform.system() == 'Windows'
 
 # This relies on the expected repository structure to find a path to
 # source of the charm under test.
@@ -682,7 +679,6 @@ class _TestMain(abc.ABC):
             self._simulate_event(event_spec)
             self.assertIn(calls, fake_script_calls(self, clear=True))
 
-    @unittest.skipIf(is_windows, 'TODO windows multiline args are hard')
     def test_excepthook(self):
         with self.assertRaises(subprocess.CalledProcessError):
             self._simulate_event(EventSpec(InstallEvent, 'install',
@@ -813,9 +809,7 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
                 self.assertTrue(hook_path.exists(), 'Missing hook: ' + event_hook)
                 if self.hooks_are_symlinks:
                     self.assertTrue(hook_path.is_symlink())
-                    if not is_windows:
-                        # TODO(benhoyt): fix this now that tests are running on GitHub Actions
-                        self.assertEqual(os.readlink(str(hook_path)), self.charm_exec_path)
+                    self.assertEqual(os.readlink(str(hook_path)), self.charm_exec_path)
                 elif event_hook in initial_hooks:
                     self.assertFalse(hook_path.is_symlink())
                 else:
@@ -918,7 +912,6 @@ class _TestMainWithDispatch(_TestMain):
         self.assertRegex(' '.join(calls.pop(-2)), 'Initializing SQLite local storage: ')
         self.assertEqual(calls, expected)
 
-    @unittest.skipIf(is_windows, "this is UNIXish; TODO: write equivalent windows test")
     def test_non_executable_hook_and_dispatch(self):
         (self.hooks_dir / "install").write_text("")
         state = self._simulate_event(EventSpec(InstallEvent, 'install'))
@@ -965,8 +958,6 @@ class _TestMainWithDispatch(_TestMain):
     def test_hook_and_dispatch_but_hook_is_dispatch(self):
         event = EventSpec(InstallEvent, 'install')
         hook_path = self.hooks_dir / 'install'
-        if is_windows:
-            hook_path = hook_path.with_suffix('.bat')
         for ((rel, ind), path) in {
                 # relative and indirect
                 (True, True): Path('../dispatch'),
@@ -978,8 +969,6 @@ class _TestMainWithDispatch(_TestMain):
                 (False, True): self.JUJU_CHARM_DIR / 'dispatch',
         }.items():
             with self.subTest(path=path, rel=rel, ind=ind):
-                if is_windows:
-                    path = path.with_suffix('.sh')
                 # sanity check
                 self.assertEqual(path.is_absolute(), not rel)
                 self.assertEqual(path.with_suffix('').name == 'dispatch', ind)
@@ -994,7 +983,6 @@ class _TestMainWithDispatch(_TestMain):
                 finally:
                     hook_path.unlink()
 
-    @unittest.skipIf(is_windows, "this needs rethinking on Windows")
     def test_hook_and_dispatch_but_hook_is_dispatch_copy(self):
         hook_path = self.hooks_dir / 'install'
         path = (self.hooks_dir / self.charm_exec_path).resolve()
@@ -1027,10 +1015,6 @@ class _TestMainWithDispatch(_TestMain):
         self.assertEqual(calls, expected)
 
 
-# NOTE
-#  AIUI On windows dispatch must be a script (see TestMainWithDispatchAsScript),
-#  because Juju won't call python even if we rename dispatch to dispatch.py
-@unittest.skipIf(is_windows, "Juju on windows won't make this work (see note)")
 class TestMainWithDispatch(_TestMainWithDispatch, unittest.TestCase):
     def _setup_entry_point(self, directory, entry_point):
         path = self.JUJU_CHARM_DIR / 'dispatch'
@@ -1093,17 +1077,10 @@ class TestMainWithDispatchAsScript(_TestMainWithDispatch, unittest.TestCase):
 
     has_dispatch = True
 
-    if is_windows:
-        suffix = '.BAT'
-        script = '@ECHO OFF\n"{}" "{}"\n'
-    else:
-        suffix = ''
-        script = '#!/bin/sh\nexec "{}" "{}"\n'
-
     def _setup_entry_point(self, directory, entry_point):
-        path = (self.JUJU_CHARM_DIR / 'dispatch').with_suffix(self.suffix)
+        path = (self.JUJU_CHARM_DIR / 'dispatch')
         if not path.exists():
-            path.write_text(self.script.format(
+            path.write_text('#!/bin/sh\nexec "{}" "{}"\n'.format(
                 sys.executable,
                 self.JUJU_CHARM_DIR / 'src/charm.py'))
             path.chmod(0o755)
@@ -1151,7 +1128,7 @@ class TestMainWithDispatchAsScript(_TestMainWithDispatch, unittest.TestCase):
             echo '["disks/0"]'
             """,
         )
-        dispatch = (self.JUJU_CHARM_DIR / 'dispatch').with_suffix(self.suffix)
+        dispatch = (self.JUJU_CHARM_DIR / 'dispatch')
         subprocess.check_call([str(dispatch)], env=env, cwd=str(self.JUJU_CHARM_DIR))
 
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1120,7 +1120,6 @@ recursive_push_pull_cases = [
 ]
 
 
-@unittest.skipIf(os.name == 'nt', "These pebble ops are not supported on windows")
 @pytest.mark.parametrize('case', recursive_push_pull_cases)
 def test_recursive_push_and_pull(case):
     # full "integration" test of push+pull

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -20,7 +20,6 @@ import io
 import json
 import os
 import signal
-import sys
 import tempfile
 import test.fake_pebble as fake_pebble
 import threading
@@ -2390,7 +2389,7 @@ bad path\r
             ('POST', '/v1/signals', None, {'signal': 'SIGHUP', 'services': ['s1', 's2']}),
         ])
 
-    @unittest.skipUnless(hasattr(signal, 'SIGHUP'), 'signal constants not present on Windows')
+    @unittest.skipUnless(hasattr(signal, 'SIGHUP'), 'signal constants not present')
     def test_send_signal_number(self):
         self.client.responses.append({
             'result': True,
@@ -2502,7 +2501,6 @@ bad path\r
         ])
 
 
-@unittest.skipIf(sys.platform == 'win32', "Unix sockets don't work on Windows")
 class TestSocketClient(unittest.TestCase):
     def test_socket_not_found(self):
         client = pebble.Client(socket_path='does_not_exist')
@@ -2737,7 +2735,7 @@ class TestExec(unittest.TestCase):
         process = self.client.exec(['server'])
         process.send_signal('SIGHUP')
         num_sends = 1
-        if hasattr(signal, 'SIGHUP'):  # Skip this part on Windows
+        if hasattr(signal, 'SIGHUP'):
             process.send_signal(1)
             process.send_signal(signal.SIGHUP)
             num_sends += 2
@@ -3001,7 +2999,6 @@ class TestExec(unittest.TestCase):
         ])
         self.assertEqual(io_ws.sends, [])
 
-    @unittest.skipIf(sys.platform == 'win32', "exec() with files doesn't work on Windows")
     def test_wait_file_io(self):
         fin = tempfile.TemporaryFile(mode='w+', encoding='utf-8')
         out = tempfile.TemporaryFile(mode='w+', encoding='utf-8')


### PR DESCRIPTION
Juju 3.0 no longer supports Windows, so we don't need to either.
