### PR TITLE
Add `Relation.active` attribute to indicate if a relation is active or currently breaking

### DIFF
--- a/ops/main.py
+++ b/ops/main.py
@@ -361,6 +361,15 @@ def _should_use_controller_storage(db_path: Path, meta: CharmMeta) -> bool:
         return False
 
 
+def _get_breaking_relation_id() -> Optional[int]:
+    """Returns the relation id of the currently breaking relation, if applicable."""
+    if not os.environ.get("JUJU_HOOK_NAME", "").endswith("-relation-broken"):
+        # Not the relation-broken event
+        return None
+
+    return int(os.environ.get("JUJU_RELATION_ID"))
+
+
 def main(charm_class: Type[ops.charm.CharmBase],
          use_juju_for_storage: Optional[bool] = None):
     """Setup the charm and dispatch the observed event.
@@ -391,8 +400,10 @@ def main(charm_class: Type[ops.charm.CharmBase],
     else:
         actions_metadata = None
 
+    breaking_relation_id = _get_breaking_relation_id()
+
     meta = CharmMeta.from_yaml(metadata, actions_metadata)
-    model = ops.model.Model(meta, model_backend)
+    model = ops.model.Model(meta, model_backend, breaking_relation_id)
 
     charm_state_path = charm_dir / CHARM_STATE_FILE
 


### PR DESCRIPTION
(Still WIP - opened as draft to start discussion on implementation)

This PR adds the `Relation.active` attribute to indicate whether the relation is active (most cases) or inactive (as implemented here, if the relation is part of a relation-broken event, but maybe there are other cases that should be inactive as well).  See #940 for more context.

Alternate approaches/ideas:
* This could have been `Relation.broken` or `Relation.breaking`, which is more directly descriptive, but the expectation is that people probably want to know what is active rather than not, and there may be other future reasons that a `Relation` is inactive
* as discussed [here](https://github.com/canonical/operator/issues/940#issuecomment-1613869865), if iterating through `model.relations[my_relation_name]`, should you even see inactive relations?  Hiding inactive relations from that iterable would be a breaking change, but probably one most people would expect in the first place.  We could add something like `model.relations.get_active()` or similar so at least people don't need to do their own filtering.  

## Checklist

 - [x] Have any types changed? If so, have the type annotations been updated?
 - [x] If this code exposes model data, does it do so thoughtfully, in a way that aids understanding?

       We want to avoid simple passthrough of model data, without contextualization, where possible.

 - [ ] **NA** Do error messages, if any, present charm authors or operators with enough information to solve the problem?

## QA steps

TODO

## Documentation changes

TODO: May need to elaborate in the docs

## Bug reference

Closes #940

## Changelog

- adds `Relation.active` attribute, indicating whether a relation is active vs breaking
