### PR TITLE
Disallow deferral of relation-broken events (doesn't make sense)

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -548,6 +548,10 @@ class RelationBrokenEvent(RelationEvent):
     are currently known locally.
     """
 
+    def defer(self) -> None:
+        """Relation-broken events are not deferrable."""
+        raise RuntimeError('Cannot defer relation-broken events')
+
 
 class StorageEvent(HookEvent):
     """Base class representing storage-related events.


### PR DESCRIPTION
Deferring relation-broken events doesn't make sense, as the relation has gone away.