### PR TITLE
Remove "dying" units from planned units

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -2938,7 +2938,7 @@ class _ModelBackend:
         # concept is being deprecated, however, in favor of approaches such as the one that we use
         # here.
         app_state = self._run('goal-state', return_output=True, use_json=True)
-        app_state = typing.cast(Dict[str, List[str]], app_state)
+        app_state = typing.cast(Dict[str, Dict[str, str]], app_state)
 
         # Planned units can be zero. We don't need to do error checking here.
         # But we need to filter out dying units as they may be reported before being deleted

--- a/ops/model.py
+++ b/ops/model.py
@@ -2934,8 +2934,6 @@ class _ModelBackend:
         Includes the current unit in the count.
 
         """
-        # TODO: here, query the "life" of the application, if it's "dying", return -1
-
         # The goal-state tool will return the information that we need. Goal state as a general
         # concept is being deprecated, however, in favor of approaches such as the one that we use
         # here.
@@ -2949,6 +2947,10 @@ class _ModelBackend:
             for unit_name, unit_info in app_state.get('units', {})
             if unit_info['status'] != 'dying'
         ]
+
+        # TODO: here, if len(units) == 0, query the "life" of the application
+        #  if it's "dying", return -1, otherwise 0 (all units removed but app not removed)
+
         return len(units)
 
     def update_relation_data(self, relation_id: int, _entity: 'UnitOrApplication',

--- a/ops/model.py
+++ b/ops/model.py
@@ -2934,13 +2934,22 @@ class _ModelBackend:
         Includes the current unit in the count.
 
         """
+        # TODO: here, query the "life" of the application, if it's "dying", return -1
+
         # The goal-state tool will return the information that we need. Goal state as a general
         # concept is being deprecated, however, in favor of approaches such as the one that we use
         # here.
         app_state = self._run('goal-state', return_output=True, use_json=True)
         app_state = typing.cast(Dict[str, List[str]], app_state)
+
         # Planned units can be zero. We don't need to do error checking here.
-        return len(app_state.get('units', []))
+        # But we need to filter out dying units as they may be reported before being deleted
+        units = [
+            unit_name
+            for unit_name, unit_info in app_state.get('units', {})
+            if unit_info['status'] != 'dying'
+        ]
+        return len(units)
 
     def update_relation_data(self, relation_id: int, _entity: 'UnitOrApplication',
                              key: str, value: str):

--- a/ops/model.py
+++ b/ops/model.py
@@ -2947,10 +2947,6 @@ class _ModelBackend:
             for unit_name, unit_info in app_state.get('units', {}).items()
             if unit_info['status'] != 'dying'
         ]
-
-        # TODO: here, if len(units) == 0, query the "life" of the application
-        #  if it's "dying", return -1, otherwise 0 (all units removed but app not removed)
-
         return len(units)
 
     def update_relation_data(self, relation_id: int, _entity: 'UnitOrApplication',

--- a/ops/model.py
+++ b/ops/model.py
@@ -2938,7 +2938,7 @@ class _ModelBackend:
         # concept is being deprecated, however, in favor of approaches such as the one that we use
         # here.
         app_state = self._run('goal-state', return_output=True, use_json=True)
-        app_state = typing.cast(Dict[str, Dict[str, str]], app_state)
+        app_state = typing.cast(Dict[str, Dict[str, Any]], app_state)
 
         # Planned units can be zero. We don't need to do error checking here.
         # But we need to filter out dying units as they may be reported before being deleted

--- a/ops/model.py
+++ b/ops/model.py
@@ -2942,12 +2942,9 @@ class _ModelBackend:
 
         # Planned units can be zero. We don't need to do error checking here.
         # But we need to filter out dying units as they may be reported before being deleted
-        units = [
-            unit_name
-            for unit_name, unit_info in app_state.get('units', {}).items()
-            if unit_info['status'] != 'dying'
-        ]
-        return len(units)
+        units = app_state.get('units', {})
+        num_alive = sum(1 for unit in units.values() if unit['status'] != 'dying')
+        return num_alive
 
     def update_relation_data(self, relation_id: int, _entity: 'UnitOrApplication',
                              key: str, value: str):

--- a/ops/model.py
+++ b/ops/model.py
@@ -2931,7 +2931,8 @@ class _ModelBackend:
     def planned_units(self) -> int:
         """Count of "planned" units that will run this application.
 
-        Includes the current unit in the count, but does not include dying units.
+        This will include the current unit, any units that are alive, units that are in the process
+        of being started, but will not include units that are being shut down.
 
         """
         # The goal-state tool will return the information that we need. Goal state as a general

--- a/ops/model.py
+++ b/ops/model.py
@@ -2931,7 +2931,7 @@ class _ModelBackend:
     def planned_units(self) -> int:
         """Count of "planned" units that will run this application.
 
-        Includes the current unit in the count.
+        Includes the current unit in the count, but does not include dying units.
 
         """
         # The goal-state tool will return the information that we need. Goal state as a general

--- a/ops/model.py
+++ b/ops/model.py
@@ -2944,7 +2944,7 @@ class _ModelBackend:
         # But we need to filter out dying units as they may be reported before being deleted
         units = [
             unit_name
-            for unit_name, unit_info in app_state.get('units', {})
+            for unit_name, unit_info in app_state.get('units', {}).items()
             if unit_info['status'] != 'dying'
         ]
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -2712,6 +2712,35 @@ exit 2
             ['relation-list', '-r', '6', '--app', '--format=json'],
         ])
 
+    def test_planned_units(self):
+        # no units
+        fake_script(self, 'goal-state', """
+echo '{"units":{}, "relations":{}}'
+""")
+        self.assertEqual(self.backend.planned_units(), 0)
+
+        # only active units
+        fake_script(self, 'goal-state', """
+echo '{
+    "units":{
+        "app/0": {"status":"active","since":"2023-05-23 17:05:05Z"},
+        "app/1": {"status":"active","since":"2023-05-23 17:57:05Z"}
+    },
+    "relations": {}
+}'""")
+        self.assertEqual(self.backend.planned_units(), 2)
+
+        # active and dying units
+        fake_script(self, 'goal-state', """
+echo '{
+    "units":{
+        "app/0": {"status":"active","since":"2023-05-23 17:05:05Z"},
+        "app/1": {"status":"dying","since":"2023-05-23 17:57:05Z"}
+    },
+    "relations": {}
+}'""")
+        self.assertEqual(self.backend.planned_units(), 1)
+
 
 class TestLazyMapping(unittest.TestCase):
 


### PR DESCRIPTION
This PR addresses an issue that happens during a scale-down event, where `planned_units` includes units with the status marked as `dying`.
This becomes visible when say the `_storage_detaching` hook errors based on certain preconditions preventing a unit from immediately disappearing. 
This PR essentially filters out those dying units to have an accurate count of live units.