### PR TITLE
Only use PR SHA if it's actually a PR (it broke once merged)

### DIFF
--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -14,11 +14,16 @@ jobs:
 
     - name: Update 'ops' dependency in test charm to latest
       run: |
-        # We need to reference the PR branch's repo and commit (not the GITHUB_SHA
-        # temporary merge commit), because charmcraft pack does a git checkout which
-        # can't see the temporary merge commit.
         sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" requirements.txt
-        echo -e "\ngit+${{ github.event.pull_request.head.repo.clone_url }}@${{ github.event.pull_request.head.sha }}#egg=ops" >> requirements.txt
+        if [ -z "${{ github.event.pull_request.head.sha }}" ]
+        then
+          echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
+        else
+          # If on a PR, we need to reference the PR branch's repo and commit (not the GITHUB_SHA
+          # temporary merge commit), because charmcraft pack does a git checkout which
+          # can't see the temporary merge commit.
+          echo -e "\ngit+${{ github.event.pull_request.head.repo.clone_url }}@${{ github.event.pull_request.head.sha }}#egg=ops" >> requirements.txt
+        fi
         cat requirements.txt
 
     - name: Set up LXD


### PR DESCRIPTION
The change in https://github.com/canonical/operator/pull/915 was all good on the PR branch but of course didn't work once merged, because `${{ github.event.pull_request.head.sha }}` doesn't exist when running CI on the main branch. Update to only use that variable if present, otherwise revert to the normal `$GITHUB_SHA` method.