### PR TITLE
Make secret-get consistently use "secret:<id>" fmt to avoid confusion

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -276,6 +276,9 @@ class Model:
         """
         if not (id or label):
             raise TypeError('Must provide an id or label, or both')
+        if id is not None:
+            # Canonicalize to "secret:<id>" form for consistency in backend calls.
+            id = Secret._canonicalize_id(id)
         try:
             content = self._backend.secret_get(id=id, label=label)
             return Secret(self._backend, id=id, label=label, content=content)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -2841,7 +2841,18 @@ class TestSecrets(unittest.TestCase):
         self.assertEqual(secret.get_content(), {'foo': 'g'})
 
         self.assertEqual(fake_script_calls(self, clear=True),
-                         [['secret-get', '123', '--format=json']])
+                         [['secret-get', 'secret:123', '--format=json']])
+
+    def test_get_secret_label(self):
+        fake_script(self, 'secret-get', """echo '{"foo": "g"}'""")
+
+        secret = self.model.get_secret(label='lbl')
+        self.assertIsNone(secret.id)
+        self.assertEqual(secret.label, 'lbl')
+        self.assertEqual(secret.get_content(), {'foo': 'g'})
+
+        self.assertEqual(fake_script_calls(self, clear=True),
+                         [['secret-get', '--label', 'lbl', '--format=json']])
 
     def test_get_secret_id_and_label(self):
         fake_script(self, 'secret-get', """echo '{"foo": "h"}'""")
@@ -2852,7 +2863,7 @@ class TestSecrets(unittest.TestCase):
         self.assertEqual(secret.get_content(), {'foo': 'h'})
 
         self.assertEqual(fake_script_calls(self, clear=True),
-                         [['secret-get', '123', '--label', 'l', '--format=json']])
+                         [['secret-get', 'secret:123', '--label', 'l', '--format=json']])
 
     def test_get_secret_no_args(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
This won't actually fix any `ops` issues in the field, but it makes the backend calls more consistent and less confusing.

Also add test for label-only Model.get_secret() variant.

Fixes #902

