### PR TITLE
added ExecProcess.returncode

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1186,6 +1186,10 @@ class ExecProcess:
             the caller can use to stream error output from the process. It is
             None if stderr was passed to :meth:`Client.exec` or combine_stderr
             was True.
+        returncode: After the ExecProcess results have been obtained, either by
+            calling :meth: `Client.wait` or :meth: `Client.get_output`,
+            you can retrieve the exit code via this attribute. Until then,
+            it will be None.
     """
 
     def __init__(
@@ -1208,6 +1212,8 @@ class ExecProcess:
         self.stdin = stdin
         self.stdout = stdout
         self.stderr = stderr
+        self.returncode = None
+
         self._client = client
         self._timeout = timeout
         self._control_ws = control_ws
@@ -1273,6 +1279,7 @@ class ExecProcess:
         exit_code = -1
         if change.tasks:
             exit_code = change.tasks[0].data.get('exit-code', -1)
+        self.returncode = exit_code
         return exit_code
 
     def wait_output(self) -> Tuple['_StrOrBytes', Optional['_StrOrBytes']]:

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -2700,7 +2700,9 @@ class TestExec(unittest.TestCase):
         process = self.client.exec(['true'])
         self.assertIsNotNone(process.stdout)
         self.assertIsNotNone(process.stderr)
+        self.assertIsNone(process.returncode)
         process.wait()
+        self.assertEqual(process.returncode, 0)
 
         self.assertEqual(self.client.requests, [
             ('POST', '/v1/exec', None, self.build_exec_data(['true'])),
@@ -2711,8 +2713,10 @@ class TestExec(unittest.TestCase):
         self.add_responses('456', 1)
 
         process = self.client.exec(['false'])
+        self.assertIsNone(process.returncode)
         with self.assertRaises(pebble.ExecError) as cm:
             process.wait()
+        self.assertEqual(process.returncode, 1)
         self.assertEqual(cm.exception.command, ['false'])
         self.assertEqual(cm.exception.exit_code, 1)
         self.assertEqual(cm.exception.stdout, None)


### PR DESCRIPTION
Added `ExecProcess.returncode` (naming conform to https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess.returncode), but elsewhere in the code it seems to be called `exit_code`, so we might want to pick one and uniform the variable naming.

## Checklist 

 - [x] Have any types changed? If so, have the type annotations been updated?
 - [x] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?
 - [x] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

added relevant tests

## Documentation changes

Nothing sphinx shouldn't handle from the docstring

## Bug reference

#877 

## Changelog

- Pebble.exec exit code exposed via ExecProcess

