### PR TITLE
Make testing pull() raise pebble.PathError and improve docs

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1936,6 +1936,10 @@ class Container:
             A readable file-like object, whose read() method will return str
             objects decoded according to the specified encoding, or bytes if
             encoding is None.
+
+        Raises:
+            pebble.PathError: If there was an error reading the file at path,
+                for example, if the file doesn't exist or is a directory.
         """
         return self._pebble.pull(str(path), encoding=encoding)
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -307,7 +307,7 @@ class PathError(Error):
 
     Attributes:
         kind: A short string representing the kind of error. Possible values
-            are 'not-found', 'permission-denied', and 'generic-file-error'.
+            are "not-found", "permission-denied", and "generic-file-error".
         message: A human-readable error message.
     """
 
@@ -321,26 +321,6 @@ class PathError(Error):
 
     def __repr__(self):
         return f'PathError({self.kind!r}, {self.message!r})'
-
-
-class NotFoundError(FileNotFoundError, PathError):
-    """A subclass of PathError specifically for file-not-found errors.
-
-    This also inherits from the builtin FileNotFoundError so that you can
-    simply catch the builtin FileNotFoundError instead of catching
-    :class:`PathError` and checking the :code:`kind` attribute.
-
-    Attributes:
-        filename: The filename (path) of the file in question. Named
-            "filename" instead of "path" to match the attribute of the builtin
-            :code:`OSError` class.
-    """
-
-    def __init__(self, kind: str, message: str, filename: str):
-        """This shouldn't be instantiated directly."""
-        self.kind = kind
-        self.message = message
-        self.filename = filename
 
 
 class APIError(Error):
@@ -1874,8 +1854,6 @@ class Client:
             raise ProtocolError(f'path not found in response metadata: {resp}')
         error = paths[path].get('error')
         if error:
-            if error['kind'] == 'not-found':
-                raise NotFoundError(error['kind'], error['message'], path)
             raise PathError(error['kind'], error['message'])
 
     def push(

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -303,14 +303,17 @@ class ProtocolError(Error):
 
 
 class PathError(Error):
-    """Raised when there's an error with a specific path."""
+    """Raised when there's an error with a specific path.
+
+    Attributes:
+        kind: A short string representing the kind of error. Possible values
+            are 'not-found', 'permission-denied', and 'generic-file-error'.
+    """
 
     def __init__(self, kind: str, message: str):
         """This shouldn't be instantiated directly."""
         self.kind = kind
-        # FIXME: pyright rightfully complains that super().message is a method
-        #  see: https://github.com/canonical/operator/issues/777
-        self.message = message  # type: ignore
+        self.message = message
 
     def __str__(self):
         return f'{self.kind} - {self.message}'
@@ -1797,6 +1800,10 @@ class Client:
             A readable file-like object, whose read() method will return str
             objects decoded according to the specified encoding, or bytes if
             encoding is None.
+
+        Raises:
+            PathError: If there was an error reading the file at path, for
+                example, if the file doesn't exist or is a directory.
         """
         query = {
             'action': 'read',

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -308,6 +308,7 @@ class PathError(Error):
     Attributes:
         kind: A short string representing the kind of error. Possible values
             are 'not-found', 'permission-denied', and 'generic-file-error'.
+        message: A human-readable error message.
     """
 
     def __init__(self, kind: str, message: str):
@@ -320,6 +321,26 @@ class PathError(Error):
 
     def __repr__(self):
         return f'PathError({self.kind!r}, {self.message!r})'
+
+
+class NotFoundError(FileNotFoundError, PathError):
+    """A subclass of PathError specifically for file-not-found errors.
+
+    This also inherits from the builtin FileNotFoundError so that you can
+    simply catch the builtin FileNotFoundError instead of catching
+    :class:`PathError` and checking the :code:`kind` attribute.
+
+    Attributes:
+        filename: The filename (path) of the file in question. Named
+            "filename" instead of "path" to match the attribute of the builtin
+            :code:`OSError` class.
+    """
+
+    def __init__(self, kind: str, message: str, filename: str):
+        """This shouldn't be instantiated directly."""
+        self.kind = kind
+        self.message = message
+        self.filename = filename
 
 
 class APIError(Error):
@@ -1853,6 +1874,8 @@ class Client:
             raise ProtocolError(f'path not found in response metadata: {resp}')
         error = paths[path].get('error')
         if error:
+            if error['kind'] == 'not-found':
+                raise NotFoundError(error['kind'], error['message'], path)
             raise PathError(error['kind'], error['message'])
 
     def push(

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -126,7 +126,7 @@ class Harness(Generic[CharmType]):
 
     Args:
         charm_cls: The Charm class that you'll be testing.
-        meta: charm.CharmBase is a A string or file-like object containing the contents of
+        meta: A string or file-like object containing the contents of
             metadata.yaml. If not supplied, we will look for a 'metadata.yaml' file in the
             parent directory of the Charm, and if not found fall back to a trivial
             'name: test-charm' metadata.

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2286,7 +2286,8 @@ class _TestingPebbleClient:
         try:
             return self._fs.open(path, encoding=encoding)
         except FileNotFoundError:
-            raise pebble.PathError('not-found', f'stat {path}: no such file or directory')
+            raise pebble.NotFoundError(
+                'not-found', f'stat {path}: no such file or directory', path)
         except IsADirectoryError:
             raise pebble.PathError('generic-file-error', f'can only read a regular file: "{path}"')
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2286,8 +2286,7 @@ class _TestingPebbleClient:
         try:
             return self._fs.open(path, encoding=encoding)
         except FileNotFoundError:
-            raise pebble.NotFoundError(
-                'not-found', f'stat {path}: no such file or directory', path)
+            raise pebble.PathError('not-found', f'stat {path}: no such file or directory')
         except IsADirectoryError:
             raise pebble.PathError('generic-file-error', f'can only read a regular file: "{path}"')
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2283,7 +2283,12 @@ class _TestingPebbleClient:
     def pull(self, path: str, *,
              encoding: str = 'utf-8') -> Union[BinaryIO, TextIO]:
         self._check_connection()
-        return self._fs.open(path, encoding=encoding)
+        try:
+            return self._fs.open(path, encoding=encoding)
+        except FileNotFoundError:
+            raise pebble.PathError('not-found', f'stat {path}: no such file or directory')
+        except IsADirectoryError:
+            raise pebble.PathError('generic-file-error', f'can only read a regular file: "{path}"')
 
     def push(
             self, path: str, source: 'ReadableBuffer', *,

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3856,12 +3856,6 @@ class _PebbleStorageAPIsTestMixin:
         self.assertEqual(cm.exception.kind, "not-found")
         self.assertIn("/not/found", cm.exception.message)
 
-        # Should also be a pebble.NotFoundError and a FileNotFoundError
-        with self.assertRaises(pebble.NotFoundError):
-            self.client.pull("/not/found")
-        with self.assertRaises(FileNotFoundError):
-            self.client.pull("/not/found")
-
     def test_pull_directory(self):
         self.client.make_dir(f"{self.prefix}/subdir")
         with self.assertRaises(pebble.PathError) as cm:

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3850,6 +3850,19 @@ class _PebbleStorageAPIsTestMixin:
             client.push('file', '')
         self.assertEqual(cm.exception.kind, 'generic-file-error')
 
+    def test_pull_not_found(self):
+        with self.assertRaises(pebble.PathError) as cm:
+            self.client.pull("/not/found")
+        self.assertEqual(cm.exception.kind, "not-found")
+        self.assertIn("/not/found", cm.exception.message)
+
+    def test_pull_directory(self):
+        self.client.make_dir(f"{self.prefix}/subdir")
+        with self.assertRaises(pebble.PathError) as cm:
+            self.client.pull(f"{self.prefix}/subdir")
+        self.assertEqual(cm.exception.kind, "generic-file-error")
+        self.assertIn(f"{self.prefix}/subdir", cm.exception.message)
+
     def test_list_files_not_found_raises(self):
         client = self.client
         with self.assertRaises(pebble.APIError) as cm:

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3856,6 +3856,12 @@ class _PebbleStorageAPIsTestMixin:
         self.assertEqual(cm.exception.kind, "not-found")
         self.assertIn("/not/found", cm.exception.message)
 
+        # Should also be a pebble.NotFoundError and a FileNotFoundError
+        with self.assertRaises(pebble.NotFoundError):
+            self.client.pull("/not/found")
+        with self.assertRaises(FileNotFoundError):
+            self.client.pull("/not/found")
+
     def test_pull_directory(self):
         self.client.make_dir(f"{self.prefix}/subdir")
         with self.assertRaises(pebble.PathError) as cm:


### PR DESCRIPTION
Currently the testing harness's version of pull() raises FileNotFoundError and IsADirectoryError instead of pebble.PathError, which is what the real pull() raises in these situations. Catch those and raise the same error as in real life.

Also document this better in the relevant docstrings.

There are probably other places the testing file system's errors leak out, but keep this PR limited in scope to just pull().

Also remove an unnecessary Pyright FIXME -- this was addressed when the message() method was removed recently.

Fixes #896
