### PR TITLE
Revert to static list for setup.py install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@
 
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
-from typing import List
 
 from setuptools import find_packages, setup
 
@@ -26,19 +25,6 @@ def _read_me() -> str:
     with open("README.md", "rt", encoding="utf8") as fh:
         readme = fh.read()
     return readme
-
-
-def _requirements() -> List[str]:
-    """Return the required packages to run the project."""
-    reqs = []
-    with open(Path(__file__).parent / 'requirements.txt', encoding='utf-8') as fh:
-        for line in fh.readlines():
-            # TODO(tinvaan): DRY, consider setuptools offering for requirements parsing
-            # https://setuptools.pypa.io/en/latest/pkg_resources.html#requirements-parsing
-            line = line.strip()
-            if line and not line.startswith("#"):
-                reqs.append(line)
-    return reqs
 
 
 def _get_version() -> str:
@@ -87,7 +73,10 @@ version = {version!r}
             "Operating System :: POSIX :: Linux",
         ],
         python_requires='>=3.8',
-        install_requires=_requirements(),
+        install_requires=[  # must stay in sync with requirements.txt (see test_install_requires)
+            'PyYAML==6.*',
+            'websocket-client==1.*',
+        ],
         package_data={'ops': ['py.typed']},
     )
 

--- a/test/test_infra.py
+++ b/test/test_infra.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ast
 import itertools
 import os
 import re
@@ -91,6 +92,26 @@ class InfrastructureTests(unittest.TestCase):
 
     def test_check(self):
         self._run_setup('check', '--strict')
+
+    def test_install_requires(self):
+        """Ensure that requirements.txt stays in sync with install_requires in setup.py."""
+        with open('requirements.txt', encoding='utf-8') as f:
+            requirements = [line.strip() for line in f
+                            if line.strip() and not line.startswith('#')]
+
+        # For some reason "setup.py --requires" doesn't work, so do this the hard way
+        with open('setup.py', encoding='utf-8') as f:
+            lines = []
+            for line in f:
+                if 'install_requires=[' in line:
+                    break
+            for line in f:
+                if line.strip() == '],':
+                    break
+                lines.append(line)
+            install_requires = ast.literal_eval('[' + '\n'.join(lines) + ']')
+
+        self.assertEqual(requirements, install_requires)
 
 
 class ImportersTestCase(unittest.TestCase):


### PR DESCRIPTION
This breaks "pip install" because requirements.txt is not included in the sdist or wheel. We could explicitly add a MANIFEST.in, but seems better to keep it simple and in line with the defaults, so just duplicate it and add a test to ensure they stay in sync.

Fixes #913.
