### PR TITLE
Add `has_open_port_k8s` to `JujuVersion`

### DIFF
--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -126,6 +126,6 @@ class JujuVersion:
 
     @property
     def has_open_port_k8s(self) -> bool:
-        """Report whether this Juju version supports open-port on Kubernetes"""
+        """Report whether this Juju version supports open-port on Kubernetes."""
         # Support added: https://bugs.launchpad.net/juju/+bug/1920960
         return (self.major, self.minor, self.patch) >= (3, 0, 3)

--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -123,3 +123,9 @@ class JujuVersion:
         # * In 3.0.3, a bug with observer labels was fixed (juju/juju#14916)
         # TODO(benhoyt): update to 3.0.3+ once shipped (for juju/juju#14916 fix)
         return (self.major, self.minor, self.patch) >= (3, 0, 2)
+
+    @property
+    def has_open_port_k8s(self) -> bool:
+        """Report whether this Juju version supports open-port on Kubernetes"""
+        # Support added: https://bugs.launchpad.net/juju/+bug/1920960
+        return (self.major, self.minor, self.patch) >= (3, 0, 3)

--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -125,7 +125,7 @@ class JujuVersion:
         return (self.major, self.minor, self.patch) >= (3, 0, 2)
 
     @property
-    def has_open_port_k8s(self) -> bool:
+    def supports_open_port_on_k8s(self) -> bool:
         """Report whether this Juju version supports open-port on Kubernetes."""
         # Support added: https://bugs.launchpad.net/juju/+bug/1920960
         return (self.major, self.minor, self.patch) >= (3, 0, 3)

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -70,8 +70,15 @@ class TestJujuVersion(unittest.TestCase):
 
     def test_has_secrets(self):
         self.assertTrue(ops.JujuVersion('3.0.2').has_secrets)
+        self.assertTrue(ops.JujuVersion('3.1.0').has_secrets)
         self.assertFalse(ops.JujuVersion('3.0.1').has_secrets)
         self.assertFalse(ops.JujuVersion('2.9.30').has_secrets)
+
+    def test_has_open_port_k8s(self):
+        self.assertTrue(ops.JujuVersion('3.0.3').has_open_port_k8s)
+        self.assertTrue(ops.JujuVersion('3.3.0').has_open_port_k8s)
+        self.assertFalse(ops.JujuVersion('3.0.2').has_open_port_k8s)
+        self.assertFalse(ops.JujuVersion('2.9.30').has_open_port_k8s)
 
     def test_parsing_errors(self):
         invalid_versions = [

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -74,7 +74,7 @@ class TestJujuVersion(unittest.TestCase):
         self.assertFalse(ops.JujuVersion('3.0.1').has_secrets)
         self.assertFalse(ops.JujuVersion('2.9.30').has_secrets)
 
-    def test_has_open_port_k8s(self):
+    def test_supports_open_port_on_k8s(self):
         self.assertTrue(ops.JujuVersion('3.0.3').supports_open_port_on_k8s)
         self.assertTrue(ops.JujuVersion('3.3.0').supports_open_port_on_k8s)
         self.assertFalse(ops.JujuVersion('3.0.2').supports_open_port_on_k8s)

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -75,10 +75,10 @@ class TestJujuVersion(unittest.TestCase):
         self.assertFalse(ops.JujuVersion('2.9.30').has_secrets)
 
     def test_has_open_port_k8s(self):
-        self.assertTrue(ops.JujuVersion('3.0.3').has_open_port_k8s)
-        self.assertTrue(ops.JujuVersion('3.3.0').has_open_port_k8s)
-        self.assertFalse(ops.JujuVersion('3.0.2').has_open_port_k8s)
-        self.assertFalse(ops.JujuVersion('2.9.30').has_open_port_k8s)
+        self.assertTrue(ops.JujuVersion('3.0.3').supports_open_port_on_k8s)
+        self.assertTrue(ops.JujuVersion('3.3.0').supports_open_port_on_k8s)
+        self.assertFalse(ops.JujuVersion('3.0.2').supports_open_port_on_k8s)
+        self.assertFalse(ops.JujuVersion('2.9.30').supports_open_port_on_k8s)
 
     def test_parsing_errors(self):
         invalid_versions = [


### PR DESCRIPTION
open-port is not supported before Juju 3.0.3 on Kubernetes

Context: https://chat.charmhub.io/charmhub/pl/91t6ip37ybncuqe11eudfx38xw