### PR TITLE
Implement filesystem operations interface for containers in test Harness

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -2012,7 +2012,7 @@ class Container:
              user_id: Optional[int] = None,
              user: Optional[str] = None,
              group_id: Optional[int] = None,
-             group: Optional[str] = None):
+             group: Optional[str] = None) -> None:
         """Write content to a given file path on the remote system.
 
         Args:
@@ -2058,7 +2058,7 @@ class Container:
 
     def push_path(self,
                   source_path: Union[StrOrPath, Iterable[StrOrPath]],
-                  dest_dir: StrOrPath):
+                  dest_dir: StrOrPath) -> None:
         """Recursively push a local path or files to the remote system.
 
         Only regular files and directories are copied; symbolic links, device files, etc. are
@@ -2137,7 +2137,7 @@ class Container:
 
     def pull_path(self,
                   source_path: Union[StrOrPath, Iterable[StrOrPath]],
-                  dest_dir: StrOrPath):
+                  dest_dir: StrOrPath) -> None:
         """Recursively pull a remote path or files to the local system.
 
         Only regular files and directories are copied; symbolic links, device files, etc. are
@@ -2302,7 +2302,7 @@ class Container:
     def make_dir(
             self, path: str, *, make_parents: bool = False, permissions: Optional[int] = None,
             user_id: Optional[int] = None, user: Optional[str] = None,
-            group_id: Optional[int] = None, group: Optional[str] = None):
+            group_id: Optional[int] = None, group: Optional[str] = None) -> None:
         """Create a directory on the remote system with the given attributes.
 
         Args:
@@ -2322,7 +2322,7 @@ class Container:
                               user_id=user_id, user=user,
                               group_id=group_id, group=group)
 
-    def remove_path(self, path: str, *, recursive: bool = False):
+    def remove_path(self, path: str, *, recursive: bool = False) -> None:
         """Remove a file or directory on the remote system.
 
         Args:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -28,6 +28,7 @@ import signal
 import tempfile
 import uuid
 import warnings
+from abc import abstractmethod
 from contextlib import contextmanager
 from io import BytesIO, StringIO
 from textwrap import dedent
@@ -236,7 +237,9 @@ class Harness(Generic[CharmType]):
         """
         if isinstance(container, str):
             container = self.model.unit.get_container(container)
-        return _TestingContainerFilesystemProxy(container=container, backend=self._backend)
+        return _TestingContainerFilesystemProxy(
+            container=container, backend=self._backend
+        )  # type: ignore
 
     @property
     def charm(self) -> CharmType:
@@ -2604,8 +2607,12 @@ class NonAbsolutePathError(Exception):
 
 
 class ContainerFilesystem(Protocol):
-    """A Protocol class that represents a filesystem-related subset of operations of container."""
+    """The subset of container operations that are filesystem-related.
 
+    Don't instantiate this directly; use :meth:`Harness.get_container_filesystem`.
+    """
+
+    @abstractmethod
     def pull(self, path: StrOrPath, *,
              encoding: Optional[str] = 'utf-8') -> Union[BinaryIO, TextIO]:
         """Read a file's content from the remote system.
@@ -2613,6 +2620,7 @@ class ContainerFilesystem(Protocol):
         See :meth:`model.Container.pull` for details.
         """
 
+    @abstractmethod
     def push(self,
              path: StrOrPath,
              source: Union[bytes, str, BinaryIO, TextIO],
@@ -2629,6 +2637,7 @@ class ContainerFilesystem(Protocol):
         See :meth:`model.Container.push` for details.
         """
 
+    @abstractmethod
     def list_files(self, path: StrOrPath, *, pattern: Optional[str] = None,
                    itself: bool = False) -> List['FileInfo']:
         """Return list of directory entries from given path on remote system.
@@ -2636,6 +2645,7 @@ class ContainerFilesystem(Protocol):
         See :meth:`model.Container.list_files` for details.
         """
 
+    @abstractmethod
     def push_path(self,
                   source_path: Union[StrOrPath, Iterable[StrOrPath]],
                   dest_dir: StrOrPath):
@@ -2644,6 +2654,7 @@ class ContainerFilesystem(Protocol):
         See :meth:`model.Container.push_path` for details.
         """
 
+    @abstractmethod
     def pull_path(self,
                   source_path: Union[StrOrPath, Iterable[StrOrPath]],
                   dest_dir: StrOrPath):
@@ -2652,18 +2663,21 @@ class ContainerFilesystem(Protocol):
         See :meth:`model.Container.pull_path` for details.
         """
 
+    @abstractmethod
     def exists(self, path: str) -> bool:
         """Return true if the path exists on the container filesystem.
 
         See :meth:`model.Container.exists` for details.
         """
 
+    @abstractmethod
     def isdir(self, path: str) -> bool:
         """Return true if a directory exists at the given path on the container filesystem.
 
         See :meth:`model.Container.isdir` for details.
         """
 
+    @abstractmethod
     def make_dir(
             self, path: str, *, make_parents: bool = False, permissions: Optional[int] = None,
             user_id: Optional[int] = None, user: Optional[str] = None,
@@ -2673,6 +2687,7 @@ class ContainerFilesystem(Protocol):
         See :meth:`model.Container.make_dir` for details.
         """
 
+    @abstractmethod
     def remove_path(self, path: str, *, recursive: bool = False):
         """Remove a file or directory on the remote system.
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2712,7 +2712,7 @@ class _ContainerFilesystemProxy:
 
     def __getattr__(self, name: str):
         if name not in ContainerFilesystem.__dict__ or name.startswith("_"):
-            raise AttributeError(f'object has no attribute {name!r}')
+            raise AttributeError(f'{self.__class__.__name__!r} object has no attribute {name!r}')
         func = getattr(self._container, name)
 
         @functools.wraps(func)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2716,7 +2716,7 @@ class _ContainerFilesystemProxy:
         func = getattr(self._container, name)
 
         @functools.wraps(func)
-        def proxy_function(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             can_connect = self._backend._can_connect(self._container._pebble)
             self._backend._set_can_connect(self._container._pebble, True)
             try:
@@ -2724,7 +2724,7 @@ class _ContainerFilesystemProxy:
             finally:
                 self._backend._set_can_connect(self._container._pebble, can_connect)
 
-        return proxy_function
+        return wrapper
 
 
 class _TestingStorageMount:

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -4375,17 +4375,22 @@ class TestTestingContainerFilesystemFacade(unittest.TestCase):
         self.assertSetEqual(set(f.name for f in self.container_fs.list_files("/")), {"foo", "bar"})
 
     def test_protocol_attributes(self):
-        for attr in ContainerFilesystem.__dict__.keys():
+        for attr, func in ContainerFilesystem.__dict__.items():
             if attr.startswith("_"):
                 continue
             self.assertEqual(
-                inspect.signature(getattr(ContainerFilesystem, attr)),
+                inspect.signature(func),
                 inspect.signature(getattr(Container, attr))
             )
 
     def test_proxy_non_exist_attr(self):
         with self.assertRaises(AttributeError):
             self.container_fs.exist()
+
+    def test_exception_safe(self):
+        with self.assertRaises(TypeError):
+            self.container_fs.exists(foo="bar")
+        self.assertFalse(self.harness._backend._can_connect(self.container._pebble))
 
 
 class TestTestingStorageMount(GenericTestingFilesystemTests, unittest.TestCase):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -36,7 +36,7 @@ import yaml
 import ops
 import ops.testing
 from ops import pebble
-from ops.model import _ModelBackend, Container
+from ops.model import Container, _ModelBackend
 from ops.testing import (
     ContainerFilesystem,
     NonAbsolutePathError,

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -36,8 +36,9 @@ import yaml
 import ops
 import ops.testing
 from ops import pebble
-from ops.model import _ModelBackend
+from ops.model import _ModelBackend, Container
 from ops.testing import (
+    ContainerFilesystem,
     NonAbsolutePathError,
     _Directory,
     _TestingFilesystem,
@@ -4372,6 +4373,15 @@ class TestTestingContainerFilesystemFacade(unittest.TestCase):
         self.container_fs.make_dir("/foo")
         self.container_fs.make_dir("/bar")
         self.assertSetEqual(set(f.name for f in self.container_fs.list_files("/")), {"foo", "bar"})
+
+    def test_protocol_attributes(self):
+        for attr in ContainerFilesystem.__dict__.keys():
+            if attr.startswith("_"):
+                continue
+            self.assertEqual(
+                inspect.signature(getattr(ContainerFilesystem, attr)),
+                inspect.signature(getattr(Container, attr))
+            )
 
     def test_proxy_non_exist_attr(self):
         with self.assertRaises(AttributeError):


### PR DESCRIPTION
This pull request addresses the enhancement request [#931](https://github.com/canonical/operator/issues/931) for an API that allows access to the virtual filesystem in the test module. 

The current testing module of the operator framework includes a mock filesystem for the pebble-controlled container but lack an easy way to manipulate and inspect the mock filesystem in tests directly. To solve this, we've added a `get_container_filesystem` method to the test `Harness` class. This method provides an interface for conducting filesystem operations on a specified container, without restrictions posed by `set_can_connect`.

Changelog:

 - Adds `Harness.get_container_filesystem` method, allowing for direct filesystem operations on a specified test container without dealing with `set_can_connect`.