### PR TITLE
added ErrorStatus

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1157,6 +1157,23 @@ class UnknownStatus(StatusBase):
 
 
 @StatusBase.register
+class ErrorStatus(StatusBase):
+    """The unit status is unknown.
+
+    A unit-agent has encountered an error.
+
+    """
+    name = 'error'
+
+    def __init__(self, message: str = ''):
+        # Error status cannot be set.
+        super().__init__(message)
+
+    def __repr__(self):
+        return "ErrorStatus()"
+
+
+@StatusBase.register
 class ActiveStatus(StatusBase):
     """The unit is ready.
 


### PR DESCRIPTION
Added ErrorStatus so that getting `Unit/App.status` when the status is "error" does not raise.

## Checklist

 - [x] Have any types changed? If so, have the type annotations been updated?
 - [x] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?
 - [x] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps
added tests

## Documentation changes
We should make it clear that there's two statuses that can't be set now: Unknown and Error.

## Bug reference

Fixes #874 

## Changelog
- *Fixes bug #874, where charms whose unit or app is in error status can't access their own status.*
