### PR TITLE
Avoid error in FileInfo repr due to permissions being None

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -66,7 +66,7 @@ if TYPE_CHECKING:
     _StringOrPath = Union[str, pathlib.PurePosixPath, pathlib.Path]
     _FileOrDir = Union['_File', '_Directory']
     _FileKwargs = TypedDict('_FileKwargs', {
-        'permissions': int,
+        'permissions': Optional[int],
         'last_modified': datetime.datetime,
         'user_id': Optional[int],
         'user': Optional[str],
@@ -2476,7 +2476,7 @@ class _TestingPebbleClient:
                 name=file.name,
                 type=get_pebble_file_type(file),
                 size=file.size if isinstance(file, _File) else None,
-                permissions=file.kwargs.get('permissions'),
+                permissions=file.kwargs.get('permissions') or 0,
                 last_modified=file.last_modified,
                 user_id=file.kwargs.get('user_id'),
                 user=file.kwargs.get('user'),


### PR DESCRIPTION
`FileInfo.__repr__` was raising a TypeError due to the expectation that permissions was never None, and the ":o" format string:

```
TypeError: unsupported format string passed to NoneType.__format__
```

At first I was surprised that Pyright didn't catch this, because clearly dict.get can return None, but we were defining a `_FileKwargs` TypedDict with a non-optional "permissions" field, so fix that too.

NOTE: this code will be removed and unnecessary if OP036 is done (using the real file system for the Harness's container filesystem), but might as well fix while the iron's hot.

Fixes #955
