### PR TITLE
Replace "# type: T" comments with proper variable type annotations

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -450,10 +450,10 @@ class RelationEvent(HookEvent):
 
         Not meant to be called by charm code.
         """
-        snapshot = {
+        snapshot: 'RelationEvent._RelationEventSnapshot' = {
             'relation_name': self.relation.name,
             'relation_id': self.relation.id,
-        }  # type: 'RelationEvent._RelationEventSnapshot'
+        }
         if self.app:
             snapshot['app_name'] = self.app.name
         if self.unit:
@@ -626,7 +626,7 @@ class StorageEvent(HookEvent):
 
         Not meant to be called by charm code.
         """
-        snapshot = {}  # type: '_StorageEventSnapshot'
+        snapshot: '_StorageEventSnapshot' = {}
         if isinstance(self.storage, model.Storage):
             snapshot["storage_name"] = self.storage.name
             snapshot["storage_index"] = self.storage.index
@@ -712,7 +712,7 @@ class WorkloadEvent(HookEvent):
 
         Not meant to be called by charm code.
         """
-        snapshot = {}  # type: "_WorkloadEventSnapshot"
+        snapshot: "_WorkloadEventSnapshot" = {}
         if isinstance(self.workload, model.Container):
             snapshot['container_name'] = self.workload.name
         return snapshot
@@ -1083,13 +1083,13 @@ class CharmMeta:
                  raw: Optional['_CharmMetaDict'] = None,  # type: ignore
                  actions_raw: '_ActionsRaw' = None  # type: ignore
                  ):
-        raw = raw or cast('_CharmMetaDict', {})  # type: _CharmMetaDict
-        actions_raw = actions_raw or {}  # type: Dict[str, _ActionMetaDict]
+        raw: _CharmMetaDict = raw or cast('_CharmMetaDict', {})
+        actions_raw: Dict[str, _ActionMetaDict] = actions_raw or {}
 
         self.name = raw.get('name', '')
         self.summary = raw.get('summary', '')
         self.description = raw.get('description', '')
-        self.maintainers = []  # type: List[str]
+        self.maintainers: List[str] = []
         if 'maintainer' in raw:
             self.maintainers.append(raw['maintainer'])
         if 'maintainers' in raw:
@@ -1105,7 +1105,7 @@ class CharmMeta:
                          for name, rel in raw.get('provides', {}).items()}
         self.peers = {name: RelationMeta(RelationRole.peer, name, rel)
                       for name, rel in raw.get('peers', {}).items()}
-        self.relations = {}  # type: Dict[str, RelationMeta]
+        self.relations: Dict[str, RelationMeta] = {}
         self.relations.update(self.requires)
         self.relations.update(self.provides)
         self.relations.update(self.peers)
@@ -1283,7 +1283,7 @@ class ContainerMeta:
 
     def __init__(self, name: str, raw: '_ContainerMetaDict'):
         self.name = name
-        self._mounts = {}  # type: Dict[str, ContainerStorageMeta]
+        self._mounts: Dict[str, ContainerStorageMeta] = {}
 
         # This is not guaranteed to be populated/is not enforced yet
         if raw:
@@ -1345,7 +1345,7 @@ class ContainerStorageMeta:
 
     def __init__(self, storage: str, location: str):
         self.storage = storage
-        self._locations = [location]  # type: List[str]
+        self._locations: List[str] = [location]
 
     def add_location(self, location: str):
         """Add an additional mountpoint to a known storage."""

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -184,7 +184,7 @@ class ActionEvent(EventBase):
                                'action ({})'.format(event_action_name, env_action_name))
         # Params are loaded at restore rather than __init__ because
         # the model is not available in __init__.
-        self.params = self.framework.model._backend.action_get()  # pyright: reportPrivateUsage=false  # noqa
+        self.params = self.framework.model._backend.action_get()
 
     def set_results(self, results: '_SerializedData'):
         """Report the result of the action.
@@ -1182,14 +1182,15 @@ class RelationMeta:
     VALID_SCOPES = ['global', 'container']
 
     def __init__(self, role: RelationRole, relation_name: str, raw: '_RelationMetaDict'):
-        assert isinstance(role, RelationRole), f"role should be one of {list(RelationRole)!r}, not {role!r}"  # noqa
+        assert isinstance(role, RelationRole), \
+            f"role should be one of {list(RelationRole)!r}, not {role!r}"
         self._default_scope = self.VALID_SCOPES[0]
         self.role = role
         self.relation_name = relation_name
         self.interface_name = raw['interface']
 
         self.limit = limit = raw.get('limit', None)
-        if limit is not None and not isinstance(limit, int):  # type: ignore  # noqa
+        if limit is not None and not isinstance(limit, int):  # type: ignore
             raise TypeError(f"limit should be an int, not {type(limit)}")
 
         self.scope = raw.get('scope') or self._default_scope

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -293,8 +293,8 @@ class EventSource(Generic[_EventType]):
             raise RuntimeError(
                 f'Event requires a subclass of EventBase as an argument, got {event_type}')
         self.event_type: Type[_EventType] = event_type
-        self.event_kind: Optional[str] = None  # noqa
-        self.emitter_type: Optional[Type[Object]] = None  # noqa
+        self.event_kind: Optional[str] = None
+        self.emitter_type: Optional[Type[Object]] = None
 
     def __set_name__(self, emitter_type: 'Type[Object]', event_kind: str):
         if self.event_kind is not None:
@@ -348,10 +348,10 @@ class BoundEvent(Generic[_EventType]):
         The current storage state is committed before and after each observer is notified.
         """
         framework = self.emitter.framework
-        key = framework._next_event_key()  # noqa
+        key = framework._next_event_key()
         event = self.event_type(Handle(self.emitter, self.event_kind, key), *args, **kwargs)
         event.framework = framework
-        framework._emit(event)  # noqa
+        framework._emit(event)
 
 
 class HandleKind:
@@ -396,8 +396,8 @@ class Object:
         def on(self) -> 'ObjectEvents': ...  # noqa
 
     def __init__(self, parent: Union['Framework', 'Object'], key: Optional[str]):
-        self.framework: Framework = None  # noqa
-        self.handle: Handle = None  # noqa
+        self.framework: Framework = None
+        self.handle: Handle = None
 
         kind = self.handle_kind
         if isinstance(parent, Framework):
@@ -409,7 +409,7 @@ class Object:
         else:
             self.framework = parent.framework
             self.handle = Handle(parent, kind, key)
-        self.framework._track(self)  # noqa
+        self.framework._track(self)
 
         # TODO Detect conflicting handles here.
 
@@ -427,7 +427,8 @@ class ObjectEvents(Object):
     def __init__(self, parent: Optional[Object] = None, key: Optional[str] = None):
         if parent is not None:
             super().__init__(parent, key)
-        self._cache: weakref.WeakKeyDictionary[Object, 'ObjectEvents'] = weakref.WeakKeyDictionary()  # noqa
+        self._cache: weakref.WeakKeyDictionary[Object, 'ObjectEvents'] = \
+            weakref.WeakKeyDictionary()
 
     def __get__(self, emitter: Object, emitter_type: 'Type[Object]'):
         if emitter is None:
@@ -592,9 +593,9 @@ class Framework(Object):
         # [(observer_path, method_name, parent_path, event_key)]
         self._observers: _ObserverPath = []
         # {observer_path: observing Object}
-        self._observer: _PathToObjectMapping = weakref.WeakValueDictionary()  # noqa
+        self._observer: _PathToObjectMapping = weakref.WeakValueDictionary()
         # {object_path: object}
-        self._objects: _PathToSerializableMapping = weakref.WeakValueDictionary()  # noqa
+        self._objects: _PathToSerializableMapping = weakref.WeakValueDictionary()
         # {(parent_path, kind): cls}
         # (parent_path, kind) is the address of _this_ object: the parent path
         # plus a 'kind' string that is the name of this object.
@@ -611,9 +612,9 @@ class Framework(Object):
         self.register_type(StoredStateData, None, StoredStateData.handle_kind)
         stored_handle = Handle(None, StoredStateData.handle_kind, '_stored')
         try:
-            self._stored = typing.cast(StoredStateData, self.load_snapshot(stored_handle))  # noqa
+            self._stored = typing.cast(StoredStateData, self.load_snapshot(stored_handle))
         except NoSnapshotError:
-            self._stored = StoredStateData(self, '_stored')  # noqa
+            self._stored = StoredStateData(self, '_stored')
             self._stored['event_count'] = 0
 
         # Flag to indicate that we already presented the welcome message in a debugger breakpoint
@@ -1029,11 +1030,11 @@ class BoundStoredState:
     if TYPE_CHECKING:
         # to help the type checker and IDEs:
         @property
-        def _data(self) -> StoredStateData:  # noqa
+        def _data(self) -> StoredStateData:
             pass
 
-        @property  # noqa
-        def _attr_name(self) -> str:  # noqa
+        @property
+        def _attr_name(self) -> str:
             pass  # pyright: reportGeneralTypeIssues=false
 
     def __init__(self, parent: Object, attr_name: str):
@@ -1200,8 +1201,8 @@ def _unwrap_stored(parent_data: StoredStateData,
 
 def _wrapped_repr(obj: '_StoredObject') -> str:
     t = type(obj)
-    if obj._under:  # pyright: reportPrivateUsage=false  # noqa
-        return f"{t.__module__}.{t.__name__}({obj._under!r})"  # type: ignore # noqa
+    if obj._under:  # pyright: reportPrivateUsage=false
+        return f"{t.__module__}.{t.__name__}({obj._under!r})"  # type: ignore
     else:
         return f"{t.__module__}.{t.__name__}()"
 
@@ -1361,7 +1362,7 @@ class StoredSet(typing.MutableSet['_StorableType']):
     def __le__(self, other: Any):
         if isinstance(other, StoredSet):
             return self._under <= other._under
-        elif isinstance(other, collections.abc.Set):  # pyright: reportUnnecessaryIsInstance=false  # noqa
+        elif isinstance(other, collections.abc.Set):
             return self._under <= other
         else:
             return NotImplemented
@@ -1369,7 +1370,7 @@ class StoredSet(typing.MutableSet['_StorableType']):
     def __ge__(self, other: Any):
         if isinstance(other, StoredSet):
             return self._under >= other._under
-        elif isinstance(other, collections.abc.Set):  # pyright: reportUnnecessaryIsInstance=false  # noqa
+        elif isinstance(other, collections.abc.Set):
             return self._under >= other
         else:
             return NotImplemented
@@ -1377,7 +1378,7 @@ class StoredSet(typing.MutableSet['_StorableType']):
     def __eq__(self, other: Any):
         if isinstance(other, StoredSet):
             return self._under == other._under
-        elif isinstance(other, collections.abc.Set):  # pyright: reportUnnecessaryIsInstance=false  # noqa
+        elif isinstance(other, collections.abc.Set):
             return self._under == other
         else:
             return NotImplemented

--- a/ops/main.py
+++ b/ops/main.py
@@ -184,7 +184,7 @@ def _get_event_args(charm: 'CharmBase',
     elif issubclass(event_type, ops.charm.RelationEvent):
         relation_name = os.environ['JUJU_RELATION']
         relation_id = int(os.environ['JUJU_RELATION_ID'].split(':')[-1])
-        relation = model.get_relation(relation_name, relation_id)  # type: Optional[Relation]
+        relation: Optional[Relation] = model.get_relation(relation_name, relation_id)
 
     remote_app_name = os.environ.get('JUJU_REMOTE_APP', '')
     remote_unit_name = os.environ.get('JUJU_REMOTE_UNIT', '')
@@ -195,7 +195,7 @@ def _get_event_args(charm: 'CharmBase',
             raise RuntimeError(f'invalid remote unit name: {remote_unit_name}')
         remote_app_name = remote_unit_name.split('/')[0]
 
-    kwargs = {}  # type: Dict[str, Any]
+    kwargs: Dict[str, Any] = {}
     if remote_app_name:
         kwargs['app'] = model.get_app(remote_app_name)
     if remote_unit_name:

--- a/ops/model.py
+++ b/ops/model.py
@@ -141,13 +141,13 @@ class Model:
         self._cache = _ModelCache(meta, backend)
         self._backend = backend
         self._unit = self.get_unit(self._backend.unit_name)
-        relations = meta.relations  # type: _RelationsMeta_Raw
+        relations: _RelationsMeta_Raw = meta.relations
         self._relations = RelationMapping(relations, self.unit, self._backend, self._cache)
         self._config = ConfigData(self._backend)
-        resources = meta.resources  # type: Iterable[str]
+        resources: Iterable[str] = meta.resources
         self._resources = Resources(list(resources), self._backend)
         self._pod = Pod(self._backend)
-        storages = meta.storages  # type: Iterable[str]
+        storages: Iterable[str] = meta.storages
         self._storages = StorageMapping(list(storages), self._backend)
         self._bindings = BindingMapping(self._backend)
 
@@ -299,7 +299,7 @@ class _ModelCache:
 
         self._meta = meta
         self._backend = backend
-        self._weakrefs = weakref.WeakValueDictionary()  # type: _weakcachetype
+        self._weakrefs: _weakcachetype = weakref.WeakValueDictionary()
 
     @typing.overload
     def get(self, entity_type: Type['Unit'], name: str) -> 'Unit': ...  # noqa
@@ -483,7 +483,7 @@ class Unit:
         self._status = None
 
         if self._is_our_unit and hasattr(meta, "containers"):
-            containers = meta.containers  # type: _ContainerMeta_Raw
+            containers: _ContainerMeta_Raw = meta.containers
             self._containers = ContainerMapping(iter(containers), backend)
 
     def _invalidate(self):
@@ -606,7 +606,7 @@ class LazyMapping(Mapping[str, str], ABC):
     """
 
     # key-value mapping
-    _lazy_data = None  # type: Optional[Dict[str, str]]
+    _lazy_data: Optional[Dict[str, str]] = None
 
     @abstractmethod
     def _load(self) -> Dict[str, str]:
@@ -643,14 +643,14 @@ class RelationMapping(Mapping[str, List['Relation']]):
 
     def __init__(self, relations_meta: '_RelationsMeta_Raw', our_unit: 'Unit',
                  backend: '_ModelBackend', cache: '_ModelCache'):
-        self._peers = set()  # type: Set[str]
+        self._peers: Set[str] = set()
         for name, relation_meta in relations_meta.items():
             if relation_meta.role.is_peer():
                 self._peers.add(name)
         self._our_unit = our_unit
         self._backend = backend
         self._cache = cache
-        self._data = {r: None for r in relations_meta}  # type: _RelationMapping_Raw
+        self._data: _RelationMapping_Raw = {r: None for r in relations_meta}
 
     def __contains__(self, key: str):
         return key in self._data
@@ -663,7 +663,7 @@ class RelationMapping(Mapping[str, List['Relation']]):
 
     def __getitem__(self, relation_name: str) -> List['Relation']:
         is_peer = relation_name in self._peers
-        relation_list = self._data[relation_name]  # type: Optional[List[Relation]]
+        relation_list: Optional[List[Relation]] = self._data[relation_name]
         if not isinstance(relation_list, list):
             relation_list = self._data[relation_name] = []  # type: ignore
             for rid in self._backend.relation_ids(relation_name):
@@ -718,7 +718,7 @@ class BindingMapping(Mapping[str, 'Binding']):
 
     def __init__(self, backend: '_ModelBackend'):
         self._backend = backend
-        self._data = {}  # type: _BindingDictType
+        self._data: _BindingDictType = {}
 
     def get(self, binding_key: Union[str, 'Relation']) -> 'Binding':
         """Get a specific Binding for an endpoint/relation.
@@ -817,19 +817,19 @@ class Network:
     """
 
     def __init__(self, network_info: '_NetworkDict'):
-        self.interfaces = []  # type: List[NetworkInterface]
+        self.interfaces: List[NetworkInterface] = []
         # Treat multiple addresses on an interface as multiple logical
         # interfaces with the same name.
         for interface_info in network_info.get('bind-addresses', []):
-            interface_name = interface_info.get('interface-name')  # type: str
-            addrs = interface_info.get('addresses')  # type: Optional[List[_AddressDict]]
+            interface_name: str = interface_info.get('interface-name')
+            addrs: Optional[List[_AddressDict]] = interface_info.get('addresses')
             if addrs is not None:
                 for address_info in addrs:
                     self.interfaces.append(NetworkInterface(interface_name, address_info))
-        self.ingress_addresses = []  # type: List[_NetworkAddress]
+        self.ingress_addresses: List[_NetworkAddress] = []
         for address in network_info.get('ingress-addresses', []):
             self.ingress_addresses.append(_cast_network_address(address))
-        self.egress_subnets = []  # type: List[_Network]
+        self.egress_subnets: List[_Network] = []
         for subnet in network_info.get('egress-subnets', []):
             self.egress_subnets.append(ipaddress.ip_network(subnet))
 
@@ -884,8 +884,8 @@ class NetworkInterface:
 
         # The value field may be empty.
         address_ = _cast_network_address(address) if address else None
-        self.address = address_  # type: Optional[_NetworkAddress]
-        cidr = address_info.get('cidr')  # type: str
+        self.address: Optional[_NetworkAddress] = address_
+        cidr: str = address_info.get('cidr')
         # The cidr field may be empty, see LP: #1864102.
         if cidr:
             subnet = ipaddress.ip_network(cidr)
@@ -894,7 +894,7 @@ class NetworkInterface:
             subnet = ipaddress.ip_network(address)
         else:
             subnet = None
-        self.subnet = subnet  # type: Optional[_Network]
+        self.subnet: Optional[_Network] = subnet
         # TODO: expose a hostname/canonical name for the address here, see LP: #1864086.
 
 
@@ -983,7 +983,7 @@ class Secret:
         self._content = content
 
     def __repr__(self):
-        fields = []  # type: List[str]
+        fields: List[str] = []
         if self._id is not None:
             fields.append(f'id={self._id!r}')
         if self._label is not None:
@@ -1206,8 +1206,8 @@ class Relation:
             backend: '_ModelBackend', cache: '_ModelCache'):
         self.name = relation_name
         self.id = relation_id
-        self.app = None  # type: Optional[Application]
-        self.units = set()  # type: Set[Unit]
+        self.app: Optional[Application] = None
+        self.units: Set[Unit] = set()
 
         if is_peer:
             # For peer relations, both the remote and the local app are the same.
@@ -1254,10 +1254,10 @@ class RelationData(Mapping['UnitOrApplication', 'RelationDataContent']):
 
     def __init__(self, relation: Relation, our_unit: Unit, backend: '_ModelBackend'):
         self.relation = weakref.proxy(relation)
-        self._data = {
+        self._data: Dict[UnitOrApplication, RelationDataContent] = {
             our_unit: RelationDataContent(self.relation, our_unit, backend),
             our_unit.app: RelationDataContent(self.relation, our_unit.app, backend),
-        }  # type: Dict[UnitOrApplication, RelationDataContent]
+        }
         self._data.update({
             unit: RelationDataContent(self.relation, unit, backend)
             for unit in self.relation.units})
@@ -1302,7 +1302,7 @@ class RelationDataContent(LazyMapping, MutableMapping[str, str]):
         self.relation = relation
         self._entity = entity
         self._backend = backend
-        self._is_app = isinstance(entity, Application)  # type: bool
+        self._is_app: bool = isinstance(entity, Application)
 
     @property
     def _hook_is_running(self) -> bool:
@@ -1385,7 +1385,7 @@ class RelationDataContent(LazyMapping, MutableMapping[str, str]):
 
         # finally, we check whether we have permissions to write this databag
         if self._is_app:
-            is_our_app = self._backend.app_name == self._entity.name  # type: bool
+            is_our_app: bool = self._backend.app_name == self._entity.name
             if not is_our_app:
                 raise RelationDataAccessError(
                     "{} cannot write the data of remote application {}".format(
@@ -1466,7 +1466,7 @@ class StatusBase:
     directly use the child class to indicate their status.
     """
 
-    _statuses = {}  # type: Dict[str, Type[StatusBase]]
+    _statuses: Dict[str, Type['StatusBase']] = {}
 
     # Subclasses should override this attribute and make it a string.
     name = NotImplemented
@@ -1584,7 +1584,7 @@ class Resources:
 
     def __init__(self, names: Iterable[str], backend: '_ModelBackend'):
         self._backend = backend
-        self._paths = {name: None for name in names}  # type: Dict[str, Optional[Path]]
+        self._paths: Dict[str, Optional[Path]] = {name: None for name in names}
 
     def fetch(self, name: str) -> Path:
         """Fetch the resource from the controller or store.
@@ -1630,8 +1630,8 @@ class StorageMapping(Mapping[str, List['Storage']]):
 
     def __init__(self, storage_names: Iterable[str], backend: '_ModelBackend'):
         self._backend = backend
-        self._storage_map = {storage_name: None for storage_name in storage_names
-                             }  # type: _StorageDictType
+        self._storage_map: _StorageDictType = {storage_name: None
+                                               for storage_name in storage_names}
 
     def __contains__(self, key: str):  # pyright: reportIncompatibleMethodOverride=false
         return key in self._storage_map
@@ -1760,7 +1760,7 @@ class Container:
         if pebble_client is None:
             socket_path = f'/charm/containers/{name}/pebble.socket'
             pebble_client = backend.get_pebble(socket_path)
-        self._pebble = pebble_client  # type: 'Client'
+        self._pebble: 'Client' = pebble_client
 
     @property
     def pebble(self) -> 'Client':
@@ -1834,8 +1834,8 @@ class Container:
             if e.code != 400:
                 raise e
             # support old Pebble instances that don't support the "restart" action
-            stop = tuple(s.name for s in self.get_services(*service_names).values(
-            ) if s.is_running())  # type: Tuple[str, ...]
+            stop: Tuple[str, ...] = tuple(s.name for s in self.get_services(
+                *service_names).values() if s.is_running())
             if stop:
                 self._pebble.stop_services(stop)
             self._pebble.start_services(service_names)
@@ -2054,7 +2054,7 @@ class Container:
             files = [self._build_fileinfo(source_path / f) for f in paths]
             return files
 
-        errors = []  # type: List[Tuple[str, Exception]]
+        errors: List[Tuple[str, Exception]] = []
         for source_path in source_paths:
             try:
                 for info in Container._list_recursive(local_list, source_path):
@@ -2129,7 +2129,7 @@ class Container:
         source_paths = [Path(p) for p in source_paths]
         dest_dir = Path(dest_dir)
 
-        errors = []  # type: List[Tuple[str, Exception]]
+        errors: List[Tuple[str, Exception]] = []
         for source_path in source_paths:
             try:
                 for info in Container._list_recursive(self.list_files, source_path):
@@ -2480,7 +2480,7 @@ def _format_action_result_dict(input: Dict[str, 'JsonObject'],
             result in duplicate keys. For example: {'a': {'b': 1}, 'a.b': 2}. Also raised if a dict
             is passed with a key that fails to meet the format requirements.
     """
-    output_ = output or {}  # type: Dict[str, str]
+    output_: Dict[str, str] = output or {}
 
     for key, value in input.items():
         # Ensure the key is of a valid format, and raise a ValueError if not
@@ -2528,22 +2528,21 @@ class _ModelBackend:
         unit_name_ = unit_name or os.getenv('JUJU_UNIT_NAME')
         if unit_name_ is None:
             raise ValueError('JUJU_UNIT_NAME not set')
-        self.unit_name = unit_name_  # type: str
+        self.unit_name: str = unit_name_
 
         # we can cast to str because these envvars are guaranteed to be set
-        self.model_name = model_name or typing.cast(str, os.getenv('JUJU_MODEL_NAME'))  # type: str
-        self.model_uuid = model_uuid or typing.cast(str, os.getenv('JUJU_MODEL_UUID'))  # type: str
-        self.app_name = self.unit_name.split('/')[0]  # type: str
+        self.model_name: str = model_name or typing.cast(str, os.getenv('JUJU_MODEL_NAME'))
+        self.model_uuid: str = model_uuid or typing.cast(str, os.getenv('JUJU_MODEL_UUID'))
+        self.app_name: str = self.unit_name.split('/')[0]
 
-        self._is_leader = None  # type: Optional[bool]
+        self._is_leader: Optional[bool] = None
         self._leader_check_time = None
         self._hook_is_running = ''
 
     def _run(self, *args: str, return_output: bool = False,
              use_json: bool = False, input_stream: Optional[str] = None
              ) -> Union[str, 'JsonObject', None]:
-        kwargs = dict(stdout=PIPE, stderr=PIPE, check=True,
-                      encoding='utf-8')  # type: Dict[str, Any]
+        kwargs = dict(stdout=PIPE, stderr=PIPE, check=True, encoding='utf-8')
         if input_stream:
             kwargs.update({"input": input_stream})
         which_cmd = shutil.which(args[0])
@@ -2847,16 +2846,16 @@ class _ModelBackend:
 
     def add_metrics(self, metrics: Mapping[str, 'Numerical'],
                     labels: Optional[Mapping[str, str]] = None) -> None:
-        cmd = ['add-metric']  # type: List[str]
+        cmd: List[str] = ['add-metric']
         if labels:
-            label_args = []  # type: List[str]
+            label_args: List[str] = []
             for k, v in labels.items():
                 _ModelBackendValidator.validate_metric_label(k)
                 _ModelBackendValidator.validate_label_value(k, v)
                 label_args.append(f'{k}={v}')
             cmd.extend(['--labels', ','.join(label_args)])
 
-        metric_args = []  # type: List[str]
+        metric_args: List[str] = []
         for k, v in metrics.items():
             _ModelBackendValidator.validate_metric_key(k)
             metric_value = _ModelBackendValidator.format_metric_value(v)
@@ -2923,7 +2922,7 @@ class _ModelBackend:
     def secret_info_get(self, *,
                         id: Optional[str] = None,
                         label: Optional[str] = None) -> SecretInfo:
-        args = []  # type: List[str]
+        args: List[str] = []
         if id is not None:
             args.append(id)
         elif label is not None:  # elif because Juju secret-info-get doesn't allow id and label
@@ -2960,7 +2959,7 @@ class _ModelBackend:
                    expire: Optional[datetime.datetime] = None,
                    rotate: Optional[SecretRotate] = None,
                    owner: Optional[str] = None) -> str:
-        args = []  # type: List[str]
+        args: List[str] = []
         if label is not None:
             args.extend(['--label', label])
         if description is not None:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1266,7 +1266,7 @@ class ExecProcess:
 def _has_fileno(f: Any) -> bool:
     """Return True if the file-like object has a valid fileno() method."""
     try:
-        f.fileno()  # type: ignore # noqa
+        f.fileno()
         return True
     except Exception:
         # Some types define a fileno method that raises io.UnsupportedOperation,

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -659,12 +659,10 @@ class Plan:
         d = typing.cast('_PlanDict', d)
 
         self._raw = raw
-        self._services = {name: Service(name, service)
-                          for name, service in d.get('services', {}).items()
-                          }  # type: Dict[str, Service]
-        self._checks = {name: Check(name, check)
-                        for name, check in d.get('checks', {}).items()
-                        }  # type: Dict[str, Check]
+        self._services: Dict[str, Service] = {name: Service(name, service)
+                                              for name, service in d.get('services', {}).items()}
+        self._checks: Dict[str, Check] = {name: Check(name, check)
+                                          for name, check in d.get('checks', {}).items()}
 
     @property
     def services(self) -> Dict[str, 'Service']:
@@ -754,7 +752,7 @@ class Service:
 
     def __init__(self, name: str, raw: Optional['_ServiceDict'] = None):
         self.name = name
-        dct = raw or {}  # type: _ServiceDict
+        dct: _ServiceDict = raw or {}
         self.summary = dct.get('summary', '')
         self.description = dct.get('description', '')
         self.startup = dct.get('startup', '')
@@ -894,35 +892,35 @@ class Check:
 
     def __init__(self, name: str, raw: Optional['_CheckDict'] = None):
         self.name = name
-        dct = raw or {}  # type: _CheckDict
-        self.override = dct.get('override', '')  # type: str
+        dct: _CheckDict = raw or {}
+        self.override: str = dct.get('override', '')
         try:
-            level = CheckLevel(dct.get('level', ''))  # type: Union[CheckLevel, str]
+            level: Union[CheckLevel, str] = CheckLevel(dct.get('level', ''))
         except ValueError:
             level = dct.get('level', '')
         self.level = level
-        self.period = dct.get('period', '')  # type: Optional[str]
-        self.timeout = dct.get('timeout', '')  # type: Optional[str]
-        self.threshold = dct.get('threshold')  # type: Optional[int]
+        self.period: Optional[str] = dct.get('period', '')
+        self.timeout: Optional[str] = dct.get('timeout', '')
+        self.threshold: Optional[int] = dct.get('threshold')
 
         http = dct.get('http')
         if http is not None:
             http = copy.deepcopy(http)
-        self.http = http  # type: Optional[_HttpDict]
+        self.http: Optional[_HttpDict] = http
 
         tcp = dct.get('tcp')
         if tcp is not None:
             tcp = copy.deepcopy(tcp)
-        self.tcp = tcp  # type: Optional[_TcpDict]
+        self.tcp: Optional[_TcpDict] = tcp
 
         exec_ = dct.get('exec')
         if exec_ is not None:
             exec_ = copy.deepcopy(exec_)
-        self.exec = exec_  # type: Optional[_ExecDict]
+        self.exec: Optional[_ExecDict] = exec_
 
     def to_dict(self) -> '_CheckDict':
         """Convert this check object to its dict representation."""
-        level = self.level.value if isinstance(self.level, CheckLevel) else self.level  # type: str
+        level: str = self.level.value if isinstance(self.level, CheckLevel) else self.level
         fields = [
             ('override', self.override),
             ('level', level),
@@ -1239,10 +1237,10 @@ class ExecProcess:
             t = _start_thread(shutil.copyfileobj, self.stderr, err)
             self._threads.append(t)
 
-        exit_code = self._wait()  # type: int
+        exit_code: int = self._wait()
 
-        out_value = out.getvalue()  # type: '_StrOrBytes'
-        err_value = err.getvalue() if err is not None else None  # type: Optional['_StrOrBytes']
+        out_value: '_StrOrBytes' = out.getvalue()
+        err_value: Optional['_StrOrBytes'] = err.getvalue() if err is not None else None
         if exit_code != 0:
             raise ExecError(self._command, exit_code, out_value, err_value)
 
@@ -1388,7 +1386,7 @@ class _WebsocketReader(io.BufferedIOBase):
 
         if n < 0:
             n = len(self.remaining)
-        result = self.remaining[:n]  # type: '_StrOrBytes'
+        result: '_StrOrBytes' = self.remaining[:n]
         self.remaining = self.remaining[n:]
         return result
 
@@ -1452,7 +1450,7 @@ class Client:
 
         response = self._request_raw(method, path, query, headers, data)
         self._ensure_content_type(response.headers, 'application/json')
-        raw_resp = json.loads(response.read())  # type: Dict[str, Any]
+        raw_resp: Dict[str, Any] = json.loads(response.read())
         return raw_resp
 
     @staticmethod
@@ -1488,11 +1486,11 @@ class Client:
             code = e.code
             status = e.reason
             try:
-                body = json.loads(e.read())  # type: Dict[str, Any]
-                message = body['result']['message']  # type: str
+                body: Dict[str, Any] = json.loads(e.read())
+                message: str = body['result']['message']
             except (OSError, ValueError, KeyError) as e2:
                 # Will only happen on read error or if Pebble sends invalid JSON.
-                body = {}  # type: Dict[str, Any]
+                body: Dict[str, Any] = {}
                 message = f'{type(e2).__name__} - {e2}'
             raise APIError(body, code, status, message)
         except urllib.error.URLError as e:
@@ -1521,7 +1519,7 @@ class Client:
         self, select: ChangeState = ChangeState.IN_PROGRESS, service: Optional[str] = None,
     ) -> List[Change]:
         """Get list of changes in given state, filter by service name if given."""
-        query = {'select': select.value}  # type: Dict[str, Union[str, int]]
+        query: Dict[str, Union[str, int]] = {'select': select.value}
         if service is not None:
             query['for'] = service
         resp = self._request('GET', '/v1/changes', query)
@@ -1910,7 +1908,7 @@ class Client:
                         user: Optional[str],
                         group_id: Optional[int],
                         group: Optional[str]) -> '_AuthDict':
-        d = {}  # type: _AuthDict
+        d: _AuthDict = {}
         if permissions is not None:
             d['permissions'] = format(permissions, '03o')
         if user_id is not None:
@@ -1928,11 +1926,11 @@ class Client:
         # Python's stdlib mime/multipart handling is screwy and doesn't handle
         # binary properly, so roll our own.
         if isinstance(source, str):
-            source_io = io.StringIO(source)  # type: _AnyStrFileLikeIO
+            source_io: _AnyStrFileLikeIO = io.StringIO(source)
         elif isinstance(source, bytes):
-            source_io = io.BytesIO(source)  # type: _AnyStrFileLikeIO
+            source_io: _AnyStrFileLikeIO = io.BytesIO(source)
         else:
-            source_io = source  # type: _AnyStrFileLikeIO
+            source_io: _AnyStrFileLikeIO = source
         boundary = binascii.hexlify(os.urandom(16))
         path_escaped = path.replace('"', '\\"').encode('utf-8')  # NOQA: test_quote_backslashes
         content_type = f"multipart/form-data; boundary=\"{boundary.decode('utf-8')}\""  # NOQA: test_quote_backslashes
@@ -1951,7 +1949,7 @@ class Client:
                 b'\r\n',
             ])
 
-            content = source_io.read(self._chunk_size)  # type: '_StrOrBytes'
+            content: '_StrOrBytes' = source_io.read(self._chunk_size)
             while content:
                 if isinstance(content, str):
                     content = content.encode(encoding)
@@ -2035,7 +2033,7 @@ class Client:
                        to `rm -rf <file|dir>`
 
         """
-        info = {'path': path}  # type: Dict[str, Any]
+        info: Dict[str, Any] = {'path': path}
         if recursive:
             info['recursive'] = True
         body = {
@@ -2206,7 +2204,7 @@ class Client:
         change_id = resp['change']
         task_id = resp['result']['task-id']
 
-        stderr_ws = None  # type: Optional['_WebSocket']
+        stderr_ws: Optional['_WebSocket'] = None
         try:
             control_ws = self._connect_websocket(task_id, 'control')
             stdio_ws = self._connect_websocket(task_id, 'stdio')
@@ -2220,9 +2218,9 @@ class Client:
                 raise ChangeError(change.err, change)
             raise ConnectionError(f'unexpected error connecting to websockets: {e}')
 
-        cancel_stdin = None  # type: Optional[Callable[[], None]]
-        cancel_reader = None  # type: Optional[int]
-        threads = []  # type: List[threading.Thread]
+        cancel_stdin: Optional[Callable[[], None]] = None
+        cancel_reader: Optional[int] = None
+        threads: List[threading.Thread] = []
 
         if stdin is not None:
             if _has_fileno(stdin):
@@ -2354,10 +2352,10 @@ class _FilesParser:
     """A limited purpose multi-part parser backed by files for memory efficiency."""
 
     def __init__(self, boundary: Union[bytes, str]):
-        self._response = None  # type: Optional[_FilesResponse] # externally managed
-        self._part_type = None  # type: Optional[Literal["response", "files"]] # externally managed
-        self._headers = None  # type: Optional['Message'] # externally managed
-        self._files = {}  # type: Dict[str, _Tempfile]
+        self._response: Optional[_FilesResponse] = None  # externally managed
+        self._part_type: Optional[Literal["response", "files"]] = None  # externally managed
+        self._headers: Optional['Message'] = None  # externally managed
+        self._files: Dict[str, _Tempfile] = {}
 
         # Prepare the MIME multipart boundary line patterns.
         if isinstance(boundary, str):

--- a/ops/storage.py
+++ b/ops/storage.py
@@ -42,7 +42,7 @@ if typing.TYPE_CHECKING:
 
 
 def _run(args: List[str], **kw: Any):
-    cmd = shutil.which(args[0])  # type: Optional[str]
+    cmd: Optional[str] = shutil.which(args[0])
     if cmd is None:
         raise FileNotFoundError(args[0])
     return subprocess.run([cmd, *args[1:]], encoding='utf-8', **kw)
@@ -201,7 +201,7 @@ class JujuStorage:
     NOTICE_KEY = "#notices#"
 
     def __init__(self, backend: Optional['_JujuStorageBackend'] = None):
-        self._backend = backend or _JujuStorageBackend()  # type: _JujuStorageBackend
+        self._backend: _JujuStorageBackend = backend or _JujuStorageBackend()
 
     def close(self):
         """Part of the Storage API, close the storage backend.
@@ -327,7 +327,7 @@ class _SimpleDumper(_BaseDumper):  # type: ignore
     YAML can support arbitrary types, but that is generally considered unsafe (like pickle). So
     we want to only support dumping out types that are safe to load.
     """
-    represent_tuple = yaml.Dumper.represent_tuple  # type: _TupleRepresenterType
+    represent_tuple: '_TupleRepresenterType' = yaml.Dumper.represent_tuple
 
 
 _SimpleDumper.add_representer(tuple, _SimpleDumper.represent_tuple)  # type: ignore

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2225,7 +2225,7 @@ class _TestingPebbleClient:
                 elif service.override == 'merge':
                     if combine and name in layer.services:
                         s = layer.services[name]
-                        s._merge(service)  # type: ignore # noqa
+                        s._merge(service)
                     else:
                         layer.services[name] = service
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -146,12 +146,12 @@ class Harness(Generic[CharmType]):
             actions: Optional[YAMLStringOrFile] = None,
             config: Optional[YAMLStringOrFile] = None):
         self._charm_cls = charm_cls
-        self._charm = None  # type: Optional[CharmType]
+        self._charm: Optional[CharmType] = None
         self._charm_dir = 'no-disk-path'  # this may be updated by _create_meta
         self._meta = self._create_meta(meta, actions)
-        self._unit_name = f"{self._meta.name}/0"  # type: str
-        self._hooks_enabled = True  # type: bool
-        self._relation_id_counter = 0  # type: int
+        self._unit_name: str = f"{self._meta.name}/0"
+        self._hooks_enabled: bool = True
+        self._relation_id_counter: int = 0
         config_ = self._get_config(config)
         self._backend = _TestingModelBackend(self._unit_name, self._meta, config_)
         self._model = model.Model(self._meta, self._backend)
@@ -562,7 +562,7 @@ class Harness(Generic[CharmType]):
 
         storage_indices = self._backend.storage_add(storage_name, count)
 
-        ids = []  # type: List[str]
+        ids: List[str] = []
         for storage_index in storage_indices:
             s = model.Storage(storage_name, storage_index, self._backend)
             ids.append(s.full_id)
@@ -1422,7 +1422,7 @@ class _TestingConfig(Dict[str, '_ConfigValue']):
         """
         if not charm_config:
             return {}
-        cfg = charm_config.get('options', {})  # type: Dict[str, '_ConfigOption']
+        cfg: Dict[str, '_ConfigOption'] = charm_config.get('options', {})
         return {key: value.get('default', None) for key, value in cfg.items()}
 
     def _config_set(self, key: str, value: '_ConfigValue'):
@@ -1510,43 +1510,41 @@ class _TestingModelBackend:
 
         self._harness_tmp_dir = tempfile.TemporaryDirectory(prefix='ops-harness-')
         # this is used by the _record_calls decorator
-        self._calls = []  # type: List[Tuple[Any, ...]]
+        self._calls: List[Tuple[Any, ...]] = []
         self._meta = meta
         # relation name to [relation_ids,...]
-        self._relation_ids_map = {}   # type: Dict[str, List[int]]
+        self._relation_ids_map: Dict[str, List[int]] = {}
         # reverse map from relation_id to relation_name
-        self._relation_names = {}  # type: Dict[int, str]
+        self._relation_names: Dict[int, str] = {}
         # relation_id: [unit_name,...]
-        self._relation_list_map = {}  # type: Dict[int, List[str]]
+        self._relation_list_map: Dict[int, List[str]] = {}
         # {relation_id: {name: Dict[str: str]}}
-        self._relation_data_raw = {}  # type: Dict[int, Dict[str, Dict[str, str]]]
+        self._relation_data_raw: Dict[int, Dict[str, Dict[str, str]]] = {}
         # {relation_id: {"app": app_name, "units": ["app/0",...]}
-        self._relation_app_and_units = {}  # type: Dict[int, _RelationEntities]
+        self._relation_app_and_units: Dict[int, _RelationEntities] = {}
         self._config = _TestingConfig(config)
-        self._is_leader = False  # type: bool
+        self._is_leader: bool = False
         # {resource_name: resource_content}
         # where resource_content is (path, content)
-        self._resources_map = {}  # type: Dict[str, Tuple[str, Union[str, bytes]]]
+        self._resources_map: Dict[str, Tuple[str, Union[str, bytes]]] = {}
         # fixme: understand how this is used and adjust the type
-        self._pod_spec = None  # type: Optional[Tuple[model.K8sSpec, Any]]
-        self._app_status = {'status': 'unknown', 'message': ''}  # type: _RawStatus
-        self._unit_status = {'status': 'maintenance', 'message': ''}  # type: _RawStatus
-        self._workload_version = None  # type: Optional[str]
-        self._resource_dir = None  # type: Optional[tempfile.TemporaryDirectory[Any]]
+        self._pod_spec: Optional[Tuple[model.K8sSpec, Any]] = None
+        self._app_status: _RawStatus = {'status': 'unknown', 'message': ''}
+        self._unit_status: _RawStatus = {'status': 'maintenance', 'message': ''}
+        self._workload_version: Optional[str] = None
+        self._resource_dir: Optional[tempfile.TemporaryDirectory[Any]] = None
         # Format:
         # { "storage_name": {"<ID1>": { <other-properties> }, ... }
         # <ID1>: device id that is key for given storage_name
         # Initialize the _storage_list with values present on metadata.yaml
-        self._storage_list = {k: {} for k in self._meta.storages
-                              }  # type: Dict[str, Dict[int, Dict[str, Any]]]
-
-        self._storage_attached = {k: set() for k in self._meta.storages
-                                  }  # type: Dict[str, Set[int]]
+        self._storage_list: Dict[str, Dict[int, Dict[str, Any]]] = {
+            k: {} for k in self._meta.storages}
+        self._storage_attached: Dict[str, Set[int]] = {k: set() for k in self._meta.storages}
         self._storage_index_counter = 0
         # {container_name : _TestingPebbleClient}
-        self._pebble_clients = {}  # type: Dict[str, _TestingPebbleClient]
-        self._pebble_clients_can_connect = {}  # type: Dict[_TestingPebbleClient, bool]
-        self._planned_units = None  # type: Optional[int]
+        self._pebble_clients: Dict[str, _TestingPebbleClient] = {}
+        self._pebble_clients_can_connect: Dict[_TestingPebbleClient, bool] = {}
+        self._planned_units: Optional[int] = None
         self._hook_is_running = ''
         self._secrets: List[_Secret] = []
 
@@ -1558,7 +1556,7 @@ class _TestingModelBackend:
         if len(relations) > 0:
             return
 
-        valid_relation_endpoints = list(self._meta.peers.keys())  # type: List[str]
+        valid_relation_endpoints: List[str] = list(self._meta.peers.keys())
         valid_relation_endpoints.extend(self._meta.requires.keys())
         valid_relation_endpoints.extend(self._meta.provides.keys())
         if self._hook_is_running == 'leader_elected' and relation_name in valid_relation_endpoints:
@@ -1599,7 +1597,7 @@ class _TestingModelBackend:
         except KeyError as e:
             if relation_name not in self._meta.relations:
                 raise model.ModelError(f'{relation_name} is not a known relation') from e
-            no_ids = []  # type: List[int]
+            no_ids: List[int] = []
             return no_ids
 
     def relation_list(self, relation_id: int):
@@ -1739,7 +1737,7 @@ class _TestingModelBackend:
 
         if name not in self._storage_list:
             self._storage_list[name] = {}
-        result = []  # type: List[int]
+        result: List[int] = []
         for _ in range(count):
             index = self._storage_index_counter
             self._storage_index_counter += 1
@@ -1846,8 +1844,8 @@ class _TestingModelBackend:
         if self._planned_units is not None:
             return self._planned_units
 
-        units = set()  # type: Set[str]
-        peer_names = set(self._meta.peers.keys())  # type: Set[str]
+        units: Set[str] = set()
+        peer_names: Set[str] = set(self._meta.peers.keys())
         for peer_id, peer_name in self._relation_names.items():
             if peer_name not in peer_names:
                 continue
@@ -2073,9 +2071,9 @@ class _TestingPebbleClient:
 
     def __init__(self, backend: _TestingModelBackend):
         self._backend = _TestingModelBackend
-        self._layers = {}  # type: Dict[str, pebble.Layer]
+        self._layers: Dict[str, pebble.Layer] = {}
         # Has a service been started/stopped?
-        self._service_status = {}  # type: Dict[str, pebble.ServiceStatus]
+        self._service_status: Dict[str, pebble.ServiceStatus] = {}
         self._fs = _TestingFilesystem()
         self._backend = backend
 
@@ -2235,7 +2233,7 @@ class _TestingPebbleClient:
             self._layers[label] = layer_obj
 
     def _render_services(self) -> Dict[str, pebble.Service]:
-        services = {}  # type: Dict[str, pebble.Service]
+        services: Dict[str, pebble.Service] = {}
         for key in sorted(self._layers.keys()):
             layer = self._layers[key]
             for name, service in layer.services.items():
@@ -2259,7 +2257,7 @@ class _TestingPebbleClient:
 
         self._check_connection()
         services = self._render_services()
-        infos = []  # type: List[pebble.ServiceInfo]
+        infos: List[pebble.ServiceInfo] = []
         if names is None:
             names = sorted(services.keys())
         for name in sorted(names):
@@ -2529,7 +2527,7 @@ class _TestingStorageMount:
             make_dirs: bool = False,
             **kwargs: Any
     ) -> '_File':
-        posixpath = self.check_contains(path)  # type: pathlib.PurePosixPath
+        posixpath: pathlib.PurePosixPath = self.check_contains(path)
         srcpath = self._srcpath(posixpath)
 
         dirname = srcpath.parent
@@ -2556,7 +2554,7 @@ class _TestingStorageMount:
         _path = self.check_contains(path)
         srcpath = self._srcpath(_path)
 
-        results = []  # type: List[_FileOrDir]
+        results: List[_FileOrDir] = []
         if not srcpath.exists():
             raise FileNotFoundError(str(_path))
         if not srcpath.is_dir():
@@ -2612,7 +2610,7 @@ class _TestingFilesystem:
 
     def __init__(self):
         self.root = _Directory(pathlib.PurePosixPath('/'))
-        self._mounts = {}  # type: Dict[str, _TestingStorageMount]
+        self._mounts: Dict[str, _TestingStorageMount] = {}
 
     def add_mount(self, name: str, mount_path: Union[str, pathlib.Path],
                   backing_src_path: Union[str, pathlib.Path]):
@@ -2756,7 +2754,7 @@ class _TestingFilesystem:
 class _Directory:
     def __init__(self, path: pathlib.PurePosixPath, **kwargs: Any):
         self.path = path
-        self._children = {}  # type: Dict[str, Union[_Directory, _File]]
+        self._children: Dict[str, Union[_Directory, _File]] = {}
         self.last_modified = datetime.datetime.now()
         self.kwargs = cast('_FileKwargs', kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,5 @@ pythonPlatform = "All"
 typeCheckingMode = "strict"
 reportIncompatibleMethodOverride = false
 reportImportCycles = false
-reportTypeCommentUsage = false
 reportMissingModuleSource = false
 stubPath = ""

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -23,7 +23,7 @@ from ops.charm import (  # noqa: E402 (module-level import after non-import code
     CharmBase,
     CharmEvents,
 )
-from ops.framework import EventBase, EventSource, StoredState  # noqa: E402
+from ops.framework import EventBase, EventSource, StoredState  # noqa: E402 (ditto)
 from ops.main import main  # noqa: E402 (ditto)
 
 logger = logging.getLogger()

--- a/test/fake_pebble.py
+++ b/test/fake_pebble.py
@@ -88,10 +88,10 @@ class Handler(http.server.BaseHTTPRequestHandler):
         }
         self.respond(d, 500)
 
-    def do_GET(self):  # noqa: N802
+    def do_GET(self):  # noqa: N802 ("should be lowercase")
         self.do_request('GET')
 
-    def do_POST(self):  # noqa: N802
+    def do_POST(self):  # noqa: N802 ("should be lowercase")
         self.do_request('POST')
 
     def do_request(self, request_method):


### PR DESCRIPTION
Now that we're using Python 3.8+ the more modern syntax is available to us, so use it. Also re-enable Pyright's reportTypeCommentUsage setting.

The second commit in this PR also removes a bunch of unneeded "noqa" and "pyright" comments.

I used a little script to find these and do a regex replace, then fixed up the few remaining ones (that were split on multiple lines) manually. Then I ran the following script to dump the AST (removing "annotated assignments") and did a diff against the original AST to ensure I hadn't messed up anything else.

```python
import ast
import os

class Transformer(ast.NodeTransformer):
    def visit_AnnAssign(self, node):
        if node.value is None:
            return None
        return ast.Assign([node.target], node.value)

PATHS = """
ops/charm.py
ops/framework.py
ops/main.py
ops/model.py
ops/pebble.py
ops/storage.py
ops/testing.py
""".split()

for path in PATHS:
    with open(path) as f:
        source = f.read()
    filename = os.path.basename(path)
    tree = ast.parse(source, filename)

    transformed = Transformer().visit(tree)

    root, ext = os.path.splitext(filename)
    outname = f'ops/{root}.ast'
    print(outname)
    with open(outname, 'w') as f:
        f.write(ast.dump(tree, indent=4))
```
