### PR TITLE
Use PurePath type annotation when path casted to string

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -126,7 +126,6 @@ if typing.TYPE_CHECKING:
 
 
 StrOrPath = typing.Union[str, Path]
-StrOrPurePath = typing.Union[str, PurePath]
 
 logger = logging.getLogger(__name__)
 
@@ -1984,7 +1983,7 @@ class Container:
             raise RuntimeError(f'expected 1 check, got {len(checks)}')
         return checks[check_name]
 
-    def pull(self, path: StrOrPurePath, *,
+    def pull(self, path: Union[str, PurePath], *,
              encoding: Optional[str] = 'utf-8') -> Union[BinaryIO, TextIO]:
         """Read a file's content from the remote system.
 
@@ -2005,7 +2004,7 @@ class Container:
         return self._pebble.pull(str(path), encoding=encoding)
 
     def push(self,
-             path: StrOrPurePath,
+             path: Union[str, PurePath],
              source: Union[bytes, str, BinaryIO, TextIO],
              *,
              encoding: str = 'utf-8',
@@ -2040,7 +2039,7 @@ class Container:
                           user_id=user_id, user=user,
                           group_id=group_id, group=group)
 
-    def list_files(self, path: StrOrPurePath, *, pattern: Optional[str] = None,
+    def list_files(self, path: Union[str, PurePath], *, pattern: Optional[str] = None,
                    itself: bool = False) -> List['FileInfo']:
         """Return list of directory entries from given path on remote system.
 
@@ -2281,7 +2280,7 @@ class Container:
         path_suffix = os.path.relpath(str(file_path), prefix)
         return dest_dir / path_suffix
 
-    def exists(self, path: StrOrPurePath) -> bool:
+    def exists(self, path: Union[str, PurePath]) -> bool:
         """Return true if the path exists on the container filesystem."""
         try:
             self._pebble.list_files(str(path), itself=True)
@@ -2291,7 +2290,7 @@ class Container:
             raise err
         return True
 
-    def isdir(self, path: StrOrPurePath) -> bool:
+    def isdir(self, path: Union[str, PurePath]) -> bool:
         """Return true if a directory exists at the given path on the container filesystem."""
         try:
             files = self._pebble.list_files(str(path), itself=True)
@@ -2303,7 +2302,7 @@ class Container:
 
     def make_dir(
             self,
-            path: StrOrPurePath,
+            path: Union[str, PurePath],
             *,
             make_parents: bool = False,
             permissions: Optional[int] = None,
@@ -2330,7 +2329,7 @@ class Container:
                               user_id=user_id, user=user,
                               group_id=group_id, group=group)
 
-    def remove_path(self, path: StrOrPurePath, *, recursive: bool = False):
+    def remove_path(self, path: Union[str, PurePath], *, recursive: bool = False):
         """Remove a file or directory on the remote system.
 
         Args:

--- a/ops/model.py
+++ b/ops/model.py
@@ -125,8 +125,6 @@ if typing.TYPE_CHECKING:
     })
 
 
-StrOrPath = typing.Union[str, Path]
-
 logger = logging.getLogger(__name__)
 
 MAX_LOG_LINE_LEN = 131071  # Max length of strings to pass to subshell.
@@ -2058,8 +2056,8 @@ class Container:
                                        pattern=pattern, itself=itself)
 
     def push_path(self,
-                  source_path: Union[StrOrPath, Iterable[StrOrPath]],
-                  dest_dir: StrOrPath):
+                  source_path: Union[str, Path, Iterable[Union[str, Path]]],
+                  dest_dir: Union[str, PurePath]):
         """Recursively push a local path or files to the remote system.
 
         Only regular files and directories are copied; symbolic links, device files, etc. are
@@ -2105,9 +2103,9 @@ class Container:
                 placed.  This must be an absolute path.
         """
         if hasattr(source_path, '__iter__') and not isinstance(source_path, str):
-            source_paths = typing.cast(Iterable[StrOrPath], source_path)
+            source_paths = typing.cast(Iterable[Union[str, Path]], source_path)
         else:
-            source_paths = typing.cast(Iterable[StrOrPath], [source_path])
+            source_paths = typing.cast(Iterable[Union[str, Path]], [source_path])
         source_paths = [Path(p) for p in source_paths]
         dest_dir = Path(dest_dir)
 
@@ -2137,8 +2135,8 @@ class Container:
             raise MultiPushPullError('failed to push one or more files', errors)
 
     def pull_path(self,
-                  source_path: Union[StrOrPath, Iterable[StrOrPath]],
-                  dest_dir: StrOrPath):
+                  source_path: Union[str, PurePath, Iterable[Union[str, PurePath]]],
+                  dest_dir: Union[str, Path]):
         """Recursively pull a remote path or files to the local system.
 
         Only regular files and directories are copied; symbolic links, device files, etc. are
@@ -2185,9 +2183,9 @@ class Container:
                 placed.
         """
         if hasattr(source_path, '__iter__') and not isinstance(source_path, str):
-            source_paths = typing.cast(Iterable[StrOrPath], source_path)
+            source_paths = typing.cast(Iterable[Union[str, Path]], source_path)
         else:
-            source_paths = typing.cast(Iterable[StrOrPath], [source_path])
+            source_paths = typing.cast(Iterable[Union[str, Path]], [source_path])
         source_paths = [Path(p) for p in source_paths]
         dest_dir = Path(dest_dir)
 
@@ -2206,7 +2204,7 @@ class Container:
             raise MultiPushPullError('failed to pull one or more files', errors)
 
     @staticmethod
-    def _build_fileinfo(path: StrOrPath) -> 'FileInfo':
+    def _build_fileinfo(path: Union[str, Path]) -> 'FileInfo':
         """Constructs a FileInfo object by stat'ing a local path."""
         path = Path(path)
         if path.is_symlink():
@@ -2234,8 +2232,7 @@ class Container:
             group=grp.getgrgid(info.st_gid).gr_name)
 
     @staticmethod
-    def _list_recursive(list_func: Callable[[Path],
-                        Iterable['FileInfo']],
+    def _list_recursive(list_func: Callable[[Path], Iterable['FileInfo']],
                         path: Path) -> Generator['FileInfo', None, None]:
         """Recursively lists all files under path using the given list_func.
 
@@ -2259,7 +2256,10 @@ class Container:
                     'skipped unsupported file in Container.[push/pull]_path: %s', info.path)
 
     @staticmethod
-    def _build_destpath(file_path: StrOrPath, source_path: StrOrPath, dest_dir: StrOrPath) -> Path:
+    def _build_destpath(
+            file_path: Union[str, Path],
+            source_path: Union[str, Path],
+            dest_dir: Union[str, Path]) -> Path:
         """Converts a source file and destination dir into a full destination filepath.
 
         file_path:


### PR DESCRIPTION
Concrete paths (pathlib.Path) are not needed since the filesystem is not being accessed from the path object; only pathlib.PurePath is needed

Added `StrOrPurePath` type annotation to ops.Container methods that only accepted `str` type for path

(`pathlib.Path` is a subclass of `pathlib.PurePath`)

More info:
https://docs.python.org/3/library/pathlib.html#pure-paths
https://docs.python.org/3/library/pathlib.html#concrete-paths

## Checklist

 - [x] Have any types changed? If so, have the type annotations been updated?
 - [ ] **N/A** If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?

       We want to avoid simple passthrough of model data, without contextualization, where possible.

 - [ ] **N/A** Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

Call ops.Container methods (e.g. `pull()`) with a `pathlib.PurePath` & check type annotation

## Documentation changes

Type annotation for some methods changes from `str | Path` to `str | PurePath`

## Bug reference

N/A

## Changelog

- Accept `pathlib.PurePath` type in `ops.Container` methods: `pull`, `push`, `list_files`, `exists`, `isdir`, `make_dir`, `remove_path`
