### PR TITLE
Use ubuntu-20.04 to run CI tests that require python<=3.6

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         python-version: ["3.5", "3.6", "3.8", "3.10"]
 
     steps:
@@ -57,7 +57,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         python-version: ["3.5", "3.6", "3.8", "3.10"]
 
     steps:


### PR DESCRIPTION
Current GitHub CI jobs (for `1.5-maintenance` branch) are using `ubuntu-latest` image to run tests. However the "latest" image was upgraded to `Ubuntu 22.04` which does not have required python versions (<=3.6). To keep testing with older python versions, it's necessary to specify `ubuntu-20.04` as a platform for running tests. ([list of python versions and their availability on different ci images](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json))

## Checklist

 - [x] Have any types changed? If so, have the type annotations been updated?
 - [x] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?
 - [x] Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

~~I believe that Github CI ignores proposed changes to `.github/workflows/` files and always uses what's currently in the target branch. Thus I don't think there's a way to test this change without merging it.~~

No code changes made. See results of the checks in this PR to verify success.

## Documentation changes

No documentation changes needed.

## Bug reference

No bug filed.

## Changelog

