### PR TITLE
Update `relation.units` docstring for subordinates

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1257,7 +1257,7 @@ class Relation:
         app: An :class:`Application` representing the remote application of this relation.
             For peer relations this will be the local application.
         units: A set of :class:`Unit` for units that have started and joined this relation.
-            For subordinate charms, this set will include one and only unit: the principal unit.
+            For subordinate charms, this set will include only one unit: the principal unit.
         data: A :class:`RelationData` holding the data buckets for each entity
             of a relation. Accessed via eg Relation.data[unit]['foo']
     """

--- a/ops/model.py
+++ b/ops/model.py
@@ -1257,6 +1257,7 @@ class Relation:
         app: An :class:`Application` representing the remote application of this relation.
             For peer relations this will be the local application.
         units: A set of :class:`Unit` for units that have started and joined this relation.
+            For subordinate charms, this set will include one and only unit: the principal unit.
         data: A :class:`RelationData` holding the data buckets for each entity
             of a relation. Accessed via eg Relation.data[unit]['foo']
     """

--- a/ops/model.py
+++ b/ops/model.py
@@ -1257,7 +1257,7 @@ class Relation:
         app: An :class:`Application` representing the remote application of this relation.
             For peer relations this will be the local application.
         units: A set of :class:`Unit` for units that have started and joined this relation.
-            For subordinate charms, this set will include only one unit: the principal unit.
+            For subordinate relations, this set will include only one unit: the principal unit.
         data: A :class:`RelationData` holding the data buckets for each entity
             of a relation. Accessed via eg Relation.data[unit]['foo']
     """


### PR DESCRIPTION
*Update `relation.units` docstring to mention the special case of subordinates units.*

## Checklist

 - [x] Have any types changed? If so, have the type annotations been updated?
 - [x] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?
 - [x] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

N/A

## Documentation changes

No change.

## Bug reference

N/A.

## Changelog

- *Update `relation.units` docstring for subordinates*
