### PR TITLE
Use a different path for DB file

### DIFF
--- a/ops/main.py
+++ b/ops/main.py
@@ -399,7 +399,7 @@ def main(charm_class: Type[ops.charm.CharmBase],
         raise RuntimeError(msg.format(JujuVersion.from_environ()))
 
     if use_juju_for_storage is None:
-        use_juju_for_storage = _should_use_controller_storage(charm_state_path, meta)
+        use_juju_for_storage = _should_use_controller_storage(new_charm_state_path, meta)
     elif use_juju_for_storage:
         warnings.warn("Controller storage is deprecated; it's intended for "
                       "podspec charms and will be removed in a future release.",

--- a/ops/main.py
+++ b/ops/main.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from ops.model import Relation
 
 OLD_CHARM_STATE_FILE = '.unit-state.db'
-CHARM_STATE_FILE = '.new-unit-state.db'
+CHARM_STATE_FILE = '.ops-unit-state.db'
 
 
 logger = logging.getLogger()


### PR DESCRIPTION
Unlike the previous PR, this one uses a different DB file path unconditionally. If a DB exists in the previous path, it's copied over beforehand (Similar to what we did in the ceph-mon charm: https://review.opendev.org/c/openstack/charm-ceph-mon/+/876901)

Fixes https://github.com/canonical/operator/issues/909