### PR TITLE
Update Pyright version to latest (1.1.313)

### DIFF
--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         charm-repo:
           - "canonical/alertmanager-k8s-operator"

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -10,7 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         charm-repo:
-          - "canonical/alertmanager-k8s-operator"
+# TODO(benhoyt): reinstate after https://github.com/canonical/alertmanager-k8s-operator-1/pull/1 is merged
+#          - "canonical/alertmanager-k8s-operator"
           - "canonical/prometheus-k8s-operator"
           - "canonical/grafana-k8s-operator"
 

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -219,7 +219,7 @@ class ActionEvent(EventBase):
         Args:
             results: The result of the action as a Dict
         """
-        self.framework.model._backend.action_set(results)   # pyright: reportPrivateUsage=false
+        self.framework.model._backend.action_set(results)
 
     def log(self, message: str):
         """Send a message that a user will see while the action is running.
@@ -227,7 +227,7 @@ class ActionEvent(EventBase):
         Args:
             message: The message for the user.
         """
-        self.framework.model._backend.action_log(message)  # pyright: reportPrivateUsage=false
+        self.framework.model._backend.action_log(message)
 
     def fail(self, message: str = ''):
         """Report that this action has failed.
@@ -235,7 +235,7 @@ class ActionEvent(EventBase):
         Args:
             message: Optional message to record why it has failed.
         """
-        self.framework.model._backend.action_fail(message)  # pyright: reportPrivateUsage=false
+        self.framework.model._backend.action_fail(message)
 
 
 class InstallEvent(HookEvent):
@@ -1141,7 +1141,7 @@ class CharmMeta:
         meta = cast('_CharmMetaDict', yaml.safe_load(metadata))
         raw_actions = {}
         if actions is not None:
-            raw_actions = cast(Dict[str, '_ActionMetaDict'], yaml.safe_load(actions))
+            raw_actions = cast(Optional[Dict[str, Any]], yaml.safe_load(actions))
             if raw_actions is None:
                 raw_actions = {}
         return cls(meta, raw_actions)

--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -61,7 +61,7 @@ class JujuVersion:
             return True
         if isinstance(other, str):
             other = type(self)(other)
-        elif not isinstance(other, JujuVersion):  # pyright: reportUnnecessaryIsInstance=false
+        elif not isinstance(other, JujuVersion):
             raise RuntimeError(f'cannot compare Juju version "{self}" with "{other}"')
         return (
             self.major == other.major

--- a/ops/log.py
+++ b/ops/log.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
     from types import TracebackType
     from typing import Type
 
-    from ops.model import _ModelBackend  # pyright: reportPrivateUsage=false
+    from ops.model import _ModelBackend
 
 
 class JujuLogHandler(logging.Handler):

--- a/ops/main.py
+++ b/ops/main.py
@@ -376,7 +376,7 @@ def main(charm_class: Type[ops.charm.CharmBase],
     """
     charm_dir = _get_charm_dir()
 
-    model_backend = ops.model._ModelBackend()  # pyright: reportPrivateUsage=false
+    model_backend = ops.model._ModelBackend()
     debug = ('JUJU_DEBUG' in os.environ)
     setup_root_logging(model_backend, debug=debug)
     logger.debug("Operator Framework %s up and running.", ops.__version__)  # type:ignore

--- a/ops/model.py
+++ b/ops/model.py
@@ -2317,7 +2317,9 @@ class Container:
         """
         self._pebble.remove_path(path, recursive=recursive)
 
-    def exec(
+    # Exec I/O is str if encoding is provided (the default)
+    @typing.overload
+    def exec(  # noqa
         self,
         command: List[str],
         *,
@@ -2333,7 +2335,47 @@ class Container:
         stderr: Optional[Union[TextIO, BinaryIO]] = None,
         encoding: str = 'utf-8',
         combine_stderr: bool = False
-    ) -> 'pebble.ExecProcess':
+    ) -> pebble.ExecProcess[str]:
+        ...
+
+    # Exec I/O is bytes if encoding is explicitly set to None
+    @typing.overload
+    def exec(  # noqa
+        self,
+        command: List[str],
+        *,
+        environment: Optional[Dict[str, str]] = None,
+        working_dir: Optional[str] = None,
+        timeout: Optional[float] = None,
+        user_id: Optional[int] = None,
+        user: Optional[str] = None,
+        group_id: Optional[int] = None,
+        group: Optional[str] = None,
+        stdin: Optional[Union[str, bytes, TextIO, BinaryIO]] = None,
+        stdout: Optional[Union[TextIO, BinaryIO]] = None,
+        stderr: Optional[Union[TextIO, BinaryIO]] = None,
+        encoding: None = None,
+        combine_stderr: bool = False
+    ) -> pebble.ExecProcess[bytes]:
+        ...
+
+    def exec(
+        self,
+        command: List[str],
+        *,
+        environment: Optional[Dict[str, str]] = None,
+        working_dir: Optional[str] = None,
+        timeout: Optional[float] = None,
+        user_id: Optional[int] = None,
+        user: Optional[str] = None,
+        group_id: Optional[int] = None,
+        group: Optional[str] = None,
+        stdin: Optional[Union[str, bytes, TextIO, BinaryIO]] = None,
+        stdout: Optional[Union[TextIO, BinaryIO]] = None,
+        stderr: Optional[Union[TextIO, BinaryIO]] = None,
+        encoding: Optional[str] = 'utf-8',
+        combine_stderr: bool = False
+    ) -> pebble.ExecProcess[Any]:
         """Execute the given command on the remote system.
 
         See :meth:`ops.pebble.Client.exec` for documentation of the parameters
@@ -2351,7 +2393,7 @@ class Container:
             stdin=stdin,
             stdout=stdout,
             stderr=stderr,
-            encoding=encoding,
+            encoding=encoding,  # type: ignore
             combine_stderr=combine_stderr,
         )
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -1806,13 +1806,13 @@ class Container:
     """
 
     def __init__(self, name: str, backend: '_ModelBackend',
-                 pebble_client: Optional['pebble.Client'] = None):
+                 pebble_client: Optional[pebble.Client] = None):
         self.name = name
 
         if pebble_client is None:
             socket_path = f'/charm/containers/{name}/pebble.socket'
             pebble_client = backend.get_pebble(socket_path)
-        self._pebble: 'pebble.Client' = pebble_client
+        self._pebble: pebble.Client = pebble_client
 
     def can_connect(self) -> bool:
         """Report whether the Pebble API is reachable in the container.
@@ -1910,7 +1910,7 @@ class Container:
         """
         self._pebble.add_layer(label, layer, combine=combine)
 
-    def get_plan(self) -> 'pebble.Plan':
+    def get_plan(self) -> pebble.Plan:
         """Get the combined Pebble configuration.
 
         This will immediately reflect changes from any previous
@@ -1929,7 +1929,7 @@ class Container:
         services = self._pebble.get_services(names)
         return ServiceInfoMapping(services)
 
-    def get_service(self, service_name: str) -> 'pebble.ServiceInfo':
+    def get_service(self, service_name: str) -> pebble.ServiceInfo:
         """Get status information for a single named service.
 
         Raises :class:`ModelError` if service_name is not found.
@@ -1944,7 +1944,7 @@ class Container:
     def get_checks(
             self,
             *check_names: str,
-            level: Optional['pebble.CheckLevel'] = None) -> 'CheckInfoMapping':
+            level: Optional[pebble.CheckLevel] = None) -> 'CheckInfoMapping':
         """Fetch and return a mapping of check information indexed by check name.
 
         Args:
@@ -1956,7 +1956,7 @@ class Container:
         checks = self._pebble.get_checks(names=check_names or None, level=level)
         return CheckInfoMapping(checks)
 
-    def get_check(self, check_name: str) -> 'pebble.CheckInfo':
+    def get_check(self, check_name: str) -> pebble.CheckInfo:
         """Get check information for a single named check.
 
         Raises :class:`ModelError` if check_name is not found.
@@ -2025,7 +2025,7 @@ class Container:
                           group_id=group_id, group=group)
 
     def list_files(self, path: StrOrPath, *, pattern: Optional[str] = None,
-                   itself: bool = False) -> List['pebble.FileInfo']:
+                   itself: bool = False) -> List[pebble.FileInfo]:
         """Return list of directory entries from given path on remote system.
 
         Despite the name, this method returns a list of files *and*
@@ -2191,7 +2191,7 @@ class Container:
             raise MultiPushPullError('failed to pull one or more files', errors)
 
     @staticmethod
-    def _build_fileinfo(path: StrOrPath) -> 'pebble.FileInfo':
+    def _build_fileinfo(path: StrOrPath) -> pebble.FileInfo:
         """Constructs a FileInfo object by stat'ing a local path."""
         path = Path(path)
         if path.is_symlink():
@@ -2220,8 +2220,8 @@ class Container:
 
     @staticmethod
     def _list_recursive(list_func: Callable[[Path],
-                        Iterable['pebble.FileInfo']],
-                        path: Path) -> Generator['pebble.FileInfo', None, None]:
+                        Iterable[pebble.FileInfo]],
+                        path: Path) -> Generator[pebble.FileInfo, None, None]:
         """Recursively lists all files under path using the given list_func.
 
         Args:
@@ -2416,7 +2416,7 @@ class Container:
 
     # Define this last to avoid clashes with the imported "pebble" module
     @property
-    def pebble(self) -> 'pebble.Client':
+    def pebble(self) -> pebble.Client:
         """The low-level :class:`ops.pebble.Client` instance for this container."""
         return self._pebble
 
@@ -2444,14 +2444,14 @@ class ContainerMapping(Mapping[str, Container]):
         return repr(self._containers)
 
 
-class ServiceInfoMapping(Mapping[str, 'pebble.ServiceInfo']):
+class ServiceInfoMapping(Mapping[str, pebble.ServiceInfo]):
     """Map of service names to :class:`ops.pebble.ServiceInfo` objects.
 
     This is done as a mapping object rather than a plain dictionary so that we
     can extend it later, and so it's not mutable.
     """
 
-    def __init__(self, services: Iterable['pebble.ServiceInfo']):
+    def __init__(self, services: Iterable[pebble.ServiceInfo]):
         self._services = {s.name: s for s in services}
 
     def __getitem__(self, key: str):
@@ -2467,14 +2467,14 @@ class ServiceInfoMapping(Mapping[str, 'pebble.ServiceInfo']):
         return repr(self._services)
 
 
-class CheckInfoMapping(Mapping[str, 'pebble.CheckInfo']):
+class CheckInfoMapping(Mapping[str, pebble.CheckInfo]):
     """Map of check names to :class:`ops.pebble.CheckInfo` objects.
 
     This is done as a mapping object rather than a plain dictionary so that we
     can extend it later, and so it's not mutable.
     """
 
-    def __init__(self, checks: Iterable['pebble.CheckInfo']):
+    def __init__(self, checks: Iterable[pebble.CheckInfo]):
         self._checks = {c.name: c for c in checks}
 
     def __getitem__(self, key: str):
@@ -2960,7 +2960,7 @@ class _ModelBackend:
         cmd.extend(metric_args)
         self._run(*cmd)
 
-    def get_pebble(self, socket_path: str) -> 'pebble.Client':
+    def get_pebble(self, socket_path: str) -> pebble.Client:
         """Create a pebble.Client instance from given socket path."""
         return pebble.Client(socket_path=socket_path)
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1305,10 +1305,10 @@ def _reader_to_websocket(reader: '_WebsocketReader',
 
 
 def _websocket_to_writer(ws: '_WebSocket', writer: '_WebsocketWriter',
-                         encoding: str):
+                         encoding: Optional[str]):
     """Receive messages from websocket (until end signal) and write to writer."""
     while True:
-        chunk: _StrOrBytes = ws.recv()
+        chunk: _StrOrBytes = typing.cast('_StrOrBytes', ws.recv())
 
         if isinstance(chunk, str):
             try:
@@ -1371,7 +1371,7 @@ class _WebsocketReader(io.BufferedIOBase):
             return b''
 
         while not self.remaining:
-            chunk: _StrOrBytes = self.ws.recv()
+            chunk = typing.cast('_StrOrBytes', self.ws.recv())
 
             if isinstance(chunk, str):
                 try:
@@ -2318,7 +2318,7 @@ class Client:
             raise TypeError('services must be of type Iterable[str], '
                             'not {}'.format(type(services).__name__))
         for s in services:
-            if not isinstance(s, str):  # pyright: reportUnnecessaryIsInstance=false
+            if not isinstance(s, str):
                 raise TypeError(f'service names must be str, not {type(s).__name__}')
 
         if isinstance(sig, int):

--- a/ops/storage.py
+++ b/ops/storage.py
@@ -24,7 +24,7 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Any, Callable, Generator, List, Optional, Tuple, Union
 
-import yaml  # pyright: reportMissingModuleSource=false
+import yaml  # pyright: ignore[reportMissingModuleSource]
 
 logger = logging.getLogger()
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -210,7 +210,7 @@ class Harness(Generic[CharmType]):
         >>>         harness.charm.event_handler(event)
 
         """
-        return self._framework._event_context(event_name)  # pyright: reportPrivateUsage=false
+        return self._framework._event_context(event_name)
 
     def set_can_connect(self, container: Union[str, model.Container], val: bool):
         """Change the simulated connection status of a container's underlying Pebble client.
@@ -269,7 +269,7 @@ class Harness(Generic[CharmType]):
         # Note: jam 2020-03-01 This is so that errors in testing say MyCharm has no attribute foo,
         # rather than TestCharm has no attribute foo.
         TestCharm.__name__ = self._charm_cls.__name__
-        self._charm = TestCharm(self._framework)
+        self._charm = TestCharm(self._framework)  # type: ignore
 
     def begin_with_initial_hooks(self) -> None:
         """Called when you want the Harness to fire the same hooks that Juju would fire at startup.
@@ -359,7 +359,7 @@ class Harness(Generic[CharmType]):
         post_setup_sts = self._backend.status_get()
         if post_setup_sts.get("status") == "maintenance" and not post_setup_sts.get("message"):
             self._backend.status_set("unknown", "", is_app=False)
-        all_ids = list(self._backend._relation_names.items())  # pyright:ReportPrivateUsage=false
+        all_ids = list(self._backend._relation_names.items())
         random.shuffle(all_ids)
         for rel_id, rel_name in all_ids:
             rel_app_and_units = self._backend._relation_app_and_units[rel_id]
@@ -439,7 +439,7 @@ class Harness(Generic[CharmType]):
         assert isinstance(charm_config, str)  # type guard
         config = yaml.safe_load(charm_config)
 
-        if not isinstance(config, dict):  # pyright: reportUnnecessaryIsInstance=false
+        if not isinstance(config, dict):
             raise TypeError(config)
         return cast('RawConfig', config)
 
@@ -587,12 +587,12 @@ class Harness(Generic[CharmType]):
             raise RuntimeError('cannot detach storage before Harness is initialised')
         storage_name, storage_index = storage_id.split('/', 1)
         storage_index = int(storage_index)
-        storage_attached = self._backend._storage_is_attached(  # pyright:ReportPrivateUsage=false
+        storage_attached = self._backend._storage_is_attached(
             storage_name, storage_index)
         if storage_attached and self._hooks_enabled:
             self.charm.on[storage_name].storage_detaching.emit(
                 model.Storage(storage_name, storage_index, self._backend))
-        self._backend._storage_detach(storage_id)  # pyright:ReportPrivateUsage=false
+        self._backend._storage_detach(storage_id)
 
     def attach_storage(self, storage_id: str) -> None:
         """Attach a storage device.
@@ -637,12 +637,12 @@ class Harness(Generic[CharmType]):
         if storage_name not in self._meta.storages:
             raise RuntimeError(
                 f"the key '{storage_name}' is not specified as a storage key in metadata")
-        is_attached = self._backend._storage_is_attached(  # pyright:ReportPrivateUsage=false
+        is_attached = self._backend._storage_is_attached(
             storage_name, storage_index)
         if self._charm is not None and self._hooks_enabled and is_attached:
             self.charm.on[storage_name].storage_detaching.emit(
                 model.Storage(storage_name, storage_index, self._backend))
-        self._backend._storage_remove(storage_id)  # pyright:ReportPrivateUsage=false
+        self._backend._storage_remove(storage_id)
 
     def add_relation(self, relation_name: str, remote_app: str) -> int:
         """Declare that there is a new relation between this app and `remote_app`.
@@ -660,22 +660,22 @@ class Harness(Generic[CharmType]):
             The relation_id created by this add_relation.
         """
         relation_id = self._next_relation_id()
-        self._backend._relation_ids_map.setdefault(  # pyright:ReportPrivateUsage=false
+        self._backend._relation_ids_map.setdefault(
             relation_name, []).append(relation_id)
         self._backend._relation_names[relation_id] = relation_name
-        self._backend._relation_list_map[relation_id] = []  # pyright:ReportPrivateUsage=false
-        self._backend._relation_data_raw[relation_id] = {  # pyright:ReportPrivateUsage=false
+        self._backend._relation_list_map[relation_id] = []
+        self._backend._relation_data_raw[relation_id] = {
             remote_app: {},
             self._backend.unit_name: {},
             self._backend.app_name: {}}
 
-        self._backend._relation_app_and_units[relation_id] = {  # pyright:ReportPrivateUsage=false
+        self._backend._relation_app_and_units[relation_id] = {
             "app": remote_app,
             "units": [],
         }
         # Reload the relation_ids list
         if self._model is not None:
-            self._model.relations._invalidate(relation_name)  # pyright:ReportPrivateUsage=false
+            self._model.relations._invalidate(relation_name)
         self._emit_relation_created(relation_name, relation_id, remote_app)
         return relation_id
 
@@ -688,25 +688,25 @@ class Harness(Generic[CharmType]):
         Raises:
             RelationNotFoundError: if relation id is not valid
         """
-        rel_names = self._backend._relation_names   # pyright:ReportPrivateUsage=false
+        rel_names = self._backend._relation_names
         try:
             relation_name = rel_names[relation_id]
             remote_app = self._backend.relation_remote_app_name(relation_id)
         except KeyError as e:
             raise model.RelationNotFoundError from e
 
-        rel_list_map = self._backend._relation_list_map  # pyright:ReportPrivateUsage=false
+        rel_list_map = self._backend._relation_list_map
         for unit_name in rel_list_map[relation_id].copy():
             self.remove_relation_unit(relation_id, unit_name)
 
         self._emit_relation_broken(relation_name, relation_id, remote_app)
         if self._model is not None:
-            self._model.relations._invalidate(relation_name)  # pyright:ReportPrivateUsage=false
+            self._model.relations._invalidate(relation_name)
 
-        self._backend._relation_app_and_units.pop(relation_id)  # pyright:ReportPrivateUsage=false
-        self._backend._relation_data_raw.pop(relation_id)  # pyright:ReportPrivateUsage=false
+        self._backend._relation_app_and_units.pop(relation_id)
+        self._backend._relation_data_raw.pop(relation_id)
         rel_list_map.pop(relation_id)
-        ids_map = self._backend._relation_ids_map  # pyright:ReportPrivateUsage=false
+        ids_map = self._backend._relation_ids_map
         ids_map[relation_name].remove(relation_id)
         rel_names.pop(relation_id)
 
@@ -771,7 +771,7 @@ class Harness(Generic[CharmType]):
                 'Remote unit name invalid: the remote application of {} is called {!r}; '
                 'the remote unit name should be {}/<some-number>, not {!r}.'
                 ''.format(relation_name, app.name, app.name, remote_unit_name))
-        app_and_units = self._backend._relation_app_and_units  # pyright: ReportPrivateUsage=false
+        app_and_units = self._backend._relation_app_and_units
         app_and_units[relation_id]["units"].append(remote_unit_name)
         # Make sure that the Model reloads the relation_list for this relation_id, as well as
         # reloading the relation data for this unit.
@@ -1576,7 +1576,7 @@ class _Secret:
     grants: Dict[int, Set[str]] = dataclasses.field(default_factory=dict)
 
 
-@_copy_docstrings(model._ModelBackend)  # pyright: reportPrivateUsage=false
+@_copy_docstrings(model._ModelBackend)
 @_record_calls
 class _TestingModelBackend:
     """This conforms to the interface for ModelBackend but provides canned data.
@@ -1840,7 +1840,7 @@ class _TestingModelBackend:
         index = int(index)
 
         for client in self._pebble_clients.values():
-            client._fs.remove_mount(name)  # pyright: ReportPrivateUsage=false
+            client._fs.remove_mount(name)
 
         if self._storage_is_attached(name, index):
             self._storage_attached[name].remove(index)
@@ -1857,7 +1857,7 @@ class _TestingModelBackend:
                 if mount.storage != name:
                     continue
                 for index, store in self._storage_list[mount.storage].items():
-                    fs = client._fs  # pyright: reportPrivateUsage=false
+                    fs = client._fs
                     fs.add_mount(mount.storage, mount.location, store['location'])
 
         index = int(index)
@@ -2203,7 +2203,7 @@ class _TestingPebbleClient:
         self._backend = backend
 
     def _check_connection(self):
-        if not self._backend._can_connect(self):  # pyright: reportPrivateUsage=false
+        if not self._backend._can_connect(self):
             msg = ('Cannot connect to Pebble; did you forget to call '
                    'begin_with_initial_hooks() or set_can_connect()?')
             raise pebble.ConnectionError(msg)
@@ -2828,7 +2828,7 @@ class _TestingFilesystem:
                 raise FileNotFoundError(str(current_dir.path / token))
             if isinstance(current_dir, _File):
                 raise NotADirectoryError(str(current_dir.path))
-            if not isinstance(current_dir, _Directory):
+            if not isinstance(current_dir, _Directory):  # type: ignore
                 # For now, ignoring other possible cases besides File and Directory (e.g. Symlink).
                 raise NotImplementedError()
         return list(current_dir)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -303,7 +303,7 @@ class Harness(Generic[CharmType]):
             harness.begin_with_initial_hooks()
             # This will cause
             # install, db-relation-created('postgresql'), leader-elected, config-changed, start
-            # db-relation-joined('postrgesql/0'), db-relation-changed('postgresql/0')
+            # db-relation-joined('postgresql/0'), db-relation-changed('postgresql/0')
             # To be fired.
         """
         self.begin()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,4 +35,7 @@ typeCheckingMode = "strict"
 reportIncompatibleMethodOverride = false
 reportImportCycles = false
 reportMissingModuleSource = false
+reportPrivateUsage = false
+reportUnnecessaryIsInstance = false
+reportUnnecessaryComparison = false
 stubPath = ""

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ coverage[toml]==7.0.5
 typing_extensions==4.2.0
 
 -r requirements.txt
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,4 +13,3 @@ coverage[toml]==7.0.5
 typing_extensions==4.2.0
 
 -r requirements.txt
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ flake8-builtins==2.1.0
 pyproject-flake8==4.0.1
 pep8-naming==0.13.2
 pytest==7.2.1
-pyright==1.1.291
+pyright==1.1.313
 pytest-operator==0.23.0
 coverage[toml]==7.0.5
 typing_extensions==4.2.0


### PR DESCRIPTION
This PR updates Pyright to the latest version, 1.1.313, and fixes the errors that resulted.

Boy this was more painful than I expected. It seems to have gotten significantly stricter. I engaged in lots of fighting with the compiler -- if I knew any swear words I'd be using them here. In one case (`_ModelBackend._run`) I stopped fighting and added a `type: ignore`. I think we need to be pragmatic here: the *code* is no worse than it was before, and we can always improve specific things in future PRs.

I also ended up disabling a few more Pyright issues, specifically the following seemed more trouble than they're worth:

* reportPrivateUsage: we do this often in the codebase, for example charm.py and testing.py poke at `_ModelBackend`, which is private
* reportUnnecessaryIsInstance: we do lots of isinstance checks to detect type issues at runtime (we've done this since the beginning, and it's useful for people not using type checking)
* reportUnnecessaryComparison: similar to the above, but for checking "if non_optional_value is None" and the like

Part of https://github.com/canonical/operator/issues/920