### PR TITLE
Reenable alertmanager-operator tests now that charm is fixed on ops 2.0

### DIFF
--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -9,10 +9,9 @@ jobs:
     strategy:
       matrix:
         charm-repo:
-# TODO(benhoyt): uncomment this once this charm's tests are fixed for 2.0.0
-#          - "canonical/alertmanager-operator"
-          - "canonical/prometheus-operator"
-          - "canonical/grafana-operator"
+          - "canonical/alertmanager-k8s-operator"
+          - "canonical/prometheus-k8s-operator"
+          - "canonical/grafana-k8s-operator"
 
     steps:
       - name: Checkout the ${{ matrix.charm-repo }} repository


### PR DESCRIPTION
Also update these repos to their new (redirected) URLs.

Reverts when this was commented out in https://github.com/canonical/operator/pull/885