### PR TITLE
Fix issue with relative paths in Container.push_path

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -2274,7 +2274,7 @@ class Container:
         # /src --> /dst/src
         file_path, source_path, dest_dir = Path(file_path), Path(source_path), Path(dest_dir)
         prefix = str(source_path.parent)
-        if os.path.commonprefix([prefix, str(file_path)]) != prefix:
+        if prefix != '.' and os.path.commonprefix([prefix, str(file_path)]) != prefix:
             raise RuntimeError(
                 f'file "{file_path}" does not have specified prefix "{prefix}"')
         path_suffix = os.path.relpath(str(file_path), prefix)

--- a/ops/model.py
+++ b/ops/model.py
@@ -2113,7 +2113,7 @@ class Container:
 
         def local_list(source_path: Path) -> List[pebble.FileInfo]:
             paths = source_path.iterdir() if source_path.is_dir() else [source_path]
-            files = [self._build_fileinfo(source_path / f) for f in paths]
+            files = [self._build_fileinfo(f) for f in paths]
             return files
 
         errors: List[Tuple[str, Exception]] = []

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -133,3 +133,20 @@ class BaseTestCase(unittest.TestCase):
         meta = ops.CharmMeta()
         model = ops.Model(meta, backend)
         return model
+
+def make_relative_path(relative_to_path, target_path) -> str:
+    """Make target_path relative to the relative_to_path.
+
+    This is a helper function to test pathing created in temporary directories.
+    If two paths are from the root directory and a path operation is applied,
+    the latter path will overwrite the former, hence this helper function is
+    required for testing purposes.
+
+    Args:
+        relative_to_path: The relative path root.
+        target_path: Target path to make relative to.
+    """
+    if target_path.startswith("/"):
+        return os.path.join(relative_to_path, target_path[1:])
+    else:
+        return os.path.join(relative_to_path, target_path)

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -133,21 +133,3 @@ class BaseTestCase(unittest.TestCase):
         meta = ops.CharmMeta()
         model = ops.Model(meta, backend)
         return model
-
-
-def make_relative_path(relative_to_path, target_path) -> str:
-    """Make target_path relative to the relative_to_path.
-
-    This is a helper function to test pathing created in temporary directories.
-    If two paths are from the root directory and a path operation is applied,
-    the latter path will overwrite the former, hence this helper function is
-    required for testing purposes.
-
-    Args:
-        relative_to_path: The relative path root.
-        target_path: Target path to make relative to.
-    """
-    if target_path.startswith("/"):
-        return os.path.join(relative_to_path, target_path[1:])
-    else:
-        return os.path.join(relative_to_path, target_path)

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -134,6 +134,7 @@ class BaseTestCase(unittest.TestCase):
         model = ops.Model(meta, backend)
         return model
 
+
 def make_relative_path(relative_to_path, target_path) -> str:
     """Make target_path relative to the relative_to_path.
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1183,14 +1183,16 @@ def change_to_relative_path(case: PushPullCase):
         path = "."
 
     files = [file[1:] for file in case.files]
+
     return PushPullCase(
-            name=case.name,
-            path=path,
-            dst=case.dst,
-            files=files,
-            want=case.want,
-            errors=case.errors,
-        )
+        name=case.name,
+        path=path,
+        dst=case.dst,
+        files=files,
+        want=case.want,
+        errors=case.errors,
+    )
+
 
 relative_recursive_push_pull_cases = map(change_to_relative_path, recursive_push_pull_cases)
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1192,10 +1192,10 @@ def change_to_relative_path(case: PushPullCase):
             errors=case.errors,
         )
 
-test_casees = map(change_to_relative_path, recursive_push_pull_cases)
+relative_recursive_push_pull_cases = map(change_to_relative_path, recursive_push_pull_cases)
 
 
-@pytest.mark.parametrize('case', test_casees)
+@pytest.mark.parametrize('case', relative_recursive_push_pull_cases)
 def test_recursive_push_and_pull_relative_paths(case):
     harness = ops.testing.Harness(ops.CharmBase, meta='''
         name: test-app


### PR DESCRIPTION
This PR fixes the error caused by duplicate paths in `container.push_path()`.

Please see #948 .

## QA steps

*Please replace with how we can verify that the change works.*

```sh
QA steps here
Running `tox`
```

## Documentation changes

No changes required. 

## Bug reference

Fixes #948

## Changelog

- Fixes bug in container.push_path, which caused FileNotFoundError when pushing paths to the container.
