### PR TITLE
Import (almost) all public names in ops __init__.py

### DIFF
--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,6 +39,122 @@ and day-2 operations specific to that application.
 Full developer documentation is available at https://juju.is/docs/sdk.
 """
 
-# Import here the bare minimum to break the circular import between modules
+# TODO: ensure there is no overlap between names in the various groups
+
+import ops.main as main_module
+
+# TODO: is this still needed?
 from . import charm  # type: ignore # noqa
+from .charm import (
+    ActionEvent,
+    ActionMeta,
+    CharmBase,
+    CharmEvents,
+    CharmMeta,
+    CollectMetricsEvent,
+    ConfigChangedEvent,
+    ContainerMeta,
+    ContainerStorageMeta,
+    HookEvent,
+    InstallEvent,
+    LeaderElectedEvent,
+    LeaderSettingsChangedEvent,
+    PayloadMeta,
+    PebbleReadyEvent,
+    PostSeriesUpgradeEvent,
+    PreSeriesUpgradeEvent,
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationCreatedEvent,
+    RelationDepartedEvent,
+    RelationEvent,
+    RelationJoinedEvent,
+    RelationMeta,
+    RelationRole,
+    RemoveEvent,
+    ResourceMeta,
+    SecretChangedEvent,
+    SecretEvent,
+    SecretExpiredEvent,
+    SecretRemoveEvent,
+    SecretRotateEvent,
+    StartEvent,
+    StopEvent,
+    StorageAttachedEvent,
+    StorageDetachingEvent,
+    StorageEvent,
+    StorageMeta,
+    UpdateStatusEvent,
+    UpgradeCharmEvent,
+    WorkloadEvent,
+)
+from .framework import (
+    BoundEvent,
+    BoundStoredState,
+    CommitEvent,
+    EventBase,
+    EventSource,
+    Framework,
+    FrameworkEvents,
+    Handle,
+    HandleKind,
+    LifecycleEvent,
+    NoTypeError,
+    Object,
+    ObjectEvents,
+    PreCommitEvent,
+    PrefixedEvents,
+    StoredDict,
+    StoredList,
+    StoredSet,
+    StoredState,
+    StoredStateData,
+)
+from .jujuversion import JujuVersion
+from .main import main
+from .model import (
+    ActiveStatus,
+    Application,
+    Binding,
+    BindingMapping,
+    BlockedStatus,
+    CheckInfoMapping,
+    ConfigData,
+    Container,
+    ContainerMapping,
+    ErrorStatus,
+    InvalidStatusError,
+    LazyMapping,
+    MaintenanceStatus,
+    Model,
+    ModelError,
+    MultiPushPullError,
+    Network,
+    NetworkInterface,
+    Pod,
+    Relation,
+    RelationData,
+    RelationDataAccessError,
+    RelationDataContent,
+    RelationDataError,
+    RelationDataTypeError,
+    RelationMapping,
+    RelationNotFoundError,
+    Resources,
+    Secret,
+    SecretInfo,
+    SecretNotFoundError,
+    SecretRotate,
+    ServiceInfoMapping,
+    StatusBase,
+    Storage,
+    StorageMapping,
+    TooManyRelatedAppsError,
+    Unit,
+    UnknownStatus,
+    WaitingStatus,
+)
 from .version import version as __version__  # type: ignore # noqa
+
+# TODO: hmmm, test that this hack works same before and after
+main.main = main

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -55,6 +55,10 @@ from . import pebble  # type: ignore # noqa: F401
 # import was here previously
 from . import charm  # type: ignore # noqa: F401
 
+# Import the main module, which we've overriden in main.py to be callable.
+# This allows "import ops; ops.main(Charm)" to work as expected.
+from . import main  # type: ignore # noqa: F401
+
 # Explicitly import names from sub-modules so users can just "import ops" and
 # then use them as "ops.X".
 from .charm import (  # noqa: F401
@@ -125,15 +129,6 @@ from .framework import (  # noqa: F401
 )
 
 from .jujuversion import JujuVersion  # noqa: F401
-
-# To allow test_main.py to patch private things in the main module itself,
-# once "main" becomes a function below.
-import ops.main as _main_module  # noqa: F401
-
-# Import the main() function, but also set main.main to the function. This
-# allows charms to keep using "from ops.main import main".
-from .main import main
-main.main = main  # type: ignore
 
 from .model import (  # noqa: F401 E402
     ActiveStatus,

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -39,13 +39,24 @@ and day-2 operations specific to that application.
 Full developer documentation is available at https://juju.is/docs/sdk.
 """
 
-# TODO: ensure there is no overlap between names in the various groups
+# The isort command wants to rearrange the nicely-formatted imports below;
+# just skip it for this file.
+# isort:skip_file
 
-import ops.main as main_module
+# Similarly, Pyright complains that all of these things are unused imports,
+# so disable it:
+# pyright: reportUnusedImport=false
 
-# TODO: is this still needed?
-from . import charm  # type: ignore # noqa
-from .charm import (
+# To allow test_main.py to patch things in the main module itself,
+# once "main" becomes a function below.
+import ops.main as _main_module  # noqa: F401
+
+# Import pebble explicitly. It's the one module we don't import names from below.
+from . import pebble  # type: ignore # noqa: F401
+
+# Explicitly import names from sub-modules so users can just "import ops" and
+# then use them as "ops.X".
+from .charm import (  # noqa: F401
     ActionEvent,
     ActionMeta,
     CharmBase,
@@ -88,7 +99,8 @@ from .charm import (
     UpgradeCharmEvent,
     WorkloadEvent,
 )
-from .framework import (
+
+from .framework import (  # noqa: F401
     BoundEvent,
     BoundStoredState,
     CommitEvent,
@@ -110,9 +122,15 @@ from .framework import (
     StoredState,
     StoredStateData,
 )
-from .jujuversion import JujuVersion
+
+from .jujuversion import JujuVersion  # noqa: F401
+
+# Import the main() function, but also set main.main to the function. This
+# allows charms to keep using "from ops.main import main".
 from .main import main
-from .model import (
+main.main = main  # type: ignore
+
+from .model import (  # noqa: F401 E402
     ActiveStatus,
     Application,
     Binding,
@@ -154,7 +172,5 @@ from .model import (
     UnknownStatus,
     WaitingStatus,
 )
-from .version import version as __version__  # type: ignore # noqa
 
-# TODO: hmmm, test that this hack works same before and after
-main.main = main
+from .version import version as __version__  # noqa: F401 E402

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -47,10 +47,6 @@ Full developer documentation is available at https://juju.is/docs/sdk.
 # so disable it:
 # pyright: reportUnusedImport=false
 
-# To allow test_main.py to patch things in the main module itself,
-# once "main" becomes a function below.
-import ops.main as _main_module  # noqa: F401
-
 # Import pebble explicitly. It's the one module we don't import names from below.
 from . import pebble  # type: ignore # noqa: F401
 
@@ -129,6 +125,10 @@ from .framework import (  # noqa: F401
 )
 
 from .jujuversion import JujuVersion  # noqa: F401
+
+# To allow test_main.py to patch private things in the main module itself,
+# once "main" becomes a function below.
+import ops.main as _main_module  # noqa: F401
 
 # Import the main() function, but also set main.main to the function. This
 # allows charms to keep using "from ops.main import main".

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2020 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -174,6 +174,4 @@ from .model import (  # noqa: F401 E402
     WaitingStatus,
 )
 
-from .testing import Harness  # noqa: F401 E402
-
 from .version import version as __version__  # noqa: F401 E402

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -54,6 +54,11 @@ import ops.main as _main_module  # noqa: F401
 # Import pebble explicitly. It's the one module we don't import names from below.
 from . import pebble  # type: ignore # noqa: F401
 
+# Also import charm explicitly. This is not strictly necessary as the
+# "from .charm" import automatically does that, but be explicit since this
+# import was here previously
+from . import charm  # type: ignore # noqa: F401
+
 # Explicitly import names from sub-modules so users can just "import ops" and
 # then use them as "ops.X".
 from .charm import (  # noqa: F401

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -149,6 +149,7 @@ from .model import (  # noqa: F401 E402
     MultiPushPullError,
     Network,
     NetworkInterface,
+    OpenedPort,
     Pod,
     Relation,
     RelationData,

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -173,4 +173,6 @@ from .model import (  # noqa: F401 E402
     WaitingStatus,
 )
 
+from .testing import Harness  # noqa: F401 E402
+
 from .version import version as __version__  # noqa: F401 E402

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -174,4 +174,7 @@ from .model import (  # noqa: F401 E402
     WaitingStatus,
 )
 
+# NOTE: don't import testing or Harness here, as that's a test-time concern
+# rather than a runtime concern.
+
 from .version import version as __version__  # noqa: F401 E402

--- a/ops/main.py
+++ b/ops/main.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Main entry point to the Operator Framework."""
+"""Main entry point to the Operator Framework.
+
+Note that this module is callable, and calls the :func:`ops.main.main` function.
+This is so that :code:`import ops` followed by :code:`ops.main(MyCharm)` works
+as expected.
+"""
 
 import logging
 import os
@@ -438,3 +443,15 @@ def main(charm_class: Type[ops.charm.CharmBase],
         framework.commit()
     finally:
         framework.close()
+
+
+# Make this module callable and call main(), so that "import ops" and then
+# "ops.main(Charm)" works as expected now that everything is imported in
+# ops/__init__.py. Idea from https://stackoverflow.com/a/48100440/68707
+class _CallableModule(sys.modules[__name__].__class__):
+    def __call__(self, charm_class: Type[ops.charm.CharmBase],
+                 use_juju_for_storage: Optional[bool] = None):
+        return main(charm_class, use_juju_for_storage=use_juju_for_storage)
+
+
+sys.modules[__name__].__class__ = _CallableModule

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -19,9 +19,8 @@ import subprocess
 import tempfile
 import unittest
 
-from ops.charm import CharmMeta
-from ops.framework import Framework
-from ops.model import Model, _ModelBackend
+import ops
+from ops.model import _ModelBackend
 from ops.storage import SQLiteStorage
 
 
@@ -120,7 +119,7 @@ class BaseTestCase(unittest.TestCase):
             data_fpath = tmpdir / "framework.data"
             charm_dir = tmpdir
 
-        framework = Framework(
+        framework = ops.Framework(
             SQLiteStorage(data_fpath),
             charm_dir,
             meta=None,
@@ -131,6 +130,6 @@ class BaseTestCase(unittest.TestCase):
     def create_model(self):
         """Create a Model object."""
         backend = _ModelBackend(unit_name='myapp/0')
-        meta = CharmMeta()
-        model = Model(meta, backend)
+        meta = ops.CharmMeta()
+        model = ops.Model(meta, backend)
         return model

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -15,7 +15,7 @@
 import os
 import unittest.mock  # in this file, importing just 'patch' would be confusing
 
-from ops.jujuversion import JujuVersion
+import ops
 
 
 class TestJujuVersion(unittest.TestCase):
@@ -34,7 +34,7 @@ class TestJujuVersion(unittest.TestCase):
         ]
 
         for vs, major, minor, tag, patch, build in test_cases:
-            v = JujuVersion(vs)
+            v = ops.JujuVersion(vs)
             self.assertEqual(v.major, major)
             self.assertEqual(v.minor, minor)
             self.assertEqual(v.tag, tag)
@@ -44,34 +44,34 @@ class TestJujuVersion(unittest.TestCase):
     @unittest.mock.patch('os.environ', new={})
     def test_from_environ(self):
         # JUJU_VERSION is not set
-        v = JujuVersion.from_environ()
-        self.assertEqual(v, JujuVersion('0.0.0'))
+        v = ops.JujuVersion.from_environ()
+        self.assertEqual(v, ops.JujuVersion('0.0.0'))
 
         os.environ['JUJU_VERSION'] = 'no'
         with self.assertRaisesRegex(RuntimeError, 'not a valid Juju version'):
-            JujuVersion.from_environ()
+            ops.JujuVersion.from_environ()
 
         os.environ['JUJU_VERSION'] = '2.8.0'
-        v = JujuVersion.from_environ()
-        self.assertEqual(v, JujuVersion('2.8.0'))
+        v = ops.JujuVersion.from_environ()
+        self.assertEqual(v, ops.JujuVersion('2.8.0'))
 
     def test_has_app_data(self):
-        self.assertTrue(JujuVersion('2.8.0').has_app_data())
-        self.assertTrue(JujuVersion('2.7.0').has_app_data())
-        self.assertFalse(JujuVersion('2.6.9').has_app_data())
+        self.assertTrue(ops.JujuVersion('2.8.0').has_app_data())
+        self.assertTrue(ops.JujuVersion('2.7.0').has_app_data())
+        self.assertFalse(ops.JujuVersion('2.6.9').has_app_data())
 
     def test_is_dispatch_aware(self):
-        self.assertTrue(JujuVersion('2.8.0').is_dispatch_aware())
-        self.assertFalse(JujuVersion('2.7.9').is_dispatch_aware())
+        self.assertTrue(ops.JujuVersion('2.8.0').is_dispatch_aware())
+        self.assertFalse(ops.JujuVersion('2.7.9').is_dispatch_aware())
 
     def test_has_controller_storage(self):
-        self.assertTrue(JujuVersion('2.8.0').has_controller_storage())
-        self.assertFalse(JujuVersion('2.7.9').has_controller_storage())
+        self.assertTrue(ops.JujuVersion('2.8.0').has_controller_storage())
+        self.assertFalse(ops.JujuVersion('2.7.9').has_controller_storage())
 
     def test_has_secrets(self):
-        self.assertTrue(JujuVersion('3.0.2').has_secrets)
-        self.assertFalse(JujuVersion('3.0.1').has_secrets)
-        self.assertFalse(JujuVersion('2.9.30').has_secrets)
+        self.assertTrue(ops.JujuVersion('3.0.2').has_secrets)
+        self.assertFalse(ops.JujuVersion('3.0.1').has_secrets)
+        self.assertFalse(ops.JujuVersion('2.9.30').has_secrets)
 
     def test_parsing_errors(self):
         invalid_versions = [
@@ -90,7 +90,7 @@ class TestJujuVersion(unittest.TestCase):
         ]
         for v in invalid_versions:
             with self.assertRaises(RuntimeError):
-                JujuVersion(v)
+                ops.JujuVersion(v)
 
     def test_equality(self):
         test_cases = [
@@ -118,8 +118,8 @@ class TestJujuVersion(unittest.TestCase):
         ]
 
         for a, b, expected in test_cases:
-            self.assertEqual(JujuVersion(a) == JujuVersion(b), expected)
-            self.assertEqual(JujuVersion(a) == b, expected)
+            self.assertEqual(ops.JujuVersion(a) == ops.JujuVersion(b), expected)
+            self.assertEqual(ops.JujuVersion(a) == b, expected)
 
     def test_comparison(self):
         test_cases = [
@@ -149,12 +149,12 @@ class TestJujuVersion(unittest.TestCase):
 
         for a, b, expected_strict, expected_weak in test_cases:
             with self.subTest(a=a, b=b):
-                self.assertEqual(JujuVersion(a) < JujuVersion(b), expected_strict)
-                self.assertEqual(JujuVersion(a) <= JujuVersion(b), expected_weak)
-                self.assertEqual(JujuVersion(b) > JujuVersion(a), expected_strict)
-                self.assertEqual(JujuVersion(b) >= JujuVersion(a), expected_weak)
+                self.assertEqual(ops.JujuVersion(a) < ops.JujuVersion(b), expected_strict)
+                self.assertEqual(ops.JujuVersion(a) <= ops.JujuVersion(b), expected_weak)
+                self.assertEqual(ops.JujuVersion(b) > ops.JujuVersion(a), expected_strict)
+                self.assertEqual(ops.JujuVersion(b) >= ops.JujuVersion(a), expected_weak)
                 # Implicit conversion.
-                self.assertEqual(JujuVersion(a) < b, expected_strict)
-                self.assertEqual(JujuVersion(a) <= b, expected_weak)
-                self.assertEqual(b > JujuVersion(a), expected_strict)
-                self.assertEqual(b >= JujuVersion(a), expected_weak)
+                self.assertEqual(ops.JujuVersion(a) < b, expected_strict)
+                self.assertEqual(ops.JujuVersion(a) <= b, expected_weak)
+                self.assertEqual(b > ops.JujuVersion(a), expected_strict)
+                self.assertEqual(b >= ops.JujuVersion(a), expected_weak)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -28,37 +28,9 @@ from unittest.mock import patch
 
 import logassert
 
-from ops.charm import (
-    ActionEvent,
-    CharmBase,
-    CharmEvents,
-    CharmMeta,
-    CollectMetricsEvent,
-    ConfigChangedEvent,
-    HookEvent,
-    InstallEvent,
-    LeaderSettingsChangedEvent,
-    PebbleReadyEvent,
-    RelationBrokenEvent,
-    RelationChangedEvent,
-    RelationDepartedEvent,
-    RelationEvent,
-    RelationJoinedEvent,
-    SecretChangedEvent,
-    SecretEvent,
-    SecretExpiredEvent,
-    SecretRemoveEvent,
-    SecretRotateEvent,
-    StartEvent,
-    StorageAttachedEvent,
-    UpdateStatusEvent,
-    UpgradeCharmEvent,
-    WorkloadEvent,
-)
-from ops.framework import Framework, LifecycleEvent, StoredStateData
-from ops.main import CHARM_STATE_FILE, _should_use_controller_storage, main
+import ops
+from ops.main import CHARM_STATE_FILE, _should_use_controller_storage
 from ops.storage import SQLiteStorage
-from ops.version import version
 
 from .charms.test_main.src.charm import MyCharmEvents
 from .test_helpers import fake_script, fake_script_calls
@@ -69,7 +41,7 @@ TEST_CHARM_DIR = Path(f"{__file__}/../charms/test_main").resolve()
 
 VERSION_LOGLINE = [
     'juju-log', '--log-level', 'DEBUG', '--',
-    f'Operator Framework {version} up and running.',
+    f'Operator Framework {ops.__version__} up and running.',
 ]
 
 logger = logging.getLogger(__name__)
@@ -105,7 +77,7 @@ class CharmInitTestCase(unittest.TestCase):
 
     @patch('sys.stderr', new_callable=io.StringIO)
     def test_breakpoint(self, fake_stderr):
-        class MyCharm(CharmBase):
+        class MyCharm(ops.CharmBase):
             pass
         self._check(MyCharm, extra_environ={'JUJU_DEBUG_AT': 'all'})
 
@@ -116,7 +88,7 @@ class CharmInitTestCase(unittest.TestCase):
         self.assertIn('Starting pdb to debug charm operator', fake_stderr.getvalue())
 
     def test_no_debug_breakpoint(self):
-        class MyCharm(CharmBase):
+        class MyCharm(ops.CharmBase):
             pass
         self._check(MyCharm, extra_environ={'JUJU_DEBUG_AT': ''})
 
@@ -144,10 +116,10 @@ class CharmInitTestCase(unittest.TestCase):
                             fh.write(b'name: test')
                         mock_charmdir.return_value = tmpdirname
 
-                        main(charm_class, **kwargs)
+                        ops.main(charm_class, **kwargs)
 
     def test_init_signature_passthrough(self):
-        class MyCharm(CharmBase):
+        class MyCharm(ops.CharmBase):
 
             def __init__(self, *args):
                 super().__init__(*args)
@@ -157,7 +129,7 @@ class CharmInitTestCase(unittest.TestCase):
         self.assertEqual(warn_cm, [])
 
     def test_init_signature_old_key_argument(self):
-        class MyCharm(CharmBase):
+        class MyCharm(ops.CharmBase):
 
             def __init__(self, framework, somekey):
                 super().__init__(framework, somekey)
@@ -167,7 +139,7 @@ class CharmInitTestCase(unittest.TestCase):
             self._check(MyCharm)
 
     def test_init_signature_only_framework(self):
-        class MyCharm(CharmBase):
+        class MyCharm(ops.CharmBase):
 
             def __init__(self, framework):
                 super().__init__(framework)
@@ -183,21 +155,21 @@ class CharmInitTestCase(unittest.TestCase):
             with self.assertRaisesRegex(
                     RuntimeError,
                     'charm set use_juju_for_storage=True, but Juju .* does not support it'):
-                self._check(CharmBase, use_juju_for_storage=True)
+                self._check(ops.CharmBase, use_juju_for_storage=True)
 
     def test_storage_with_storage(self):
         # here we patch juju_backend_available, so it gets set up and falls over when used
         with patch('ops.storage.juju_backend_available') as juju_backend_available:
             juju_backend_available.return_value = True
             with self.assertRaisesRegex(FileNotFoundError, 'state-get'):
-                self._check(CharmBase, use_juju_for_storage=True)
+                self._check(ops.CharmBase, use_juju_for_storage=True)
 
     def test_controller_storage_deprecated(self):
         with patch('ops.storage.juju_backend_available') as juju_backend_available:
             juju_backend_available.return_value = True
             with self.assertWarnsRegex(DeprecationWarning, 'Controller storage'):
                 with self.assertRaisesRegex(FileNotFoundError, 'state-get'):
-                    self._check(CharmBase, use_juju_for_storage=True)
+                    self._check(ops.CharmBase, use_juju_for_storage=True)
 
 
 @patch('sys.argv', new=("hooks/config-changed",))
@@ -205,7 +177,7 @@ class CharmInitTestCase(unittest.TestCase):
 class TestDispatch(unittest.TestCase):
     def _check(self, *, with_dispatch=False, dispatch_path=''):
         """Helper for below tests."""
-        class MyCharm(CharmBase):
+        class MyCharm(ops.CharmBase):
             def __init__(self, framework):
                 super().__init__(framework)
 
@@ -233,7 +205,7 @@ class TestDispatch(unittest.TestCase):
                 with patch('ops._main_module._emit_charm_event') as mock_charm_event:
                     with patch('ops._main_module._get_charm_dir') as mock_charmdir:
                         mock_charmdir.return_value = tmpdir
-                        main(MyCharm)
+                        ops.main(MyCharm)
 
         self.assertEqual(mock_charm_event.call_count, 1)
         return mock_charm_event.call_args[0][1]
@@ -285,12 +257,12 @@ class _TestMain(abc.ABC):
 
         # Relations events are defined dynamically and modify the class attributes.
         # We use a subclass temporarily to prevent these side effects from leaking.
-        class TestCharmEvents(CharmEvents):
+        class TestCharmEvents(ops.CharmEvents):
             pass
-        CharmBase.on = TestCharmEvents()
+        ops.CharmBase.on = TestCharmEvents()
 
         def cleanup():
-            CharmBase.on = CharmEvents()
+            ops.CharmBase.on = ops.CharmEvents()
         self.addCleanup(cleanup)
 
         fake_script(self, 'juju-log', "exit 0")
@@ -337,10 +309,10 @@ class _TestMain(abc.ABC):
                 af = (self.JUJU_CHARM_DIR / 'actions.yaml')
                 if af.exists():
                     with af.open() as a:
-                        meta = CharmMeta.from_yaml(m, a)
+                        meta = ops.CharmMeta.from_yaml(m, a)
                 else:
-                    meta = CharmMeta.from_yaml(m)
-            framework = Framework(storage, self.JUJU_CHARM_DIR, meta, None, event_name)
+                    meta = ops.CharmMeta.from_yaml(m)
+            framework = ops.Framework(storage, self.JUJU_CHARM_DIR, meta, None, event_name)
 
             class ThisCharmEvents(MyCharmEvents):
                 pass
@@ -355,7 +327,7 @@ class _TestMain(abc.ABC):
             storage.commit()
             framework.close()
         else:
-            stored = StoredStateData(None, None)
+            stored = ops.StoredStateData(None, None)
         return stored
 
     def _simulate_event(self, event_spec):
@@ -372,16 +344,16 @@ class _TestMain(abc.ABC):
         })
         if event_spec.set_in_env is not None:
             env.update(event_spec.set_in_env)
-        if issubclass(event_spec.event_type, SecretEvent):
+        if issubclass(event_spec.event_type, ops.SecretEvent):
             env.update({
                 'JUJU_SECRET_ID': event_spec.secret_id,
                 'JUJU_SECRET_LABEL': event_spec.secret_label or '',
             })
-        if issubclass(event_spec.event_type, (SecretRemoveEvent, SecretExpiredEvent)):
+        if issubclass(event_spec.event_type, (ops.SecretRemoveEvent, ops.SecretExpiredEvent)):
             env.update({
                 'JUJU_SECRET_REVISION': str(event_spec.secret_revision or ''),
             })
-        if issubclass(event_spec.event_type, RelationEvent):
+        if issubclass(event_spec.event_type, ops.RelationEvent):
             rel_name = event_spec.event_name.split('_')[0]
             env.update({
                 'JUJU_RELATION': rel_name,
@@ -406,11 +378,11 @@ class _TestMain(abc.ABC):
                 'JUJU_REMOTE_UNIT': '',
                 'JUJU_REMOTE_APP': '',
             })
-        if issubclass(event_spec.event_type, WorkloadEvent):
+        if issubclass(event_spec.event_type, ops.WorkloadEvent):
             env.update({
                 'JUJU_WORKLOAD_NAME': event_spec.workload_name,
             })
-        if issubclass(event_spec.event_type, ActionEvent):
+        if issubclass(event_spec.event_type, ops.ActionEvent):
             event_filename = event_spec.event_name[:-len('_action')].replace('_', '-')
             env.update({
                 event_spec.env_var: event_filename,
@@ -430,14 +402,14 @@ class _TestMain(abc.ABC):
 
     def test_event_reemitted(self):
         # First run "install" to make sure all hooks are set up.
-        state = self._simulate_event(EventSpec(InstallEvent, 'install'))
+        state = self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
         self.assertEqual(list(state.observed_event_types), ['InstallEvent'])
 
-        state = self._simulate_event(EventSpec(ConfigChangedEvent, 'config-changed'))
+        state = self._simulate_event(EventSpec(ops.ConfigChangedEvent, 'config-changed'))
         self.assertEqual(list(state.observed_event_types), ['ConfigChangedEvent'])
 
         # Re-emit should pick the deferred config-changed.
-        state = self._simulate_event(EventSpec(UpdateStatusEvent, 'update-status'))
+        state = self._simulate_event(EventSpec(ops.UpdateStatusEvent, 'update-status'))
         self.assertEqual(
             list(state.observed_event_types),
             ['ConfigChangedEvent', 'UpdateStatusEvent'])
@@ -446,15 +418,15 @@ class _TestMain(abc.ABC):
         fake_script(self, 'add-metric', 'exit 0')
 
         # First run "install" to make sure all hooks are set up.
-        state = self._simulate_event(EventSpec(InstallEvent, 'install'))
+        state = self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
         self.assertEqual(list(state.observed_event_types), ['InstallEvent'])
 
-        state = self._simulate_event(EventSpec(ConfigChangedEvent, 'config-changed'))
+        state = self._simulate_event(EventSpec(ops.ConfigChangedEvent, 'config-changed'))
         self.assertEqual(list(state.observed_event_types), ['ConfigChangedEvent'])
 
         # Re-emit should not pick the deferred config-changed because
         # collect-metrics runs in a restricted context.
-        state = self._simulate_event(EventSpec(CollectMetricsEvent, 'collect-metrics'))
+        state = self._simulate_event(EventSpec(ops.CollectMetricsEvent, 'collect-metrics'))
         self.assertEqual(list(state.observed_event_types), ['CollectMetricsEvent'])
 
     def test_multiple_events_handled(self):
@@ -465,19 +437,19 @@ class _TestMain(abc.ABC):
         # Sample events with a different amount of dashes used
         # and with endpoints from different sections of metadata.yaml
         events_under_test = [(
-            EventSpec(InstallEvent, 'install'),
+            EventSpec(ops.InstallEvent, 'install'),
             {},
         ), (
-            EventSpec(StartEvent, 'start'),
+            EventSpec(ops.StartEvent, 'start'),
             {},
         ), (
-            EventSpec(UpdateStatusEvent, 'update_status'),
+            EventSpec(ops.UpdateStatusEvent, 'update_status'),
             {},
         ), (
-            EventSpec(LeaderSettingsChangedEvent, 'leader_settings_changed'),
+            EventSpec(ops.LeaderSettingsChangedEvent, 'leader_settings_changed'),
             {},
         ), (
-            EventSpec(RelationJoinedEvent, 'db_relation_joined',
+            EventSpec(ops.RelationJoinedEvent, 'db_relation_joined',
                       relation_id=1,
                       remote_app='remote',
                       remote_unit='remote/0'),
@@ -486,7 +458,7 @@ class _TestMain(abc.ABC):
              'app_name': 'remote',
              'unit_name': 'remote/0'},
         ), (
-            EventSpec(RelationChangedEvent, 'mon_relation_changed',
+            EventSpec(ops.RelationChangedEvent, 'mon_relation_changed',
                       relation_id=2,
                       remote_app='remote',
                       remote_unit='remote/0'),
@@ -495,7 +467,7 @@ class _TestMain(abc.ABC):
              'app_name': 'remote',
              'unit_name': 'remote/0'},
         ), (
-            EventSpec(RelationChangedEvent, 'mon_relation_changed',
+            EventSpec(ops.RelationChangedEvent, 'mon_relation_changed',
                       relation_id=2,
                       remote_app='remote',
                       remote_unit=None),
@@ -504,7 +476,7 @@ class _TestMain(abc.ABC):
              'app_name': 'remote',
              'unit_name': None},
         ), (
-            EventSpec(RelationDepartedEvent, 'mon_relation_departed',
+            EventSpec(ops.RelationDepartedEvent, 'mon_relation_departed',
                       relation_id=2,
                       remote_app='remote',
                       remote_unit='remote/0',
@@ -515,13 +487,13 @@ class _TestMain(abc.ABC):
              'unit_name': 'remote/0',
              'departing_unit_name': 'remote/42'},
         ), (
-            EventSpec(RelationBrokenEvent, 'ha_relation_broken',
+            EventSpec(ops.RelationBrokenEvent, 'ha_relation_broken',
                       relation_id=3),
             {'relation_name': 'ha',
              'relation_id': 3},
         ), (
             # Events without a remote app specified (for Juju < 2.7).
-            EventSpec(RelationJoinedEvent, 'db_relation_joined',
+            EventSpec(ops.RelationJoinedEvent, 'db_relation_joined',
                       relation_id=1,
                       remote_unit='remote/0'),
             {'relation_name': 'db',
@@ -529,7 +501,7 @@ class _TestMain(abc.ABC):
              'app_name': 'remote',
              'unit_name': 'remote/0'},
         ), (
-            EventSpec(RelationChangedEvent, 'mon_relation_changed',
+            EventSpec(ops.RelationChangedEvent, 'mon_relation_changed',
                       relation_id=2,
                       remote_unit='remote/0'),
             {'relation_name': 'mon',
@@ -537,7 +509,7 @@ class _TestMain(abc.ABC):
              'app_name': 'remote',
              'unit_name': 'remote/0'},
         ), (
-            EventSpec(RelationDepartedEvent, 'mon_relation_departed',
+            EventSpec(ops.RelationDepartedEvent, 'mon_relation_departed',
                       relation_id=2,
                       remote_unit='remote/0',
                       departing_unit_name='remote/42'),
@@ -547,26 +519,26 @@ class _TestMain(abc.ABC):
              'unit_name': 'remote/0',
              'departing_unit_name': 'remote/42'},
         ), (
-            EventSpec(ActionEvent, 'start_action',
+            EventSpec(ops.ActionEvent, 'start_action',
                       env_var='JUJU_ACTION_NAME'),
             {},
         ), (
-            EventSpec(ActionEvent, 'foo_bar_action',
+            EventSpec(ops.ActionEvent, 'foo_bar_action',
                       env_var='JUJU_ACTION_NAME'),
             {},
         ), (
-            EventSpec(PebbleReadyEvent, 'test_pebble_ready',
+            EventSpec(ops.PebbleReadyEvent, 'test_pebble_ready',
                       workload_name='test'),
             {'container_name': 'test'},
         ), (
-            EventSpec(SecretChangedEvent, 'secret_changed',
+            EventSpec(ops.SecretChangedEvent, 'secret_changed',
                       secret_id='secret:12345',
                       secret_label='foo'),
             {'id': 'secret:12345',
              'label': 'foo',
              'revision': 42}
         ), (
-            EventSpec(SecretRotateEvent, 'secret_rotate',
+            EventSpec(ops.SecretRotateEvent, 'secret_rotate',
                       secret_id='secret:12345',
                       secret_label='foo',
                       secret_revision='42'),
@@ -574,7 +546,7 @@ class _TestMain(abc.ABC):
              'label': 'foo',
              'revision': 42}
         ), (
-            EventSpec(SecretRemoveEvent, 'secret_remove',
+            EventSpec(ops.SecretRemoveEvent, 'secret_remove',
                       secret_id='secret:12345',
                       secret_label='foo',
                       secret_revision='42'),
@@ -582,7 +554,7 @@ class _TestMain(abc.ABC):
              'label': 'foo',
              'revision': 42}
         ), (
-            EventSpec(SecretExpiredEvent, 'secret_expired',
+            EventSpec(ops.SecretExpiredEvent, 'secret_expired',
                       secret_id='secret:12345',
                       secret_label='foo',
                       secret_revision='42'),
@@ -594,7 +566,7 @@ class _TestMain(abc.ABC):
         logger.debug('Expected events %s', events_under_test)
 
         # First run "install" to make sure all hooks are set up.
-        self._simulate_event(EventSpec(InstallEvent, 'install'))
+        self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
 
         # Simulate hook executions for every event.
         for event_spec, expected_event_data in events_under_test:
@@ -624,25 +596,25 @@ class _TestMain(abc.ABC):
         hook_path.symlink_to('install')
 
         try:
-            self._simulate_event(EventSpec(HookEvent, 'not-implemented-event'))
+            self._simulate_event(EventSpec(ops.HookEvent, 'not-implemented-event'))
         except subprocess.CalledProcessError:
             self.fail('Event simulation for an unsupported event'
                       ' results in a non-zero exit code returned')
 
     def test_no_actions(self):
         (self.JUJU_CHARM_DIR / 'actions.yaml').unlink()
-        self._simulate_event(EventSpec(InstallEvent, 'install'))
+        self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
 
     def test_empty_actions(self):
         (self.JUJU_CHARM_DIR / 'actions.yaml').write_text('')
-        self._simulate_event(EventSpec(InstallEvent, 'install'))
+        self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
 
     def test_collect_metrics(self):
         fake_script(self, 'add-metric', 'exit 0')
-        self._simulate_event(EventSpec(InstallEvent, 'install'))
+        self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
         # Clear the calls during 'install'
         fake_script_calls(self, clear=True)
-        self._simulate_event(EventSpec(CollectMetricsEvent, 'collect_metrics'))
+        self._simulate_event(EventSpec(ops.CollectMetricsEvent, 'collect_metrics'))
 
         expected = [
             VERSION_LOGLINE,
@@ -654,10 +626,10 @@ class _TestMain(abc.ABC):
         self.assertEqual(calls, expected)
 
     def test_custom_event(self):
-        self._simulate_event(EventSpec(InstallEvent, 'install'))
+        self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
         # Clear the calls during 'install'
         fake_script_calls(self, clear=True)
-        self._simulate_event(EventSpec(UpdateStatusEvent, 'update-status',
+        self._simulate_event(EventSpec(ops.UpdateStatusEvent, 'update-status',
                                        set_in_env={'EMIT_CUSTOM_EVENT': "1"}))
 
         expected = [
@@ -673,24 +645,24 @@ class _TestMain(abc.ABC):
         fake_script(self, 'action-get', "echo '{}'")
 
         test_cases = [(
-            EventSpec(ActionEvent, 'log_critical_action', env_var='JUJU_ACTION_NAME'),
+            EventSpec(ops.ActionEvent, 'log_critical_action', env_var='JUJU_ACTION_NAME'),
             ['juju-log', '--log-level', 'CRITICAL', '--', 'super critical'],
         ), (
-            EventSpec(ActionEvent, 'log_error_action',
+            EventSpec(ops.ActionEvent, 'log_error_action',
                       env_var='JUJU_ACTION_NAME'),
             ['juju-log', '--log-level', 'ERROR', '--', 'grave error'],
         ), (
-            EventSpec(ActionEvent, 'log_warning_action',
+            EventSpec(ops.ActionEvent, 'log_warning_action',
                       env_var='JUJU_ACTION_NAME'),
             ['juju-log', '--log-level', 'WARNING', '--', 'wise warning'],
         ), (
-            EventSpec(ActionEvent, 'log_info_action',
+            EventSpec(ops.ActionEvent, 'log_info_action',
                       env_var='JUJU_ACTION_NAME'),
             ['juju-log', '--log-level', 'INFO', '--', 'useful info'],
         )]
 
         # Set up action symlinks.
-        self._simulate_event(EventSpec(InstallEvent, 'install'))
+        self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
 
         for event_spec, calls in test_cases:
             self._simulate_event(event_spec)
@@ -698,7 +670,7 @@ class _TestMain(abc.ABC):
 
     def test_excepthook(self):
         with self.assertRaises(subprocess.CalledProcessError):
-            self._simulate_event(EventSpec(InstallEvent, 'install',
+            self._simulate_event(EventSpec(ops.InstallEvent, 'install',
                                            set_in_env={'TRY_EXCEPTHOOK': '1'}))
 
         calls = [' '.join(i) for i in fake_script_calls(self)]
@@ -723,7 +695,7 @@ class _TestMain(abc.ABC):
 
         fake_script(self, 'action-get', "echo '{}'")
         state = self._simulate_event(EventSpec(
-            ActionEvent, 'get_model_name_action',
+            ops.ActionEvent, 'get_model_name_action',
             env_var='JUJU_ACTION_NAME',
             model_name='test-model-name'))
         self.assertIsNotNone(state)
@@ -735,7 +707,7 @@ class _TestMain(abc.ABC):
         fake_script(self, 'action-get', "echo '{}'")
         fake_script(self, 'status-get', """echo '{"status": "unknown", "message": ""}'""")
         state = self._simulate_event(EventSpec(
-            ActionEvent, 'get_status_action',
+            ops.ActionEvent, 'get_status_action',
             env_var='JUJU_ACTION_NAME'))
         self.assertIsNotNone(state)
         self.assertEqual(state.status_name, 'unknown')
@@ -743,7 +715,7 @@ class _TestMain(abc.ABC):
         fake_script(
             self, 'status-get', """echo '{"status": "blocked", "message": "help meeee"}'""")
         state = self._simulate_event(EventSpec(
-            ActionEvent, 'get_status_action',
+            ops.ActionEvent, 'get_status_action',
             env_var='JUJU_ACTION_NAME'))
         self.assertIsNotNone(state)
         self.assertEqual(state.status_name, 'blocked')
@@ -811,13 +783,13 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
         """Test auto-creation of symlinks caused by initial events."""
         all_event_hooks = [f"hooks/{name.replace('_', '-')}"
                            for name, event_source in self.charm_module.Charm.on.events().items()
-                           if issubclass(event_source.event_type, LifecycleEvent)]
+                           if issubclass(event_source.event_type, ops.LifecycleEvent)]
 
         initial_events = {
-            EventSpec(InstallEvent, 'install'),
-            EventSpec(StorageAttachedEvent, 'disks-storage-attached'),
-            EventSpec(StartEvent, 'start'),
-            EventSpec(UpgradeCharmEvent, 'upgrade-charm'),
+            EventSpec(ops.InstallEvent, 'install'),
+            EventSpec(ops.StorageAttachedEvent, 'disks-storage-attached'),
+            EventSpec(ops.StartEvent, 'start'),
+            EventSpec(ops.UpgradeCharmEvent, 'upgrade-charm'),
         }
         initial_hooks = {f"hooks/{ev.event_name}" for ev in initial_events}
 
@@ -847,7 +819,7 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
             _assess_event_links(initial_event)
 
     def test_setup_action_links(self):
-        self._simulate_event(EventSpec(InstallEvent, 'install'))
+        self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
         # foo-bar is one of the actions defined in actions.yaml
         action_hook = self.JUJU_CHARM_DIR / 'actions' / 'foo-bar'
         self.assertTrue(action_hook.exists())
@@ -886,10 +858,10 @@ class _TestMainWithDispatch(_TestMain):
         all_event_hooks = [f"hooks/{e.replace('_', '-')}"
                            for e in self.charm_module.Charm.on.events().keys()]
         initial_events = {
-            EventSpec(InstallEvent, 'install'),
-            EventSpec(StorageAttachedEvent, 'disks-storage-attached'),
-            EventSpec(StartEvent, 'start'),
-            EventSpec(UpgradeCharmEvent, 'upgrade-charm'),
+            EventSpec(ops.InstallEvent, 'install'),
+            EventSpec(ops.StorageAttachedEvent, 'disks-storage-attached'),
+            EventSpec(ops.StartEvent, 'start'),
+            EventSpec(ops.UpgradeCharmEvent, 'upgrade-charm'),
         }
 
         def _assess_event_links(event_spec):
@@ -908,7 +880,7 @@ class _TestMainWithDispatch(_TestMain):
         old_path = self.fake_script_path
         self.fake_script_path = self.hooks_dir
         fake_script(self, 'install', 'exit 0')
-        state = self._simulate_event(EventSpec(InstallEvent, 'install'))
+        state = self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
 
         # the script was called, *and*, the .on. was called
         self.assertEqual(fake_script_calls(self), [['install', '']])
@@ -933,7 +905,7 @@ class _TestMainWithDispatch(_TestMain):
 
     def test_non_executable_hook_and_dispatch(self):
         (self.hooks_dir / "install").write_text("")
-        state = self._simulate_event(EventSpec(InstallEvent, 'install'))
+        state = self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
 
         self.assertEqual(list(state.observed_event_types), ['InstallEvent'])
 
@@ -957,7 +929,7 @@ class _TestMainWithDispatch(_TestMain):
         old_path = self.fake_script_path
         self.fake_script_path = self.hooks_dir
         fake_script(self, 'install', 'exit 42')
-        event = EventSpec(InstallEvent, 'install')
+        event = EventSpec(ops.InstallEvent, 'install')
         with self.assertRaises(subprocess.CalledProcessError):
             self._simulate_event(event)
         self.fake_script_path = old_path
@@ -975,7 +947,7 @@ class _TestMainWithDispatch(_TestMain):
         self.assertEqual(calls, expected)
 
     def test_hook_and_dispatch_but_hook_is_dispatch(self):
-        event = EventSpec(InstallEvent, 'install')
+        event = EventSpec(ops.InstallEvent, 'install')
         hook_path = self.hooks_dir / 'install'
         for ((rel, ind), path) in {
                 # relative and indirect
@@ -1007,7 +979,7 @@ class _TestMainWithDispatch(_TestMain):
         path = (self.hooks_dir / self.charm_exec_path).resolve()
         shutil.copy(str(path), str(hook_path))
 
-        event = EventSpec(InstallEvent, 'install')
+        event = EventSpec(ops.InstallEvent, 'install')
         state = self._simulate_event(event)
 
         # the .on. was only called once
@@ -1156,24 +1128,24 @@ class TestStorageHeuristics(unittest.TestCase):
         logassert.setup(self, '')
 
     def test_fallback_to_current_juju_version__too_old(self):
-        meta = CharmMeta.from_yaml("series: [kubernetes]")
+        meta = ops.CharmMeta.from_yaml("series: [kubernetes]")
         with patch.dict(os.environ, {"JUJU_VERSION": "1.0"}):
             self.assertFalse(_should_use_controller_storage(Path("/xyzzy"), meta))
             self.assertLogged('Using local storage: JUJU_VERSION=1.0.0')
 
     def test_fallback_to_current_juju_version__new_enough(self):
-        meta = CharmMeta.from_yaml("series: [kubernetes]")
+        meta = ops.CharmMeta.from_yaml("series: [kubernetes]")
         with patch.dict(os.environ, {"JUJU_VERSION": "2.8"}):
             self.assertTrue(_should_use_controller_storage(Path("/xyzzy"), meta))
             self.assertLogged('Using controller storage: JUJU_VERSION=2.8.0')
 
     def test_not_if_not_in_k8s(self):
-        meta = CharmMeta.from_yaml("series: [ecs]")
+        meta = ops.CharmMeta.from_yaml("series: [ecs]")
         with patch.dict(os.environ, {"JUJU_VERSION": "2.8"}):
             self.assertFalse(_should_use_controller_storage(Path("/xyzzy"), meta))
             self.assertLogged('Using local storage: not a Kubernetes podspec charm')
 
     def test_not_if_already_local(self):
-        meta = CharmMeta.from_yaml("series: [kubernetes]")
+        meta = ops.CharmMeta.from_yaml("series: [kubernetes]")
         with patch.dict(os.environ, {"JUJU_VERSION": "2.8"}), tempfile.NamedTemporaryFile() as fd:
             self.assertFalse(_should_use_controller_storage(Path(fd.name), meta))

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -100,7 +100,7 @@ class EventSpec:
         self.secret_revision = secret_revision
 
 
-@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
+@patch('ops.main_module.setup_root_logging', new=lambda *a, **kw: None)
 class CharmInitTestCase(unittest.TestCase):
 
     @patch('sys.stderr', new_callable=io.StringIO)
@@ -135,8 +135,8 @@ class CharmInitTestCase(unittest.TestCase):
         if extra_environ is not None:
             fake_environ.update(extra_environ)
         with patch.dict(os.environ, fake_environ):
-            with patch('ops.main._emit_charm_event'):
-                with patch('ops.main._get_charm_dir') as mock_charmdir:
+            with patch('ops.main_module._emit_charm_event'):
+                with patch('ops.main_module._get_charm_dir') as mock_charmdir:
                     with tempfile.TemporaryDirectory() as tmpdirname:
                         tmpdirname = Path(tmpdirname)
                         fake_metadata = tmpdirname / 'metadata.yaml'
@@ -201,7 +201,7 @@ class CharmInitTestCase(unittest.TestCase):
 
 
 @patch('sys.argv', new=("hooks/config-changed",))
-@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
+@patch('ops.main_module.setup_root_logging', new=lambda *a, **kw: None)
 class TestDispatch(unittest.TestCase):
     def _check(self, *, with_dispatch=False, dispatch_path=''):
         """Helper for below tests."""
@@ -230,8 +230,8 @@ class TestDispatch(unittest.TestCase):
                 dispatch.chmod(0o755)
 
             with patch.dict(os.environ, fake_environ):
-                with patch('ops.main._emit_charm_event') as mock_charm_event:
-                    with patch('ops.main._get_charm_dir') as mock_charmdir:
+                with patch('ops.main_module._emit_charm_event') as mock_charm_event:
+                    with patch('ops.main_module._get_charm_dir') as mock_charmdir:
                         mock_charmdir.return_value = tmpdir
                         main(MyCharm)
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -72,7 +72,7 @@ class EventSpec:
         self.secret_revision = secret_revision
 
 
-@patch('ops._main_module.setup_root_logging', new=lambda *a, **kw: None)
+@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class CharmInitTestCase(unittest.TestCase):
 
     @patch('sys.stderr', new_callable=io.StringIO)
@@ -107,8 +107,8 @@ class CharmInitTestCase(unittest.TestCase):
         if extra_environ is not None:
             fake_environ.update(extra_environ)
         with patch.dict(os.environ, fake_environ):
-            with patch('ops._main_module._emit_charm_event'):
-                with patch('ops._main_module._get_charm_dir') as mock_charmdir:
+            with patch('ops.main._emit_charm_event'):
+                with patch('ops.main._get_charm_dir') as mock_charmdir:
                     with tempfile.TemporaryDirectory() as tmpdirname:
                         tmpdirname = Path(tmpdirname)
                         fake_metadata = tmpdirname / 'metadata.yaml'
@@ -173,7 +173,7 @@ class CharmInitTestCase(unittest.TestCase):
 
 
 @patch('sys.argv', new=("hooks/config-changed",))
-@patch('ops._main_module.setup_root_logging', new=lambda *a, **kw: None)
+@patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)
 class TestDispatch(unittest.TestCase):
     def _check(self, *, with_dispatch=False, dispatch_path=''):
         """Helper for below tests."""
@@ -202,8 +202,8 @@ class TestDispatch(unittest.TestCase):
                 dispatch.chmod(0o755)
 
             with patch.dict(os.environ, fake_environ):
-                with patch('ops._main_module._emit_charm_event') as mock_charm_event:
-                    with patch('ops._main_module._get_charm_dir') as mock_charmdir:
+                with patch('ops.main._emit_charm_event') as mock_charm_event:
+                    with patch('ops.main._get_charm_dir') as mock_charmdir:
                         mock_charmdir.return_value = tmpdir
                         ops.main(MyCharm)
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -100,7 +100,7 @@ class EventSpec:
         self.secret_revision = secret_revision
 
 
-@patch('ops.main_module.setup_root_logging', new=lambda *a, **kw: None)
+@patch('ops._main_module.setup_root_logging', new=lambda *a, **kw: None)
 class CharmInitTestCase(unittest.TestCase):
 
     @patch('sys.stderr', new_callable=io.StringIO)
@@ -135,8 +135,8 @@ class CharmInitTestCase(unittest.TestCase):
         if extra_environ is not None:
             fake_environ.update(extra_environ)
         with patch.dict(os.environ, fake_environ):
-            with patch('ops.main_module._emit_charm_event'):
-                with patch('ops.main_module._get_charm_dir') as mock_charmdir:
+            with patch('ops._main_module._emit_charm_event'):
+                with patch('ops._main_module._get_charm_dir') as mock_charmdir:
                     with tempfile.TemporaryDirectory() as tmpdirname:
                         tmpdirname = Path(tmpdirname)
                         fake_metadata = tmpdirname / 'metadata.yaml'
@@ -201,7 +201,7 @@ class CharmInitTestCase(unittest.TestCase):
 
 
 @patch('sys.argv', new=("hooks/config-changed",))
-@patch('ops.main_module.setup_root_logging', new=lambda *a, **kw: None)
+@patch('ops._main_module.setup_root_logging', new=lambda *a, **kw: None)
 class TestDispatch(unittest.TestCase):
     def _check(self, *, with_dispatch=False, dispatch_path=''):
         """Helper for below tests."""
@@ -230,8 +230,8 @@ class TestDispatch(unittest.TestCase):
                 dispatch.chmod(0o755)
 
             with patch.dict(os.environ, fake_environ):
-                with patch('ops.main_module._emit_charm_event') as mock_charm_event:
-                    with patch('ops.main_module._get_charm_dir') as mock_charmdir:
+                with patch('ops._main_module._emit_charm_event') as mock_charm_event:
+                    with patch('ops._main_module._get_charm_dir') as mock_charmdir:
                         mock_charmdir.return_value = tmpdir
                         main(MyCharm)
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -28,6 +28,7 @@ from textwrap import dedent
 import pytest
 
 import ops
+import ops.testing
 from ops import pebble
 from ops._private import yaml
 from ops.model import _ModelBackend
@@ -35,7 +36,7 @@ from ops.model import _ModelBackend
 
 class TestModel(unittest.TestCase):
     def setUp(self):
-        self.harness = ops.Harness(ops.CharmBase, meta='''
+        self.harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: myapp
             provides:
               db0:
@@ -1111,7 +1112,7 @@ recursive_push_pull_cases = [
 @pytest.mark.parametrize('case', recursive_push_pull_cases)
 def test_recursive_push_and_pull(case):
     # full "integration" test of push+pull
-    harness = ops.Harness(ops.CharmBase, meta='''
+    harness = ops.testing.Harness(ops.CharmBase, meta='''
         name: test-app
         containers:
           foo:
@@ -1176,7 +1177,7 @@ def test_recursive_push_and_pull(case):
 class TestApplication(unittest.TestCase):
 
     def setUp(self):
-        self.harness = ops.Harness(ops.CharmBase, meta='''
+        self.harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: myapp
             provides:
               db0:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -3178,7 +3178,7 @@ class TestPorts(unittest.TestCase):
     def test_open_port_error(self):
         fake_script(self, 'open-port', "echo 'ERROR bad protocol' >&2; exit 1")
 
-        with self.assertRaises(model.ModelError) as cm:
+        with self.assertRaises(ops.ModelError) as cm:
             self.unit.open_port('ftp', 8080)
         self.assertEqual(str(cm.exception), 'ERROR bad protocol\n')
 
@@ -3202,7 +3202,7 @@ class TestPorts(unittest.TestCase):
     def test_close_port_error(self):
         fake_script(self, 'close-port', "echo 'ERROR bad protocol' >&2; exit 1")
 
-        with self.assertRaises(model.ModelError) as cm:
+        with self.assertRaises(ops.ModelError) as cm:
             self.unit.close_port('ftp', 8080)
         self.assertEqual(str(cm.exception), 'ERROR bad protocol\n')
 
@@ -3217,10 +3217,10 @@ class TestPorts(unittest.TestCase):
         self.assertIsInstance(ports_set, set)
         ports = sorted(ports_set, key=lambda p: (p.protocol, p.port))
         self.assertEqual(len(ports), 2)
-        self.assertIsInstance(ports[0], model.OpenedPort)
+        self.assertIsInstance(ports[0], ops.OpenedPort)
         self.assertEqual(ports[0].protocol, 'icmp')
         self.assertIsNone(ports[0].port)
-        self.assertIsInstance(ports[1], model.OpenedPort)
+        self.assertIsInstance(ports[1], ops.OpenedPort)
         self.assertEqual(ports[1].protocol, 'tcp')
         self.assertEqual(ports[1].port, 8080)
 
@@ -3240,10 +3240,10 @@ class TestPorts(unittest.TestCase):
         self.assertIsInstance(ports_set, set)
         ports = sorted(ports_set, key=lambda p: (p.protocol, p.port))
         self.assertEqual(len(ports), 2)
-        self.assertIsInstance(ports[0], model.OpenedPort)
+        self.assertIsInstance(ports[0], ops.OpenedPort)
         self.assertEqual(ports[0].protocol, 'tcp')
         self.assertEqual(ports[0].port, 8080)
-        self.assertIsInstance(ports[1], model.OpenedPort)
+        self.assertIsInstance(ports[1], ops.OpenedPort)
         self.assertEqual(ports[1].protocol, 'udp')
         self.assertEqual(ports[1].port, 1000)
 

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -34,7 +34,7 @@ import uuid
 import pytest
 import websocket
 
-import ops.pebble as pebble
+from ops import pebble
 from ops._private import yaml
 
 # Ensure unittest diffs don't get truncated like "[17 chars]"

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -33,6 +33,7 @@ import pytest
 import yaml
 
 import ops
+import ops.testing
 from ops import pebble
 from ops.model import _ModelBackend
 from ops.testing import (
@@ -94,7 +95,7 @@ class StorageWithHyphensHelper(ops.Object):
 class TestHarness(unittest.TestCase):
 
     def test_add_relation(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             requires:
                 db:
@@ -111,7 +112,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(backend.relation_get(rel_id, 'test-app/0', is_app=False), {})
 
     def test_can_connect_default(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             containers:
               foo:
@@ -149,7 +150,7 @@ class TestHarness(unittest.TestCase):
                 assert event.workload.can_connect()
                 pebble_ready_calls[event.workload.name] += 1
 
-        harness = ops.Harness(MyCharm, meta='''
+        harness = ops.testing.Harness(MyCharm, meta='''
             name: test-app
             containers:
               foo:
@@ -173,7 +174,7 @@ class TestHarness(unittest.TestCase):
         container.get_plan()  # shouldn't raise ConnectionError
 
     def test_add_relation_and_unit(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             requires:
                 db:
@@ -193,7 +194,7 @@ class TestHarness(unittest.TestCase):
 
     def test_add_relation_with_remote_app_data(self):
         # language=YAML
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             requires:
                 db:
@@ -222,7 +223,7 @@ class TestHarness(unittest.TestCase):
                 self.observed_events.append(event)
 
         # language=YAML
-        harness = ops.Harness(InitialDataTester, meta='''
+        harness = ops.testing.Harness(InitialDataTester, meta='''
             name: test-app
             requires:
                 db:
@@ -273,7 +274,7 @@ class TestHarness(unittest.TestCase):
                 self.observed_events.append(event)
 
         # language=YAML
-        harness = ops.Harness(InitialDataTester, meta='''
+        harness = ops.testing.Harness(InitialDataTester, meta='''
             name: test-app
             peers:
                 cluster:
@@ -312,7 +313,7 @@ class TestHarness(unittest.TestCase):
         self.assertIsInstance(harness.charm.observed_events[0], ops.RelationEvent)
 
     def test_relation_get_when_broken(self):
-        harness = ops.Harness(RelationBrokenTester, meta='''
+        harness = ops.testing.Harness(RelationBrokenTester, meta='''
             name: test-app
             requires:
                 foo:
@@ -330,7 +331,7 @@ class TestHarness(unittest.TestCase):
             harness.remove_relation(rel_id)
 
     def test_remove_relation(self):
-        harness = ops.Harness(RelationEventCharm, meta='''
+        harness = ops.testing.Harness(RelationEventCharm, meta='''
             name: test-app
             requires:
                 db:
@@ -370,7 +371,7 @@ class TestHarness(unittest.TestCase):
                                    'relation_id': rel_id}})
 
     def test_remove_specific_relation_id(self):
-        harness = ops.Harness(RelationEventCharm, meta='''
+        harness = ops.testing.Harness(RelationEventCharm, meta='''
             name: test-app
             requires:
                 db:
@@ -424,7 +425,7 @@ class TestHarness(unittest.TestCase):
                                    'relation_id': rel_id_2}})
 
     def test_removing_invalid_relation_id_raises_exception(self):
-        harness = ops.Harness(RelationEventCharm, meta='''
+        harness = ops.testing.Harness(RelationEventCharm, meta='''
             name: test-app
             requires:
                 db:
@@ -447,7 +448,7 @@ class TestHarness(unittest.TestCase):
             harness.remove_relation(rel_id + 1)
 
     def test_remove_relation_unit(self):
-        harness = ops.Harness(RelationEventCharm, meta='''
+        harness = ops.testing.Harness(RelationEventCharm, meta='''
             name: test-app
             requires:
                 db:
@@ -497,7 +498,7 @@ class TestHarness(unittest.TestCase):
 
     def test_removing_relation_removes_remote_app_data(self):
         # language=YAML
-        harness = ops.Harness(RelationEventCharm, meta='''
+        harness = ops.testing.Harness(RelationEventCharm, meta='''
             name: test-app
             requires:
                 db:
@@ -524,7 +525,7 @@ class TestHarness(unittest.TestCase):
 
     def test_removing_relation_refreshes_charm_model(self):
         # language=YAML
-        harness = ops.Harness(RelationEventCharm, meta='''
+        harness = ops.testing.Harness(RelationEventCharm, meta='''
             name: test-app
             requires:
                 db:
@@ -555,7 +556,7 @@ class TestHarness(unittest.TestCase):
         return None
 
     def test_removing_relation_unit_removes_data_also(self):
-        harness = ops.Harness(RelationEventCharm, meta='''
+        harness = ops.testing.Harness(RelationEventCharm, meta='''
             name: test-app
             requires:
                 db:
@@ -597,7 +598,7 @@ class TestHarness(unittest.TestCase):
                                    'relation_id': rel_id}})
 
     def test_removing_relation_unit_does_not_remove_other_unit_and_data(self):
-        harness = ops.Harness(RelationEventCharm, meta='''
+        harness = ops.testing.Harness(RelationEventCharm, meta='''
             name: test-app
             requires:
                 db:
@@ -643,7 +644,7 @@ class TestHarness(unittest.TestCase):
                                    'relation_id': rel_id}})
 
     def test_relation_events(self):
-        harness = ops.Harness(RelationEventCharm, meta='''
+        harness = ops.testing.Harness(RelationEventCharm, meta='''
             name: test-app
             requires:
                 db:
@@ -701,7 +702,7 @@ class TestHarness(unittest.TestCase):
                 db:
                     interface: pgsql
         '''
-        harness = ops.Harness(ops.CharmBase, meta=charm_meta)
+        harness = ops.testing.Harness(ops.CharmBase, meta=charm_meta)
         self.addCleanup(harness.cleanup)
         rel_id = harness.add_relation('db', 'postgresql')
         harness.update_relation_data(rel_id, 'postgresql', {'remote': 'data'})
@@ -730,9 +731,9 @@ class TestHarness(unittest.TestCase):
               db:
                 interface: pgsql
             '''
-        harness1 = ops.Harness(ops.CharmBase, meta=metadata)
+        harness1 = ops.testing.Harness(ops.CharmBase, meta=metadata)
         self.addCleanup(harness1.cleanup)
-        harness2 = ops.Harness(ops.CharmBase, meta=metadata)
+        harness2 = ops.testing.Harness(ops.CharmBase, meta=metadata)
         self.addCleanup(harness2.cleanup)
         harness1.begin()
         harness2.begin()
@@ -746,7 +747,7 @@ class TestHarness(unittest.TestCase):
 
     def test_begin_twice(self):
         # language=YAML
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             requires:
                 db:
@@ -758,7 +759,7 @@ class TestHarness(unittest.TestCase):
             harness.begin()
 
     def test_update_relation_exposes_new_data(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: my-charm
             requires:
               db:
@@ -777,7 +778,7 @@ class TestHarness(unittest.TestCase):
 
     def test_update_relation_no_local_unit_change_event(self):
         # language=YAML
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: my-charm
             requires:
               db:
@@ -802,7 +803,7 @@ class TestHarness(unittest.TestCase):
 
     def test_update_peer_relation_no_local_unit_change_event(self):
         # language=YAML
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: postgresql
             peers:
               db:
@@ -839,7 +840,7 @@ class TestHarness(unittest.TestCase):
 
     def test_harness_leader_misconfig(self):
         # language=YAML
-        harness = ops.Harness(SetLeaderErrorTester, meta='''
+        harness = ops.testing.Harness(SetLeaderErrorTester, meta='''
             name: postgresql
             peers:
               peer:
@@ -854,7 +855,7 @@ class TestHarness(unittest.TestCase):
 
     def test_update_peer_relation_app_data(self):
         # language=YAML
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: postgresql
             peers:
               db:
@@ -885,7 +886,7 @@ class TestHarness(unittest.TestCase):
 
     def test_update_relation_no_local_app_change_event(self):
         # language=YAML
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: my-charm
             requires:
               db:
@@ -910,7 +911,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(helper.changes, [])
 
     def test_update_relation_remove_data(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: my-charm
             requires:
               db:
@@ -926,7 +927,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(viewer.changes, [{'initial': 'data'}, {}])
 
     def test_no_event_on_empty_update_relation_unit_app(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: my-charm
             requires:
               db:
@@ -942,7 +943,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(viewer.changes, [{'initial': 'data'}])
 
     def test_no_event_on_no_diff_update_relation_unit_app(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: my-charm
             requires:
               db:
@@ -958,7 +959,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(viewer.changes, [{'initial': 'data'}])
 
     def test_no_event_on_empty_update_relation_unit_bag(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: my-charm
             requires:
               db:
@@ -974,7 +975,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(viewer.changes, [{'initial': 'data'}])
 
     def test_no_event_on_no_diff_update_relation_unit_bag(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: my-charm
             requires:
               db:
@@ -991,10 +992,10 @@ class TestHarness(unittest.TestCase):
 
     def test_empty_config_raises(self):
         with self.assertRaises(TypeError):
-            ops.Harness(RecordingCharm, config='')
+            ops.testing.Harness(RecordingCharm, config='')
 
     def test_update_config(self):
-        harness = ops.Harness(RecordingCharm, config='''
+        harness = ops.testing.Harness(RecordingCharm, config='''
             options:
                 a:
                     description: a config option
@@ -1024,14 +1025,14 @@ class TestHarness(unittest.TestCase):
              ])
 
     def test_update_config_undefined_option(self):
-        harness = ops.Harness(RecordingCharm)
+        harness = ops.testing.Harness(RecordingCharm)
         self.addCleanup(harness.cleanup)
         harness.begin()
         with self.assertRaises(ValueError):
             harness.update_config(key_values={'nonexistent': 'foo'})
 
     def test_update_config_bad_type(self):
-        harness = ops.Harness(RecordingCharm, config='''
+        harness = ops.testing.Harness(RecordingCharm, config='''
             options:
                 a:
                     description: a config option
@@ -1057,7 +1058,7 @@ class TestHarness(unittest.TestCase):
 
     def test_bad_config_option_type(self):
         with self.assertRaises(RuntimeError):
-            ops.Harness(RecordingCharm, config='''
+            ops.testing.Harness(RecordingCharm, config='''
                 options:
                     a:
                         description: a config option
@@ -1067,7 +1068,7 @@ class TestHarness(unittest.TestCase):
 
     def test_no_config_option_type(self):
         with self.assertRaises(RuntimeError):
-            ops.Harness(RecordingCharm, config='''
+            ops.testing.Harness(RecordingCharm, config='''
                 options:
                     a:
                         description: a config option
@@ -1076,7 +1077,7 @@ class TestHarness(unittest.TestCase):
 
     def test_uncastable_config_option_type(self):
         with self.assertRaises(RuntimeError):
-            ops.Harness(RecordingCharm, config='''
+            ops.testing.Harness(RecordingCharm, config='''
                 options:
                     a:
                         description: a config option
@@ -1085,7 +1086,7 @@ class TestHarness(unittest.TestCase):
                 ''')
 
     def test_update_config_unset_boolean(self):
-        harness = ops.Harness(RecordingCharm, config='''
+        harness = ops.testing.Harness(RecordingCharm, config='''
             options:
                 a:
                     description: a config option
@@ -1107,7 +1108,7 @@ class TestHarness(unittest.TestCase):
              {'name': 'config-changed', 'data': {'a': False}}])
 
     def test_set_leader(self):
-        harness = ops.Harness(RecordingCharm)
+        harness = ops.testing.Harness(RecordingCharm)
         self.addCleanup(harness.cleanup)
         # No event happens here
         harness.set_leader(False)
@@ -1128,7 +1129,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness.charm.get_changes(reset=True), [])
 
     def test_relation_set_app_not_leader(self):
-        harness = ops.Harness(RecordingCharm, meta='''
+        harness = ops.testing.Harness(RecordingCharm, meta='''
             name: test-charm
             requires:
                 db:
@@ -1150,7 +1151,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness.get_relation_data(rel_id, 'test-charm'), {'foo': 'bar'})
 
     def test_hooks_enabled_and_disabled(self):
-        harness = ops.Harness(
+        harness = ops.testing.Harness(
             RecordingCharm,
             meta='''
                     name: test-charm
@@ -1182,7 +1183,7 @@ class TestHarness(unittest.TestCase):
             [{'name': 'config-changed', 'data': {'value': 'fourth', 'third': '3'}}])
 
     def test_hooks_disabled_contextmanager(self):
-        harness = ops.Harness(RecordingCharm, meta='''
+        harness = ops.testing.Harness(RecordingCharm, meta='''
                 name: test-charm
                 ''', config='''
                 options:
@@ -1210,7 +1211,7 @@ class TestHarness(unittest.TestCase):
             [{'name': 'config-changed', 'data': {'value': 'fourth', 'third': '3'}}])
 
     def test_hooks_disabled_nested_contextmanager(self):
-        harness = ops.Harness(RecordingCharm, meta='''
+        harness = ops.testing.Harness(RecordingCharm, meta='''
                 name: test-charm
             ''', config='''
                 options:
@@ -1229,7 +1230,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness.charm.get_changes(reset=True), [])
 
     def test_hooks_disabled_noop(self):
-        harness = ops.Harness(RecordingCharm, meta='''
+        harness = ops.testing.Harness(RecordingCharm, meta='''
                 name: test-charm
             ''', config='''
             options:
@@ -1305,7 +1306,7 @@ class TestHarness(unittest.TestCase):
         self.assertIsNone(harness._backend._config._defaults['opt_no_default'])
 
     def test_set_model_name(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-charm
         ''')
         self.addCleanup(harness.cleanup)
@@ -1313,7 +1314,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual('foo', harness.model.name)
 
     def test_set_model_name_after_begin(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-charm
         ''')
         self.addCleanup(harness.cleanup)
@@ -1324,7 +1325,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness.model.name, 'bar')
 
     def test_set_model_uuid_after_begin(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-charm
         ''')
         self.addCleanup(harness.cleanup)
@@ -1336,7 +1337,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness.model.uuid, '96957e90-e006-11eb-ba80-0242ac130004')
 
     def test_set_model_info_after_begin(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-charm
         ''')
         self.addCleanup(harness.cleanup)
@@ -1356,7 +1357,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness.model.uuid, '96957e90-e006-11eb-ba80-0242ac130004')
 
     def test_add_storage_before_harness_begin(self):
-        harness = ops.Harness(StorageTester, meta='''
+        harness = ops.testing.Harness(StorageTester, meta='''
             name: test-app
             requires:
                 db:
@@ -1378,7 +1379,7 @@ class TestHarness(unittest.TestCase):
             harness._backend.storage_get("test/0", "location")[-6:]
 
     def test_add_storage_then_harness_begin(self):
-        harness = ops.Harness(StorageTester, meta='''
+        harness = ops.testing.Harness(StorageTester, meta='''
             name: test-app
             requires:
                 db:
@@ -1405,7 +1406,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(want, harness._backend.storage_get("test/0", "location")[-6:])
 
     def test_add_storage_not_attached_default(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             requires:
                 db:
@@ -1422,7 +1423,7 @@ class TestHarness(unittest.TestCase):
             'storage should start in detached state and be excluded from storage listing'
 
     def test_add_storage_without_metadata_key_fails(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             requires:
                 db:
@@ -1437,7 +1438,7 @@ class TestHarness(unittest.TestCase):
             "the key 'test' is not specified as a storage key in metadata")
 
     def test_add_storage_after_harness_begin(self):
-        harness = ops.Harness(StorageTester, meta='''
+        harness = ops.testing.Harness(StorageTester, meta='''
             name: test-app
             requires:
                 db:
@@ -1474,7 +1475,7 @@ class TestHarness(unittest.TestCase):
             self.assertTrue(isinstance(harness.charm.observed_events[i], ops.StorageAttachedEvent))
 
     def test_detach_storage(self):
-        harness = ops.Harness(StorageTester, meta='''
+        harness = ops.testing.Harness(StorageTester, meta='''
             name: test-app
             requires:
                 db:
@@ -1514,7 +1515,7 @@ class TestHarness(unittest.TestCase):
         self.assertTrue(isinstance(harness.charm.observed_events[1], ops.StorageDetachingEvent))
 
     def test_detach_storage_before_harness_begin(self):
-        harness = ops.Harness(StorageTester, meta='''
+        harness = ops.testing.Harness(StorageTester, meta='''
             name: test-app
             requires:
                 db:
@@ -1532,7 +1533,7 @@ class TestHarness(unittest.TestCase):
                          "cannot detach storage before Harness is initialised")
 
     def test_storage_with_hyphens_works(self):
-        harness = ops.Harness(StorageTester, meta='''
+        harness = ops.testing.Harness(StorageTester, meta='''
             name: test-app
             requires:
                 db:
@@ -1553,7 +1554,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(len(helper.changes), 1)
 
     def test_attach_storage(self):
-        harness = ops.Harness(StorageTester, meta='''
+        harness = ops.testing.Harness(StorageTester, meta='''
             name: test-app
             requires:
                 db:
@@ -1593,7 +1594,7 @@ class TestHarness(unittest.TestCase):
         self.assertTrue(isinstance(harness.charm.observed_events[2], ops.StorageAttachedEvent))
 
     def test_attach_storage_before_harness_begin(self):
-        harness = ops.Harness(StorageTester, meta='''
+        harness = ops.testing.Harness(StorageTester, meta='''
             name: test-app
             requires:
                 db:
@@ -1610,7 +1611,7 @@ class TestHarness(unittest.TestCase):
         self.assertTrue(stor_id)
 
     def test_remove_storage_before_harness_begin(self):
-        harness = ops.Harness(StorageTester, meta='''
+        harness = ops.testing.Harness(StorageTester, meta='''
             name: test-app
             requires:
                 db:
@@ -1638,7 +1639,7 @@ class TestHarness(unittest.TestCase):
         self.assertTrue(isinstance(harness.charm.observed_events[0], ops.StorageAttachedEvent))
 
     def test_remove_storage_without_metadata_key_fails(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             requires:
                 db:
@@ -1655,7 +1656,7 @@ class TestHarness(unittest.TestCase):
             "the key 'test' is not specified as a storage key in metadata")
 
     def test_remove_storage_after_harness_begin(self):
-        harness = ops.Harness(StorageTester, meta='''
+        harness = ops.testing.Harness(StorageTester, meta='''
             name: test-app
             requires:
                 db:
@@ -1686,7 +1687,7 @@ class TestHarness(unittest.TestCase):
         return int(stor_id.split('/')[-1])
 
     def test_remove_detached_storage(self):
-        harness = ops.Harness(StorageTester, meta='''
+        harness = ops.testing.Harness(StorageTester, meta='''
             name: test-app
             requires:
                 db:
@@ -1726,7 +1727,7 @@ class TestHarness(unittest.TestCase):
     def _get_dummy_charm_harness(self, tmp):
         self._write_dummy_charm(tmp)
         charm_mod = importlib.import_module('testcharm')
-        harness = ops.Harness(charm_mod.MyTestingCharm)
+        harness = ops.testing.Harness(charm_mod.MyTestingCharm)
         self.addCleanup(harness.cleanup)
         return harness
 
@@ -1751,7 +1752,7 @@ class TestHarness(unittest.TestCase):
         self.addCleanup(cleanup)
 
     def test_actions_passed_in(self):
-        harness = ops.Harness(
+        harness = ops.testing.Harness(
             ops.CharmBase,
             meta='''
                 name: test-app
@@ -1768,7 +1769,7 @@ class TestHarness(unittest.TestCase):
             def event_handler(self, evt):
                 evt.relation.data[evt.relation.app]['foo'] = 'bar'
 
-        harness = ops.Harness(MyCharm, meta='''
+        harness = ops.testing.Harness(MyCharm, meta='''
             name: test-charm
             requires:
                 db:
@@ -1796,7 +1797,7 @@ class TestHarness(unittest.TestCase):
                 # do things with APIs we cannot easily mock
                 raise NotImplementedError
 
-        harness = ops.Harness(MyCharm, meta='''
+        harness = ops.testing.Harness(MyCharm, meta='''
             name: test-charm
             requires:
                 db:
@@ -1825,7 +1826,7 @@ class TestHarness(unittest.TestCase):
         assert rel.data[harness.charm.app]['foo'] == 'bar'
 
     def test_relation_set_deletes(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-charm
             requires:
                 db:
@@ -1842,7 +1843,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual({}, harness.get_relation_data(rel_id, 'test-charm/0'))
 
     def test_relation_set_nonstring(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-charm
             requires:
                 db:
@@ -1858,7 +1859,7 @@ class TestHarness(unittest.TestCase):
                                              {'foo': invalid_value})
 
     def test_set_workload_version(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: app
             ''')
         self.addCleanup(harness.cleanup)
@@ -1868,7 +1869,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness.get_workload_version(), '1.2.3')
 
     def test_get_backend_calls(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-charm
             requires:
                 db:
@@ -1923,7 +1924,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness._get_backend_calls(), [])
 
     def test_get_backend_calls_with_kwargs(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-charm
             requires:
                 db:
@@ -1947,7 +1948,7 @@ class TestHarness(unittest.TestCase):
             harness._get_backend_calls())
 
     def test_unit_status(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: test-app')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: test-app')
         self.addCleanup(harness.cleanup)
         harness.set_leader(True)
         harness.begin()
@@ -1958,7 +1959,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness.model.unit.status, status)
 
     def test_app_status(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: test-app')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: test-app')
         self.addCleanup(harness.cleanup)
         harness.set_leader(True)
         harness.begin()
@@ -1969,7 +1970,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness.model.app.status, status)
 
     def test_populate_oci_resources(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             resources:
               image:
@@ -1994,7 +1995,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(path.parent.name, 'image2')
 
     def test_resource_folder_cleanup(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             resources:
               image:
@@ -2011,7 +2012,7 @@ class TestHarness(unittest.TestCase):
         self.assertFalse(path.parent.parent.exists())
 
     def test_container_isdir_and_exists(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             containers:
               foo:
@@ -2039,7 +2040,7 @@ class TestHarness(unittest.TestCase):
         self.assertTrue(c.exists(file_path))
 
     def test_add_oci_resource_custom(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             resources:
               image:
@@ -2061,7 +2062,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(contents['password'], 'custom_password')
 
     def test_add_oci_resource_no_image(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             resources:
               image:
@@ -2076,7 +2077,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(len(harness._backend._resources_map), 0)
 
     def test_add_resource_unknown(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             resources:
               image:
@@ -2088,7 +2089,7 @@ class TestHarness(unittest.TestCase):
             harness.add_resource('unknown', 'content')
 
     def test_add_resource_but_oci(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             resources:
               image:
@@ -2100,7 +2101,7 @@ class TestHarness(unittest.TestCase):
             harness.add_resource('image', 'content')
 
     def test_add_resource_string(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             resources:
               image:
@@ -2117,7 +2118,7 @@ class TestHarness(unittest.TestCase):
             self.assertEqual('foo contents\n', f.read())
 
     def test_add_resource_bytes(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             resources:
               image:
@@ -2135,7 +2136,7 @@ class TestHarness(unittest.TestCase):
             self.assertEqual(raw_contents, f.read())
 
     def test_add_resource_unknown_filename(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             resources:
               image:
@@ -2149,7 +2150,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(path.parent.name, 'image')
 
     def test_get_pod_spec(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             ''')
         self.addCleanup(harness.cleanup)
@@ -2160,7 +2161,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness.get_pod_spec(), (container_spec, k8s_resources))
 
     def test_begin_with_initial_hooks_no_relations(self):
-        harness = ops.Harness(RecordingCharm, meta='''
+        harness = ops.testing.Harness(RecordingCharm, meta='''
             name: test-app
             ''', config='''
             options:
@@ -2186,7 +2187,7 @@ class TestHarness(unittest.TestCase):
         )
 
     def test_begin_with_initial_hooks_no_relations_not_leader(self):
-        harness = ops.Harness(RecordingCharm, meta='''
+        harness = ops.testing.Harness(RecordingCharm, meta='''
             name: test-app
             ''', config='''
             options:
@@ -2215,7 +2216,7 @@ class TestHarness(unittest.TestCase):
             def __init__(self, framework):
                 super().__init__(framework)
                 self.observe_relation_events('peer')
-        harness = ops.Harness(PeerCharm, meta='''
+        harness = ops.testing.Harness(PeerCharm, meta='''
             name: test-app
             peers:
               peer:
@@ -2255,7 +2256,7 @@ class TestHarness(unittest.TestCase):
             def __init__(self, framework):
                 super().__init__(framework)
                 self.observe_relation_events('peer')
-        harness = ops.Harness(PeerCharm, meta='''
+        harness = ops.testing.Harness(PeerCharm, meta='''
             name: test-app
             peers:
               peer:
@@ -2287,7 +2288,7 @@ class TestHarness(unittest.TestCase):
             def __init__(self, framework):
                 super().__init__(framework)
                 self.observe_relation_events('db')
-        harness = ops.Harness(CharmWithDB, meta='''
+        harness = ops.testing.Harness(CharmWithDB, meta='''
             name: test-app
             requires:
               db:
@@ -2310,7 +2311,7 @@ class TestHarness(unittest.TestCase):
             def __init__(self, framework):
                 super().__init__(framework)
                 self.observe_relation_events('db')
-        harness = ops.Harness(CharmWithDB, meta='''
+        harness = ops.testing.Harness(CharmWithDB, meta='''
             name: test-app
             requires:
               db:
@@ -2357,7 +2358,7 @@ class TestHarness(unittest.TestCase):
             def __init__(self, framework):
                 super().__init__(framework)
                 self.observe_relation_events('db')
-        harness = ops.Harness(CharmWithDB, meta='''
+        harness = ops.testing.Harness(CharmWithDB, meta='''
             name: test-app
             requires:
               db:
@@ -2412,7 +2413,7 @@ class TestHarness(unittest.TestCase):
             def __init__(self, framework):
                 super().__init__(framework)
                 self.observe_relation_events('db')
-        harness = ops.Harness(CharmWithDB, meta='''
+        harness = ops.testing.Harness(CharmWithDB, meta='''
             name: test-app
             requires:
               db:
@@ -2475,7 +2476,7 @@ class TestHarness(unittest.TestCase):
             def __init__(self, framework):
                 super().__init__(framework)
                 self.observe_relation_events('db')
-        harness = ops.Harness(CharmWithDB, meta='''
+        harness = ops.testing.Harness(CharmWithDB, meta='''
             name: test-app
             requires:
               db:
@@ -2562,7 +2563,7 @@ class TestHarness(unittest.TestCase):
     def test_begin_with_initial_hooks_unknown_status(self):
         # Verify that a charm that does not set a status in the install hook will have an
         # unknown status in the harness.
-        harness = ops.Harness(RecordingCharm, meta='''
+        harness = ops.testing.Harness(RecordingCharm, meta='''
             name: test-app
             ''', config='''
           options:
@@ -2583,7 +2584,7 @@ class TestHarness(unittest.TestCase):
             {'status': 'unknown', 'message': ''})
 
     def test_begin_with_initial_hooks_install_sets_status(self):
-        harness = ops.Harness(RecordingCharm, meta='''
+        harness = ops.testing.Harness(RecordingCharm, meta='''
             name: test-app
             ''', config='''
             options:
@@ -2602,7 +2603,7 @@ class TestHarness(unittest.TestCase):
             {'status': 'maintenance', 'message': 'Status set on install'})
 
     def test_get_pebble_container_plan(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             containers:
               foo:
@@ -2643,7 +2644,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness_plan.to_yaml(), plan.to_yaml())
 
     def test_get_pebble_container_plan_unknown(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             containers:
               foo:
@@ -2658,7 +2659,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(plan.to_yaml(), "{}\n")
 
     def test_container_pebble_ready(self):
-        harness = ops.Harness(ContainerEventCharm, meta='''
+        harness = ops.testing.Harness(ContainerEventCharm, meta='''
             name: test-app
             containers:
               foo:
@@ -2863,7 +2864,7 @@ def get_public_methods(obj):
 class TestTestingModelBackend(unittest.TestCase):
 
     def test_conforms_to_model_backend(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: app
             ''')
         self.addCleanup(harness.cleanup)
@@ -2873,7 +2874,7 @@ class TestTestingModelBackend(unittest.TestCase):
         self.assertEqual(mb_methods, backend_methods)
 
     def test_model_uuid_is_uuid_v4(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-charm
         ''')
         self.addCleanup(harness.cleanup)
@@ -2881,7 +2882,7 @@ class TestTestingModelBackend(unittest.TestCase):
         self.assertEqual(uuid.UUID(backend.model_uuid).version, 4)
 
     def test_status_set_get_unit(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: app
             ''')
         self.addCleanup(harness.cleanup)
@@ -2895,7 +2896,7 @@ class TestTestingModelBackend(unittest.TestCase):
             {'status': 'unknown', 'message': ''})
 
     def test_status_set_get_app(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: app
             ''')
         self.addCleanup(harness.cleanup)
@@ -2909,7 +2910,7 @@ class TestTestingModelBackend(unittest.TestCase):
             {'status': 'maintenance', 'message': ''})
 
     def test_relation_ids_unknown_relation(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-charm
             provides:
               db:
@@ -2924,7 +2925,7 @@ class TestTestingModelBackend(unittest.TestCase):
             backend.relation_ids('unknown')
 
     def test_relation_get_unknown_relation_id(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-charm
             ''')
         self.addCleanup(harness.cleanup)
@@ -2933,7 +2934,7 @@ class TestTestingModelBackend(unittest.TestCase):
             backend.relation_get(1234, 'unit/0', False)
 
     def test_relation_list_unknown_relation_id(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-charm
             ''')
         self.addCleanup(harness.cleanup)
@@ -2942,7 +2943,7 @@ class TestTestingModelBackend(unittest.TestCase):
             backend.relation_list(1234)
 
     def test_lazy_resource_directory(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             resources:
               image:
@@ -2960,7 +2961,7 @@ class TestTestingModelBackend(unittest.TestCase):
             msg=f'expected {path} to be a subdirectory of {backend._resource_dir.name}')
 
     def test_resource_get_no_resource(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             resources:
               image:
@@ -2976,7 +2977,7 @@ class TestTestingModelBackend(unittest.TestCase):
             str(cm.exception))
 
     def test_relation_remote_app_name(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-charm
             requires:
                db:
@@ -2996,7 +2997,7 @@ class TestTestingModelBackend(unittest.TestCase):
         self.assertIs(backend.relation_remote_app_name(7), None)
 
     def test_get_pebble_methods(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             ''')
         self.addCleanup(harness.cleanup)
@@ -3008,7 +3009,7 @@ class TestTestingModelBackend(unittest.TestCase):
 
 class _TestingPebbleClientMixin:
     def get_testing_client(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             containers:
               mycontainer: {}
@@ -4208,7 +4209,7 @@ class TestPebbleStorageAPIsUsingMocks(
 
     @unittest.skipUnless(is_linux, 'Pebble runs on Linux')
     def test_container_storage_mounts(self):
-        harness = ops.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app
             containers:
                 c1:
@@ -4321,7 +4322,7 @@ class TestPebbleStorageAPIsUsingRealPebble(unittest.TestCase, _PebbleStorageAPIs
 
 class TestSecrets(unittest.TestCase):
     def test_add_model_secret_by_app_name_str(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: webapp')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: webapp')
         self.addCleanup(harness.cleanup)
         relation_id = harness.add_relation('db', 'database')
         harness.add_relation_unit(relation_id, 'database/0')
@@ -4333,7 +4334,7 @@ class TestSecrets(unittest.TestCase):
         self.assertEqual(secret.get_content(), {'password': 'hunter2'})
 
     def test_add_model_secret_by_app_instance(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: webapp')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: webapp')
         self.addCleanup(harness.cleanup)
         relation_id = harness.add_relation('db', 'database')
         harness.add_relation_unit(relation_id, 'database/0')
@@ -4346,7 +4347,7 @@ class TestSecrets(unittest.TestCase):
         self.assertEqual(secret.get_content(), {'password': 'hunter3'})
 
     def test_add_model_secret_by_unit_instance(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: webapp')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: webapp')
         self.addCleanup(harness.cleanup)
         relation_id = harness.add_relation('db', 'database')
         harness.add_relation_unit(relation_id, 'database/0')
@@ -4359,14 +4360,14 @@ class TestSecrets(unittest.TestCase):
         self.assertEqual(secret.get_content(), {'password': 'hunter4'})
 
     def test_add_model_secret_invalid_content(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: webapp')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: webapp')
         self.addCleanup(harness.cleanup)
 
         with self.assertRaises(ValueError):
             harness.add_model_secret('database', {'x': 'y'})  # key too short
 
     def test_set_secret_content(self):
-        harness = ops.Harness(EventRecorder, meta='name: webapp')
+        harness = ops.testing.Harness(EventRecorder, meta='name: webapp')
         self.addCleanup(harness.cleanup)
         relation_id = harness.add_relation('db', 'database')
         harness.add_relation_unit(relation_id, 'database/0')
@@ -4387,7 +4388,7 @@ class TestSecrets(unittest.TestCase):
         self.assertEqual(harness.get_secret_revisions(secret_id), [1, 2])
 
     def test_set_secret_content_wrong_owner(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: webapp')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: webapp')
         self.addCleanup(harness.cleanup)
 
         secret = harness.model.app.add_secret({'foo': 'bar'})
@@ -4395,14 +4396,14 @@ class TestSecrets(unittest.TestCase):
             harness.set_secret_content(secret.id, {'bar': 'foo'})
 
     def test_set_secret_content_invalid_secret_id(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: webapp')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: webapp')
         self.addCleanup(harness.cleanup)
 
         with self.assertRaises(RuntimeError):
             harness.set_secret_content('asdf', {'foo': 'bar'})
 
     def test_set_secret_content_invalid_content(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: webapp')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: webapp')
         self.addCleanup(harness.cleanup)
 
         secret_id = harness.add_model_secret('database', {'foo': 'bar'})
@@ -4410,7 +4411,7 @@ class TestSecrets(unittest.TestCase):
             harness.set_secret_content(secret_id, {'x': 'y'})
 
     def test_grant_secret_and_revoke_secret(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: webapp')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: webapp')
         self.addCleanup(harness.cleanup)
         relation_id = harness.add_relation('db', 'database')
         harness.add_relation_unit(relation_id, 'database/0')
@@ -4426,7 +4427,7 @@ class TestSecrets(unittest.TestCase):
             harness.model.get_secret(id=secret_id)
 
     def test_grant_secret_wrong_app(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: webapp')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: webapp')
         self.addCleanup(harness.cleanup)
         relation_id = harness.add_relation('db', 'database')
         harness.add_relation_unit(relation_id, 'database/0')
@@ -4437,7 +4438,7 @@ class TestSecrets(unittest.TestCase):
             harness.model.get_secret(id=secret_id)
 
     def test_grant_secret_wrong_unit(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: webapp')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: webapp')
         self.addCleanup(harness.cleanup)
         relation_id = harness.add_relation('db', 'database')
         harness.add_relation_unit(relation_id, 'database/0')
@@ -4448,7 +4449,7 @@ class TestSecrets(unittest.TestCase):
             harness.model.get_secret(id=secret_id)
 
     def test_grant_secret_no_relation(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: webapp')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: webapp')
         self.addCleanup(harness.cleanup)
 
         secret_id = harness.add_model_secret('database', {'password': 'hunter2'})
@@ -4456,7 +4457,7 @@ class TestSecrets(unittest.TestCase):
             harness.grant_secret(secret_id, 'webapp')
 
     def test_get_secret_grants(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: database')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: database')
         self.addCleanup(harness.cleanup)
 
         relation_id = harness.add_relation('db', 'webapp')
@@ -4473,7 +4474,7 @@ class TestSecrets(unittest.TestCase):
         self.assertEqual(harness.get_secret_grants(secret.id, relation_id), {'webapp/0'})
 
     def test_trigger_secret_rotation(self):
-        harness = ops.Harness(EventRecorder, meta='name: database')
+        harness = ops.testing.Harness(EventRecorder, meta='name: database')
         self.addCleanup(harness.cleanup)
 
         secret = harness.model.app.add_secret({'foo': 'x'}, label='lbl')
@@ -4496,7 +4497,7 @@ class TestSecrets(unittest.TestCase):
             harness.trigger_secret_rotation('nosecret')
 
     def test_trigger_secret_removal(self):
-        harness = ops.Harness(EventRecorder, meta='name: database')
+        harness = ops.testing.Harness(EventRecorder, meta='name: database')
         self.addCleanup(harness.cleanup)
 
         secret = harness.model.app.add_secret({'foo': 'x'}, label='lbl')
@@ -4521,7 +4522,7 @@ class TestSecrets(unittest.TestCase):
             harness.trigger_secret_removal('nosecret', 1)
 
     def test_trigger_secret_expiration(self):
-        harness = ops.Harness(EventRecorder, meta='name: database')
+        harness = ops.testing.Harness(EventRecorder, meta='name: database')
         self.addCleanup(harness.cleanup)
 
         secret = harness.model.app.add_secret({'foo': 'x'}, label='lbl')
@@ -4557,7 +4558,7 @@ class EventRecorder(ops.CharmBase):
 
 class TestPorts(unittest.TestCase):
     def test_ports(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: webapp')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: webapp')
         self.addCleanup(harness.cleanup)
         unit = harness.model.unit
 
@@ -4597,7 +4598,7 @@ class TestPorts(unittest.TestCase):
         self.assertEqual(ports_set, set())
 
     def test_errors(self):
-        harness = ops.Harness(ops.CharmBase, meta='name: webapp')
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: webapp')
         self.addCleanup(harness.cleanup)
         unit = harness.model.unit
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -4557,7 +4557,7 @@ class EventRecorder(ops.CharmBase):
 
 class TestPorts(unittest.TestCase):
     def test_ports(self):
-        harness = Harness(CharmBase, meta='name: webapp')
+        harness = ops.Harness(ops.CharmBase, meta='name: webapp')
         self.addCleanup(harness.cleanup)
         unit = harness.model.unit
 
@@ -4569,13 +4569,13 @@ class TestPorts(unittest.TestCase):
         self.assertIsInstance(ports_set, set)
         ports = sorted(ports_set, key=lambda p: (p.protocol, p.port))
         self.assertEqual(len(ports), 3)
-        self.assertIsInstance(ports[0], model.OpenedPort)
+        self.assertIsInstance(ports[0], ops.OpenedPort)
         self.assertEqual(ports[0].protocol, 'icmp')
         self.assertIsNone(ports[0].port)
-        self.assertIsInstance(ports[1], model.OpenedPort)
+        self.assertIsInstance(ports[1], ops.OpenedPort)
         self.assertEqual(ports[1].protocol, 'tcp')
         self.assertEqual(ports[1].port, 8080)
-        self.assertIsInstance(ports[2], model.OpenedPort)
+        self.assertIsInstance(ports[2], ops.OpenedPort)
         self.assertEqual(ports[2].protocol, 'udp')
         self.assertEqual(ports[2].port, 4000)
 
@@ -4587,7 +4587,7 @@ class TestPorts(unittest.TestCase):
         self.assertIsInstance(ports_set, set)
         ports = sorted(ports_set, key=lambda p: (p.protocol, p.port))
         self.assertEqual(len(ports), 1)
-        self.assertIsInstance(ports[0], model.OpenedPort)
+        self.assertIsInstance(ports[0], ops.OpenedPort)
         self.assertEqual(ports[0].protocol, 'icmp')
         self.assertIsNone(ports[0].port)
 
@@ -4597,19 +4597,19 @@ class TestPorts(unittest.TestCase):
         self.assertEqual(ports_set, set())
 
     def test_errors(self):
-        harness = Harness(CharmBase, meta='name: webapp')
+        harness = ops.Harness(ops.CharmBase, meta='name: webapp')
         self.addCleanup(harness.cleanup)
         unit = harness.model.unit
 
-        with self.assertRaises(model.ModelError):
+        with self.assertRaises(ops.ModelError):
             unit.open_port('icmp', 8080)  # icmp cannot have port
-        with self.assertRaises(model.ModelError):
+        with self.assertRaises(ops.ModelError):
             unit.open_port('ftp', 8080)  # invalid protocol
-        with self.assertRaises(model.ModelError):
+        with self.assertRaises(ops.ModelError):
             unit.open_port('tcp')  # tcp must have port
-        with self.assertRaises(model.ModelError):
+        with self.assertRaises(ops.ModelError):
             unit.open_port('udp')  # udp must have port
-        with self.assertRaises(model.ModelError):
+        with self.assertRaises(ops.ModelError):
             unit.open_port('tcp', 0)  # port out of range
-        with self.assertRaises(model.ModelError):
+        with self.assertRaises(ops.ModelError):
             unit.open_port('tcp', 65536)  # port out of range


### PR DESCRIPTION
This is to address #731: it's hard to remember or discover which `ops` sub-module (like `ops.charm` or `ops.framework`) a name comes from. That, and imports become a bit of a mess (`from ops.charm import X; from ops.framework import Y; from ops.main import main`).

In my view we had previously split them up somewhat arbitrarily (eg: `FooEvent` types are in `ops.charm`, but they could just as well be in `ops.framework`). I considered a different, more logical sub-module arrangement, but I think it'd still be hard to remember and know where things were.

This solution is simple: import all the public names into the top-level `ops` module in the `__init__.py` file. They're quite unique, so there's no conflicts. The only exception is `ops.pebble`, whose names aren't imported there (most charms don't use `ops.pebble` directly anyway, they use it via `model.Container`, but if you need it its still readily importable).

This makes all the names easily discoverable, either by looking in `ops/__init__.py` manually, or via your editor's code completion when you've done `import ops`. I expect that many charms will change to just `import ops` and access names like `ops.CharmBase` (`ops` is a nice short prefix) ... see [this PR on my database test charm](https://github.com/benhoyt/test-charms/pull/1/files) for an example of what that would look like.

Folks can also use explicit imports like `from ops import CharmBase` if they prefer. And of course the existing usage `from ops.charm import CharmBase` still works fine too.

The one quirky thing is that `ops.main` is currently a module, but we want to allow `import ops ... ops.main()` or `from ops import main ... main()`. To solve this we've main the main module callable (and it just calls the `main` function). This allows the new usage, but also allows the existing usages `from ops.main import main ... main()` and  `import ops.main ... main.main()` to continue working.

### Testing note

The user-facing changes here are all done in `ops/__init__.py` and `ops/main.py`, but I've also updated the `test/test_*.py` files to show using the single `import ops` approach (partly to set that as a precedent).

However, I ran all the previous, unmodified tests against the new `ops/__init__.py`, and they all pass. This ensures that I haven't messed anything up, including the `main` shenanigans mentioned above.

Fixes #731.