### PR TITLE
Deprecate controller storage and clarify log when local storage is chosen

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -961,8 +961,6 @@ class CharmBase(Object):
     Args:
         framework: The framework responsible for managing the Model and events for this
             charm.
-        key: Ignored; will remove after deprecation period of the signature change.
-
     """
 
     # note that without the #: below, sphinx will copy the whole of CharmEvents
@@ -974,7 +972,7 @@ class CharmBase(Object):
         @property
         def on(self) -> CharmEvents: ...  # noqa
 
-    def __init__(self, framework: Framework, key: Optional[str] = None):
+    def __init__(self, framework: Framework):
         super().__init__(framework, None)
 
         for relation_name in self.framework.meta.relations:

--- a/ops/main.py
+++ b/ops/main.py
@@ -340,9 +340,10 @@ def _should_use_controller_storage(db_path: Path, meta: CharmMeta) -> bool:
     if db_path.exists():
         return False
 
-    # if you're not in k8s you don't need controller storage
-    if 'kubernetes' not in meta.series:
-        logger.debug("Using local storage: not a kubernetes charm")
+    # only use controller storage for Kubernetes podspec charms
+    is_podspec = 'kubernetes' in meta.series
+    if not is_podspec:
+        logger.debug("Using local storage: not a Kubernetes podspec charm")
         return False
 
     # are we in a new enough Juju?

--- a/ops/main.py
+++ b/ops/main.py
@@ -398,6 +398,10 @@ def main(charm_class: Type[ops.charm.CharmBase],
 
     if use_juju_for_storage is None:
         use_juju_for_storage = _should_use_controller_storage(charm_state_path, meta)
+    elif use_juju_for_storage:
+        warnings.warn("Controller storage is deprecated; it's intended for "
+                      "podspec charms and will be removed in a future release.",
+                      category=DeprecationWarning)
 
     if use_juju_for_storage:
         if dispatcher.is_restricted_context():

--- a/ops/main.py
+++ b/ops/main.py
@@ -14,7 +14,6 @@
 
 """Main entry point to the Operator Framework."""
 
-import inspect
 import logging
 import os
 import shutil
@@ -421,17 +420,7 @@ def main(charm_class: Type[ops.charm.CharmBase],
     framework = ops.framework.Framework(store, charm_dir, meta, model)
     framework.set_breakpointhook()
     try:
-        sig = inspect.signature(charm_class)
-        try:
-            sig.bind(framework)
-        except TypeError:
-            msg = (
-                "the second argument, 'key', has been deprecated and will be "
-                "removed after the 0.7 release")
-            warnings.warn(msg, DeprecationWarning)
-            charm = charm_class(framework, None)
-        else:
-            charm = charm_class(framework)
+        charm = charm_class(framework)
         dispatcher.ensure_event_links(charm)
 
         # TODO: Remove the collect_metrics check below as soon as the relevant

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -180,10 +180,6 @@ class Harness(Generic[CharmType]):
         self._framework = framework.Framework(
             self._storage, self._charm_dir, self._meta, self._model)
 
-        # TODO: will be removed in the next breaking-changes release
-        #  together with self._oci_resources
-        self._deprecated_oci_resources_do_not_use = {}  # type: Dict[Any, Any]
-
         # TODO: If/when we decide to allow breaking changes for a release,
         #  change SIMULATE_CAN_CONNECT default value to True and remove the
         #  warning message below.  This warning was added 2022-03-22
@@ -191,13 +187,6 @@ class Harness(Generic[CharmType]):
             warnings.warn(
                 'Please set ops.testing.SIMULATE_CAN_CONNECT=True. '
                 'See https://juju.is/docs/sdk/testing#heading--simulate-can-connect for details.')
-
-    @property
-    def _oci_resources(self):
-        warnings.warn('Harness._oci_resources is deprecated and will be '
-                      'removed in a future release.',
-                      category=DeprecationWarning)
-        return self._deprecated_oci_resources_do_not_use
 
     def _event_context(self, event_name: str):
         """Configures the Harness to behave as if an event hook were running.

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -194,8 +194,9 @@ class Harness(Generic[CharmType]):
 
     @property
     def _oci_resources(self):
-        warnings.warn('Deprecation warning: Harness.`_oci_resources` is '
-                      'deprecated and will be removed in a future release.')
+        warnings.warn('Harness._oci_resources is deprecated and will be '
+                      'removed in a future release.',
+                      category=DeprecationWarning)
         return self._deprecated_oci_resources_do_not_use
 
     def _event_context(self, event_name: str):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -155,15 +155,14 @@ class CharmInitTestCase(unittest.TestCase):
             self._check(MyCharm)
         self.assertEqual(warn_cm, [])
 
-    def test_init_signature_both_arguments(self):
+    def test_init_signature_old_key_argument(self):
         class MyCharm(CharmBase):
 
             def __init__(self, framework, somekey):
                 super().__init__(framework, somekey)
 
-        msg = ("the second argument, 'key', has been deprecated and will be removed "
-               "after the 0.7 release")
-        with self.assertWarnsRegex(DeprecationWarning, msg):
+        # Support for "key" has been deprecated since ops 0.7 and was removed in 2.0
+        with self.assertRaises(TypeError):
             self._check(MyCharm)
 
     def test_init_signature_only_framework(self):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -688,7 +688,7 @@ class _TestMain(abc.ABC):
         calls = [' '.join(i) for i in fake_script_calls(self)]
 
         self.assertEqual(calls.pop(0), ' '.join(VERSION_LOGLINE))
-        self.assertRegex(calls.pop(0), 'Using local storage: not a kubernetes charm')
+        self.assertRegex(calls.pop(0), 'Using local storage: not a Kubernetes podspec charm')
         self.assertRegex(calls.pop(0), 'Initializing SQLite local storage: ')
 
         self.maxDiff = None
@@ -905,7 +905,7 @@ class _TestMainWithDispatch(_TestMain):
             ['juju-log', '--log-level', 'DEBUG', '--',
              'Legacy {} exited with status 0.'.format(hook)],
             ['juju-log', '--log-level', 'DEBUG', '--',
-             'Using local storage: not a kubernetes charm'],
+             'Using local storage: not a Kubernetes podspec charm'],
             ['juju-log', '--log-level', 'DEBUG', '--',
              'Emitting Juju event install.'],
         ]
@@ -924,7 +924,7 @@ class _TestMainWithDispatch(_TestMain):
             ['juju-log', '--log-level', 'WARNING', '--',
              'Legacy hooks/install exists but is not executable.'],
             ['juju-log', '--log-level', 'DEBUG', '--',
-             'Using local storage: not a kubernetes charm'],
+             'Using local storage: not a Kubernetes podspec charm'],
             ['juju-log', '--log-level', 'DEBUG', '--',
              'Emitting Juju event install.'],
         ]
@@ -1006,7 +1006,7 @@ class _TestMainWithDispatch(_TestMain):
             ['juju-log', '--log-level', 'DEBUG', '--',
              'Legacy {} exited with status 0.'.format(hook)],
             ['juju-log', '--log-level', 'DEBUG', '--',
-             'Using local storage: not a kubernetes charm'],
+             'Using local storage: not a Kubernetes podspec charm'],
             ['juju-log', '--log-level', 'DEBUG', '--',
              'Emitting Juju event install.'],
         ]
@@ -1153,7 +1153,7 @@ class TestStorageHeuristics(unittest.TestCase):
         meta = CharmMeta.from_yaml("series: [ecs]")
         with patch.dict(os.environ, {"JUJU_VERSION": "2.8"}):
             self.assertFalse(_should_use_controller_storage(Path("/xyzzy"), meta))
-            self.assertLogged('Using local storage: not a kubernetes charm')
+            self.assertLogged('Using local storage: not a Kubernetes podspec charm')
 
     def test_not_if_already_local(self):
         meta = CharmMeta.from_yaml("series: [kubernetes]")

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -22,7 +22,6 @@ import shutil
 import sys
 import tempfile
 import textwrap
-import typing
 import unittest
 import uuid
 from io import BytesIO, StringIO
@@ -1799,9 +1798,8 @@ class TestHarness(unittest.TestCase):
 
     def test_event_context_inverse(self):
         class MyCharm(CharmBase):
-            def __init__(self, framework: Framework,
-                         key: typing.Optional = None):
-                super().__init__(framework, key)
+            def __init__(self, framework: Framework):
+                super().__init__(framework)
                 self.framework.observe(self.on.db_relation_joined,
                                        self._join_db)
 


### PR DESCRIPTION
Per discussion with Gustavo, John, and Jon, we want to deprecate `use_juju_for_storage=True` (it's intended for pod-spec charms).

This PR also:

* Clarifies the warning message when local storage is chosen: "not a Kubernetes *podspec* charm" instead of "not a kubernetes charm" (the latter is incorrect). See also https://github.com/canonical/operator/issues/880.
* Removes the long-deprecated `key` argument to charm's `__init__`.
* Removes the deprecated (and private!) `Harness._oci_resources` attribute.
