### PR TITLE
Add CI tests for 'pip install' and 'charmcraft pack'

### DIFF
--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -23,7 +23,7 @@ jobs:
         # temporary merge commit), because charmcraft pack does a git checkout which
         # can't see the temporary merge commit.
         sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" requirements.txt
-        echo -e "\ngit+${{ github.event.pull_request.repo.clone_url }}@${{ github.event.pull_request.head.sha }}#egg=ops" >> requirements.txt
+        echo -e "\ngit+${{ github.event.pull_request.head.repo.clone_url }}@${{ github.event.pull_request.head.sha }}#egg=ops" >> requirements.txt
         cat requirements.txt
 
     - name: Install charmcraft

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -22,7 +22,7 @@ jobs:
         cat requirements.txt
 
     - name: Set up LXD
-      uses: canonical/setup-lxd
+      uses: canonical/setup-lxd@ea57509
       with:
         channel: 5.0/stable
 

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -30,4 +30,4 @@ jobs:
       run: sudo snap install charmcraft --classic
 
     - name: Pack the charm
-      run: sudo -g lxd charmcraft pack --verbose
+      run: sudo charmcraft pack --verbose

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -4,16 +4,11 @@ on: [push, pull_request, workflow_call]
 
 jobs:
   charmcraft-pack:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.8"
-
     - name: Checkout test charm repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: jnsgruk/hello-kubecon
 
@@ -26,13 +21,14 @@ jobs:
         echo -e "\ngit+${{ github.event.pull_request.head.repo.clone_url }}@${{ github.event.pull_request.head.sha }}#egg=ops" >> requirements.txt
         cat requirements.txt
 
+    steps:
+    - name: Set up LXD
+      uses: canonical/setup-lxd
+      with:
+        channel: 5.0/stable
+
     - name: Install charmcraft
-      run: |
-          sudo snap refresh lxd --channel=latest
-          sudo adduser "$USER" lxd
-          sudo lxd init --auto
-          sudo snap install charmcraft --classic
+      run: sudo snap install charmcraft --classic
 
     - name: Pack the charm
-      run: |
-          sudo -g lxd charmcraft pack --verbose
+      run: sudo -g lxd charmcraft pack --verbose

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -1,0 +1,35 @@
+name: Charmcraft Pack Test
+
+on: [push, pull_request, workflow_call]
+
+jobs:
+  charmcraft-pack:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Set up Python 3
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+
+    - name: Checkout test charm repository
+      uses: actions/checkout@v2
+      with:
+        repository: jnsgruk/hello-kubecon
+        ref: ${{ github.event.pull_request.head.sha }}  # TODO: remove
+
+    - name: Update 'ops' dependency in test charm to latest
+      run: |
+        sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" requirements.txt
+        echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
+
+    - name: Install charmcraft
+      run: |
+          sudo snap refresh lxd --channel=latest
+          sudo adduser "$USER" lxd
+          sudo lxd init --auto
+          sudo snap install charmcraft --classic
+
+    - name: Pack the charm
+      run: |
+          sudo -g lxd charmcraft pack --verbose

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -7,6 +7,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - uses: actions/checkout@v2
+      with:  # TODO: remove
+        ref: ${{ github.event.pull_request.head.sha }}
+
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
@@ -16,7 +20,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: jnsgruk/hello-kubecon
-        ref: ${{ github.event.pull_request.head.sha }}  # TODO: remove
 
     - name: Update 'ops' dependency in test charm to latest
       run: |

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -19,8 +19,11 @@ jobs:
 
     - name: Update 'ops' dependency in test charm to latest
       run: |
+        # We need to reference the PR branch's repo and commit (not the GITHUB_SHA
+        # temporary merge commit), because charmcraft pack does a git checkout which
+        # can't see the temporary merge commit.
         sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" requirements.txt
-        echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
+        echo -e "\ngit+${{ github.event.pull_request.repo.clone_url }}@${{ github.event.pull_request.head.sha }}#egg=ops" >> requirements.txt
         cat requirements.txt
 
     - name: Install charmcraft

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -8,8 +8,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:  # TODO: remove
-        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Set up Python 3
       uses: actions/setup-python@v2

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -22,7 +22,7 @@ jobs:
         cat requirements.txt
 
     - name: Set up LXD
-      uses: canonical/setup-lxd@ea57509
+      uses: canonical/setup-lxd@ea57509243d3cf39f8ab926e021bb353947b01b5
       with:
         channel: 5.0/stable
 

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -21,7 +21,6 @@ jobs:
         echo -e "\ngit+${{ github.event.pull_request.head.repo.clone_url }}@${{ github.event.pull_request.head.sha }}#egg=ops" >> requirements.txt
         cat requirements.txt
 
-    steps:
     - name: Set up LXD
       uses: canonical/setup-lxd
       with:

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -7,12 +7,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Python 3
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "3.8"
 
     - name: Checkout test charm repository
       uses: actions/checkout@v2
@@ -23,6 +21,7 @@ jobs:
       run: |
         sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" requirements.txt
         echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
+        cat requirements.txt
 
     - name: Install charmcraft
       run: |

--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout the ${{ matrix.charm-repo }} repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ matrix.charm-repo }}
 

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3
         uses: actions/setup-python@v2
 
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3
         uses: actions/setup-python@v2
 
@@ -40,7 +40,7 @@ jobs:
         python-version: ["3.8", "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -61,7 +61,7 @@ jobs:
         python-version: ["3.8", "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3
         uses: actions/setup-python@v2
 

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -96,8 +96,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:  # TODO: remove
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python 3
         uses: actions/setup-python@v2
 

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -89,4 +89,21 @@ jobs:
         run: tox -e unit -- -k RealPebble
         env:
           RUN_REAL_PEBBLE_TESTS: 1 
-          PEBBLE: /tmp/pebble 
+          PEBBLE: /tmp/pebble
+
+  pip-install:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3
+        uses: actions/setup-python@v2
+
+      - name: Build
+        run: python setup.py sdist
+
+      # Test that a pip install of the source dist .tar.gz will work
+      - name: Test 'pip install'
+        run: |
+          ls dist/ops*.gz  # should only be 1
+          pip install $(ls dist/ops*.gz | head -n1)

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -96,6 +96,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:  # TODO: remove
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python 3
         uses: actions/setup-python@v2
 

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -105,9 +105,4 @@ jobs:
       # Test that a pip install of the source dist .tar.gz will work
       - name: Test 'pip install'
         run: |
-          ls dist/ops*.gz  # should only be 1
-          echo -------------------------------------
-          cat setup.py
-          echo -------------------------------------
-          tar -tf $(ls dist/ops*.gz | head -n1)
           pip install $(ls dist/ops*.gz | head -n1)

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -106,4 +106,8 @@ jobs:
       - name: Test 'pip install'
         run: |
           ls dist/ops*.gz  # should only be 1
+          echo -------------------------------------
+          cat setup.py
+          echo -------------------------------------
+          tar -tf $(ls dist/ops*.gz | head -n1)
           pip install $(ls dist/ops*.gz | head -n1)

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -104,5 +104,5 @@ jobs:
 
       # Test that a pip install of the source dist .tar.gz will work
       - name: Test 'pip install'
-        run: |
-          pip install $(ls dist/ops*.gz | head -n1)
+        # Shouldn't happen, but pip install will fail if ls returns multiple lines
+        run: pip install $(ls dist/ops*.gz)

--- a/.github/workflows/hello-charm-tests.yaml
+++ b/.github/workflows/hello-charm-tests.yaml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.8"
 
       - name: Checkout the ${{ matrix.charm-repo }} repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ matrix.charm-repo }}
 

--- a/.github/workflows/hello-charm-tests.yaml
+++ b/.github/workflows/hello-charm-tests.yaml
@@ -40,5 +40,5 @@ jobs:
       - name: Ensure 'charmcraft pack' works
         run: |
           grep --quiet git charmcraft.yaml || echo -e "\nparts:\n  charm:\n    build-packages: [git]" >>charmcraft.yaml
-          snap install charmcraft
+          snap install charmcraft --classic
           charmcraft pack --verbose

--- a/.github/workflows/hello-charm-tests.yaml
+++ b/.github/workflows/hello-charm-tests.yaml
@@ -36,9 +36,3 @@ jobs:
         run: |
           export PYTHONPATH="lib:src:$PYTHONPATH"
           python3 -m unittest
-
-      - name: Ensure 'charmcraft pack' works
-        run: |
-          grep --quiet git charmcraft.yaml || echo -e "\nparts:\n  charm:\n    build-packages: [git]" >>charmcraft.yaml
-          sudo snap install charmcraft --classic
-          charmcraft pack --verbose

--- a/.github/workflows/hello-charm-tests.yaml
+++ b/.github/workflows/hello-charm-tests.yaml
@@ -40,5 +40,5 @@ jobs:
       - name: Ensure 'charmcraft pack' works
         run: |
           grep --quiet git charmcraft.yaml || echo -e "\nparts:\n  charm:\n    build-packages: [git]" >>charmcraft.yaml
-          sudo snap install charmcraft
+          sudo snap install charmcraft --classic
           charmcraft pack --verbose

--- a/.github/workflows/hello-charm-tests.yaml
+++ b/.github/workflows/hello-charm-tests.yaml
@@ -36,3 +36,9 @@ jobs:
         run: |
           export PYTHONPATH="lib:src:$PYTHONPATH"
           python3 -m unittest
+
+      - name: Ensure 'charmcraft pack' works
+        run: |
+          grep --quiet git charmcraft.yaml || echo -e "\nparts:\n  charm:\n    build-packages: [git]" >>charmcraft.yaml
+          snap install charmcraft
+          charmcraft pack --verbose

--- a/.github/workflows/hello-charm-tests.yaml
+++ b/.github/workflows/hello-charm-tests.yaml
@@ -40,5 +40,5 @@ jobs:
       - name: Ensure 'charmcraft pack' works
         run: |
           grep --quiet git charmcraft.yaml || echo -e "\nparts:\n  charm:\n    build-packages: [git]" >>charmcraft.yaml
-          snap install charmcraft --classic
+          sudo snap install charmcraft
           charmcraft pack --verbose

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout the ${{ matrix.charm-repo }} repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ matrix.charm-repo }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [framework-tests, observability-charm-tests, hello-charm-tests]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
         uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
This is to find any issues early and avoid breakage like that caused by 2.1.0 missing the requirements.txt file: https://github.com/canonical/operator/issues/913 (the specific issue was fixed in #914).