### PR TITLE
Conditionally change the local DB file name

### DIFF
--- a/ops/main.py
+++ b/ops/main.py
@@ -36,7 +36,16 @@ if TYPE_CHECKING:
     from ops.framework import BoundEvent, EventSource
     from ops.model import Relation
 
-CHARM_STATE_FILE = '.unit-state.db'
+
+try:
+    # If charmhelpers is present in the system, use a different path for
+    # the DB, as it otherwise leads to clashes.
+    # See: https://bugs.launchpad.net/charm-ceph-mon/+bug/2005137
+    import charmhelers.core.unitdata as _unitdata
+    CHARM_STATE_FILE = '.unit-state2.db'
+    del _unitdata
+except BaseException:
+    CHARM_STATE_FILE = '.unit-state.db'
 
 
 logger = logging.getLogger()

--- a/ops/main.py
+++ b/ops/main.py
@@ -41,11 +41,11 @@ try:
     # If charmhelpers is present in the system, use a different path for
     # the DB, as it otherwise leads to clashes.
     # See: https://bugs.launchpad.net/charm-ceph-mon/+bug/2005137
-    import charmhelers.core.unitdata as _unitdata
+    import charmhelers.core.unitdata as _unitdata   # type: ignore
     CHARM_STATE_FILE = '.unit-state2.db'
     del _unitdata
-except BaseException:
-    CHARM_STATE_FILE = '.unit-state.db'
+except ImportError:
+    CHARM_STATE_FILE = '.unit-state.db'   # type: ignore
 
 
 logger = logging.getLogger()

--- a/ops/main.py
+++ b/ops/main.py
@@ -41,11 +41,11 @@ try:
     # If charmhelpers is present in the system, use a different path for
     # the DB, as it otherwise leads to clashes.
     # See: https://bugs.launchpad.net/charm-ceph-mon/+bug/2005137
-    import charmhelers.core.unitdata as _unitdata   # type: ignore
+    import charmhelers.core.unitdata as _unitdata  # type: ignore
     CHARM_STATE_FILE = '.unit-state2.db'
     del _unitdata
 except ImportError:
-    CHARM_STATE_FILE = '.unit-state.db'   # type: ignore
+    CHARM_STATE_FILE = '.unit-state.db'  # type: ignore
 
 
 logger = logging.getLogger()


### PR DESCRIPTION
This PR tests whether the charm-helpers library is present in the system to decide the final file name for the local key/value database in order to avoid conflicts between that library and the ops framework.

Fixes https://github.com/canonical/operator/issues/909