### PR TITLE
Support Layer equality checks

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -744,11 +744,14 @@ class Layer:
     def __repr__(self) -> str:
         return f'Layer({self.to_dict()!r})'
 
-    def __eq__(self, other: Any) -> bool:
-        if isinstance(other, Layer):
+    def __eq__(self, other: Union['LayerDict', 'Layer']) -> bool:
+        """Reports whether this layer configuration is equal to another."""
+        if isinstance(other, dict):
+            return self.to_dict() == other
+        elif isinstance(other, Layer):
             return self.to_dict() == other.to_dict()
         else:
-            return NotImplemented
+            raise TypeError(f"Cannot compare pebble.Layer to {type(other)}")
 
     __str__ = to_yaml
 
@@ -825,15 +828,13 @@ class Service:
         return f'Service({self.to_dict()!r})'
 
     def __eq__(self, other: Union['_ServiceDict', 'Service']) -> bool:
-        """Compare this service description to another."""
+        """Reports whether this service configuration is equal to another."""
         if isinstance(other, dict):
             return self.to_dict() == other
         elif isinstance(other, Service):
             return self.to_dict() == other.to_dict()
         else:
-            raise ValueError(
-                f"Cannot compare pebble.Service to {type(other)}"
-            )
+            raise TypeError(f"Cannot compare pebble.Service to {type(other)}")
 
 
 class ServiceStartup(enum.Enum):
@@ -944,13 +945,13 @@ class Check:
         return f'Check({self.to_dict()!r})'
 
     def __eq__(self, other: Union['_CheckDict', 'Check']) -> bool:
-        """Compare this check configuration to another."""
-        if isinstance(other, dict):  # pyright: reportUnnecessaryComparison=false
+        """Reports whether this check configuration is equal to another."""
+        if isinstance(other, dict):
             return self.to_dict() == other
         elif isinstance(other, Check):
             return self.to_dict() == other.to_dict()
         else:
-            raise ValueError(f"Cannot compare pebble.Check to {type(other)}")
+            raise TypeError(f"Cannot compare pebble.Check to {type(other)}")
 
 
 class CheckLevel(enum.Enum):

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -744,6 +744,12 @@ class Layer:
     def __repr__(self) -> str:
         return f'Layer({self.to_dict()!r})'
 
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, Layer):
+            return self.to_dict() == other.to_dict()
+        else:
+            return NotImplemented
+
     __str__ = to_yaml
 
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -751,7 +751,7 @@ class Layer:
         elif isinstance(other, Layer):
             return self.to_dict() == other.to_dict()
         else:
-            raise TypeError(f"Cannot compare pebble.Layer to {type(other)}")
+            return NotImplemented
 
     __str__ = to_yaml
 
@@ -834,7 +834,7 @@ class Service:
         elif isinstance(other, Service):
             return self.to_dict() == other.to_dict()
         else:
-            raise TypeError(f"Cannot compare pebble.Service to {type(other)}")
+            return NotImplemented
 
 
 class ServiceStartup(enum.Enum):
@@ -951,7 +951,7 @@ class Check:
         elif isinstance(other, Check):
             return self.to_dict() == other.to_dict()
         else:
-            raise TypeError(f"Cannot compare pebble.Check to {type(other)}")
+            return NotImplemented
 
 
 class CheckLevel(enum.Enum):

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -634,6 +634,30 @@ summary: Sum Mary
 
         self.assertEqual(s.services, t.services)
 
+    def test_layer_equality(self):
+        s = pebble.Layer({})
+        self._assert_empty(s)
+
+        d = {
+            'summary': 'Sum Mary',
+            'description': 'The quick brown fox!',
+            'services': {
+                'foo': {
+                    'summary': 'Foo',
+                    'command': 'echo foo',
+                },
+                'bar': {
+                    'summary': 'Bar',
+                    'command': 'echo bar',
+                },
+            }
+        }
+        t = pebble.Layer(d)
+        self.assertNotEqual(s, t)
+
+        s = pebble.Layer(d)
+        self.assertEqual(s, t)
+
 
 class TestService(unittest.TestCase):
     def _assert_empty(self, service, name):

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -654,9 +654,16 @@ summary: Sum Mary
         }
         t = pebble.Layer(d)
         self.assertNotEqual(s, t)
+        self.assertNotEqual(t, {})
+        self.assertEqual(t, d)
 
         s = pebble.Layer(d)
         self.assertEqual(s, t)
+        self.assertNotEqual(s, {})
+        self.assertEqual(s, d)
+
+        with self.assertRaises(TypeError):
+            self.assertEqual(s, 5)
 
 
 class TestService(unittest.TestCase):
@@ -788,7 +795,7 @@ class TestService(unittest.TestCase):
         }
         self.assertEqual(one, as_dict)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.assertEqual(one, 5)
 
 
@@ -873,7 +880,7 @@ class TestCheck(unittest.TestCase):
         d['level'] = 'ready'
         self.assertNotEqual(one, d)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.assertEqual(one, 5)
 
 

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -662,8 +662,7 @@ summary: Sum Mary
         self.assertNotEqual(s, {})
         self.assertEqual(s, d)
 
-        with self.assertRaises(TypeError):
-            self.assertEqual(s, 5)
+        self.assertNotEqual(s, 5)
 
 
 class TestService(unittest.TestCase):
@@ -795,8 +794,7 @@ class TestService(unittest.TestCase):
         }
         self.assertEqual(one, as_dict)
 
-        with self.assertRaises(TypeError):
-            self.assertEqual(one, 5)
+        self.assertNotEqual(one, 5)
 
 
 class TestCheck(unittest.TestCase):
@@ -880,8 +878,7 @@ class TestCheck(unittest.TestCase):
         d['level'] = 'ready'
         self.assertNotEqual(one, d)
 
-        with self.assertRaises(TypeError):
-            self.assertEqual(one, 5)
+        self.assertNotEqual(one, 5)
 
 
 class TestServiceInfo(unittest.TestCase):


### PR DESCRIPTION
This PR adds support for directly comparing `Layer` objects for equality. While writing tests using `ops-scenario`, I was surprised by an assertion failing with identical `Layers`. 

## Checklist

 - [ ] Have any types changed? If so, have the type annotations been updated?
 - [ ] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?

       We want to avoid simple passthrough of model data, without contextualization, where possible.

 - [ ] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

The PR includes a new test for this feature.

## Documentation changes

This does not impact documentation, but will more correctly match users expectation that 2 identical `Layers` are equal.

## Bug reference

N/A

## Changelog

- *Adds support for Layer equality checks*

