### PR TITLE
Use f-strings (almost) everywhere

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-python@v2
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox==4.2.8
 
       - name: Run linting
         run: tox -e lint
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-python@v2
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox==4.2.8
 
       - name: Run static type checks
         run: tox -e static
@@ -47,7 +47,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox==4.2.8
 
       - name: Run unit tests
         run: tox -e unit
@@ -73,7 +73,7 @@ jobs:
           go-version: "1.17"
 
       - name: Install tox
-        run: pip install tox
+        run: pip install tox==4.2.8
 
       - name: Install Pebble
         run: go install github.com/canonical/pebble/cmd/pebble@latest

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -26,7 +26,7 @@ jobs:
           echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
 
       - name: Install dependencies
-        run: pip install tox
+        run: pip install tox==4.2.8
 
       - name: Run the charm tests
         run: tox -vve unit

--- a/ops/_private/timeconv.py
+++ b/ops/_private/timeconv.py
@@ -36,7 +36,7 @@ def parse_rfc3339(s: str) -> datetime.datetime:
     """
     match = _TIMESTAMP_RE.match(s)
     if not match:
-        raise ValueError('invalid timestamp {!r}'.format(s))
+        raise ValueError(f'invalid timestamp {s!r}')
     y, m, d, hh, mm, ss, sfrac, zone = match.groups()
 
     if zone in ('Z', 'z'):
@@ -44,7 +44,7 @@ def parse_rfc3339(s: str) -> datetime.datetime:
     else:
         match = _TIMEOFFSET_RE.match(zone)
         if not match:
-            raise ValueError('invalid timestamp {!r}'.format(s))
+            raise ValueError(f'invalid timestamp {s!r}')
         sign, zh, zm = match.groups()
         tz_delta = datetime.timedelta(hours=int(zh), minutes=int(zm))
         tz = datetime.timezone(tz_delta if sign == '+' else -tz_delta)

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -977,24 +977,24 @@ class CharmBase(Object):
 
         for relation_name in self.framework.meta.relations:
             relation_name = relation_name.replace('-', '_')
-            self.on.define_event(relation_name + '_relation_created', RelationCreatedEvent)
-            self.on.define_event(relation_name + '_relation_joined', RelationJoinedEvent)
-            self.on.define_event(relation_name + '_relation_changed', RelationChangedEvent)
-            self.on.define_event(relation_name + '_relation_departed', RelationDepartedEvent)
-            self.on.define_event(relation_name + '_relation_broken', RelationBrokenEvent)
+            self.on.define_event(f"{relation_name}_relation_created", RelationCreatedEvent)
+            self.on.define_event(f"{relation_name}_relation_joined", RelationJoinedEvent)
+            self.on.define_event(f"{relation_name}_relation_changed", RelationChangedEvent)
+            self.on.define_event(f"{relation_name}_relation_departed", RelationDepartedEvent)
+            self.on.define_event(f"{relation_name}_relation_broken", RelationBrokenEvent)
 
         for storage_name in self.framework.meta.storages:
             storage_name = storage_name.replace('-', '_')
-            self.on.define_event(storage_name + '_storage_attached', StorageAttachedEvent)
-            self.on.define_event(storage_name + '_storage_detaching', StorageDetachingEvent)
+            self.on.define_event(f"{storage_name}_storage_attached", StorageAttachedEvent)
+            self.on.define_event(f"{storage_name}_storage_detaching", StorageDetachingEvent)
 
         for action_name in self.framework.meta.actions:
             action_name = action_name.replace('-', '_')
-            self.on.define_event(action_name + '_action', ActionEvent)
+            self.on.define_event(f"{action_name}_action", ActionEvent)
 
         for container_name in self.framework.meta.containers:
             container_name = container_name.replace('-', '_')
-            self.on.define_event(container_name + '_pebble_ready', PebbleReadyEvent)
+            self.on.define_event(f"{container_name}_pebble_ready", PebbleReadyEvent)
 
     @property
     def app(self) -> model.Application:

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -439,7 +439,7 @@ class RelationEvent(HookEvent):
 
         if unit is not None and unit.app != app:
             raise RuntimeError(
-                'cannot create RelationEvent with application {} and unit {}'.format(app, unit))
+                f'cannot create RelationEvent with application {app} and unit {unit}')
 
         self.relation = relation
         self.app = app
@@ -1182,7 +1182,7 @@ class RelationMeta:
     VALID_SCOPES = ['global', 'container']
 
     def __init__(self, role: RelationRole, relation_name: str, raw: '_RelationMetaDict'):
-        assert isinstance(role, RelationRole), "role should be one of {!r}, not {!r}".format(list(RelationRole), role)  # noqa
+        assert isinstance(role, RelationRole), f"role should be one of {list(RelationRole)!r}, not {role!r}"  # noqa
         self._default_scope = self.VALID_SCOPES[0]
         self.role = role
         self.relation_name = relation_name
@@ -1190,7 +1190,7 @@ class RelationMeta:
 
         self.limit = limit = raw.get('limit', None)
         if limit is not None and not isinstance(limit, int):  # type: ignore  # noqa
-            raise TypeError("limit should be an int, not {}".format(type(limit)))
+            raise TypeError(f"limit should be an int, not {type(limit)}")
 
         self.scope = raw.get('scope') or self._default_scope
         if self.scope not in self.VALID_SCOPES:
@@ -1367,5 +1367,5 @@ class ContainerStorageMeta:
                 )
         else:
             raise AttributeError(
-                "{.__class__.__name__} has no such attribute: {}!".format(self, name)
+                f"{self.__class__.__name__} has no such attribute: {name}!"
             )

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -131,7 +131,7 @@ class Handle:
             if key:
                 self._path = f"{kind}[{key}]"
             else:
-                self._path = kind
+                self._path = f"{kind}"  # don't need f-string, but consistent with above
 
     def nest(self, kind: str, key: str) -> 'Handle':
         """Create a new handle as child of the current one."""

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -131,7 +131,7 @@ class Handle:
             if key:
                 self._path = f"{kind}[{key}]"
             else:
-                self._path = f"{kind}"
+                self._path = kind
 
     def nest(self, kind: str, key: str) -> 'Handle':
         """Create a new handle as child of the current one."""
@@ -507,7 +507,7 @@ class PrefixedEvents:
 
     def __init__(self, emitter: Object, key: str):
         self._emitter = emitter
-        self._prefix = f"{key.replace('-', '_')}_"
+        self._prefix = key.replace('-', '_') + '_'
 
     def __getattr__(self, name: str) -> BoundEvent[Any]:
         return getattr(self._emitter, self._prefix + name)

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -464,13 +464,13 @@ class ObjectEvents(Object):
         """
         prefix = 'unable to define an event with event_kind that '
         if not event_kind.isidentifier():
-            raise RuntimeError(prefix + 'is not a valid python identifier: ' + event_kind)
+            raise RuntimeError(f"{prefix}is not a valid python identifier: {event_kind}")
         elif keyword.iskeyword(event_kind):
-            raise RuntimeError(prefix + 'is a python keyword: ' + event_kind)
+            raise RuntimeError(f"{prefix}is a python keyword: {event_kind}")
         try:
             getattr(cls, event_kind)
             raise RuntimeError(
-                prefix + f'overlaps with an existing type {cls} attribute: {event_kind}')
+                f"{prefix}overlaps with an existing type {cls} attribute: {event_kind}")
         except AttributeError:
             pass
 
@@ -507,7 +507,7 @@ class PrefixedEvents:
 
     def __init__(self, emitter: Object, key: str):
         self._emitter = emitter
-        self._prefix = key.replace("-", "_") + '_'
+        self._prefix = f"{key.replace('-', '_')}_"
 
     def __getattr__(self, name: str) -> BoundEvent[Any]:
         return getattr(self._emitter, self._prefix + name)

--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -38,7 +38,7 @@ class JujuVersion:
     def __init__(self, version: str):
         m = re.match(self.PATTERN, version, re.VERBOSE)
         if not m:
-            raise RuntimeError('"{}" is not a valid Juju version string'.format(version))
+            raise RuntimeError(f'"{version}" is not a valid Juju version string')
 
         d = m.groupdict()
         self.major = int(m.group('major'))
@@ -49,11 +49,11 @@ class JujuVersion:
 
     def __repr__(self):
         if self.tag:
-            s = '{}.{}-{}{}'.format(self.major, self.minor, self.tag, self.patch)
+            s = f'{self.major}.{self.minor}-{self.tag}{self.patch}'
         else:
-            s = '{}.{}.{}'.format(self.major, self.minor, self.patch)
+            s = f'{self.major}.{self.minor}.{self.patch}'
         if self.build > 0:
-            s += '.{}'.format(self.build)
+            s += f'.{self.build}'
         return s
 
     def __eq__(self, other: Union[str, 'JujuVersion']) -> bool:
@@ -62,7 +62,7 @@ class JujuVersion:
         if isinstance(other, str):
             other = type(self)(other)
         elif not isinstance(other, JujuVersion):  # pyright: reportUnnecessaryIsInstance=false
-            raise RuntimeError('cannot compare Juju version "{}" with "{}"'.format(self, other))
+            raise RuntimeError(f'cannot compare Juju version "{self}" with "{other}"')
         return (
             self.major == other.major
             and self.minor == other.minor
@@ -76,7 +76,7 @@ class JujuVersion:
         if isinstance(other, str):
             other = type(self)(other)
         elif not isinstance(other, JujuVersion):
-            raise RuntimeError('cannot compare Juju version "{}" with "{}"'.format(self, other))
+            raise RuntimeError(f'cannot compare Juju version "{self}" with "{other}"')
         if self.major != other.major:
             return self.major < other.major
         elif self.minor != other.minor:

--- a/ops/lib/__init__.py
+++ b/ops/lib/__init__.py
@@ -157,7 +157,9 @@ def _join_and(keys: List[str]) -> str:
         return ""
     if len(keys) == 1:
         return keys[0]
-    return f"{', '.join(keys[:-1])}, and {keys[-1]}"
+    all_except_last = ', '.join(keys[:-1])
+    last = keys[-1]
+    return f'{all_except_last}, and {last}'
 
 
 class _Missing:

--- a/ops/lib/__init__.py
+++ b/ops/lib/__init__.py
@@ -53,17 +53,17 @@ def use(name: str, api: int, author: str) -> ModuleType:
         ValueError: if the name, api, or author are invalid.
     """
     if not isinstance(name, str):
-        raise TypeError("invalid library name: {!r} (must be a str)".format(name))
+        raise TypeError(f"invalid library name: {name!r} (must be a str)")
     if not isinstance(author, str):
-        raise TypeError("invalid library author: {!r} (must be a str)".format(author))
+        raise TypeError(f"invalid library author: {author!r} (must be a str)")
     if not isinstance(api, int):
-        raise TypeError("invalid library API: {!r} (must be an int)".format(api))
+        raise TypeError(f"invalid library API: {api!r} (must be an int)")
     if api < 0:
-        raise ValueError('invalid library api: {} (must be ≥0)'.format(api))
+        raise ValueError(f'invalid library api: {api} (must be ≥0)')
     if not _libname_re.match(name):
-        raise ValueError("invalid library name: {!r} (chars and digits only)".format(name))
+        raise ValueError(f"invalid library name: {name!r} (chars and digits only)")
     if not _libauthor_re.match(author):
-        raise ValueError("invalid library author email: {!r}".format(author))
+        raise ValueError(f"invalid library author email: {author!r}")
 
     if _libraries is None:
         autoimport()
@@ -75,10 +75,9 @@ def use(name: str, api: int, author: str) -> ModuleType:
 
     others = ', '.join(str(lib.api) for lib in versions)
     if others:
-        msg = 'cannot find "{}" from "{}" with API version {} (have {})'.format(
-            name, author, api, others)
+        msg = f'cannot find "{name}" from "{author}" with API version {api} (have {others})'
     else:
-        msg = 'cannot find library "{}" from "{}"'.format(name, author)
+        msg = f'cannot find library "{name}" from "{author}"'
 
     raise ImportError(msg, name=name)
 
@@ -133,7 +132,7 @@ def _find_all_specs(path):
                 logger.debug("  Finder for '%s' has no find_spec", opslib)
                 continue
             for lib_dir in lib_dirs:
-                spec_name = "{}.opslib.{}".format(top_dir, lib_dir)
+                spec_name = f"{top_dir}.opslib.{lib_dir}"
                 spec = finder.find_spec(spec_name)
                 if spec is None:
                     logger.debug("    No spec for %r", spec_name)
@@ -171,10 +170,8 @@ class _Missing:
         exp = set(_NEEDED_KEYS)
         got = set(self._found)
         if len(got) == 0:
-            return "missing {}".format(_join_and(sorted(exp)))
-        return "got {}, but missing {}".format(
-            _join_and(sorted(got)),
-            _join_and(sorted(exp - got)))
+            return f"missing {_join_and(sorted(exp))}"
+        return f"got {_join_and(sorted(got))}, but missing {_join_and(sorted(exp - got))}"
 
 
 def _parse_lib(spec):
@@ -236,7 +233,7 @@ class _Lib:
         self._module = None
 
     def __repr__(self):
-        return "<_Lib {}>".format(self)
+        return f"<_Lib {self}>"
 
     def __str__(self):
         return "{0.name} by {0.author}, API {0.api}, patch {0.patch}".format(self)

--- a/ops/lib/__init__.py
+++ b/ops/lib/__init__.py
@@ -157,7 +157,7 @@ def _join_and(keys: List[str]) -> str:
         return ""
     if len(keys) == 1:
         return keys[0]
-    return ", ".join(keys[:-1]) + ", and " + keys[-1]
+    return f"{', '.join(keys[:-1])}, and {keys[-1]}"
 
 
 class _Missing:

--- a/ops/main.py
+++ b/ops/main.py
@@ -57,7 +57,7 @@ def _get_charm_dir():
     charm_dir = os.environ.get("JUJU_CHARM_DIR")
     if charm_dir is None:
         # Assume $JUJU_CHARM_DIR/lib/op/main.py structure.
-        charm_dir = Path('{}/../../..'.format(__file__)).resolve()
+        charm_dir = Path(f'{__file__}/../../..').resolve()
     else:
         charm_dir = Path(charm_dir).resolve()
     return charm_dir
@@ -73,7 +73,7 @@ def _create_event_link(charm: 'CharmBase', bound_event: 'EventSource[Any]',
         link_to: What the event link should point to
     """
     # type guard
-    assert bound_event.event_kind, "unbound EventSource {}".format(bound_event)
+    assert bound_event.event_kind, f"unbound EventSource {bound_event}"
 
     if issubclass(bound_event.event_type, ops.charm.HookEvent):
         event_dir = charm.framework.charm_dir / 'hooks'
@@ -81,13 +81,13 @@ def _create_event_link(charm: 'CharmBase', bound_event: 'EventSource[Any]',
     elif issubclass(bound_event.event_type, ops.charm.ActionEvent):
         if not bound_event.event_kind.endswith("_action"):
             raise RuntimeError(
-                'action event name {} needs _action suffix'.format(bound_event.event_kind))
+                f'action event name {bound_event.event_kind} needs _action suffix')
         event_dir = charm.framework.charm_dir / 'actions'
         # The event_kind is suffixed with "_action" while the executable is not.
         event_path = event_dir / bound_event.event_kind[:-len('_action')].replace('_', '-')
     else:
         raise RuntimeError(
-            'cannot create a symlink: unsupported event type {}'.format(bound_event.event_type))
+            f'cannot create a symlink: unsupported event type {bound_event.event_type}')
 
     event_dir.mkdir(exist_ok=True)
     if not event_path.exists():
@@ -192,7 +192,7 @@ def _get_event_args(charm: 'CharmBase',
 
     if not remote_app_name and remote_unit_name:
         if '/' not in remote_unit_name:
-            raise RuntimeError('invalid remote unit name: {}'.format(remote_unit_name))
+            raise RuntimeError(f'invalid remote unit name: {remote_unit_name}')
         remote_app_name = remote_unit_name.split('/')[0]
 
     kwargs = {}  # type: Dict[str, Any]
@@ -292,7 +292,7 @@ class _Dispatcher:
         """Sets the name attribute to that which can be inferred from the given path."""
         name = path.name.replace('-', '_')
         if path.parent.name == 'actions':
-            name = '{}_action'.format(name)
+            name = f'{name}_action'
         self.event_name = name
 
     def _init_legacy(self):

--- a/ops/model.py
+++ b/ops/model.py
@@ -990,14 +990,14 @@ class Secret:
             fields.append(f'id={self._id!r}')
         if self._label is not None:
             fields.append(f'label={self._label!r}')
-        return '<Secret ' + ' '.join(fields) + '>'
+        return f"<Secret {' '.join(fields)}>"
 
     @staticmethod
     def _canonicalize_id(id: str) -> str:
         """Return the canonical form of the given secret ID, with the 'secret:' prefix."""
         id = id.strip()
         if not id.startswith('secret:'):
-            id = 'secret:' + id  # add the prefix if not there already
+            id = f"secret:{id}"  # add the prefix if not there already
         return id
 
     @classmethod

--- a/ops/model.py
+++ b/ops/model.py
@@ -378,17 +378,17 @@ class Application:
     def status(self, value: 'StatusBase'):
         if not isinstance(value, StatusBase):
             raise InvalidStatusError(
-                'invalid value provided for application {} status: {}'.format(self, value)
+                f'invalid value provided for application {self} status: {value}'
             )
 
         if not self._is_our_app:
-            raise RuntimeError('cannot set status for a remote application {}'.format(self))
+            raise RuntimeError(f'cannot set status for a remote application {self}')
 
         if not self._backend.is_leader():
             raise RuntimeError('cannot set application status as a non-leader unit')
 
         for _key in {'name', 'message'}:
-            assert isinstance(getattr(value, _key), str), 'status.%s must be a string' % _key
+            assert isinstance(getattr(value, _key), str), f'status.{_key} must be a string'
         self._backend.status_set(value.name, value.message, is_app=True)
         self._status = value
 
@@ -409,12 +409,12 @@ class Application:
         """
         if not self._is_our_app:
             raise RuntimeError(
-                'cannot get planned units for a remote application {}.'.format(self))
+                f'cannot get planned units for a remote application {self}.')
 
         return self._backend.planned_units()
 
     def __repr__(self):
-        return '<{}.{} {}>'.format(type(self).__module__, type(self).__name__, self.name)
+        return f'<{type(self).__module__}.{type(self).__name__} {self.name}>'
 
     def add_secret(self, content: Dict[str, str], *,
                    label: Optional[str] = None,
@@ -519,18 +519,18 @@ class Unit:
     def status(self, value: 'StatusBase'):
         if not isinstance(value, StatusBase):
             raise InvalidStatusError(
-                'invalid value provided for unit {} status: {}'.format(self, value)
+                f'invalid value provided for unit {self} status: {value}'
             )
 
         if not self._is_our_unit:
-            raise RuntimeError('cannot set status for a remote unit {}'.format(self))
+            raise RuntimeError(f'cannot set status for a remote unit {self}')
 
         # fixme: if value.messages
         self._backend.status_set(value.name, value.message, is_app=False)
         self._status = value
 
     def __repr__(self):
-        return '<{}.{} {}>'.format(type(self).__module__, type(self).__name__, self.name)
+        return f'<{type(self).__module__}.{type(self).__name__} {self.name}>'
 
     def is_leader(self) -> bool:
         """Return whether this unit is the leader of its application.
@@ -548,8 +548,7 @@ class Unit:
             return self._backend.is_leader()
         else:
             raise RuntimeError(
-                'leadership status of remote units ({}) is not visible to other'
-                ' applications'.format(self)
+                f'leadership status of remote units ({self}) is not visible to other applications'
             )
 
     def set_workload_version(self, version: str) -> None:
@@ -567,7 +566,7 @@ class Unit:
     def containers(self) -> Mapping[str, 'Container']:
         """Return a mapping of containers indexed by name."""
         if not self._is_our_unit:
-            raise RuntimeError('cannot get container for a remote unit {}'.format(self))
+            raise RuntimeError(f'cannot get container for a remote unit {self}')
         return self._containers
 
     def get_container(self, container_name: str) -> 'Container':
@@ -579,7 +578,7 @@ class Unit:
         try:
             return self.containers[container_name]
         except KeyError:
-            raise ModelError('container {!r} not found'.format(container_name))
+            raise ModelError(f'container {container_name!r} not found')
 
     def add_secret(self, content: Dict[str, str], *,
                    label: Optional[str] = None,
@@ -792,7 +791,7 @@ def _cast_network_address(raw: str) -> '_NetworkAddress':
     try:
         return ipaddress.ip_address(raw)
     except ValueError:
-        logger.debug("could not cast {} to IPv4/v6 address".format(raw))
+        logger.debug(f"could not cast {raw} to IPv4/v6 address")
         return raw
 
 
@@ -988,9 +987,9 @@ class Secret:
     def __repr__(self):
         fields = []  # type: List[str]
         if self._id is not None:
-            fields.append('id={!r}'.format(self._id))
+            fields.append(f'id={self._id!r}')
         if self._label is not None:
-            fields.append('label={!r}'.format(self._label))
+            fields.append(f'label={self._label!r}')
         return '<Secret ' + ' '.join(fields) + '>'
 
     @staticmethod
@@ -1237,10 +1236,7 @@ class Relation:
         self.data = RelationData(self, our_unit, backend)
 
     def __repr__(self):
-        return '<{}.{} {}:{}>'.format(type(self).__module__,
-                                      type(self).__name__,
-                                      self.name,
-                                      self.id)
+        return f'<{type(self).__module__}.{type(self).__name__} {self.name}:{self.id}>'
 
 
 class RelationData(Mapping['UnitOrApplication', 'RelationDataContent']):
@@ -1348,9 +1344,7 @@ class RelationDataContent(LazyMapping, MutableMapping[str, str]):
         app = self.relation.app
         if app is None:
             raise RelationDataAccessError(
-                "Remote application instance cannot be retrieved for {}.".format(
-                    self.relation
-                )
+                f"Remote application instance cannot be retrieved for {self.relation}."
             )
 
         # is this a peer relation?
@@ -1382,10 +1376,10 @@ class RelationDataContent(LazyMapping, MutableMapping[str, str]):
         # this is independent of whether we're in testing code or production.
         if not isinstance(key, str):
             raise RelationDataTypeError(
-                'relation data keys must be strings, not {}'.format(type(key)))
+                f'relation data keys must be strings, not {type(key)}')
         if not isinstance(value, str):
             raise RelationDataTypeError(
-                'relation data values must be strings, not {}'.format(type(value)))
+                f'relation data values must be strings, not {type(value)}')
 
         # if we're not in production (we're testing): we skip access control rules
         if not self._hook_is_running:
@@ -1405,9 +1399,7 @@ class RelationDataContent(LazyMapping, MutableMapping[str, str]):
             if self._backend.is_leader():
                 return  # all good
             raise RelationDataAccessError(
-                "{} is not leader and cannot write application data.".format(
-                    self._backend.unit_name
-                )
+                f"{self._backend.unit_name} is not leader and cannot write application data."
             )
         else:
             # we are attempting to write a unit databag
@@ -1496,7 +1488,7 @@ class StatusBase:
         return self.message == other.message
 
     def __repr__(self):
-        return "{.__class__.__name__}({!r})".format(self, self.message)
+        return f"{self.__class__.__name__}({self.message!r})"
 
     @classmethod
     def from_name(cls, name: str, message: str):
@@ -1511,7 +1503,7 @@ class StatusBase:
     def register(cls, child: Type['StatusBase']):
         """Register a Status for the child's name."""
         if not isinstance(getattr(child, 'name'), str):
-            raise TypeError("Can't register StatusBase subclass %s: " % child,
+            raise TypeError(f"Can't register StatusBase subclass {child}: ",
                             "missing required `name: str` class attribute")
         cls._statuses[child.name] = child
         return child
@@ -1603,7 +1595,7 @@ class Resources:
         on disk, otherwise it raises a NameError.
         """
         if name not in self._paths:
-            raise NameError('invalid resource name: {}'.format(name))
+            raise NameError(f'invalid resource name: {name}')
         if self._paths[name] is None:
             self._paths[name] = Path(self._backend.resource_get(name))
         return typing.cast(Path, self._paths[name])
@@ -1654,9 +1646,9 @@ class StorageMapping(Mapping[str, List['Storage']]):
 
     def __getitem__(self, storage_name: str) -> List['Storage']:
         if storage_name not in self._storage_map:
-            meant = ', or '.join(['{!r}'.format(k) for k in self._storage_map.keys()])
+            meant = ', or '.join([f'{k!r}' for k in self._storage_map.keys()])
             raise KeyError(
-                'Storage {!r} not found. Did you mean {}?'.format(storage_name, meant))
+                f'Storage {storage_name!r} not found. Did you mean {meant}?')
         storage_list = self._storage_map[storage_name]
         if storage_list is None:
             storage_list = self._storage_map[storage_name] = []
@@ -1712,7 +1704,7 @@ class Storage:
     @property
     def full_id(self) -> str:
         """Returns the canonical storage name and id/index based identifier."""
-        return '{}/{}'.format(self.name, self._index)
+        return f'{self.name}/{self._index}'
 
     @property
     def location(self) -> Path:
@@ -1747,11 +1739,10 @@ class MultiPushPullError(Exception):
         self.message = message
 
     def __str__(self):
-        return '{} ({} errors): {}, ...'.format(
-            self.message, len(self.errors), self.errors[0][1])
+        return f'{self.message} ({len(self.errors)} errors): {self.errors[0][1]}, ...'
 
     def __repr__(self):
-        return 'MultiError({!r}, {} errors)'.format(self.message, len(self.errors))
+        return f'MultiError({self.message!r}, {len(self.errors)} errors)'
 
 
 class Container:
@@ -1769,7 +1760,7 @@ class Container:
         self.name = name
 
         if pebble_client is None:
-            socket_path = '/charm/containers/{}/pebble.socket'.format(name)
+            socket_path = f'/charm/containers/{name}/pebble.socket'
             pebble_client = backend.get_pebble(socket_path)
         self._pebble = pebble_client  # type: 'Client'
 
@@ -1900,9 +1891,9 @@ class Container:
         """
         services = self.get_services(service_name)
         if not services:
-            raise ModelError('service {!r} not found'.format(service_name))
+            raise ModelError(f'service {service_name!r} not found')
         if len(services) > 1:
-            raise RuntimeError('expected 1 service, got {}'.format(len(services)))
+            raise RuntimeError(f'expected 1 service, got {len(services)}')
         return services[service_name]
 
     def get_checks(
@@ -1927,9 +1918,9 @@ class Container:
         """
         checks = self.get_checks(check_name)
         if not checks:
-            raise ModelError('check {!r} not found'.format(check_name))
+            raise ModelError(f'check {check_name!r} not found')
         if len(checks) > 1:
-            raise RuntimeError('expected 1 check, got {}'.format(len(checks)))
+            raise RuntimeError(f'expected 1 check, got {len(checks)}')
         return checks[check_name]
 
     def pull(self, path: StrOrPath, *,
@@ -2221,8 +2212,7 @@ class Container:
         prefix = str(source_path.parent)
         if os.path.commonprefix([prefix, str(file_path)]) != prefix:
             raise RuntimeError(
-                'file "{}" does not have specified prefix "{}"'.format(
-                    file_path, prefix))
+                f'file "{file_path}" does not have specified prefix "{prefix}"')
         path_suffix = os.path.relpath(str(file_path), prefix)
         return dest_dir / path_suffix
 
@@ -2495,13 +2485,13 @@ def _format_action_result_dict(input: Dict[str, 'JsonObject'],
         if not isinstance(key, str):
             # technically a type error, but for consistency with the
             # other exceptions raised on key validation...
-            raise ValueError('invalid key {!r}; must be a string'.format(key))
+            raise ValueError(f'invalid key {key!r}; must be a string')
         if not _ACTION_RESULT_KEY_REGEX.match(key):
             raise ValueError("key '{!r}' is invalid: must be similar to 'key', 'some-key2', or "
                              "'some.key'".format(key))
 
         if parent_key:
-            key = "{}.{}".format(parent_key, key)
+            key = f"{parent_key}.{key}"
 
         if isinstance(value, MutableMapping):
             value = typing.cast(Dict[str, 'JsonObject'], value)
@@ -2556,7 +2546,7 @@ class _ModelBackend:
             kwargs.update({"input": input_stream})
         which_cmd = shutil.which(args[0])
         if which_cmd is None:
-            raise RuntimeError('command not found: {}'.format(args[0]))
+            raise RuntimeError(f'command not found: {args[0]}')
         args = (which_cmd,) + args[1:]
         if use_json:
             args += ('--format=json',)
@@ -2639,7 +2629,7 @@ class _ModelBackend:
             version = JujuVersion.from_environ()
             if not version.has_app_data():
                 raise RuntimeError(
-                    'getting application data is not supported on Juju version {}'.format(version))
+                    f'getting application data is not supported on Juju version {version}')
 
         args = ['relation-get', '-r', str(relation_id), '-', member_name]
         if is_app:
@@ -2661,7 +2651,7 @@ class _ModelBackend:
             version = JujuVersion.from_environ()
             if not version.has_app_data():
                 raise RuntimeError(
-                    'setting application data is not supported on Juju version {}'.format(version))
+                    f'setting application data is not supported on Juju version {version}')
 
         args = ['relation-set', '-r', str(relation_id)]
         if is_app:
@@ -2730,7 +2720,7 @@ class _ModelBackend:
                 or an application.
         """
         content = self._run(
-            'status-get', '--include-data', '--application={}'.format(is_app),
+            'status-get', '--include-data', f'--application={is_app}',
             use_json=True,
             return_output=True)
         # Unit status looks like (in YAML):
@@ -2767,7 +2757,7 @@ class _ModelBackend:
         """
         if not isinstance(is_app, bool):
             raise TypeError('is_app parameter must be boolean')
-        self._run('status-set', '--application={}'.format(is_app), status, message)
+        self._run('status-set', f'--application={is_app}', status, message)
 
     def storage_list(self, name: str) -> List[int]:
         storages = self._run('storage-list', name, return_output=True, use_json=True)
@@ -2780,7 +2770,7 @@ class _ModelBackend:
         # Match the entire string at once instead of going line by line
         match = self._STORAGE_KEY_RE.match(output)
         if match is None:
-            raise RuntimeError('unable to find storage key in {output!r}'.format(output=output))
+            raise RuntimeError(f'unable to find storage key in {output!r}')
         key = match.groupdict()["storage_key"]
 
         index = int(key.split("/")[1])
@@ -2797,9 +2787,8 @@ class _ModelBackend:
 
     def storage_add(self, name: str, count: int = 1) -> None:
         if not isinstance(count, int) or isinstance(count, bool):
-            raise TypeError('storage count must be integer, got: {} ({})'.format(count,
-                                                                                 type(count)))
-        self._run('storage-add', '{}={}'.format(name, count))
+            raise TypeError(f'storage count must be integer, got: {count} ({type(count)})')
+        self._run('storage-add', f'{name}={count}')
 
     def action_get(self) -> Dict[str, str]:  # todo: what do we know about this dict?
         out = self._run('action-get', return_output=True, use_json=True)
@@ -2809,7 +2798,7 @@ class _ModelBackend:
         # The Juju action-set hook tool cannot interpret nested dicts, so we use a helper to
         # flatten out any nested dict structures into a dotted notation, and validate keys.
         flat_results = _format_action_result_dict(results)
-        self._run('action-set', *["{}={}".format(k, v) for k, v in flat_results.items()])
+        self._run('action-set', *[f"{k}={v}" for k, v in flat_results.items()])
 
     def action_log(self, message: str) -> None:
         self._run('action-log', message)
@@ -2829,7 +2818,7 @@ class _ModelBackend:
         to safely pass to bash. Will only generate a single entry if the line is not too long.
         """
         if len(message) > max_len:
-            yield "Log string greater than {}. Splitting into multiple chunks: ".format(max_len)
+            yield f"Log string greater than {max_len}. Splitting into multiple chunks: "
 
         while message:
             yield message[:max_len]
@@ -2866,14 +2855,14 @@ class _ModelBackend:
             for k, v in labels.items():
                 _ModelBackendValidator.validate_metric_label(k)
                 _ModelBackendValidator.validate_label_value(k, v)
-                label_args.append('{}={}'.format(k, v))
+                label_args.append(f'{k}={v}')
             cmd.extend(['--labels', ','.join(label_args)])
 
         metric_args = []  # type: List[str]
         for k, v in metrics.items():
             _ModelBackendValidator.validate_metric_key(k)
             metric_value = _ModelBackendValidator.format_metric_value(v)
-            metric_args.append('{}={}'.format(k, metric_value))
+            metric_args.append(f'{k}={metric_value}')
         cmd.extend(metric_args)
         self._run(*cmd)
 
@@ -2964,7 +2953,7 @@ class _ModelBackend:
         if content is not None:
             # The content has already been validated with Secret._validate_content
             for k, v in content.items():
-                args.append('{}={}'.format(k, v))
+                args.append(f'{k}={v}')
         self._run_for_secret('secret-set', *args)
 
     def secret_add(self, content: Dict[str, str], *,
@@ -2986,7 +2975,7 @@ class _ModelBackend:
             args += ['--owner', owner]
         # The content has already been validated with Secret._validate_content
         for k, v in content.items():
-            args.append('{}={}'.format(k, v))
+            args.append(f'{k}={v}')
         result = self._run('secret-add', *args, return_output=True)
         secret_id = typing.cast(str, result)
         return secret_id.strip()
@@ -3019,8 +3008,7 @@ class _ModelBackendValidator:
     def validate_metric_key(cls, key: str):
         if cls.METRIC_KEY_REGEX.match(key) is None:
             raise ModelError(
-                'invalid metric key {!r}: must match {}'.format(
-                    key, cls.METRIC_KEY_REGEX.pattern))
+                f'invalid metric key {key!r}: must match {cls.METRIC_KEY_REGEX.pattern}')
 
     @classmethod
     def validate_metric_label(cls, label_name: str):
@@ -3046,8 +3034,8 @@ class _ModelBackendValidator:
         # used by add-metric as separators.
         if not value:
             raise ModelError(
-                'metric label {} has an empty value, which is not allowed'.format(label))
+                f'metric label {label} has an empty value, which is not allowed')
         v = str(value)
         if re.search('[,=]', v) is not None:
             raise ModelError(
-                'metric label values must not contain "," or "=": {}={!r}'.format(label, value))
+                f'metric label values must not contain "," or "=": {label}={value!r}')

--- a/ops/model.py
+++ b/ops/model.py
@@ -1646,7 +1646,7 @@ class StorageMapping(Mapping[str, List['Storage']]):
 
     def __getitem__(self, storage_name: str) -> List['Storage']:
         if storage_name not in self._storage_map:
-            meant = ', or '.join([f'{k!r}' for k in self._storage_map.keys()])
+            meant = ', or '.join(repr(k) for k in self._storage_map.keys())
             raise KeyError(
                 f'Storage {storage_name!r} not found. Did you mean {meant}?')
         storage_list = self._storage_map[storage_name]

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -239,7 +239,7 @@ class _UnixSocketConnection(http.client.HTTPConnection):
     def connect(self):
         """Override connect to use Unix socket (instead of TCP socket)."""
         if not hasattr(socket, 'AF_UNIX'):
-            raise NotImplementedError('Unix sockets not supported on {}'.format(sys.platform))
+            raise NotImplementedError(f'Unix sockets not supported on {sys.platform}')
         self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.sock.connect(self.socket_path)
         if self.timeout is not _not_provided:
@@ -265,7 +265,7 @@ def _format_timeout(timeout: float) -> str:
     The format is in seconds with a millisecond resolution and an 's' suffix,
     as accepted by the Pebble API (which uses Go's time.ParseDuration).
     """
-    return '{:.3f}s'.format(timeout)
+    return f'{timeout:.3f}s'
 
 
 def _start_thread(target: Callable[..., Any], *args: Any, **kwargs: Any) -> threading.Thread:
@@ -279,7 +279,7 @@ class Error(Exception):
     """Base class of most errors raised by the Pebble client."""
 
     def __repr__(self):
-        return '<{}.{} {}>'.format(type(self).__module__, type(self).__name__, self.args)
+        return f'<{type(self).__module__}.{type(self).__name__} {self.args}>'
 
 
 class TimeoutError(TimeoutError, Error):
@@ -305,10 +305,10 @@ class PathError(Error):
         self.message = message  # type: ignore
 
     def __str__(self):
-        return '{} - {}'.format(self.kind, self.message)
+        return f'{self.kind} - {self.message}'
 
     def __repr__(self):
-        return 'PathError({!r}, {!r})'.format(self.kind, self.message)
+        return f'PathError({self.kind!r}, {self.message!r})'
 
 
 class APIError(Error):
@@ -324,8 +324,7 @@ class APIError(Error):
         self.message = message  # type: ignore
 
     def __repr__(self):
-        return 'APIError({!r}, {!r}, {!r}, {!r})'.format(
-            self.body, self.code, self.status, self.message)
+        return f'APIError({self.body!r}, {self.code!r}, {self.status!r}, {self.message!r})'
 
 
 class ChangeError(Error):
@@ -343,7 +342,7 @@ class ChangeError(Error):
         for i, task in enumerate(self.change.tasks):
             if not task.log:
                 continue
-            parts.append('\n----- Logs from task {} -----\n'.format(i))
+            parts.append(f'\n----- Logs from task {i} -----\n')
             parts.append('\n'.join(task.log))
 
         if len(parts) > 1:
@@ -352,7 +351,7 @@ class ChangeError(Error):
         return ''.join(parts)
 
     def __repr__(self):
-        return 'ChangeError({!r}, {!r})'.format(self.err, self.change)
+        return f'ChangeError({self.err!r}, {self.change!r})'
 
 
 class ExecError(Error):
@@ -385,15 +384,14 @@ class ExecError(Error):
         self.stderr = stderr
 
     def __str__(self):
-        message = 'non-zero exit code {} executing {!r}'.format(
-            self.exit_code, self.command)
+        message = f'non-zero exit code {self.exit_code} executing {self.command!r}'
 
         for name, out in [('stdout', self.stdout), ('stderr', self.stderr)]:
             if out is None:
                 continue
             truncated = ' [truncated]' if len(out) > self.STR_MAX_OUTPUT else ''
             out = out[:self.STR_MAX_OUTPUT]
-            message = '{}, {}={!r}{}'.format(message, name, out, truncated)
+            message = f'{message}, {name}={out!r}{truncated}'
 
         return message
 
@@ -425,7 +423,7 @@ class SystemInfo:
         return cls(version=d['version'])
 
     def __repr__(self):
-        return 'SystemInfo(version={self.version!r})'.format(self=self)
+        return f'SystemInfo(version={self.version!r})'
 
 
 class Warning:
@@ -513,7 +511,7 @@ class TaskID(str):
     """Task ID (a more strongly-typed string)."""
 
     def __repr__(self):
-        return 'TaskID({!r})'.format(str(self))
+        return f'TaskID({str(self)!r})'
 
 
 class Task:
@@ -575,7 +573,7 @@ class ChangeID(str):
     """Change ID (a more strongly-typed string)."""
 
     def __repr__(self):
-        return 'ChangeID({!r})'.format(str(self))
+        return f'ChangeID({str(self)!r})'
 
 
 class Change:
@@ -734,7 +732,7 @@ class Layer:
         return typing.cast('LayerDict', dct)
 
     def __repr__(self) -> str:
-        return 'Layer({!r})'.format(self.to_dict())
+        return f'Layer({self.to_dict()!r})'
 
     __str__ = to_yaml
 
@@ -808,7 +806,7 @@ class Service:
                 setattr(self, name, value)
 
     def __repr__(self) -> str:
-        return 'Service({!r})'.format(self.to_dict())
+        return f'Service({self.to_dict()!r})'
 
     def __eq__(self, other: Union['_ServiceDict', 'Service']) -> bool:
         """Compare this service description to another."""
@@ -818,7 +816,7 @@ class Service:
             return self.to_dict() == other.to_dict()
         else:
             raise ValueError(
-                "Cannot compare pebble.Service to {}".format(type(other))
+                f"Cannot compare pebble.Service to {type(other)}"
             )
 
 
@@ -927,7 +925,7 @@ class Check:
         return typing.cast('_CheckDict', dct)
 
     def __repr__(self) -> str:
-        return 'Check({!r})'.format(self.to_dict())
+        return f'Check({self.to_dict()!r})'
 
     def __eq__(self, other: Union['_CheckDict', 'Check']) -> bool:
         """Compare this check configuration to another."""
@@ -936,7 +934,7 @@ class Check:
         elif isinstance(other, Check):
             return self.to_dict() == other.to_dict()
         else:
-            raise ValueError("Cannot compare pebble.Check to {}".format(type(other)))
+            raise ValueError(f"Cannot compare pebble.Check to {type(other)}")
 
 
 class CheckLevel(enum.Enum):
@@ -1305,7 +1303,7 @@ def _websocket_to_writer(ws: websocket.WebSocket, writer: '_WebsocketWriter',
             command = payload.get('command')
             if command != 'end':
                 # A command we don't recognize, keep going
-                logger.warning('Invalid I/O command {!r}'.format(command))
+                logger.warning(f'Invalid I/O command {command!r}')
                 continue
             # Received "end" command (EOF signal), stop thread
             break
@@ -1328,7 +1326,7 @@ class _WebsocketWriter(io.BufferedIOBase):
     def write(self, chunk: '_StrOrBytes') -> int:
         """Write chunk to the websocket."""
         if not isinstance(chunk, bytes):
-            raise TypeError('value to write must be bytes, not {}'.format(type(chunk).__name__))
+            raise TypeError(f'value to write must be bytes, not {type(chunk).__name__}')
         self.ws.send_binary(chunk)  # type: ignore
         return len(chunk)
 
@@ -1368,7 +1366,7 @@ class _WebsocketReader(io.BufferedIOBase):
                 command = payload.get('command')
                 if command != 'end':
                     # A command we don't recognize, keep going
-                    logger.warning('Invalid I/O command {!r}'.format(command))
+                    logger.warning(f'Invalid I/O command {command!r}')
                     continue
                 # Received "end" command, return EOF designator
                 self.eof = True
@@ -1402,8 +1400,7 @@ class Client:
         unless a custom opener is provided).
         """
         if not isinstance(socket_path, str):
-            raise TypeError('`socket_path` should be a string, '
-                            'not: {}'.format(type(socket_path)))
+            raise TypeError(f'`socket_path` should be a string, not: {type(socket_path)}')
         if opener is None:
             opener = self._get_default_opener(socket_path)
         self.socket_path = socket_path
@@ -1455,7 +1452,7 @@ class Client:
         """
         ctype, options = cgi.parse_header(headers.get('Content-Type', ''))
         if ctype != expected:
-            raise ProtocolError('expected Content-Type {!r}, got {!r}'.format(expected, ctype))
+            raise ProtocolError(f'expected Content-Type {expected!r}, got {ctype!r}')
         return options
 
     def _request_raw(
@@ -1484,7 +1481,7 @@ class Client:
             except (IOError, ValueError, KeyError) as e2:
                 # Will only happen on read error or if Pebble sends invalid JSON.
                 body = {}  # type: Dict[str, Any]
-                message = '{} - {}'.format(type(e2).__name__, e2)
+                message = f'{type(e2).__name__} - {e2}'
             raise APIError(body, code, status, message)
         except urllib.error.URLError as e:
             raise ConnectionError(e.reason)
@@ -1520,13 +1517,13 @@ class Client:
 
     def get_change(self, change_id: ChangeID) -> Change:
         """Get single change by ID."""
-        resp = self._request('GET', '/v1/changes/{}'.format(change_id))
+        resp = self._request('GET', f'/v1/changes/{change_id}')
         return Change.from_dict(resp['result'])
 
     def abort_change(self, change_id: ChangeID) -> Change:
         """Abort change with given ID."""
         body = {'action': 'abort'}
-        resp = self._request('POST', '/v1/changes/{}'.format(change_id), body=body)
+        resp = self._request('POST', f'/v1/changes/{change_id}', body=body)
         return Change.from_dict(resp['result'])
 
     def autostart_services(self, timeout: float = 30.0, delay: float = 0.1) -> ChangeID:
@@ -1629,13 +1626,12 @@ class Client:
     ) -> ChangeID:
         if isinstance(services, (str, bytes)) or not hasattr(services, '__iter__'):
             raise TypeError(
-                'services must be of type Iterable[str], not {}'.format(
-                    type(services).__name__))
+                f'services must be of type Iterable[str], not {type(services).__name__}')
 
         services = list(services)
         for s in services:
             if not isinstance(s, str):
-                raise TypeError('service names must be str, not {}'.format(type(s).__name__))
+                raise TypeError(f'service names must be str, not {type(s).__name__}')
 
         body = {'action': action, 'services': services}
         resp = self._request('POST', '/v1/services', body=body)
@@ -1696,8 +1692,7 @@ class Client:
                 # Catch timeout from wait endpoint and loop to check deadline
                 pass
 
-        raise TimeoutError('timed out waiting for change {} ({} seconds)'.format(
-            change_id, timeout))
+        raise TimeoutError(f'timed out waiting for change {change_id} ({timeout} seconds)')
 
     def _wait_change(self, change_id: ChangeID, timeout: Optional[float] = None) -> Change:
         """Call the wait-change API endpoint directly."""
@@ -1706,13 +1701,12 @@ class Client:
             query['timeout'] = _format_timeout(timeout)
 
         try:
-            resp = self._request('GET', '/v1/changes/{}/wait'.format(change_id), query)
+            resp = self._request('GET', f'/v1/changes/{change_id}/wait', query)
         except APIError as e:
             if e.code == 404:
                 raise NotImplementedError('server does not implement wait-change endpoint')
             if e.code == 504:
-                raise TimeoutError('timed out waiting for change {} ({} seconds)'.format(
-                    change_id, timeout))
+                raise TimeoutError(f'timed out waiting for change {change_id} ({timeout} seconds)')
             raise
 
         return Change.from_dict(resp['result'])
@@ -1729,8 +1723,7 @@ class Client:
 
             time.sleep(delay)
 
-        raise TimeoutError('timed out waiting for change {} ({} seconds)'.format(
-            change_id, timeout))
+        raise TimeoutError(f'timed out waiting for change {change_id} ({timeout} seconds)')
 
     def add_layer(
             self, label: str, layer: Union[str, 'LayerDict', Layer], *,
@@ -1743,7 +1736,7 @@ class Client:
         layer override rules; if the layer doesn't exist, it is added as usual.
         """
         if not isinstance(label, str):
-            raise TypeError('label must be a str, not {}'.format(type(label).__name__))
+            raise TypeError(f'label must be a str, not {type(label).__name__}')
 
         if isinstance(layer, str):
             layer_yaml = layer
@@ -1752,8 +1745,8 @@ class Client:
         elif isinstance(layer, Layer):
             layer_yaml = layer.to_yaml()
         else:
-            raise TypeError('layer must be str, dict, or pebble.Layer, not {}'.format(
-                type(layer).__name__))
+            raise TypeError(
+                f'layer must be str, dict, or pebble.Layer, not {type(layer).__name__}')
 
         body = {
             'action': 'add',
@@ -1807,7 +1800,7 @@ class Client:
         options = self._ensure_content_type(response.headers, 'multipart/form-data')
         boundary = options.get('boundary', '')
         if not boundary:
-            raise ProtocolError('invalid boundary {!r}'.format(boundary))
+            raise ProtocolError(f'invalid boundary {boundary!r}')
 
         parser = _FilesParser(boundary)
 
@@ -1830,7 +1823,7 @@ class Client:
 
         filename = filenames[0]
         if filename != path:
-            raise ProtocolError('path not expected: {!r}'.format(filename))
+            raise ProtocolError(f'path not expected: {filename!r}')
 
         f = parser.get_file(path, encoding)
 
@@ -1842,7 +1835,7 @@ class Client:
         result = resp['result'] or []  # in case it's null instead of []
         paths = {item['path']: item for item in result}
         if path not in paths:
-            raise ProtocolError('path not found in response metadata: {}'.format(resp))
+            raise ProtocolError(f'path not found in response metadata: {resp}')
         error = paths[path].get('error')
         if error:
             raise PathError(error['kind'], error['message'])
@@ -2163,8 +2156,7 @@ class Client:
             not.
         """
         if not isinstance(command, list) or not all(isinstance(s, str) for s in command):
-            raise TypeError('command must be a list of str, not {}'.format(
-                type(command).__name__))
+            raise TypeError(f'command must be a list of str, not {type(command).__name__}')
         if len(command) < 1:
             raise ValueError('command must contain at least one item')
 
@@ -2210,7 +2202,7 @@ class Client:
             change = self.wait_change(ChangeID(change_id))
             if change.err:
                 raise ChangeError(change.err, change)
-            raise ConnectionError('unexpected error connecting to websockets: {}'.format(e))
+            raise ConnectionError(f'unexpected error connecting to websockets: {e}')
 
         cancel_stdin = None  # type: Optional[Callable[[], None]]
         cancel_reader = None  # type: Optional[int]
@@ -2287,7 +2279,7 @@ class Client:
 
     def _websocket_url(self, task_id: str, websocket_id: str) -> str:
         base_url = self.base_url.replace('http://', 'ws://')
-        url = '{}/v1/tasks/{}/websocket/{}'.format(base_url, task_id, websocket_id)
+        url = f'{base_url}/v1/tasks/{task_id}/websocket/{websocket_id}'
         return url
 
     def send_signal(self, sig: Union[int, str], services: Iterable[str]):
@@ -2307,7 +2299,7 @@ class Client:
                             'not {}'.format(type(services).__name__))
         for s in services:
             if not isinstance(s, str):  # pyright: reportUnnecessaryIsInstance=false
-                raise TypeError('service names must be str, not {}'.format(type(s).__name__))
+                raise TypeError(f'service names must be str, not {type(s).__name__}')
 
         if isinstance(sig, int):
             sig = signal.Signals(sig).name
@@ -2379,7 +2371,7 @@ class _FilesParser:
         content_disposition = self._headers.get_content_disposition()
         if content_disposition != 'form-data':
             raise ProtocolError(
-                'unexpected content disposition: {!r}'.format(content_disposition))
+                f'unexpected content disposition: {content_disposition!r}')
 
         name = self._headers.get_param('name', header='content-disposition')
         if name == 'files':
@@ -2389,7 +2381,7 @@ class _FilesParser:
             self._prepare_tempfile(filename)
         elif name != 'response':
             raise ProtocolError(
-                'unexpected name in content-disposition header: {!r}'.format(name))
+                f'unexpected name in content-disposition header: {name!r}')
 
         self._part_type = typing.cast('Literal["response", "files"]', name)
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1464,7 +1464,7 @@ class Client:
         """Make a request to the Pebble server; return the raw HTTPResponse object."""
         url = self.base_url + path
         if query:
-            url = url + '?' + urllib.parse.urlencode(query, doseq=True)
+            url = f"{url}?{urllib.parse.urlencode(query, doseq=True)}"
 
         if headers is None:
             headers = {}
@@ -1919,7 +1919,7 @@ class Client:
             source_io = source  # type: _AnyStrFileLikeIO
         boundary = binascii.hexlify(os.urandom(16))
         path_escaped = path.replace('"', '\\"').encode('utf-8')  # NOQA: test_quote_backslashes
-        content_type = 'multipart/form-data; boundary="' + boundary.decode('utf-8') + '"'
+        content_type = f"multipart/form-data; boundary=\"{boundary.decode('utf-8')}\""  # NOQA: test_quote_backslashes
 
         def generator() -> Generator[bytes, None, None]:
             yield b''.join([

--- a/ops/storage.py
+++ b/ops/storage.py
@@ -59,7 +59,7 @@ class SQLiteStorage:
 
         if not os.path.exists(str(filename)):
             # sqlite3.connect creates the file silently if it does not exist
-            logger.debug("Initializing SQLite local storage: {}.".format(filename))
+            logger.debug(f"Initializing SQLite local storage: {filename}.")
 
         self._db = sqlite3.connect(str(filename),
                                    isolation_level=None,
@@ -396,4 +396,4 @@ class NoSnapshotError(Exception):
         self.handle_path = handle_path
 
     def __str__(self):
-        return 'no snapshot data found for {} object'.format(self.handle_path)
+        return f'no snapshot data found for {self.handle_path} object'

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -459,9 +459,9 @@ class Harness(Generic[CharmType]):
                         'password': 'password',
                         }
         if resource_name not in self._meta.resources.keys():
-            raise RuntimeError('Resource {} is not a defined resources'.format(resource_name))
+            raise RuntimeError(f'Resource {resource_name} is not a defined resources')
         if self._meta.resources[resource_name].type != "oci-image":
-            raise RuntimeError('Resource {} is not an OCI Image'.format(resource_name))
+            raise RuntimeError(f'Resource {resource_name} is not an OCI Image')
 
         as_yaml = yaml.safe_dump(contents)
         self._backend._resources_map[resource_name] = ('contents.yaml', as_yaml)
@@ -478,11 +478,11 @@ class Harness(Generic[CharmType]):
                 returned by resource-get. If contents is a string, it will be encoded in utf-8
         """
         if resource_name not in self._meta.resources.keys():
-            raise RuntimeError('Resource {} is not a defined resources'.format(resource_name))
+            raise RuntimeError(f'Resource {resource_name} is not a defined resources')
         record = self._meta.resources[resource_name]
         if record.type != "file":
             raise RuntimeError(
-                'Resource {} is not a file, but actually {}'.format(resource_name, record.type))
+                f'Resource {resource_name} is not a file, but actually {record.type}')
         filename = record.filename
         if filename is None:
             filename = resource_name
@@ -558,7 +558,7 @@ class Harness(Generic[CharmType]):
         """
         if storage_name not in self._meta.storages:
             raise RuntimeError(
-                "the key '{}' is not specified as a storage key in metadata".format(storage_name))
+                f"the key '{storage_name}' is not specified as a storage key in metadata")
 
         storage_indices = self._backend.storage_add(storage_name, count)
 
@@ -634,7 +634,7 @@ class Harness(Generic[CharmType]):
         storage_index = int(storage_index)
         if storage_name not in self._meta.storages:
             raise RuntimeError(
-                "the key '{}' is not specified as a storage key in metadata".format(storage_name))
+                f"the key '{storage_name}' is not specified as a storage key in metadata")
         is_attached = self._backend._storage_is_attached(  # pyright:ReportPrivateUsage=false
             storage_name, storage_index)
         if self._charm is not None and self._hooks_enabled and is_attached:
@@ -896,7 +896,7 @@ class Harness(Generic[CharmType]):
         """
         client = self._backend._pebble_clients.get(container_name)
         if client is None:
-            raise KeyError('no known pebble client for container "{}"'.format(container_name))
+            raise KeyError(f'no known pebble client for container "{container_name}"')
         return client.get_plan()
 
     def container_pebble_ready(self, container_name: str):
@@ -1064,7 +1064,7 @@ class Harness(Generic[CharmType]):
                     if value is not None:
                         config._config_set(key, value)
                 else:
-                    raise ValueError("unknown config option: '{}'".format(key))
+                    raise ValueError(f"unknown config option: '{key}'")
 
         for key in unset:
             # When the key is unset, revert to the default if one exists
@@ -1347,7 +1347,7 @@ def _get_app_or_unit_name(app_or_unit: AppUnitOrName) -> str:
     elif isinstance(app_or_unit, str):
         return app_or_unit
     else:
-        raise TypeError('Expected Application | Unit | str, got {}'.format(type(app_or_unit)))
+        raise TypeError(f'Expected Application | Unit | str, got {type(app_or_unit)}')
 
 
 def _record_calls(cls: Any):
@@ -1463,10 +1463,10 @@ class _TestingRelationDataContents(Dict[str, str]):
     def __setitem__(self, key: str, value: str):
         if not isinstance(key, str):
             raise model.RelationDataError(
-                'relation data keys must be strings, not {}'.format(type(key)))
+                f'relation data keys must be strings, not {type(key)}')
         if not isinstance(value, str):
             raise model.RelationDataError(
-                'relation data values must be strings, not {}'.format(type(value)))
+                f'relation data values must be strings, not {type(value)}')
         super().__setitem__(key, value)
 
     def copy(self):
@@ -1598,7 +1598,7 @@ class _TestingModelBackend:
             return self._relation_ids_map[relation_name]
         except KeyError as e:
             if relation_name not in self._meta.relations:
-                raise model.ModelError('{} is not a known relation'.format(relation_name)) from e
+                raise model.ModelError(f'{relation_name} is not a known relation') from e
             no_ids = []  # type: List[int]
             return no_ids
 
@@ -1731,7 +1731,7 @@ class _TestingModelBackend:
                 return self._storage_list[name][index][attribute]
         except KeyError:
             raise model.ModelError(
-                'ERROR invalid value "{}/{}" for option -s: storage not found'.format(name, index))
+                f'ERROR invalid value "{name}/{index}" for option -s: storage not found')
 
     def storage_add(self, name: str, count: int = 1) -> List[int]:
         if '/' in name:
@@ -2131,8 +2131,7 @@ class _TestingPebbleClient:
         # A common mistake is to pass just the name of a service, rather than a list of services,
         # so trap that so it is caught quickly.
         if isinstance(services, str):
-            raise TypeError('start_services should take a list of names, not just "{}"'.format(
-                services))
+            raise TypeError(f'start_services should take a list of names, not just "{services}"')
 
         self._check_connection()
 
@@ -2143,7 +2142,7 @@ class _TestingPebbleClient:
         for name in services:
             if name not in known_services:
                 # TODO: jam 2021-04-20 This needs a better error type
-                raise RuntimeError('400 Bad Request: service "{}" does not exist'.format(name))
+                raise RuntimeError(f'400 Bad Request: service "{name}" does not exist')
         for name in services:
             self._service_status[name] = pebble.ServiceStatus.ACTIVE
 
@@ -2152,8 +2151,7 @@ class _TestingPebbleClient:
     ):
         # handle a common mistake of passing just a name rather than a list of names
         if isinstance(services, str):
-            raise TypeError('stop_services should take a list of names, not just "{}"'.format(
-                services))
+            raise TypeError(f'stop_services should take a list of names, not just "{services}"')
 
         self._check_connection()
 
@@ -2164,7 +2162,7 @@ class _TestingPebbleClient:
             if name not in known_services:
                 # TODO: jam 2021-04-20 This needs a better error type
                 #  400 Bad Request: service "bal" does not exist
-                raise RuntimeError('400 Bad Request: service "{}" does not exist'.format(name))
+                raise RuntimeError(f'400 Bad Request: service "{name}" does not exist')
         for name in services:
             self._service_status[name] = pebble.ServiceStatus.INACTIVE
 
@@ -2173,8 +2171,7 @@ class _TestingPebbleClient:
     ):
         # handle a common mistake of passing just a name rather than a list of names
         if isinstance(services, str):
-            raise TypeError('restart_services should take a list of names, not just "{}"'.format(
-                services))
+            raise TypeError(f'restart_services should take a list of names, not just "{services}"')
 
         self._check_connection()
 
@@ -2185,7 +2182,7 @@ class _TestingPebbleClient:
             if name not in known_services:
                 # TODO: jam 2021-04-20 This needs a better error type
                 #  400 Bad Request: service "bal" does not exist
-                raise RuntimeError('400 Bad Request: service "{}" does not exist'.format(name))
+                raise RuntimeError(f'400 Bad Request: service "{name}" does not exist')
         for name in services:
             self._service_status[name] = pebble.ServiceStatus.ACTIVE
 
@@ -2200,21 +2197,21 @@ class _TestingPebbleClient:
         # I wish we could combine some of this helpful object corralling with the actual backend,
         # rather than having to re-implement it. Maybe we could subclass
         if not isinstance(label, str):
-            raise TypeError('label must be a str, not {}'.format(type(label).__name__))
+            raise TypeError(f'label must be a str, not {type(label).__name__}')
 
         if isinstance(layer, (str, dict)):
             layer_obj = pebble.Layer(layer)
         elif isinstance(layer, pebble.Layer):
             layer_obj = layer
         else:
-            raise TypeError('layer must be str, dict, or pebble.Layer, not {}'.format(
-                type(layer).__name__))
+            raise TypeError(
+                f'layer must be str, dict, or pebble.Layer, not {type(layer).__name__}')
 
         self._check_connection()
 
         if label in self._layers:
             if not combine:
-                raise RuntimeError('400 Bad Request: layer "{}" already exists'.format(label))
+                raise RuntimeError(f'400 Bad Request: layer "{label}" already exists')
             layer = self._layers[label]
             for name, service in layer_obj.services.items():
                 # 'override' is actually single quoted in the real error, but
@@ -2258,8 +2255,7 @@ class _TestingPebbleClient:
 
     def get_services(self, names: Optional[List[str]] = None) -> List[pebble.ServiceInfo]:
         if isinstance(names, str):
-            raise TypeError('start_services should take a list of names, not just "{}"'.format(
-                names))
+            raise TypeError(f'start_services should take a list of names, not just "{names}"')
 
         self._check_connection()
         services = self._render_services()
@@ -2301,18 +2297,18 @@ class _TestingPebbleClient:
         if permissions is not None and not (0 <= permissions <= 0o777):
             raise pebble.PathError(
                 'generic-file-error',
-                'permissions not within 0o000 to 0o777: {:#o}'.format(permissions))
+                f'permissions not within 0o000 to 0o777: {permissions:#o}')
         try:
             self._fs.create_file(
                 path, source, encoding=encoding, make_dirs=make_dirs, permissions=permissions,
                 user_id=user_id, user=user, group_id=group_id, group=group)
         except FileNotFoundError as e:
             raise pebble.PathError(
-                'not-found', 'parent directory not found: {}'.format(e.args[0]))
+                'not-found', f'parent directory not found: {e.args[0]}')
         except NonAbsolutePathError as e:
             raise pebble.PathError(
                 'generic-file-error',
-                'paths must be absolute, got {!r}'.format(e.args[0])
+                f'paths must be absolute, got {e.args[0]!r}'
             )
 
     def list_files(self, path: str, *, pattern: Optional[str] = None,
@@ -2324,7 +2320,7 @@ class _TestingPebbleClient:
             # conform with the real pebble api
             raise pebble.APIError(
                 body={}, code=404, status='Not Found',
-                message="stat {}: no such file or directory".format(path))
+                message=f"stat {path}: no such file or directory")
 
         if not itself:
             try:
@@ -2343,8 +2339,8 @@ class _TestingPebbleClient:
         def get_pebble_file_type(file: '_FileOrDir') -> pebble.FileType:
             pebble_type = type_mappings.get(type(file))
             if not pebble_type:
-                raise ValueError('unable to convert file {} '
-                                 '(type not one of {})'.format(file, type_mappings))
+                raise ValueError(
+                    f'unable to convert file {file} (type not one of {type_mappings})')
             return pebble_type
 
         return [
@@ -2376,7 +2372,7 @@ class _TestingPebbleClient:
         if permissions is not None and not (0 <= permissions <= 0o777):
             raise pebble.PathError(
                 'generic-file-error',
-                'permissions not within 0o000 to 0o777: {:#o}'.format(permissions))
+                f'permissions not within 0o000 to 0o777: {permissions:#o}')
         try:
             self._fs.create_dir(
                 path, make_parents=make_parents, permissions=permissions,
@@ -2384,14 +2380,14 @@ class _TestingPebbleClient:
         except FileNotFoundError as e:
             # Parent directory doesn't exist and make_parents is False
             raise pebble.PathError(
-                'not-found', 'parent directory not found: {}'.format(e.args[0]))
+                'not-found', f'parent directory not found: {e.args[0]}')
         except NotADirectoryError as e:
             # Attempted to create a subdirectory of a file
-            raise pebble.PathError('generic-file-error', 'not a directory: {}'.format(e.args[0]))
+            raise pebble.PathError('generic-file-error', f'not a directory: {e.args[0]}')
         except NonAbsolutePathError as e:
             raise pebble.PathError(
                 'generic-file-error',
-                'paths must be absolute, got {!r}'.format(e.args[0])
+                f'paths must be absolute, got {e.args[0]!r}'
             )
 
     def remove_path(self, path: str, *, recursive: bool = False):
@@ -2403,7 +2399,7 @@ class _TestingPebbleClient:
                 # Pebble doesn't give not-found error when recursive is specified
                 return
             raise pebble.PathError(
-                'not-found', 'remove {}: no such file or directory'.format(path))
+                'not-found', f'remove {path}: no such file or directory')
 
         if isinstance(file_or_dir, _Directory) and len(file_or_dir) > 0 and not recursive:
             raise pebble.PathError(
@@ -2428,7 +2424,7 @@ class _TestingPebbleClient:
         for service in service_names:
             if service not in plan.services or not self.get_services([service])[0].is_running():
                 # conform with the real pebble api
-                message = 'cannot send signal to "{}": service is not running'.format(service)
+                message = f'cannot send signal to "{service}": service is not running'
                 body = {'type': 'error', 'status-code': 500, 'status': 'Internal Server Error',
                         'result': {'message': message}}
                 raise pebble.APIError(
@@ -2440,9 +2436,7 @@ class _TestingPebbleClient:
             signal.Signals[sig]
         except KeyError:
             # conform with the real pebble api
-            message = 'cannot send signal to "{}": invalid signal name "{}"'.format(
-                service_names[0],
-                sig)
+            message = f'cannot send signal to "{service_names[0]}": invalid signal name "{sig}"'
             body = {'type': 'error', 'status-code': 500, 'status': 'Internal Server Error',
                     'result': {'message': message}}
             raise pebble.APIError(
@@ -2570,7 +2564,7 @@ class _TestingStorageMount:
                 with fpath.open('rb') as f:
                     results.append(_File(mountpath, f.read()))
             else:
-                raise RuntimeError('unsupported file type at path {}'.format(fpath))
+                raise RuntimeError(f'unsupported file type at path {fpath}')
         return results
 
     def open(
@@ -2689,7 +2683,7 @@ class _TestingFilesystem:
                 raise
         if not isinstance(dir_, _Directory):
             raise pebble.PathError(
-                'generic-file-error', 'parent is not a directory: {}'.format(str(dir_)))
+                'generic-file-error', f'parent is not a directory: {str(dir_)}')
         return dir_.create_file(path_obj.name, data, encoding=encoding, **kwargs)
 
     def list_dir(self, path: '_StringOrPath') -> List['_FileOrDir']:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -149,7 +149,7 @@ class Harness(Generic[CharmType]):
         self._charm = None  # type: Optional[CharmType]
         self._charm_dir = 'no-disk-path'  # this may be updated by _create_meta
         self._meta = self._create_meta(meta, actions)
-        self._unit_name = self._meta.name + '/0'  # type: str
+        self._unit_name = f"{self._meta.name}/0"  # type: str
         self._hooks_enabled = True  # type: bool
         self._relation_id_counter = 0  # type: int
         config_ = self._get_config(config)
@@ -1987,7 +1987,7 @@ class _TestingModelBackend:
     @classmethod
     def _generate_secret_id(cls) -> str:
         # Not a proper Juju secrets-style xid, but that's okay
-        return 'secret:' + str(uuid.uuid4())
+        return f"secret:{str(uuid.uuid4())}"
 
     def secret_add(self, content: Dict[str, str], *,
                    label: Optional[str] = None,

--- a/ops/version.py
+++ b/ops/version.py
@@ -26,7 +26,7 @@ _FALLBACK = '1.0'  # this gets bumped after release
 
 
 def _get_version():
-    version = _FALLBACK + ".dev0+unknown"
+    version = f"{_FALLBACK}.dev0+unknown"
 
     p = Path(__file__).parent
     if (p.parent / '.git').exists():
@@ -47,7 +47,7 @@ def _get_version():
                 # in terms of PEP 440, the tag we'll make sure is a 'public version identifier';
                 # everything after the first - needs to be a 'local version'
                 public, local = version.split('-', 1)
-                version = public + '+' + local.replace('-', '.')
+                version = f"{public}+{local.replace('-', '.')}"
                 # version now <tag>+<#commits>.g<hex>[.dirty]
                 # which is PEP440-compliant (as long as <tag> is :-)
     return version

--- a/setup.py
+++ b/setup.py
@@ -46,11 +46,10 @@ version_backup.unlink(missing_ok=True)
 version_path.rename(version_backup)
 try:
     with version_path.open("wt", encoding="utf8") as fh:
-        fh.write('''\
-# this is a generated file
+        fh.write(f'''# this is a generated file
 
-version = {!r}
-'''.format(version))
+version = {version!r}
+''')
 
     setup(
         name="ops",

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -174,8 +174,7 @@ class Charm(CharmBase):
     def _on_secret_changed(self, event):
         # subprocess and isinstance don't mix well
         assert type(event.secret).__name__ == 'Secret', (
-            'SecretEvent.secret must be a Secret instance, not '
-            '{}'.format(type(event.secret)))
+            f'SecretEvent.secret must be a Secret instance, not {type(event.secret)}')
         assert event.secret.id, 'secret must have an ID'
         self._stored.on_secret_changed.append(type(event).__name__)
         self._stored.observed_event_types.append(type(event).__name__)
@@ -183,8 +182,7 @@ class Charm(CharmBase):
     def _on_secret_remove(self, event):
         # subprocess and isinstance don't mix well
         assert type(event.secret).__name__ == 'Secret', (
-            'SecretEvent.secret must be a Secret instance, not '
-            '{}'.format(type(event.secret)))
+            f'SecretEvent.secret must be a Secret instance, not {type(event.secret)}')
         assert event.secret.id, 'secret must have an ID'
         self._stored.on_secret_remove.append(type(event).__name__)
         self._stored.observed_event_types.append(type(event).__name__)
@@ -192,8 +190,7 @@ class Charm(CharmBase):
     def _on_secret_rotate(self, event):
         # subprocess and isinstance don't mix well
         assert type(event.secret).__name__ == 'Secret', (
-            'SecretEvent.secret must be a Secret instance, not '
-            '{}'.format(type(event.secret)))
+            f'SecretEvent.secret must be a Secret instance, not {type(event.secret)}')
         assert event.secret.id, 'secret must have an ID'
         self._stored.on_secret_rotate.append(type(event).__name__)
         self._stored.observed_event_types.append(type(event).__name__)
@@ -201,8 +198,7 @@ class Charm(CharmBase):
     def _on_secret_expired(self, event):
         # subprocess and isinstance don't mix well
         assert type(event.secret).__name__ == 'Secret', (
-            'SecretEvent.secret must be a Secret instance, not '
-            '{}'.format(type(event.secret)))
+            f'SecretEvent.secret must be a Secret instance, not {type(event.secret)}')
         assert event.secret.id, 'secret must have an ID'
         self._stored.on_secret_expired.append(type(event).__name__)
         self._stored.observed_event_types.append(type(event).__name__)

--- a/test/fake_pebble.py
+++ b/test/fake_pebble.py
@@ -80,7 +80,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
     def internal_server_error(self, msg):
         d = {
             "result": {
-                "message": "internal server error: {}".format(msg),
+                "message": f"internal server error: {msg}",
             },
             "status": "Internal Server Error",
             "status-code": 500,
@@ -152,7 +152,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
         if action == 'start':
             for service in services:
                 if service not in self._services:
-                    self.bad_request('service "{}" does not exist'.format(service))
+                    self.bad_request(f'service "{service}" does not exist')
                     return
             self.respond({
                 "change": "1234",
@@ -162,7 +162,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 "type": "async"
             })
         else:
-            self.bad_request('action "{}" not implemented'.format(action))
+            self.bad_request(f'action "{action}" not implemented')
 
 
 def start_server():

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -152,10 +152,9 @@ def main():
                 with open(args.layer_path, encoding='utf-8') as f:
                     layer_yaml = f.read()
             except IOError as e:
-                parser.error('cannot read layer YAML: {}'.format(e))
+                parser.error(f'cannot read layer YAML: {e}')
             client.add_layer(args.label, layer_yaml, combine=bool(args.combine))
-            result = 'Layer {!r} added successfully from {!r}'.format(
-                args.label, args.layer_path)
+            result = f'Layer {args.label!r} added successfully from {args.layer_path!r}'
         elif args.command == 'autostart':
             result = client.autostart_services()
         elif args.command == 'change':
@@ -226,7 +225,7 @@ def main():
             result = client.list_files(args.path, pattern=args.pattern, itself=args.directory)
         elif args.command == 'mkdir':
             client.make_dir(args.path, make_parents=bool(args.parents))
-            result = 'created remote directory {}'.format(args.path)
+            result = f'created remote directory {args.path}'
         elif args.command == 'plan':
             result = client.get_plan().to_yaml()
         elif args.command == 'pull':
@@ -234,7 +233,7 @@ def main():
             if args.local_path != '-':
                 with open(args.local_path, 'wb') as f:
                     f.write(content)
-                result = 'wrote remote file {} to {}'.format(args.remote_path, args.local_path)
+                result = f'wrote remote file {args.remote_path} to {args.local_path}'
             else:
                 sys.stdout.buffer.write(content)
                 return
@@ -244,10 +243,10 @@ def main():
                     args.remote_path, f, make_dirs=args.dirs,
                     permissions=int(args.mode, 8) if args.mode is not None else None,
                     user=args.user, group=args.group)
-            result = 'wrote {} to remote file {}'.format(args.local_path, args.remote_path)
+            result = f'wrote {args.local_path} to remote file {args.remote_path}'
         elif args.command == 'rm':
             client.remove_path(args.path, recursive=bool(args.recursive))
-            result = 'removed remote path {}'.format(args.path)
+            result = f'removed remote path {args.path}'
         elif args.command == 'services':
             result = client.get_services(args.service)
         elif args.command == 'start':
@@ -263,10 +262,10 @@ def main():
         else:
             raise AssertionError("shouldn't happen")
     except pebble.APIError as e:
-        print('APIError: {} {}: {}'.format(e.code, e.status, e.message), file=sys.stderr)
+        print(f'APIError: {e.code} {e.status}: {e.message}', file=sys.stderr)
         sys.exit(1)
     except pebble.ConnectionError as e:
-        print('ConnectionError: cannot connect to socket {!r}: {}'.format(socket_path, e),
+        print(f'ConnectionError: cannot connect to socket {socket_path!r}: {e}',
               file=sys.stderr)
         sys.exit(1)
     except pebble.ChangeError as e:

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -30,8 +30,7 @@ async def test_smoke(ops_test: OpsTest):
 
     for series in ['focal', 'bionic', 'xenial']:
         app = await ops_test.model.deploy(
-            charm, series=series, application_name="{}-smoke".format(series))
+            charm, series=series, application_name=f"{series}-smoke")
         await ops_test.model.wait_for_idle(timeout=600)
 
-        assert app.status == "active", "Series {} failed with '{}' status".format(
-            series, app.status)
+        assert app.status == "active", f"Series {series} failed with '{app.status}' status"

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -516,7 +516,7 @@ start:
             def _on_start_action(self, event):
                 event.defer()
 
-        fake_script(self, cmd_type + '-get', """echo '{"foo-name": "name", "silent": true}'""")
+        fake_script(self, f"{cmd_type}-get", """echo '{"foo-name": "name", "silent": true}'""")
         self.meta = self._get_action_test_meta()
 
         os.environ[f'JUJU_{cmd_type.upper()}_NAME'] = 'start'

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -519,7 +519,7 @@ start:
         fake_script(self, cmd_type + '-get', """echo '{"foo-name": "name", "silent": true}'""")
         self.meta = self._get_action_test_meta()
 
-        os.environ['JUJU_{}_NAME'.format(cmd_type.upper())] = 'start'
+        os.environ[f'JUJU_{cmd_type.upper()}_NAME'] = 'start'
         framework = self.create_framework()
         charm = MyCharm(framework)
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -366,7 +366,7 @@ class TestFramework(BaseTestCase):
                 self.seen = []
 
             def _on_foo(self, event):
-                self.seen.append("on_foo:{}={}".format(event.handle.kind, event.my_n))
+                self.seen.append(f"on_foo:{event.handle.kind}={event.my_n}")
                 event.defer()
 
         pub = MyNotifier(framework, "1")
@@ -512,11 +512,11 @@ class TestFramework(BaseTestCase):
                 self.seen = []
 
             def _on_foo(self, event):
-                self.seen.append("on_foo:{}".format(event.handle.kind))
+                self.seen.append(f"on_foo:{event.handle.kind}")
                 event.defer()
 
             def _on_bar(self, event):
-                self.seen.append("on_bar:{}".format(event.handle.kind))
+                self.seen.append(f"on_bar:{event.handle.kind}")
 
         pub = MyNotifier(framework, "1")
         obs = MyObserver(framework, "1")
@@ -531,7 +531,7 @@ class TestFramework(BaseTestCase):
 
         self.assertEqual(obs.seen, ["on_foo:foo"])
         fqn = pub.on.__class__.__module__ + "." + pub.on.__class__.__qualname__
-        self.assertEqual(repr(pub.on), "<{}: bar, foo>".format(fqn))
+        self.assertEqual(repr(pub.on), f"<{fqn}: bar, foo>")
 
     def test_conflicting_event_attributes(self):
         class MyEvent(EventBase):
@@ -621,11 +621,11 @@ class TestFramework(BaseTestCase):
                 self.seen = []
 
             def _on_foo(self, event):
-                self.seen.append("on_foo:{}:{}".format(type(event).__name__, event.handle.kind))
+                self.seen.append(f"on_foo:{type(event).__name__}:{event.handle.kind}")
                 event.defer()
 
             def _on_bar(self, event):
-                self.seen.append("on_bar:{}:{}".format(type(event).__name__, event.handle.kind))
+                self.seen.append(f"on_bar:{type(event).__name__}:{event.handle.kind}")
                 event.defer()
 
         pub = MyNotifier(framework, "1")
@@ -661,11 +661,11 @@ class TestFramework(BaseTestCase):
                 self.seen = []
 
             def _on_foo(self, event):
-                self.seen.append("on_foo:{}:{}".format(type(event).__name__, event.handle.kind))
+                self.seen.append(f"on_foo:{type(event).__name__}:{event.handle.kind}")
                 event.defer()
 
             def _on_bar(self, event):
-                self.seen.append("on_bar:{}:{}".format(type(event).__name__, event.handle.kind))
+                self.seen.append(f"on_bar:{type(event).__name__}:{event.handle.kind}")
                 event.defer()
 
         pub = MyNotifier(framework, "1")

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -166,11 +166,11 @@ class TestFramework(BaseTestCase):
                 self.reprs = []
 
             def on_any(self, event):
-                self.seen.append("on_any:" + event.handle.kind)
+                self.seen.append(f"on_any:{event.handle.kind}")
                 self.reprs.append(repr(event))
 
             def on_foo(self, event):
-                self.seen.append("on_foo:" + event.handle.kind)
+                self.seen.append(f"on_foo:{event.handle.kind}")
                 self.reprs.append(repr(event))
 
         pub = MyNotifier(framework, "1")
@@ -530,7 +530,7 @@ class TestFramework(BaseTestCase):
         pub.on.foo.emit()
 
         self.assertEqual(obs.seen, ["on_foo:foo"])
-        fqn = pub.on.__class__.__module__ + "." + pub.on.__class__.__qualname__
+        fqn = f"{pub.on.__class__.__module__}.{pub.on.__class__.__qualname__}"
         self.assertEqual(repr(pub.on), f"<{fqn}: bar, foo>")
 
     def test_conflicting_event_attributes(self):

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -55,7 +55,7 @@ def fake_script(test_case, name, content):
     # TODO: this hardcodes the path to bash.exe, which works for now but might
     #       need to be set via environ or something like that.
     path.with_suffix(".bat").write_text(
-        '@"C:\\Program Files\\git\\bin\\bash.exe" {} %*\n'.format(path))
+        f'@"C:\\Program Files\\git\\bin\\bash.exe" {path} %*\n')
 
 
 def fake_script_calls(test_case, clear=False):

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -466,8 +466,7 @@ class TestLibFunctional(TestCase):
                     # everything-is-the-same :-)
                     continue
                 for patch_a in [38, 42]:
-                    desc = "A: {}/{}/{}; B: {}/{}/{}".format(
-                        pkg_a, lib_a, patch_a, pkg_b, lib_b, patch_b)
+                    desc = f"A: {pkg_a}/{lib_a}/{patch_a}; B: {pkg_b}/{lib_b}/{patch_b}"
                     with self.subTest(desc):
                         tmpdir = self._mkdtemp()
                         sys.path = [tmpdir]
@@ -504,8 +503,7 @@ class TestLibFunctional(TestCase):
         for pkg_a in ["foo", "fooA"]:
             for lib_a in ["bar", "barA"]:
                 for patch_a in [38, 42]:
-                    desc = "A: {}/{}/{}; B: {}/{}/{}".format(
-                        pkg_a, lib_a, patch_a, pkg_b, lib_b, patch_b)
+                    desc = f"A: {pkg_a}/{lib_a}/{patch_a}; B: {pkg_b}/{lib_b}/{patch_b}"
                     with self.subTest(desc):
                         tmp_dir_a = self._mkdtemp()
                         tmp_dir_b = self._mkdtemp()

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -134,14 +134,14 @@ class TestLogging(unittest.TestCase):
         with patch('sys.stderr', buffer):
             ops.log.setup_root_logging(self.backend, debug=True)
             logger = logging.getLogger()
-            logger.debug(f"{'l' * MAX_LOG_LINE_LEN}")
+            logger.debug('l' * MAX_LOG_LINE_LEN)
 
         self.assertEqual(len(self.backend.calls()), 1)
 
         self.backend.calls(clear=True)
 
         with patch('sys.stderr', buffer):
-            logger.debug(f"{'l' * (MAX_LOG_LINE_LEN + 9)}")
+            logger.debug('l' * (MAX_LOG_LINE_LEN + 9))
 
         calls = self.backend.calls()
         self.assertEqual(len(calls), 3)

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -134,14 +134,14 @@ class TestLogging(unittest.TestCase):
         with patch('sys.stderr', buffer):
             ops.log.setup_root_logging(self.backend, debug=True)
             logger = logging.getLogger()
-            logger.debug('{}'.format('l' * MAX_LOG_LINE_LEN))
+            logger.debug(f"{'l' * MAX_LOG_LINE_LEN}")
 
         self.assertEqual(len(self.backend.calls()), 1)
 
         self.backend.calls(clear=True)
 
         with patch('sys.stderr', buffer):
-            logger.debug('{}'.format('l' * (MAX_LOG_LINE_LEN + 9)))
+            logger.debug(f"{'l' * (MAX_LOG_LINE_LEN + 9)}")
 
         calls = self.backend.calls()
         self.assertEqual(len(calls), 3)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -68,7 +68,7 @@ TEST_CHARM_DIR = Path(__file__ + '/../charms/test_main').resolve()
 
 VERSION_LOGLINE = [
     'juju-log', '--log-level', 'DEBUG', '--',
-    'Operator Framework {} up and running.'.format(version),
+    f'Operator Framework {version} up and running.',
 ]
 
 logger = logging.getLogger(__name__)
@@ -699,7 +699,7 @@ class _TestMain(abc.ABC):
             '    raise RuntimeError."failing as requested".\n'
             'RuntimeError: failing as requested'
         )
-        self.assertEqual(len(calls), 1, "expected 1 call, but got extra: {}".format(calls[1:]))
+        self.assertEqual(len(calls), 1, f"expected 1 call, but got extra: {calls[1:]}")
 
     def test_sets_model_name(self):
         self._prepare_actions()
@@ -900,9 +900,9 @@ class _TestMainWithDispatch(_TestMain):
         expected = [
             VERSION_LOGLINE,
             ['juju-log', '--log-level', 'INFO', '--',
-             'Running legacy {}.'.format(hook)],
+             f'Running legacy {hook}.'],
             ['juju-log', '--log-level', 'DEBUG', '--',
-             'Legacy {} exited with status 0.'.format(hook)],
+             f'Legacy {hook} exited with status 0.'],
             ['juju-log', '--log-level', 'DEBUG', '--',
              'Using local storage: not a Kubernetes podspec charm'],
             ['juju-log', '--log-level', 'DEBUG', '--',
@@ -949,9 +949,9 @@ class _TestMainWithDispatch(_TestMain):
         hook = Path('hooks/install')
         expected = [
             VERSION_LOGLINE,
-            ['juju-log', '--log-level', 'INFO', '--', 'Running legacy {}.'.format(hook)],
+            ['juju-log', '--log-level', 'INFO', '--', f'Running legacy {hook}.'],
             ['juju-log', '--log-level', 'WARNING', '--',
-             'Legacy {} exited with status 42.'.format(hook)],
+             f'Legacy {hook} exited with status 42.'],
         ]
         self.assertEqual(calls, expected)
 
@@ -998,12 +998,12 @@ class _TestMainWithDispatch(_TestMain):
         expected = [
             VERSION_LOGLINE,
             ['juju-log', '--log-level', 'INFO', '--',
-             'Running legacy {}.'.format(hook)],
+             f'Running legacy {hook}.'],
             VERSION_LOGLINE,    # because it called itself
             ['juju-log', '--log-level', 'DEBUG', '--',
-             'Charm called itself via {}.'.format(hook)],
+             f'Charm called itself via {hook}.'],
             ['juju-log', '--log-level', 'DEBUG', '--',
-             'Legacy {} exited with status 0.'.format(hook)],
+             f'Legacy {hook} exited with status 0.'],
             ['juju-log', '--log-level', 'DEBUG', '--',
              'Using local storage: not a Kubernetes podspec charm'],
             ['juju-log', '--log-level', 'DEBUG', '--',

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -64,7 +64,7 @@ from .test_helpers import fake_script, fake_script_calls
 
 # This relies on the expected repository structure to find a path to
 # source of the charm under test.
-TEST_CHARM_DIR = Path(__file__ + '/../charms/test_main').resolve()
+TEST_CHARM_DIR = Path(f"{__file__}/../charms/test_main").resolve()
 
 VERSION_LOGLINE = [
     'juju-log', '--log-level', 'DEBUG', '--',
@@ -599,7 +599,7 @@ class _TestMain(abc.ABC):
         for event_spec, expected_event_data in events_under_test:
             state = self._simulate_event(event_spec)
 
-            state_key = 'on_' + event_spec.event_name
+            state_key = f"on_{event_spec.event_name}"
             handled_events = getattr(state, state_key, [])
 
             # Make sure that a handler for that event was called once.
@@ -611,7 +611,7 @@ class _TestMain(abc.ABC):
             self.assertEqual(list(state.observed_event_types), [event_spec.event_type.__name__])
 
             if event_spec.event_name in expected_event_data:
-                self.assertEqual(state[event_spec.event_name + '_data'],
+                self.assertEqual(state[f"{event_spec.event_name}_data"],
                                  expected_event_data[event_spec.event_name])
 
     def test_event_not_implemented(self):
@@ -792,7 +792,7 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
 
     def test_setup_event_links(self):
         """Test auto-creation of symlinks caused by initial events."""
-        all_event_hooks = ['hooks/' + e.replace("_", "-")
+        all_event_hooks = [f"hooks/{e.replace('_', '-')}"
                            for e in self.charm_module.Charm.on.events().keys()]
         initial_events = {
             EventSpec(InstallEvent, 'install'),
@@ -800,13 +800,13 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
             EventSpec(StartEvent, 'start'),
             EventSpec(UpgradeCharmEvent, 'upgrade-charm'),
         }
-        initial_hooks = {'hooks/' + ev.event_name for ev in initial_events}
+        initial_hooks = {f"hooks/{ev.event_name}" for ev in initial_events}
 
         def _assess_event_links(event_spec):
             self.assertTrue(self.hooks_dir / event_spec.event_name in self.hooks_dir.iterdir())
             for event_hook in all_event_hooks:
                 hook_path = self.JUJU_CHARM_DIR / event_hook
-                self.assertTrue(hook_path.exists(), 'Missing hook: ' + event_hook)
+                self.assertTrue(hook_path.exists(), f"Missing hook: {event_hook}")
                 if self.hooks_are_symlinks:
                     self.assertTrue(hook_path.is_symlink())
                     self.assertEqual(os.readlink(str(hook_path)), self.charm_exec_path)
@@ -864,7 +864,7 @@ class _TestMainWithDispatch(_TestMain):
 
         Symlink creation caused by initial events should _not_ happen when using dispatch.
         """
-        all_event_hooks = ['hooks/' + e.replace("_", "-")
+        all_event_hooks = [f"hooks/{e.replace('_', '-')}"
                            for e in self.charm_module.Charm.on.events().keys()]
         initial_events = {
             EventSpec(InstallEvent, 'install'),
@@ -877,7 +877,7 @@ class _TestMainWithDispatch(_TestMain):
             self.assertNotIn(self.hooks_dir / event_spec.event_name, self.hooks_dir.iterdir())
             for event_hook in all_event_hooks:
                 self.assertFalse((self.JUJU_CHARM_DIR / event_hook).exists(),
-                                 'Spurious hook: ' + event_hook)
+                                 f"Spurious hook: {event_hook}")
 
         for initial_event in initial_events:
             self._setup_charm_dir()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -128,7 +128,7 @@ class TestModel(unittest.TestCase):
 
         with self.assertRaises(ops.model.ModelError):
             # You have to specify it by just the integer ID
-            self.model.get_relation('db1', 'db1:{}'.format(relation_id_db1))
+            self.model.get_relation('db1', f'db1:{relation_id_db1}')
         rel_db1 = self.model.get_relation('db1', relation_id_db1)
         self.assertIsInstance(rel_db1, ops.model.Relation)
         self.assertBackendCalls([
@@ -1048,8 +1048,7 @@ def test_recursive_list(case):
             _, path = f.path, ops.model.Container._build_destpath(
                 f.path, case.path, case.dst)
         files.add(path)
-    assert case.want == files, 'case {!r} has wrong files: want {}, got {}'.format(
-        case.name, case.want, files)
+    assert case.want == files, f'case {case.name!r} has wrong files: want {case.want}, got {files}'
 
 
 recursive_push_pull_cases = [
@@ -1160,9 +1159,9 @@ def test_recursive_push_and_pull(case):
         errors = {src[len(push_src.name):] for src, _ in err.errors}
 
     assert case.errors == errors, \
-        'push_path gave wrong expected errors: want {}, got {}'.format(case.errors, errors)
+        f'push_path gave wrong expected errors: want {case.errors}, got {errors}'
     for fpath in case.want:
-        assert c.exists(fpath), 'push_path failed: file {} missing at destination'.format(fpath)
+        assert c.exists(fpath), f'push_path failed: file {fpath} missing at destination'
 
     # create pull test case filesystem structure
     pull_dst = tempfile.TemporaryDirectory()
@@ -1179,9 +1178,9 @@ def test_recursive_push_and_pull(case):
         errors = {src for src, _ in err.errors}
 
     assert case.errors == errors, \
-        'pull_path gave wrong expected errors: want {}, got {}'.format(case.errors, errors)
+        f'pull_path gave wrong expected errors: want {case.errors}, got {errors}'
     for fpath in case.want:
-        assert c.exists(fpath), 'pull_path failed: file {} missing at destination'.format(fpath)
+        assert c.exists(fpath), f'pull_path failed: file {fpath} missing at destination'
 
 
 class TestApplication(unittest.TestCase):
@@ -1969,14 +1968,14 @@ class TestModelBindings(unittest.TestCase):
         fake_script(
             self,
             'network-get',
-            '''
+            f'''
                 if [ "$1" = db0 ] && [ "$2" = --format=json ]; then
-                    echo '{}'
+                    echo '{self.network_get_out}'
                 else
                     echo ERROR invalid value "$2" for option -r: relation not found >&2
                     exit 2
                 fi
-            '''.format(self.network_get_out))
+            ''')
         # Validate the behavior for dead relations.
         binding = ops.model.Binding('db0', 42, self.model._backend)
         self.assertEqual(binding.network.bind_address, ipaddress.ip_address('192.0.2.2'))
@@ -1987,7 +1986,7 @@ class TestModelBindings(unittest.TestCase):
 
     def test_binding_by_relation_name(self):
         fake_script(self, 'network-get',
-                    '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(self.network_get_out))
+                    f'''[ "$1" = db0 ] && echo '{self.network_get_out}' || exit 1''')
         binding_name = 'db0'
         expected_calls = [['network-get', 'db0', '--format=json']]
 
@@ -1997,7 +1996,7 @@ class TestModelBindings(unittest.TestCase):
 
     def test_binding_by_relation(self):
         fake_script(self, 'network-get',
-                    '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(self.network_get_out))
+                    f'''[ "$1" = db0 ] && echo '{self.network_get_out}' || exit 1''')
         binding_name = 'db0'
         expected_calls = [
             ['relation-ids', 'db0', '--format=json'],
@@ -2033,7 +2032,7 @@ class TestModelBindings(unittest.TestCase):
         }
         network_get_out = json.dumps(network_get_out_obj)
         fake_script(self, 'network-get',
-                    '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(network_get_out))
+                    f'''[ "$1" = db0 ] && echo '{network_get_out}' || exit 1''')
         binding_name = 'db0'
         expected_calls = [['network-get', 'db0', '--format=json']]
 
@@ -2046,7 +2045,7 @@ class TestModelBindings(unittest.TestCase):
     def test_missing_bind_addresses(self):
         network_data = json.dumps({})
         fake_script(self, 'network-get',
-                    '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(network_data))
+                    f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
         binding_name = 'db0'
         binding = self.model.get_binding(self.model.get_relation(binding_name))
         self.assertEqual(binding.network.interfaces, [])
@@ -2054,7 +2053,7 @@ class TestModelBindings(unittest.TestCase):
     def test_empty_bind_addresses(self):
         network_data = json.dumps({'bind-addresses': [{}]})
         fake_script(self, 'network-get',
-                    '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(network_data))
+                    f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
         binding_name = 'db0'
         binding = self.model.get_binding(self.model.get_relation(binding_name))
         self.assertEqual(binding.network.interfaces, [])
@@ -2062,7 +2061,7 @@ class TestModelBindings(unittest.TestCase):
     def test_no_bind_addresses(self):
         network_data = json.dumps({'bind-addresses': [{'addresses': None}]})
         fake_script(self, 'network-get',
-                    '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(network_data))
+                    f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
         binding_name = 'db0'
         binding = self.model.get_binding(self.model.get_relation(binding_name))
         self.assertEqual(binding.network.interfaces, [])
@@ -2075,7 +2074,7 @@ class TestModelBindings(unittest.TestCase):
             }],
         })
         fake_script(self, 'network-get',
-                    '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(network_data))
+                    f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
         binding_name = 'db0'
         binding = self.model.get_binding(self.model.get_relation(binding_name))
         self.assertEqual(len(binding.network.interfaces), 1)
@@ -2088,7 +2087,7 @@ class TestModelBindings(unittest.TestCase):
             'bind-addresses': [],
         })
         fake_script(self, 'network-get',
-                    '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(network_data))
+                    f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
         binding_name = 'db0'
         binding = self.model.get_binding(self.model.get_relation(binding_name))
         self.assertEqual(binding.network.ingress_addresses, [])
@@ -2100,7 +2099,7 @@ class TestModelBindings(unittest.TestCase):
             'ingress-addresses': [],
         })
         fake_script(self, 'network-get',
-                    '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(network_data))
+                    f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
         binding_name = 'db0'
         binding = self.model.get_binding(self.model.get_relation(binding_name))
         self.assertEqual(binding.network.egress_subnets, [])
@@ -2114,7 +2113,7 @@ class TestModelBindings(unittest.TestCase):
             ],
         })
         fake_script(self, 'network-get',
-                    '''[ "$1" = db0 ] && echo '{}' || exit 1'''.format(network_data))
+                    f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
         binding_name = 'db0'
         binding = self.model.get_binding(self.model.get_relation(binding_name))
         self.assertEqual(binding.network.ingress_addresses, ['foo.bar.baz.com'])
@@ -2179,7 +2178,7 @@ class TestModelBackend(unittest.TestCase):
             ops.model.ModelError,
             [['relation-list', '-r', '3', '--format=json']],
         ), (
-            lambda: fake_script(self, 'relation-list', 'echo {} >&2 ; exit 2'.format(err_msg)),
+            lambda: fake_script(self, 'relation-list', f'echo {err_msg} >&2 ; exit 2'),
             lambda: self.backend.relation_list(3),
             ops.model.RelationNotFoundError,
             [['relation-list', '-r', '3', '--format=json']],
@@ -2189,7 +2188,7 @@ class TestModelBackend(unittest.TestCase):
             ops.model.ModelError,
             [['relation-set', '-r', '3', '--file', '-']],
         ), (
-            lambda: fake_script(self, 'relation-set', 'echo {} >&2 ; exit 2'.format(err_msg)),
+            lambda: fake_script(self, 'relation-set', f'echo {err_msg} >&2 ; exit 2'),
             lambda: self.backend.relation_set(3, 'foo', 'bar', is_app=False),
             ops.model.RelationNotFoundError,
             [['relation-set', '-r', '3', '--file', '-']],
@@ -2204,7 +2203,7 @@ class TestModelBackend(unittest.TestCase):
             ops.model.ModelError,
             [['relation-get', '-r', '3', '-', 'remote/0', '--format=json']],
         ), (
-            lambda: fake_script(self, 'relation-get', 'echo {} >&2 ; exit 2'.format(err_msg)),
+            lambda: fake_script(self, 'relation-get', f'echo {err_msg} >&2 ; exit 2'),
             lambda: self.backend.relation_get(3, 'remote/0', is_app=False),
             ops.model.RelationNotFoundError,
             [['relation-get', '-r', '3', '-', 'remote/0', '--format=json']],
@@ -2273,7 +2272,7 @@ class TestModelBackend(unittest.TestCase):
     def test_status_get(self):
         # taken from actual Juju output
         content = '{"message": "", "status": "unknown", "status-data": {}}'
-        fake_script(self, 'status-get', "echo '{}'".format(content))
+        fake_script(self, 'status-get', f"echo '{content}'")
         s = self.backend.status_get(is_app=False)
         self.assertEqual(s['status'], "unknown")
         self.assertEqual(s['message'], "")
@@ -2294,7 +2293,7 @@ class TestModelBackend(unittest.TestCase):
                 }
             }
             """)
-        fake_script(self, 'status-get', "echo '{}'".format(content))
+        fake_script(self, 'status-get', f"echo '{content}'")
         s = self.backend.status_get(is_app=True)
         self.assertEqual(s['status'], "maintenance")
         self.assertEqual(s['message'], "installing")
@@ -2368,7 +2367,7 @@ class TestModelBackend(unittest.TestCase):
                     "status": name,
                     "status-data": {},
                 })
-                fake_script(self, 'status-get', "echo '{}'".format(content))
+                fake_script(self, 'status-get', f"echo '{content}'")
 
                 self.assertIsInstance(model.unit.status, expected_cls)
                 self.assertEqual(model.unit.status.name, name)
@@ -2381,7 +2380,7 @@ class TestModelBackend(unittest.TestCase):
                         "status-data": {},
                     }
                 })
-                fake_script(self, 'status-get', "echo '{}'".format(content))
+                fake_script(self, 'status-get', f"echo '{content}'")
                 fake_script(self, 'is-leader', 'echo true')
 
                 self.assertIsInstance(model.app.status, expected_cls)
@@ -2449,7 +2448,7 @@ class TestModelBackend(unittest.TestCase):
   ]
 }'''
         fake_script(self, 'network-get',
-                    '''[ "$1" = deadbeef ] && echo '{}' || exit 1'''.format(network_get_out))
+                    f'''[ "$1" = deadbeef ] && echo '{network_get_out}' || exit 1''')
         network_info = self.backend.network_get('deadbeef')
         self.assertEqual(network_info, json.loads(network_get_out))
         self.assertEqual(fake_script_calls(self, clear=True),
@@ -2466,12 +2465,12 @@ class TestModelBackend(unittest.TestCase):
 
         test_cases = [(
             lambda: fake_script(self, 'network-get',
-                                'echo {} >&2 ; exit 1'.format(err_no_endpoint)),
+                                f'echo {err_no_endpoint} >&2 ; exit 1'),
             lambda: self.backend.network_get("deadbeef"),
             ops.model.ModelError,
             [['network-get', 'deadbeef', '--format=json']],
         ), (
-            lambda: fake_script(self, 'network-get', 'echo {} >&2 ; exit 2'.format(err_no_rel)),
+            lambda: fake_script(self, 'network-get', f'echo {err_no_rel} >&2 ; exit 2'),
             lambda: self.backend.network_get("deadbeef", 3),
             ops.model.RelationNotFoundError,
             [['network-get', 'deadbeef', '-r', '3', '--format=json']],

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -1206,9 +1206,9 @@ class TestMultipartParser(unittest.TestCase):
                     self.assertEqual(test.error, str(err))
                 else:
                     if test.error:
-                        self.fail('missing expected error: {!r}'.format(test.error))
+                        self.fail(f'missing expected error: {test.error!r}')
 
-                    msg = 'test case {} ({}), chunk size {}'.format(i + 1, test.name, chunk_size)
+                    msg = f'test case {i + 1} ({test.name}), chunk size {chunk_size}'
                     self.assertEqual(test.want_headers, headers, msg)
                     self.assertEqual(test.want_bodies, bodies, msg)
                     self.assertEqual(test.want_bodies_done, bodies_done, msg)
@@ -2617,7 +2617,7 @@ class TestExec(unittest.TestCase):
             'command': command,
             'environment': environment or {},
             'working-dir': working_dir,
-            'timeout': '{:.3f}s'.format(timeout) if timeout is not None else None,
+            'timeout': f'{timeout:.3f}s' if timeout is not None else None,
             'user-id': user_id,
             'user': user,
             'group-id': group_id,
@@ -3316,7 +3316,7 @@ class TestRealPebble(unittest.TestCase):
         self.assertEqual(err, b'')
 
     def test_push_pull(self):
-        fname = os.path.join(tempfile.gettempdir(), 'pebbletest-{}'.format(uuid.uuid4()))
+        fname = os.path.join(tempfile.gettempdir(), f'pebbletest-{uuid.uuid4()}')
         content = 'foo\nbar\nbaz-42'
         self.client.push(fname, content)
         with self.client.pull(fname) as f:

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -2586,7 +2586,7 @@ class TestExec(unittest.TestCase):
         self.addCleanup(time_patcher.stop)
 
     def add_responses(self, change_id, exit_code, change_err=None):
-        task_id = 'T' + change_id  # create a task_id based on change_id
+        task_id = f"T{change_id}"  # create a task_id based on change_id
         self.client.responses.append({
             'change': change_id,
             'result': {'task-id': task_id},
@@ -3334,7 +3334,7 @@ class TestRealPebble(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             process = self.client.exec(['pwd'], working_dir=temp_dir)
             out, err = process.wait_output()
-            self.assertEqual(out, temp_dir + '\n')
+            self.assertEqual(out, f"{temp_dir}\n")
             self.assertEqual(err, '')
 
     def test_exec_environment(self):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1546,7 +1546,7 @@ class TestHarness(unittest.TestCase):
 
         stor_id = harness.add_storage("test")[0]
         with self.assertRaises(RuntimeError) as cm:
-            harness.detach_storage("test/{}".format(stor_id))
+            harness.detach_storage(f"test/{stor_id}")
         self.assertEqual(cm.exception.args[0],
                          "cannot detach storage before Harness is initialised")
 
@@ -2976,7 +2976,7 @@ class TestTestingModelBackend(unittest.TestCase):
         self.assertIsNotNone(backend._resource_dir)
         self.assertTrue(
             str(path).startswith(str(backend._resource_dir.name)),
-            msg='expected {} to be a subdirectory of {}'.format(path, backend._resource_dir.name))
+            msg=f'expected {path} to be a subdirectory of {backend._resource_dir.name}')
 
     def test_resource_get_no_resource(self):
         harness = Harness(CharmBase, meta='''
@@ -3956,7 +3956,7 @@ class _PebbleStorageAPIsTestMixin:
             -1,      # Less than 0o000
         )):
             with self.assertRaises(pebble.PathError) as cm:
-                client.make_dir(self.prefix + '/dir3_{}'.format(i), permissions=bad_permission)
+                client.make_dir(self.prefix + f'/dir3_{i}', permissions=bad_permission)
             self.assertEqual(cm.exception.kind, 'generic-file-error')
 
     def test_remove_path(self):


### PR DESCRIPTION
Now that we require Python 3.8+, we can use f-strings (introduced in Python 3.6). This conversion was done automatically using the [Flynt](https://github.com/ikamensh/flynt) tool in two steps (separate commits):

* Base step to upgrade `.format()` to f-strings: `flynt -ll 100 --exclude ops/_vendor/ -- .`
* Also use f-strings for string concatenations (helps in most cases): `flynt -ll 100 -tc --exclude ops/_vendor/ -- .`

All tests pass. I haven't done a thorough check over the diff yet, but will before merging.

The intention is to do further upgrades (variable type annotations, and so on) in future PRs.