### PR TITLE
Remove SIMULATE_CAN_CONNECT, make begin_with_initial_hooks trigger pebble-ready

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -360,7 +360,7 @@ class Harness(Generic[CharmType]):
 
         # Set can_connect and fire pebble-ready for any containers.
         for container_name in self._meta.containers:
-            self.set_can_connect(container_name, True)
+            self.container_pebble_ready(container_name)
 
         # If the initial hooks do not set a unit status, the Juju controller will switch
         # the unit status from "Maintenance" to "Unknown". See gh#726

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2081,7 +2081,9 @@ class _TestingPebbleClient:
 
     def _check_connection(self):
         if not self._backend._can_connect(self):  # pyright: reportPrivateUsage=false
-            raise pebble.ConnectionError('cannot connect to pebble')
+            msg = ('Cannot connect to Pebble; did you forget to call '
+                   'begin_with_initial_hooks() or set_can_connect()?')
+            raise pebble.ConnectionError(msg)
 
     def get_system_info(self) -> pebble.SystemInfo:
         self._check_connection()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1131,6 +1131,7 @@ def test_recursive_push_and_pull(case):
             resource: foo-image
         ''')
     harness.begin()
+    harness.set_can_connect('foo', True)
     c = harness.model.unit.containers['foo']
 
     # create push test case filesystem structure
@@ -1213,6 +1214,7 @@ class TestApplication(unittest.TestCase):
     # Tests fix for https://github.com/canonical/operator/issues/694.
     def test_mocked_get_services(self):
         self.harness.begin()
+        self.harness.set_can_connect('bar', True)
         c = self.harness.charm.unit.get_container('bar')
         c.add_layer('layer1', {
             'summary': 'layer',

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -166,6 +166,7 @@ class TestHarness(unittest.TestCase):
                 self.framework.observe(self.on.bar_pebble_ready, self._on_pebble_ready)
 
             def _on_pebble_ready(self, event: PebbleReadyEvent):
+                assert event.workload.can_connect()
                 pebble_ready_calls[event.workload.name] += 1
 
         harness = Harness(MyCharm, meta='''


### PR DESCRIPTION
When we introduced `can_connect` it would have been a breaking change to enable it by default, so we added the `SIMULATE_CAN_CONNECT` global to enable it. The default was False to avoid breaking changes. We've been planning on turning this on by default for the 2.0 release (basically the only breaking change for 2.0). Note that it's been a recommendation and a warning to date.

This PR removes the global flag and enables simulation by default. The default value of `container.can_connect()` is still False when using `begin()` ("manual mode"), but this PR updates `begin_with_initial_hooks()` to set `can_connect` to True and fire pebble-ready for all containers in the charm's metadata.