### PR TITLE
Remove jargon from and simplify README

### DIFF
--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -1,4 +1,4 @@
-name: Data Platform Charm Tests
+name: Data Charm Tests
 
 on: [push, pull_request, workflow_call]
 

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -1,4 +1,4 @@
-name: Operator Framework Tests
+name: ops Tests
 
 on: [push, pull_request, workflow_call]
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -86,14 +86,14 @@ should always be accompanied by user-focused documentation that is posted to
 https://juju.is/docs/sdk.  The content for this site is written and hosted on
 https://discourse.charmhub.io/c/doc.  New documentation should get a new
 topic/post on this discourse forum and then should be linked into the main
-docs navigation page(s) as appropriate.  The operator framework SDK page
+docs navigation page(s) as appropriate.  The ops library's SDK page
 content is pulled from
 [here](https://discourse.charmhub.io/t/the-charmed-operator-software-development-kit-sdk-docs/4449).
 Each page on [juju.is](https://juju.is/docs/sdk) has a link at the bottom that
 takes you to the corresponding discourse page where docs can be commented on
 and edited (if you have earned those privileges).
 
-The Operator Framework API docs are automatically built and published to
+The ops library's API reference is automatically built and published to
 [here](https://ops.readthedocs.io/en/latest/).  Please be complete with
 docstrings and keep them informative for _users_.
 
@@ -115,7 +115,7 @@ are listed in [requirements.txt](requirements.txt).
 
 # Publishing a Release
 
-To make a release of the Operator Framework, do the following:
+To make a release of the ops library, do the following:
 
 1. Visit the [releases page on github](https://github.com/canonical/operator/releases).
 2. Click "Draft a new release"
@@ -126,7 +126,7 @@ To make a release of the Operator Framework, do the following:
 
 This will trigger an automatic build for the Python package and publish it to PyPI (the API token/secret is already set up in the repository settings).
 
-See [.github/workflows/publish.yml](.github/workflows/publish.yml) for details. (Note that the versions in publish.yml refer to versions of the github actions, not the versions of the Operator Framework.)
+See [.github/workflows/publish.yml](.github/workflows/publish.yml) for details. (Note that the versions in publish.yml refer to versions of the github actions, not the versions of the ops library.)
 
 You can troubleshoot errors on the [Actions Tab](https://github.com/canonical/operator/actions).
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -105,6 +105,14 @@ Currently we don't publish separate versions of documentation for separate relea
 
 next to the relevant content (e.g. headings, etc.).
 
+
+## Dependencies
+
+The Python dependencies of `ops` are kept as minimal as possible, to avoid
+bloat and to minimise conflict with the charm's dependencies. The dependencies
+are listed in [requirements.txt](requirements.txt).
+
+
 # Publishing a Release
 
 To make a release of the Operator Framework, do the following:

--- a/README.md
+++ b/README.md
@@ -1,103 +1,56 @@
 # The Charmed Operator Framework
 
-This Charmed Operator Framework simplifies [operator](https://charmhub.io/about) development
-for [model-driven application management](https://juju.is/model-driven-operations).
+The Charmed Operator Framework is a Python library (available as [ops]
+(https://pypi.org/project/ops/)) for developing and testing [Juju]
+(https://juju.is/) charms in a consistent way, using standard Python constructs
+to allow for clean, maintainable, and reusable code.
 
-Operators emerged from the Kubernetes community; an operator is software that drives lifecycle
-management, configuration, integration and daily actions for an application. Operators simplify
-software management and operations. They capture reusable app domain knowledge from experts in a
-software component that can be shared.
+Charms written with the Charmed Operator Framework support Kubernetes using
+Juju's "sidecar charm" pattern, but they also fully support charms that deploy
+to traditional Linux virtual machines.
 
-This project extends the operator pattern to enable
-[charmed operators](https://juju.is/universal-operators), not just for Kubernetes but also
-operators for traditional Linux application management.
+Charms should do one thing and do it well. Each charm drives a single Juju
+application and can be integrated with other charms to deliver a complex
+system. A charm handles creating the application in addition to scaling,
+configuration, optimisation, networking, service mesh, observability, and other
+day-2 operations specific to the application.
 
-Operators use a [Charmed Operator Lifecycle Manager
-(Charmed OLM)](https://juju.is/operator-lifecycle-manager) to coordinate their work in a cluster.
-The system uses Golang for concurrent event processing under the hood, but enables the operators to
-be written in Python.
+The Charmed Operator Framework is part of the Charm SDK (the other part being
+Charmcraft). Full developer documentation for the Charm SDK is available at
+https://juju.is/docs/sdk.
 
-## Simple, composable operators
+To learn more about the Juju engine, visit https://juju.is/docs/olm.
 
-Operators should 'do one thing and do it well'. Each operator drives a single microservice and can
-be [composed with other operators](https://juju.is/integration) to deliver a complex application.
 
-It is better to have small, reusable operators that each drive a single microservice very well.
-The operator handles instantiation, scaling, configuration, optimisation, networking, service mesh,
-observability, and day-2 operations specific to that microservice.
+## Pure Python
 
-Operator composition takes place through declarative integration in the OLM. Operators declare
-integration endpoints, and discover lines of integration between those endpoints dynamically at
-runtime.
+The framework provides a standardized Python object model that represents the
+application graph, as well as an event-handling mechanism for distributed
+system coordination and communication.
 
-## Pure Python operators
+The latest version of `ops` currently required Python 3.8 or above.
 
-The framework provides a standard Python library and object model that represents the application
-graph, and an event distribution mechanism for distributed system coordination and communication.
+Juju itself is written in Go for efficient concurrency even in large
+deployments. Charms can be written in any language, however, we recommend using
+Python with this framework to make development easier and more standardised
+(all new charms at Canonical are written using it).
 
-The OLM is written in Golang for efficient concurrency in event handling and distribution.
-Operators can be written in any language. We recommend this Python framework for ease of design,
-development and collaboration.
-
-## Better collaboration
-
-Operator developers publish Python libraries that make it easy to integrate your operator with
-their operator. The framework includes standard tools to distribute these integration libraries and
-keep them up to date.
-
-Development collaboration happens at [Charmhub.io](https://charmhub.io/) where operators are
-published along with integration libraries. Design and code review discussions are hosted in the
-Charmhub [discourse]. We recommend the [Open Operator Manifesto](https://charmhub.io/manifesto)
-as a guideline for high quality operator engineering.
-
-## Event serialization and operator services
-
-Distributed systems can be hard! So this framework exists to make it much simpler to reason about
-operator behaviour, especially in complex deployments. The Charmed OLM provides
-[operator services](https://juju.is/operator-services) such as provisioning, event delivery,
-leader election and model management.
-
-Coordination between operators is provided by a cluster-wide event distribution system. Events are
-serialized to avoid race conditions in any given container or machine. This greatly simplifies the
-development of operators for high availability, scale-out and integrated applications.
-
-## Model-driven Operator Lifecycle Manager
-
-A key goal of the project is to improve the user experience for admins working with multiple
-different operators.
-
-We embrace [model-driven operations](https://juju.is/model-driven-operations) in the Charmed
-Operator Lifecycle Manager. The model encompasses capacity, storage, networking, the application
-graph and administrative access.
-
-Admins describe the application graph of integrated microservices, and the OLM then drives
-instantiation. A change in the model is propagated to all affected operators, reducing the
-duplication of effort and repetition normally found in operating a complex topology of services.
-
-Administrative actions, updates, configuration and integration are all driven through the OLM.
 
 # Getting started
 
-A package of operator code is called a charmed operator or “charm. You will use `charmcraft` to
-register your operator name, and publish it when you are ready. There are more details on how to
-get a complete development environment setup over in the
-[documentation](https://juju.is/docs/sdk/dev-setup)
+A package of operator code is called a charmed operator or simply "charm".
+You'll use [charmcraft](https://juju.is/docs/sdk/install-charmcraft) to
+register your charm name and publish it when you are ready. You can follow one
+of our [charming tutorials](https://juju.is/docs/sdk/tutorials) to get started
+writing your first charm.
 
-Charmed Operators written using the Charmed Operator Framework are just Python code. The goal
-is to feel natural for somebody used to coding in Python, and reasonably easy to learn for somebody
-who is not a pythonista.
 
-The dependencies of the operator framework are kept as minimal as possible; currently that's Python
-3.8 or greater, and the small number of Python libraries referenced in [requirements.txt](requirements.txt).
+# Testing your charms
 
-For a brief intro on how to get started, check out the
-[Hello, World!](https://juju.is/docs/sdk/hello-world) section of the documentation!
-
-# Testing your charmed operators
-
-The operator framework provides a testing harness, so you can check your charmed operator does the
-right thing in different scenarios, without having to create a full deployment.
-`pydoc3 ops.testing` has the details, including this example:
+The framework provides a testing harness, so you can ensure that your charm
+does the right thing in different scenarios, without having to create
+a full deployment. Our [API documentation](https://ops.readthedocs.io/en/latest/#module-ops.testing)
+has the details, including this example:
 
 ```python
 harness = Harness(MyCharm)
@@ -111,6 +64,7 @@ harness.update_relation_data(relation_id, 'postgresql/0', {'key': 'val'})
 self.assertEqual(harness.charm. ...)
 ```
 
+
 ## Talk to us
 
 If you need help, have ideas, or would just like to chat with us, reach out on
@@ -118,14 +72,14 @@ the Charmhub [Mattermost].
 
 We also pay attention to the Charmhub [Discourse]
 
-You can deep dive into the [API docs] if that's your thing.
+And of course you can deep dive into the [API reference].
 
-[discourse]: https://discourse.charmhub.io
-[api docs]: https://ops.rtfd.io/
-[sdk docs]: https://juju.is/docs/sdk
-[mattermost]: https://chat.charmhub.io/charmhub/channels/charm-dev
+[Discourse]: https://discourse.charmhub.io/
+[API reference]: https://ops.readthedocs.io/
+[Mattermost]: https://chat.charmhub.io/charmhub/channels/charm-dev
 
-## Operator Framework development
 
-See [HACKING.md](HACKING.md) for details on dev environments, testing, etc.
+## Development of the framework
 
+See [HACKING.md](HACKING.md) for details on dev environments, testing, and so
+on.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # The Operator Framework
 
+<!-- The text below is also at the top of ops/__init__.py. Keep in sync! -->
+
 The Operator Framework is a Python library (available as [ops](https://pypi.org/project/ops/))
 for developing and testing [Juju](https://juju.is/) charms in a consistent way, using standard Python constructs
 to allow for clean, maintainable, and reusable code.
 
+A charm is an operator -- business logic encapsulated in a reusable software
+package that automates every aspect of an application's life.
+
 Charms written with the Operator Framework support Kubernetes using Juju's
 "sidecar charm" pattern, as well as charms that deploy to Linux-based
-virtual machines.
+machines and containers.
 
-Charms should do one thing and do it well. Each charm drives a single Juju
+Charms should do one thing and do it well. Each charm drives a single
 application and can be integrated with other charms to deliver a complex
 system. A charm handles creating the application in addition to scaling,
 configuration, optimisation, networking, service mesh, observability, and other
@@ -18,7 +23,7 @@ The Operator Framework is part of the Charm SDK (the other part being
 Charmcraft). Full developer documentation for the Charm SDK is available at
 https://juju.is/docs/sdk.
 
-To learn more about the Juju engine, visit https://juju.is/docs/olm.
+To learn more about Juju, visit https://juju.is/docs/olm.
 
 
 ## Pure Python

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # The Charmed Operator Framework
 
-The Charmed Operator Framework is a Python library (available as [ops]
-(https://pypi.org/project/ops/)) for developing and testing [Juju]
-(https://juju.is/) charms in a consistent way, using standard Python constructs
+The Charmed Operator Framework is a Python library (available as [ops](https://pypi.org/project/ops/))
+for developing and testing [Juju](https://juju.is/) charms in a consistent way, using standard Python constructs
 to allow for clean, maintainable, and reusable code.
 
 Charms written with the Charmed Operator Framework support Kubernetes using

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
-# The Operator Framework
+# The ops library
 
 <!-- The text below is also at the top of ops/__init__.py. Keep in sync! -->
 
-The Operator Framework is a Python library (available as [ops](https://pypi.org/project/ops/))
-for developing and testing [Juju](https://juju.is/) charms in a consistent way, using standard Python constructs
+The ops library is a Python framework ([`available on PyPI`](https://pypi.org/project/ops/)) for developing
+and testing [Juju](https://juju.is/) charms in a consistent way, using standard Python constructs
 to allow for clean, maintainable, and reusable code.
 
 A charm is an operator -- business logic encapsulated in a reusable software
 package that automates every aspect of an application's life.
 
-Charms written with the Operator Framework support Kubernetes using Juju's
-"sidecar charm" pattern, as well as charms that deploy to Linux-based
-machines and containers.
+Charms written with ops support Kubernetes using Juju's "sidecar charm"
+pattern, as well as charms that deploy to Linux-based machines and containers.
 
 Charms should do one thing and do it well. Each charm drives a single
 application and can be integrated with other charms to deliver a complex
@@ -19,8 +18,8 @@ system. A charm handles creating the application in addition to scaling,
 configuration, optimisation, networking, service mesh, observability, and other
 day-2 operations specific to the application.
 
-The Operator Framework is part of the Charm SDK (the other part being
-Charmcraft). Full developer documentation for the Charm SDK is available at
+The ops library is part of the Charm SDK (the other part being Charmcraft).
+Full developer documentation for the Charm SDK is available at
 https://juju.is/docs/sdk.
 
 To learn more about Juju, visit https://juju.is/docs/olm.
@@ -32,7 +31,7 @@ The framework provides a standardised Python object model that represents the
 application graph, as well as an event-handling mechanism for distributed
 system coordination and communication.
 
-The latest version of `ops` requires Python 3.8 or above.
+The latest version of ops requires Python 3.8 or above.
 
 Juju itself is written in Go for efficient concurrency even in large
 deployments. Charms can be written in any language, however, we recommend using

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# The Charmed Operator Framework
+# The Operator Framework
 
-The Charmed Operator Framework is a Python library (available as [ops](https://pypi.org/project/ops/))
+The Operator Framework is a Python library (available as [ops](https://pypi.org/project/ops/))
 for developing and testing [Juju](https://juju.is/) charms in a consistent way, using standard Python constructs
 to allow for clean, maintainable, and reusable code.
 
-Charms written with the Charmed Operator Framework support Kubernetes using
-Juju's "sidecar charm" pattern, as well as charms that deploy to Linux-based
+Charms written with the Operator Framework support Kubernetes using Juju's
+"sidecar charm" pattern, as well as charms that deploy to Linux-based
 virtual machines.
 
 Charms should do one thing and do it well. Each charm drives a single Juju
@@ -14,7 +14,7 @@ system. A charm handles creating the application in addition to scaling,
 configuration, optimisation, networking, service mesh, observability, and other
 day-2 operations specific to the application.
 
-The Charmed Operator Framework is part of the Charm SDK (the other part being
+The Operator Framework is part of the Charm SDK (the other part being
 Charmcraft). Full developer documentation for the Charm SDK is available at
 https://juju.is/docs/sdk.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ for developing and testing [Juju](https://juju.is/) charms in a consistent way, 
 to allow for clean, maintainable, and reusable code.
 
 Charms written with the Charmed Operator Framework support Kubernetes using
-Juju's "sidecar charm" pattern, but they also fully support charms that deploy
-to traditional Linux virtual machines.
+Juju's "sidecar charm" pattern, as well as charms that deploy to Linux-based
+virtual machines.
 
 Charms should do one thing and do it well. Each charm drives a single Juju
 application and can be integrated with other charms to deliver a complex
@@ -23,19 +23,19 @@ To learn more about the Juju engine, visit https://juju.is/docs/olm.
 
 ## Pure Python
 
-The framework provides a standardized Python object model that represents the
+The framework provides a standardised Python object model that represents the
 application graph, as well as an event-handling mechanism for distributed
 system coordination and communication.
 
-The latest version of `ops` currently required Python 3.8 or above.
+The latest version of `ops` requires Python 3.8 or above.
 
 Juju itself is written in Go for efficient concurrency even in large
 deployments. Charms can be written in any language, however, we recommend using
-Python with this framework to make development easier and more standardised
-(all new charms at Canonical are written using it).
+Python with this framework to make development easier and more standardised.
+All new charms at Canonical are written using it.
 
 
-# Getting started
+## Getting started
 
 A package of operator code is called a charmed operator or simply "charm".
 You'll use [charmcraft](https://juju.is/docs/sdk/install-charmcraft) to
@@ -44,7 +44,7 @@ of our [charming tutorials](https://juju.is/docs/sdk/tutorials) to get started
 writing your first charm.
 
 
-# Testing your charms
+## Testing your charms
 
 The framework provides a testing harness, so you can ensure that your charm
 does the right thing in different scenarios, without having to create
@@ -69,7 +69,7 @@ self.assertEqual(harness.charm. ...)
 If you need help, have ideas, or would just like to chat with us, reach out on
 the Charmhub [Mattermost].
 
-We also pay attention to the Charmhub [Discourse]
+We also pay attention to the Charmhub [Discourse].
 
 And of course you can deep dive into the [API reference].
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ sphinx.ext.autodoc.py_ext_sig_re = re.compile(
 
 # -- Project information -----------------------------------------------------
 
-project = 'The Operator Framework'
+project = 'The ops library'
 copyright = '2019-2023, Canonical Ltd.'
 author = 'Canonical Ltd'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,31 +1,31 @@
 
-Welcome to The Operator Framework's documentation!
-==================================================
+ops library API reference
+=========================
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
-ops package
-===========
+ops module
+==========
 
 .. automodule:: ops
 
 
 ops.pebble module
------------------
+=================
 
 .. automodule:: ops.pebble
 
 
 ops.testing module
-------------------
+==================
 
 .. automodule:: ops.testing
 
 
-Indices and tables
-==================
+Indices
+=======
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -12,31 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The Charmed Operator Framework.
+"""The Charmed Operator Framework: a Python library for writing Juju charms.
 
-The Charmed Operator Framework allows the development of operators in a simple
-and straightforward way, using standard Python structures to allow for clean,
-maintainable, and reusable code.
+The Charmed Operator Framework is a Python library (available as `ops`_) for
+developing and testing Juju charms in a consistent way, using standard Python
+constructs to allow for clean, maintainable, and reusable code.
 
-A Kubernetes operator is a container that drives lifecycle management,
-configuration, integration and daily actions for an application. Operators
-simplify software management and operations. They capture reusable app domain
-knowledge from experts in a software component that can be shared.
+Charms written with the Charmed Operator Framework support Kubernetes using
+Juju's "sidecar charm" pattern, but they also fully support charms that deploy
+to traditional Linux virtual machines.
 
-The Charmed Operator Framework extends the "operator pattern" to enable Charmed
-Operators, packaged as and often referred to as "charms". Charms are not just
-for Kubernetes but also operators for traditional Linux application management.
-Operators use an Operator Lifecycle Manager (OLM), like Juju, to coordinate
-their work in a cluster. The system uses Golang for concurrent event processing
-under the hood, but enables the operators to be written in Python.
-
-Operators should do one thing and do it well. Each operator drives a single
-application or service and can be composed with other operators to deliver a
-complex application or service. An operator handles instantiation, scaling,
+Charms should do one thing and do it well. Each charm drives a single Juju
+application and can be integrated with other charms to deliver a complex
+system. A charm handles creating the application in addition to scaling,
 configuration, optimisation, networking, service mesh, observability,
-and day-2 operations specific to that application.
+and other day-2 operations specific to the application.
 
-Full developer documentation is available at https://juju.is/docs/sdk.
+The Charmed Operator Framework is part of the Charm SDK (the other part being
+Charmcraft). Full developer documentation for the Charm SDK is available at
+https://juju.is/docs/sdk.
+
+To learn more about the Juju engine, visit https://juju.is/docs/olm.
+
+.. _ops: https://pypi.org/project/ops/
 """
 
 # The "from .X import Y" imports below don't explicitly tell Pyright (or MyPy)

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -19,8 +19,8 @@ developing and testing Juju charms in a consistent way, using standard Python
 constructs to allow for clean, maintainable, and reusable code.
 
 Charms written with the Charmed Operator Framework support Kubernetes using
-Juju's "sidecar charm" pattern, but they also fully support charms that deploy
-to traditional Linux virtual machines.
+Juju's "sidecar charm" pattern, as well as charms that deploy to Linux-based
+virtual machines.
 
 Charms should do one thing and do it well. Each charm drives a single Juju
 application and can be integrated with other charms to deliver a complex

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -12,17 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NOTE: The text below is also at the top of README.md. Keep in sync!
+
 """The Operator Framework: a Python library for writing Juju charms.
 
 The Operator Framework is a Python library (available as `ops`_) for
 developing and testing Juju charms in a consistent way, using standard Python
 constructs to allow for clean, maintainable, and reusable code.
 
+A charm is an operator -- business logic encapsulated in a reusable software
+package that automates every aspect of an application's life.
+
 Charms written with the Operator Framework support Kubernetes using Juju's
 "sidecar charm" pattern, as well as charms that deploy to Linux-based
-virtual machines.
+machines and containers.
 
-Charms should do one thing and do it well. Each charm drives a single Juju
+Charms should do one thing and do it well. Each charm drives a single
 application and can be integrated with other charms to deliver a complex
 system. A charm handles creating the application in addition to scaling,
 configuration, optimisation, networking, service mesh, observability,
@@ -32,7 +37,7 @@ The Operator Framework is part of the Charm SDK (the other part being
 Charmcraft). Full developer documentation for the Charm SDK is available at
 https://juju.is/docs/sdk.
 
-To learn more about the Juju engine, visit https://juju.is/docs/olm.
+To learn more about Juju, visit https://juju.is/docs/olm.
 
 .. _ops: https://pypi.org/project/ops/
 """

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The Charmed Operator Framework: a Python library for writing Juju charms.
+"""The Operator Framework: a Python library for writing Juju charms.
 
-The Charmed Operator Framework is a Python library (available as `ops`_) for
+The Operator Framework is a Python library (available as `ops`_) for
 developing and testing Juju charms in a consistent way, using standard Python
 constructs to allow for clean, maintainable, and reusable code.
 
-Charms written with the Charmed Operator Framework support Kubernetes using
-Juju's "sidecar charm" pattern, as well as charms that deploy to Linux-based
+Charms written with the Operator Framework support Kubernetes using Juju's
+"sidecar charm" pattern, as well as charms that deploy to Linux-based
 virtual machines.
 
 Charms should do one thing and do it well. Each charm drives a single Juju
@@ -28,7 +28,7 @@ system. A charm handles creating the application in addition to scaling,
 configuration, optimisation, networking, service mesh, observability,
 and other day-2 operations specific to the application.
 
-The Charmed Operator Framework is part of the Charm SDK (the other part being
+The Operator Framework is part of the Charm SDK (the other part being
 Charmcraft). Full developer documentation for the Charm SDK is available at
 https://juju.is/docs/sdk.
 

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -14,32 +14,31 @@
 
 # NOTE: The text below is also at the top of README.md. Keep in sync!
 
-"""The Operator Framework: a Python library for writing Juju charms.
+"""The ops library: a Python framework for writing Juju charms.
 
-The Operator Framework is a Python library (available as `ops`_) for
-developing and testing Juju charms in a consistent way, using standard Python
-constructs to allow for clean, maintainable, and reusable code.
+The ops library is a Python framework (`available on PyPI`_) for developing
+and testing Juju charms in a consistent way, using standard Python constructs
+to allow for clean, maintainable, and reusable code.
 
 A charm is an operator -- business logic encapsulated in a reusable software
 package that automates every aspect of an application's life.
 
-Charms written with the Operator Framework support Kubernetes using Juju's
-"sidecar charm" pattern, as well as charms that deploy to Linux-based
-machines and containers.
+Charms written with ops support Kubernetes using Juju's "sidecar charm"
+pattern, as well as charms that deploy to Linux-based machines and containers.
 
 Charms should do one thing and do it well. Each charm drives a single
 application and can be integrated with other charms to deliver a complex
 system. A charm handles creating the application in addition to scaling,
-configuration, optimisation, networking, service mesh, observability,
-and other day-2 operations specific to the application.
+configuration, optimisation, networking, service mesh, observability, and other
+day-2 operations specific to the application.
 
-The Operator Framework is part of the Charm SDK (the other part being
-Charmcraft). Full developer documentation for the Charm SDK is available at
+The ops library is part of the Charm SDK (the other part being Charmcraft).
+Full developer documentation for the Charm SDK is available at
 https://juju.is/docs/sdk.
 
 To learn more about Juju, visit https://juju.is/docs/olm.
 
-.. _ops: https://pypi.org/project/ops/
+.. _available on PyPI: https://pypi.org/project/ops/
 """
 
 # The "from .X import Y" imports below don't explicitly tell Pyright (or MyPy)

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -117,7 +117,7 @@ class ActionEvent(EventBase):
         raise RuntimeError('cannot defer action events')
 
     def restore(self, snapshot: Dict[str, Any]):
-        """Used by the operator framework to record the action.
+        """Used by the framework to record the action.
 
         Not meant to be called directly by charm code.
         """

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The Operator Framework infrastructure."""
+"""The ops library's infrastructure."""
 
 import collections
 import collections.abc
@@ -541,7 +541,7 @@ _event_regex = r'^(|.*/)on/[a-zA-Z_]+\[\d+\]$'
 
 
 class Framework(Object):
-    """Main interface from the Charm to the Operator Framework internals."""
+    """Main interface from the Charm to the ops library's infrastructure."""
 
     on = FrameworkEvents()  # type: ignore
 

--- a/ops/log.py
+++ b/ops/log.py
@@ -35,7 +35,7 @@ class JujuLogHandler(logging.Handler):
     def emit(self, record: logging.LogRecord):
         """Send the specified logging record to the Juju backend.
 
-        This method is not used directly by the Operator Framework code, but by
+        This method is not used directly by the ops library, but by
         :class:`logging.Handler` itself as part of the logging machinery.
         """
         self.model_backend.juju_log(record.levelname, self.format(record))

--- a/ops/main.py
+++ b/ops/main.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Main entry point to the Operator Framework.
+"""Main entry point to the framework.
 
 Note that this module is callable, and calls the :func:`ops.main.main` function.
 This is so that :code:`import ops` followed by :code:`ops.main(MyCharm)` works
@@ -379,7 +379,7 @@ def main(charm_class: Type[ops.charm.CharmBase],
     model_backend = ops.model._ModelBackend()
     debug = ('JUJU_DEBUG' in os.environ)
     setup_root_logging(model_backend, debug=debug)
-    logger.debug("Operator Framework %s up and running.", ops.__version__)  # type:ignore
+    logger.debug("ops %s up and running.", ops.__version__)  # type:ignore
 
     dispatcher = _Dispatcher(charm_dir)
     dispatcher.run_any_legacy_hook()

--- a/ops/model.py
+++ b/ops/model.py
@@ -363,7 +363,7 @@ class Application:
     def planned_units(self) -> int:
         """Get the number of units that Juju has "planned" for this application.
 
-        E.g., if an operator runs "juju deploy foo", then "juju add-unit -n 2 foo", the
+        E.g., if an admin runs "juju deploy foo", then "juju add-unit -n 2 foo", the
         planned unit count for foo will be 3.
 
         The data comes from the Juju agent, based on data it fetches from the
@@ -573,7 +573,7 @@ class Unit:
 
         Calling this registers intent with Juju that the application should be
         accessed on the given port, but the port isn't actually opened
-        externally until the operator runs "juju expose".
+        externally until the admin runs "juju expose".
 
         On Kubernetes sidecar charms, the ports opened are not strictly
         per-unit: Juju will open the union of ports from all units.
@@ -1596,7 +1596,7 @@ class ActiveStatus(StatusBase):
 class BlockedStatus(StatusBase):
     """The unit requires manual intervention.
 
-    An operator has to manually intervene to unblock the unit and let it proceed.
+    An admin has to manually intervene to unblock the unit and let it proceed.
     """
     name = 'blocked'
 

--- a/ops/storage.py
+++ b/ops/storage.py
@@ -340,7 +340,7 @@ def juju_backend_available() -> bool:
 
 
 class _JujuStorageBackend:
-    """Implements the interface from the Operator framework to Juju's state-get/set/etc."""
+    """Implements the interface from the ops library to Juju's state-get/set/etc."""
 
     def set(self, key: str, value: Any) -> None:
         """Set a key to a given value.

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Infrastructure to build unit tests for charms using the Operator Framework."""
+"""Infrastructure to build unit tests for charms using the ops library."""
 
 
 import dataclasses

--- a/ops/version.py
+++ b/ops/version.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Helper to define the version of the Operator Framework project.
+"""Helper to define the version of the ops library.
 
-This module is NOT to be used when developing charms using the Operator Framework.
+This module is NOT to be used when developing charms using ops.
 """
 
 import subprocess

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Setup script for the Operator Framework."""
+"""Setup script for the ops library."""
 
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path

--- a/test/charms/test_smoke/src/charm.py
+++ b/test/charms/test_smoke/src/charm.py
@@ -17,7 +17,7 @@
 """Charm the service.
 
 Refer to the following post for a quick-start guide that will help you
-develop a new k8s charm using the Operator Framework:
+develop a new k8s charm using the ops library:
 
     https://discourse.charmhub.io/t/4208
 """

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -41,7 +41,7 @@ TEST_CHARM_DIR = Path(f"{__file__}/../charms/test_main").resolve()
 
 VERSION_LOGLINE = [
     'juju-log', '--log-level', 'DEBUG', '--',
-    f'Operator Framework {ops.__version__} up and running.',
+    f'ops {ops.__version__} up and running.',
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
**[View rendered version updated README.md here.](https://github.com/benhoyt/operator/blob/readme-update/README.md)**

Remove a lot of the "operator" and K8s jargon from the top of our README. I feel fairly strongly this isn't the place to sell how great Juju, K8s operators, and model-driven development are -- we should do that on our landing page and/or docs, not in the ops README. Charmers shouldn't normally be landing here, and if they do, I think we should give them succinct, developer-oriented documentation.

Also simplify and update some of the terminology to be consistent with our updated Juju Terminology doc.

The first part of the README is copied to `ops/__init__.py` for consistency. That will appear at the top of our API reference at https://ops.readthedocs.io/

Move the note about dependencies to HACKING.md where I think it belongs.
