### PR TITLE
add pebble idempotency behavior

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2175,15 +2175,6 @@ class _TestingPebbleClient:
             if name not in known_services:
                 # TODO: jam 2021-04-20 This needs a better error type
                 raise RuntimeError('400 Bad Request: service "{}" does not exist'.format(name))
-            current = self._service_status.get(name, pebble.ServiceStatus.INACTIVE)
-            if current == pebble.ServiceStatus.ACTIVE:
-                # TODO: jam 2021-04-20 I believe pebble actually validates all the service names
-                #  can be started before starting any, and gives a list of things that couldn't
-                #  be done, but this is good enough for now
-                raise pebble.ChangeError('''\
-cannot perform the following tasks:
-- Start service "{}" (service "{}" was previously started)
-'''.format(name, name), change=1234)  # type:ignore # the change id is not respected
         for name in services:
             # If you try to start a service which is started, you get a ChangeError:
             # $ PYTHONPATH=. python3 ./test/pebble_cli.py start serv
@@ -2201,7 +2192,6 @@ cannot perform the following tasks:
 
         self._check_connection()
 
-        # TODO: handle invalid names
         # Note: jam 2021-04-20 We don't implement ChangeID, but the default caller of this is
         # Container.stop() which currently ignores the return value
         known_services = self._render_services()
@@ -2210,15 +2200,6 @@ cannot perform the following tasks:
                 # TODO: jam 2021-04-20 This needs a better error type
                 #  400 Bad Request: service "bal" does not exist
                 raise RuntimeError('400 Bad Request: service "{}" does not exist'.format(name))
-            current = self._service_status.get(name, pebble.ServiceStatus.INACTIVE)
-            if current != pebble.ServiceStatus.ACTIVE:
-                # TODO: jam 2021-04-20 I believe pebble actually validates all the service names
-                #  can be started before starting any, and gives a list of things that couldn't
-                #  be done, but this is good enough for now
-                raise pebble.ChangeError('''\
-ChangeError: cannot perform the following tasks:
-- Stop service "{}" (service "{}" is not active)
-'''.format(name, name), change=1234)  # type: ignore # the change id is not respected
         for name in services:
             self._service_status[name] = pebble.ServiceStatus.INACTIVE
 
@@ -2232,7 +2213,6 @@ ChangeError: cannot perform the following tasks:
 
         self._check_connection()
 
-        # TODO: handle invalid names
         # Note: jam 2021-04-20 We don't implement ChangeID, but the default caller of this is
         # Container.restart() which currently ignores the return value
         known_services = self._render_services()

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2176,10 +2176,6 @@ class _TestingPebbleClient:
                 # TODO: jam 2021-04-20 This needs a better error type
                 raise RuntimeError('400 Bad Request: service "{}" does not exist'.format(name))
         for name in services:
-            # If you try to start a service which is started, you get a ChangeError:
-            # $ PYTHONPATH=. python3 ./test/pebble_cli.py start serv
-            # ChangeError: cannot perform the following tasks:
-            # - Start service "serv" (service "serv" was previously started)
             self._service_status[name] = pebble.ServiceStatus.ACTIVE
 
     def stop_services(


### PR DESCRIPTION
(Reopen of #866)
This PR changes the behavior of pebble in ops.testing module, to match the behavior of a real pebble server.
The previous code does not allow idempotent operations (start on started service, stop on stopped service) where a real pebble server is idempotent (https://juju.is/docs/sdk/interact-with-pebble#heading--start-and-stop).

Code for checking for previous service status in pebble has been removed in both `start_services` and `stop_services`, which does not match the idempotent behavior of a real pebble server. 
Pebble server does the following as validation which seems unnecessary to be implemented in testing module as of now.
1. Validate names of services
2. Validates dependencies (service before, after) and checks for loops
3. Applies changes with timeout

It should be noted that these services are supposed to be long-running (processes exiting within 1 second will still return pebble.ChangError), I would be happy to add this behavior as a test in `TestRealPebble` under `test/test_pebble.py` `class TestRealPebble`.

## QA steps

*Please replace with how we can verify that the change works.*

```sh
tox -e unit -- -k test_start_started_service
tox -e unit -- -k test_stop_stopped_service
```

## Documentation changes

No docs needs updating(https://ops.readthedocs.io/en/latest/index.html?highlight=testing#ops.pebble.Client.start_services is fine)

## Bug reference

No bug ref

## Changelog

*Please include a bulleted list of items here, suitable for inclusion in a release changelog.*

- *Fixes testing behavior of start_services and stop_services to be idempotent*