### PR TITLE
Fixing the function signature of send_signal in _TestingPebbleClient

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2537,7 +2537,7 @@ class _TestingPebbleClient:
     def exec(self, command, **kwargs):  # type:ignore
         raise NotImplementedError(self.exec)  # type:ignore
 
-    def send_signal(self, sig: Union[int, str], *service_names: str):
+    def send_signal(self, sig: Union[int, str], service_names: Iterable[str]):
         if not service_names:
             raise TypeError('send_signal expected at least 1 service name, got 0')
         self._check_connection()

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2564,7 +2564,8 @@ class _TestingPebbleClient:
             signal.Signals[sig]
         except KeyError:
             # conform with the real pebble api
-            message = f'cannot send signal to "{service_names[0]}": invalid signal name "{sig}"'
+            first_service = next(iter(service_names))
+            message = f'cannot send signal to "{first_service}": invalid signal name "{sig}"'
             body = {'type': 'error', 'status-code': 500, 'status': 'Internal Server Error',
                     'result': {'message': message}}
             raise pebble.APIError(

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3833,27 +3833,27 @@ class TestTestingPebbleClient(unittest.TestCase, _TestingPebbleClientMixin):
         # Foo is now started, but Bar is not
 
         # Send a valid signal to a running service
-        client.send_signal("SIGINT", "foo")
+        client.send_signal("SIGINT", ("foo",))
 
         # Send a valid signal but omit service name
         with self.assertRaises(TypeError):
-            client.send_signal("SIGINT")
+            client.send_signal("SIGINT", tuple())
 
         # Send an invalid signal to a running service
         with self.assertRaises(pebble.APIError):
-            client.send_signal("sigint", "foo")
+            client.send_signal("sigint", ("foo",))
 
         # Send a valid signal to a stopped service
         with self.assertRaises(pebble.APIError):
-            client.send_signal("SIGINT", "bar")
+            client.send_signal("SIGINT", ("bar",))
 
         # Send a valid signal to a non-existing service
         with self.assertRaises(pebble.APIError):
-            client.send_signal("SIGINT", "baz")
+            client.send_signal("SIGINT", ("baz",))
 
         # Send a valid signal to a multiple services, one of which is not running
         with self.assertRaises(pebble.APIError):
-            client.send_signal("SIGINT", "foo", "bar")
+            client.send_signal("SIGINT", ("foo", "bar",))
 
 
 # For testing file-ops of the pebble client.  This is refactored into a


### PR DESCRIPTION
This pull request addresses the issue of incorrect function signature in the `send_signal` method of the mocking class `_TestingPebbleClient` in the operator framework. Currently, the signature of `send_signal` method in `_TestingPebbleClient` does not match the `send_signal` method of `Client` in the `ops.pebble` module. As a result, unit tests that involve the `send_signal` method are failing.

Here's the function signature of `send_signal` in `ops.testing._TestingPebbleClient` right now :

https://github.com/canonical/operator/blob/a8717eadfbf97f001f9b1e06214fa19aa5df6204/ops/testing.py#L2540

And here's the `send_signal` method of `ops.pebble.Client`:

https://github.com/canonical/operator/blob/a8717eadfbf97f001f9b1e06214fa19aa5df6204/ops/pebble.py#L2306