### PR TITLE
Support for open-port, close-port, and opened-ports

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -634,7 +634,7 @@ class Unit:
         return self._backend.opened_ports()
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class OpenedPort:
     """Represents a port opened by :meth:`Unit.open_port`."""
 
@@ -3068,18 +3068,13 @@ class _ModelBackend:
             return OpenedPort('icmp', None)
         port_range, slash, protocol = port_str.partition('/')
         if not slash or protocol not in ['tcp', 'udp']:
-            logger.warning('Invalid line from opened-ports: %s', port_str)
+            logger.warning('Unexpected opened-ports protocol: %s', port_str)
             return None
-        start, hyphen, _ = port_range.partition('-')
+        port, hyphen, _ = port_range.partition('-')
         if hyphen:
-            logger.warning('Unexpected port range from opened-ports: %s', port_str)
-        try:
-            port = int(start)
-        except ValueError:
-            logger.warning('Invalid line from opened-ports: %s', port_str)
-            return None
+            logger.warning('Ignoring opened-ports port range: %s', port_str)
         protocol_lit = typing.cast(typing.Literal['tcp', 'udp', 'icmp'], protocol)
-        return OpenedPort(protocol_lit, port)
+        return OpenedPort(protocol_lit, int(port))
 
 
 class _ModelBackendValidator:

--- a/ops/model.py
+++ b/ops/model.py
@@ -626,7 +626,20 @@ class Unit:
 
     def close_port(self, protocol: typing.Literal['tcp', 'udp', 'icmp'],
                    port: Optional[int] = None):
-        """Close a port with the given protocol for this unit."""
+        """Close a port with the given protocol for this unit.
+
+        On Kubernetes sidecar charms, Juju will only close the port once the
+        last unit that opened that port has closed it. However, this is
+        usually not an issue; normally charms should make the same
+        close_port() call from every unit.
+
+        Args:
+            protocol: String representing the protocol; must be one of
+                'tcp', 'udp', or 'icmp' (lowercase is recommended, but
+                uppercase is also supported).
+            port: The port to open. Required for TCP and UDP; not allowed
+                for ICMP.
+        """
         self._backend.close_port(protocol.lower(), port)
 
     def opened_ports(self) -> Set['OpenedPort']:

--- a/ops/model.py
+++ b/ops/model.py
@@ -3051,6 +3051,10 @@ class _ModelBackend:
         self._run('close-port', arg)
 
     def opened_ports(self) -> Set[OpenedPort]:
+        # We could use "opened-ports --format=json", but it's not really
+        # structured; it's just an array of strings which are the lines of the
+        # text output, like ["icmp","8081/udp"]. So it's probably just as
+        # likely to change as the text output, and doesn't seem any better.
         output = typing.cast(str, self._run('opened-ports', return_output=True))
         ports: Set[OpenedPort] = set()
         for line in output.splitlines():

--- a/ops/model.py
+++ b/ops/model.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 """Representations of Juju's model, application, unit, and other entities."""
+
+import dataclasses
 import datetime
 import enum
 import ipaddress
@@ -599,6 +601,48 @@ class Unit:
             rotate=rotate,
             owner='unit')
         return Secret(self._backend, id=id, label=label, content=content)
+
+    def open_port(self, protocol: typing.Literal['tcp', 'udp', 'icmp'],
+                  port: Optional[int] = None):
+        """Open a port with the given protocol for this unit.
+
+        Calling this registers intent with Juju that the application should be
+        accessed on the given port, but the port isn't actually opened
+        externally until the operator runs "juju expose".
+
+        On Kubernetes sidecar charms, the ports opened are not strictly
+        per-unit: Juju will open the union of ports from all units.
+        However, normally charms should make the same open_port() call from
+        every unit.
+
+        Args:
+            protocol: String representing the protocol; must be one of
+                'tcp', 'udp', or 'icmp' (lowercase is recommended, but
+                uppercase is also supported).
+            port: The port to open. Required for TCP and UDP; not allowed
+                for ICMP.
+        """
+        self._backend.open_port(protocol.lower(), port)
+
+    def close_port(self, protocol: typing.Literal['tcp', 'udp', 'icmp'],
+                   port: Optional[int] = None):
+        """Close a port with the given protocol for this unit."""
+        self._backend.close_port(protocol.lower(), port)
+
+    def opened_ports(self) -> List['OpenedPort']:
+        """Return a list of opened ports for this unit."""
+        return self._backend.opened_ports()
+
+
+@dataclasses.dataclass
+class OpenedPort:
+    """Represents a port opened by :meth:`Unit.open_port`."""
+
+    """The IP protocol: 'tcp', 'udp', or 'icmp'."""
+    protocol: typing.Literal['tcp', 'udp', 'icmp']
+
+    """The port number. Will be None if protocol is 'icmp'."""
+    port: Optional[int]
 
 
 class LazyMapping(Mapping[str, str], ABC):
@@ -2997,6 +3041,45 @@ class _ModelBackend:
         if revision is not None:
             args.extend(['--revision', str(revision)])
         self._run_for_secret('secret-remove', *args)
+
+    def open_port(self, protocol: str, port: Optional[int] = None):
+        arg = f'{port}/{protocol}' if port is not None else protocol
+        self._run('open-port', arg)
+
+    def close_port(self, protocol: str, port: Optional[int] = None):
+        arg = f'{port}/{protocol}' if port is not None else protocol
+        self._run('close-port', arg)
+
+    def opened_ports(self) -> List[OpenedPort]:
+        output = typing.cast(str, self._run('opened-ports', return_output=True))
+        ports: List[OpenedPort] = []
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            port = self._parse_opened_port(line)
+            if port is not None:
+                ports.append(port)
+        return ports
+
+    @classmethod
+    def _parse_opened_port(cls, port_str: str) -> Optional[OpenedPort]:
+        if port_str == 'icmp':
+            return OpenedPort('icmp', None)
+        port_range, slash, protocol = port_str.partition('/')
+        if not slash or protocol not in ['tcp', 'udp']:
+            logger.warning('Invalid line from opened-ports: %s', port_str)
+            return None
+        start, hyphen, _ = port_range.partition('-')
+        if hyphen:
+            logger.warning('Unexpected port range from opened-ports: %s', port_str)
+        try:
+            port = int(start)
+        except ValueError:
+            logger.warning('Invalid line from opened-ports: %s', port_str)
+            return None
+        protocol_lit = typing.cast(typing.Literal['tcp', 'udp', 'icmp'], protocol)
+        return OpenedPort(protocol_lit, port)
 
 
 class _ModelBackendValidator:

--- a/ops/model.py
+++ b/ops/model.py
@@ -3090,7 +3090,7 @@ class _ModelBackend:
         port, hyphen, _ = port_range.partition('-')
         if hyphen:
             logger.warning('Ignoring opened-ports port range: %s', port_str)
-        protocol_lit = typing.cast(typing.Literal['tcp', 'udp', 'icmp'], protocol)
+        protocol_lit = typing.cast(typing.Literal['tcp', 'udp'], protocol)
         return OpenedPort(protocol_lit, int(port))
 
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -629,7 +629,7 @@ class Unit:
         """Close a port with the given protocol for this unit."""
         self._backend.close_port(protocol.lower(), port)
 
-    def opened_ports(self) -> List['OpenedPort']:
+    def opened_ports(self) -> Set['OpenedPort']:
         """Return a list of opened ports for this unit."""
         return self._backend.opened_ports()
 
@@ -3050,16 +3050,16 @@ class _ModelBackend:
         arg = f'{port}/{protocol}' if port is not None else protocol
         self._run('close-port', arg)
 
-    def opened_ports(self) -> List[OpenedPort]:
+    def opened_ports(self) -> Set[OpenedPort]:
         output = typing.cast(str, self._run('opened-ports', return_output=True))
-        ports: List[OpenedPort] = []
+        ports: Set[OpenedPort] = set()
         for line in output.splitlines():
             line = line.strip()
             if not line:
                 continue
             port = self._parse_opened_port(line)
             if port is not None:
-                ports.append(port)
+                ports.add(port)
         return ports
 
     @classmethod

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2072,10 +2072,8 @@ class _TestingModelBackend:
         # TODO: is this an error if not opened?
         self._opened_ports.discard(model.OpenedPort(protocol_lit, port))
 
-    def opened_ports(self) -> List[model.OpenedPort]:
-        ports = list(self._opened_ports)
-        ports.sort(key=lambda p: (p.protocol, p.port))  # ensure stable order
-        return ports
+    def opened_ports(self) -> Set[model.OpenedPort]:
+        return set(self._opened_ports)
 
     def _check_protocol_and_port(self, protocol: str, port: Optional[int]):
         if protocol == 'icmp':

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -39,6 +39,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Literal,
     Mapping,
     Optional,
     Set,
@@ -56,7 +57,7 @@ from ops.charm import CharmBase, CharmMeta, RelationRole
 from ops.model import RelationNotFoundError
 
 if TYPE_CHECKING:
-    from typing_extensions import Literal, TypedDict
+    from typing_extensions import TypedDict
 
     from ops.model import UnitOrApplication
 
@@ -2072,7 +2073,9 @@ class _TestingModelBackend:
         self._opened_ports.discard(model.OpenedPort(protocol_lit, port))
 
     def opened_ports(self) -> List[model.OpenedPort]:
-        return list(self._opened_ports)
+        ports = list(self._opened_ports)
+        ports.sort(key=lambda p: (p.protocol, p.port))  # ensure stable order
+        return ports
 
     def _check_protocol_and_port(self, protocol: str, port: Optional[int]):
         if protocol == 'icmp':

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2079,14 +2079,14 @@ class _TestingModelBackend:
         # should be testing details of error messages).
         if protocol == 'icmp':
             if port is not None:
-                raise model.ModelError(f'ERROR protocol "{protocol}" doesn\'t support any ports; got "{port}"\n')
+                raise model.ModelError(f'ERROR protocol "{protocol}" doesn\'t support any ports; got "{port}"\n')  # NOQA: test_quote_backslashes
         elif protocol in ['tcp', 'udp']:
             if port is None:
-                raise model.ModelError(f'ERROR invalid port "{protocol}": strconv.Atoi: parsing "{protocol}": invalid syntax\n')
+                raise model.ModelError(f'ERROR invalid port "{protocol}": strconv.Atoi: parsing "{protocol}": invalid syntax\n')  # NOQA: test_quote_backslashes
             if not (1 <= port <= 65535):
-                raise model.ModelError(f'ERROR port range bounds must be between 1 and 65535, got {port}-{port}\n')
+                raise model.ModelError(f'ERROR port range bounds must be between 1 and 65535, got {port}-{port}\n')  # NOQA: test_quote_backslashes
         else:
-            raise model.ModelError(f'ERROR invalid protocol "{protocol}", expected "tcp", "udp", or "icmp"\n')
+            raise model.ModelError(f'ERROR invalid protocol "{protocol}", expected "tcp", "udp", or "icmp"\n')  # NOQA: test_quote_backslashes
 
 
 @_copy_docstrings(pebble.Client)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2069,25 +2069,24 @@ class _TestingModelBackend:
     def close_port(self, protocol: str, port: Optional[int] = None):
         self._check_protocol_and_port(protocol, port)
         protocol_lit = cast(Literal['tcp', 'udp', 'icmp'], protocol)
-        # TODO: is this an error if not opened?
         self._opened_ports.discard(model.OpenedPort(protocol_lit, port))
 
     def opened_ports(self) -> Set[model.OpenedPort]:
         return set(self._opened_ports)
 
     def _check_protocol_and_port(self, protocol: str, port: Optional[int]):
+        # Simulate the error messages we get from Juju (not that charm tests
+        # should be testing details of error messages).
         if protocol == 'icmp':
             if port is not None:
-                raise model.ModelError('icmp cannot have port')  # TODO: correct error message
+                raise model.ModelError(f'ERROR protocol "{protocol}" doesn\'t support any ports; got "{port}"\n')
         elif protocol in ['tcp', 'udp']:
             if port is None:
-                raise model.ModelError('tcp/udp must have port')  # TODO: correct error message
+                raise model.ModelError(f'ERROR invalid port "{protocol}": strconv.Atoi: parsing "{protocol}": invalid syntax\n')
             if not (1 <= port <= 65535):
-                # TODO: correct error message
-                raise model.ModelError("port not in range 1 through 65535")
+                raise model.ModelError(f'ERROR port range bounds must be between 1 and 65535, got {port}-{port}\n')
         else:
-            # TODO: correct error message
-            raise model.ModelError("protocol must be 'tcp', 'udp', or 'icmp'")
+            raise model.ModelError(f'ERROR invalid protocol "{protocol}", expected "tcp", "udp", or "icmp"\n')
 
 
 @_copy_docstrings(pebble.Client)

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -4572,3 +4572,59 @@ class EventRecorder(CharmBase):
 
     def record_event(self, event):
         self.events.append(event)
+
+
+class TestPorts(unittest.TestCase):
+    def test_ports(self):
+        harness = Harness(CharmBase, meta='name: webapp')
+        self.addCleanup(harness.cleanup)
+        unit = harness.model.unit
+
+        unit.open_port('tcp', 8080)
+        unit.open_port('udp', 4000)
+        unit.open_port('icmp')
+
+        ports = unit.opened_ports()
+        self.assertEqual(len(ports), 3)
+        self.assertIsInstance(ports[0], model.OpenedPort)
+        self.assertEqual(ports[0].protocol, 'icmp')
+        self.assertIsNone(ports[0].port)
+        self.assertIsInstance(ports[1], model.OpenedPort)
+        self.assertEqual(ports[1].protocol, 'tcp')
+        self.assertEqual(ports[1].port, 8080)
+        self.assertIsInstance(ports[2], model.OpenedPort)
+        self.assertEqual(ports[2].protocol, 'udp')
+        self.assertEqual(ports[2].port, 4000)
+
+        unit.close_port('tcp', 8080)
+        unit.close_port('tcp', 8080)  # closing same port again has no effect
+        unit.close_port('udp', 4000)
+
+        ports = unit.opened_ports()
+        self.assertEqual(len(ports), 1)
+        self.assertIsInstance(ports[0], model.OpenedPort)
+        self.assertEqual(ports[0].protocol, 'icmp')
+        self.assertIsNone(ports[0].port)
+
+        unit.close_port('icmp')
+
+        ports = unit.opened_ports()
+        self.assertEqual(ports, [])
+
+    def test_errors(self):
+        harness = Harness(CharmBase, meta='name: webapp')
+        self.addCleanup(harness.cleanup)
+        unit = harness.model.unit
+
+        with self.assertRaises(model.ModelError):
+            unit.open_port('icmp', 8080)  # icmp cannot have port
+        with self.assertRaises(model.ModelError):
+            unit.open_port('ftp', 8080)  # invalid protocol
+        with self.assertRaises(model.ModelError):
+            unit.open_port('tcp')  # tcp must have port
+        with self.assertRaises(model.ModelError):
+            unit.open_port('udp')  # udp must have port
+        with self.assertRaises(model.ModelError):
+            unit.open_port('tcp', 0)  # port out of range
+        with self.assertRaises(model.ModelError):
+            unit.open_port('tcp', 65536)  # port out of range

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -4584,7 +4584,9 @@ class TestPorts(unittest.TestCase):
         unit.open_port('udp', 4000)
         unit.open_port('icmp')
 
-        ports = unit.opened_ports()
+        ports_set = unit.opened_ports()
+        self.assertIsInstance(ports_set, set)
+        ports = sorted(ports_set, key=lambda p: (p.protocol, p.port))
         self.assertEqual(len(ports), 3)
         self.assertIsInstance(ports[0], model.OpenedPort)
         self.assertEqual(ports[0].protocol, 'icmp')
@@ -4600,7 +4602,9 @@ class TestPorts(unittest.TestCase):
         unit.close_port('tcp', 8080)  # closing same port again has no effect
         unit.close_port('udp', 4000)
 
-        ports = unit.opened_ports()
+        ports_set = unit.opened_ports()
+        self.assertIsInstance(ports_set, set)
+        ports = sorted(ports_set, key=lambda p: (p.protocol, p.port))
         self.assertEqual(len(ports), 1)
         self.assertIsInstance(ports[0], model.OpenedPort)
         self.assertEqual(ports[0].protocol, 'icmp')
@@ -4608,8 +4612,8 @@ class TestPorts(unittest.TestCase):
 
         unit.close_port('icmp')
 
-        ports = unit.opened_ports()
-        self.assertEqual(ports, [])
+        ports_set = unit.opened_ports()
+        self.assertEqual(ports_set, set())
 
     def test_errors(self):
         harness = Harness(CharmBase, meta='name: webapp')


### PR DESCRIPTION
Adds support for open-port, close-port and opened-ports as per the [OP029 spec](https://docs.google.com/document/d/1xHLzBgcXtLsBpMsjuqUW2pI1tP4D8lgSUD_sg3HClng/edit#).

Also adds testing backend support for the same for use in charm tests.

Fixes https://github.com/canonical/operator/issues/179