### PR TITLE
Further separate between hook tools and model

### DIFF
--- a/ops/hook_tools.py
+++ b/ops/hook_tools.py
@@ -1,0 +1,540 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wrappers for juju hook tools."""
+
+import datetime
+import json
+import math
+import re
+import shutil
+import subprocess
+import tempfile
+import typing
+from pathlib import Path
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Set,
+    Union,
+)
+
+from ops._private import yaml
+
+if typing.TYPE_CHECKING:
+    from typing_extensions import TypedDict
+
+    _ConfigOption = TypedDict('_ConfigOption', {
+        'type': Literal['string', 'int', 'float', 'boolean'],
+        'description': str,
+        'default': Union[str, int, float, bool],
+    })
+
+    _StatusDict = TypedDict('_StatusDict', {'status': str, 'message': str})
+
+    # relation data is a string key: string value mapping so far as the
+    # controller is concerned
+    _RelationDataContent_Raw = Dict[str, str]
+
+    _AddressDict = TypedDict('_AddressDict', {
+        'address': str,  # Juju < 2.9
+        'value': str,  # Juju >= 2.9
+        'cidr': str
+    })
+    _BindAddressDict = TypedDict('_BindAddressDict', {
+        'interface-name': str,
+        'addresses': List[_AddressDict]
+    })
+    _NetworkDict = TypedDict('_NetworkDict', {
+        'bind-addresses': List[_BindAddressDict],
+        'ingress-addresses': List[str],
+        'egress-subnets': List[str]
+    })
+
+
+class HookError(Exception):
+    """Raised when a subprocess call fails."""
+
+
+def _run(*args: str, return_output: bool = False,
+         use_json: bool = False, input_stream: Optional[str] = None
+         ) -> Union[str, Any, None]:
+    kwargs = dict(stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, encoding='utf-8')
+    if input_stream:
+        kwargs.update({"input": input_stream})
+    which_cmd = shutil.which(args[0])
+    if which_cmd is None:
+        raise RuntimeError(f'command not found: {args[0]}')
+    args = (which_cmd,) + args[1:]
+    if use_json:
+        args += ('--format=json',)
+    # TODO(benhoyt): all the "type: ignore"s below kinda suck, but I've
+    #                been fighting with Pyright for half an hour now...
+    try:
+        result = subprocess.run(args, **kwargs)  # type: ignore
+    except subprocess.CalledProcessError as e:
+        raise HookError(e.stderr)
+    if return_output:
+        if result.stdout is None:  # type: ignore
+            return ''
+        else:
+            text: str = result.stdout  # type: ignore
+            if use_json:
+                return json.loads(text)  # type: ignore
+            else:
+                return text  # type: ignore
+
+
+_ACTION_RESULT_KEY_REGEX = re.compile(r'^[a-z0-9](([a-z0-9-.]+)?[a-z0-9])?$')
+
+
+def _format_action_result_dict(input: Dict[str, Any],
+                               parent_key: Optional[str] = None,
+                               output: Optional[Dict[str, str]] = None
+                               ) -> Dict[str, str]:
+    """Turn a nested dictionary into a flattened dictionary, using '.' as a key seperator.
+
+    This is used to allow nested dictionaries to be translated into the dotted format required by
+    the Juju `action-set` hook tool in order to set nested data on an action.
+
+    Additionally, this method performs some validation on keys to ensure they only use permitted
+    characters.
+
+    Example::
+
+        >>> test_dict = {'a': {'b': 1, 'c': 2}}
+        >>> _format_action_result_dict(test_dict)
+        {'a.b': 1, 'a.c': 2}
+
+    Arguments:
+        input: The dictionary to flatten
+        parent_key: The string to prepend to dictionary's keys
+        output: The current dictionary to be returned, which may or may not yet be completely flat
+
+    Returns:
+        A flattened dictionary with validated keys
+
+    Raises:
+        ValueError: if the dict is passed with a mix of dotted/non-dotted keys that expand out to
+            result in duplicate keys. For example: {'a': {'b': 1}, 'a.b': 2}. Also raised if a dict
+            is passed with a key that fails to meet the format requirements.
+    """
+    output_: Dict[str, str] = output or {}
+
+    for key, value in input.items():
+        # Ensure the key is of a valid format, and raise a ValueError if not
+        if not isinstance(key, str):
+            # technically a type error, but for consistency with the
+            # other exceptions raised on key validation...
+            raise ValueError(f'invalid key {key!r}; must be a string')
+        if not _ACTION_RESULT_KEY_REGEX.match(key):
+            raise ValueError("key '{!r}' is invalid: must be similar to 'key', 'some-key2', or "
+                             "'some.key'".format(key))
+
+        if parent_key:
+            key = f"{parent_key}.{key}"
+
+        if isinstance(value, MutableMapping):
+            value = typing.cast(Dict[str, Any], value)
+            output_ = _format_action_result_dict(value, key, output_)
+        elif key in output_:
+            raise ValueError("duplicate key detected in dictionary passed to 'action-set': {!r}"
+                             .format(key))
+        else:
+            output_[key] = value  # type: ignore
+
+    return output_
+
+
+class _Validator:
+    """Provides facilities for validating inputs and formatting them for model backends."""
+
+    METRIC_KEY_REGEX = re.compile(r'^[a-zA-Z](?:[a-zA-Z0-9-_]*[a-zA-Z0-9])?$')
+
+    @classmethod
+    def validate_metric_key(cls, key: str):
+        if cls.METRIC_KEY_REGEX.match(key) is None:
+            raise HookError(
+                f'invalid metric key {key!r}: must match {cls.METRIC_KEY_REGEX.pattern}')
+
+    @classmethod
+    def validate_metric_label(cls, label_name: str):
+        if cls.METRIC_KEY_REGEX.match(label_name) is None:
+            raise HookError(
+                'invalid metric label name {!r}: must match {}'.format(
+                    label_name, cls.METRIC_KEY_REGEX.pattern))
+
+    @classmethod
+    def format_metric_value(cls, value: Union[int, float]):
+        if not isinstance(value, (int, float)):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise HookError('invalid metric value {!r} provided:'
+                            ' must be a positive finite float'.format(value))
+
+        if math.isnan(value) or math.isinf(value) or value < 0:
+            raise HookError('invalid metric value {!r} provided:'
+                            ' must be a positive finite float'.format(value))
+        return str(value)
+
+    @classmethod
+    def validate_label_value(cls, label: str, value: str):
+        # Label values cannot be empty, contain commas or equal signs as those are
+        # used by add-metric as separators.
+        if not value:
+            raise HookError(
+                f'metric label {label} has an empty value, which is not allowed')
+        v = str(value)
+        if re.search('[,=]', v) is not None:
+            raise HookError(
+                f'metric label values must not contain "," or "=": {label}={value!r}')
+
+
+def relation_ids(relation_name: str) -> List[int]:
+    rel_ids = _run('relation-ids', relation_name, return_output=True, use_json=True)
+    rel_ids = typing.cast(Iterable[str], rel_ids)
+    return [int(rel_id.split(':')[-1]) for rel_id in rel_ids]
+
+
+def relation_list(relation_id: int) -> List[str]:
+    rel_list = _run('relation-list', '-r', str(relation_id),
+                    return_output=True, use_json=True)
+    return typing.cast(List[str], rel_list)
+
+
+def relation_list_app(relation_id: int) -> str:
+    rel_id = _run('relation-list', '-r', str(relation_id), '--app',
+                  return_output=True, use_json=True)
+    # if it returned anything at all, it's a str.
+    return typing.cast(str, rel_id)
+
+
+def relation_get(relation_id: int, member_name: str, is_app: bool
+                 ) -> '_RelationDataContent_Raw':
+    args = ['relation-get', '-r', str(relation_id), '-', member_name]
+    if is_app:
+        args.append('--app')
+
+    raw_data_content = _run(*args, return_output=True, use_json=True)
+    return typing.cast('_RelationDataContent_Raw', raw_data_content)
+
+
+def relation_set(relation_id: int, key: str, value: str, is_app: bool) -> None:
+    args = ['relation-set', '-r', str(relation_id)]
+    if is_app:
+        args.append('--app')
+    args.extend(["--file", "-"])
+
+    content = yaml.safe_dump({key: value})
+    _run(*args, input_stream=content)
+
+
+def config_get() -> Dict[str, '_ConfigOption']:
+    out = _run('config-get', return_output=True, use_json=True)
+    return typing.cast(Dict[str, '_ConfigOption'], out)
+
+
+def is_leader() -> bool:
+    return typing.cast(bool, _run('is-leader', return_output=True, use_json=True))
+
+
+def resource_get(resource_name: str) -> str:
+    out = _run('resource-get', resource_name, return_output=True)
+    return typing.cast(str, out).strip()
+
+
+def pod_spec_set(spec: Mapping[str, Any],
+                 k8s_resources: Optional[Mapping[str, Any]] = None):
+    tmpdir = Path(tempfile.mkdtemp('-pod-spec-set'))
+    try:
+        spec_path = tmpdir / 'spec.yaml'
+        with spec_path.open("wt", encoding="utf8") as f:
+            yaml.safe_dump(spec, stream=f)
+        args = ['--file', str(spec_path)]
+        if k8s_resources:
+            k8s_res_path = tmpdir / 'k8s-resources.yaml'
+            with k8s_res_path.open("wt", encoding="utf8") as f:
+                yaml.safe_dump(k8s_resources, stream=f)
+            args.extend(['--k8s-resources', str(k8s_res_path)])
+        _run('pod-spec-set', *args)
+    finally:
+        shutil.rmtree(str(tmpdir))
+
+
+def status_get(*, is_app: bool = False) -> '_StatusDict':
+    """Get a status of a unit or an application.
+
+    Args:
+        is_app: A boolean indicating whether the status should be retrieved for a unit
+            or an application.
+    """
+    content = _run(
+        'status-get', '--include-data', f'--application={is_app}',
+        use_json=True,
+        return_output=True)
+    # Unit status looks like (in YAML):
+    # message: 'load: 0.28 0.26 0.26'
+    # status: active
+    # status-data: {}
+    # Application status looks like (in YAML):
+    # application-status:
+    #   message: 'load: 0.28 0.26 0.26'
+    #   status: active
+    #   status-data: {}
+    #   units:
+    #     uo/0:
+    #       message: 'load: 0.28 0.26 0.26'
+    #       status: active
+    #       status-data: {}
+
+    if is_app:
+        content = typing.cast(Dict[str, Dict[str, str]], content)
+        app_status = content['application-status']
+        return {'status': app_status['status'],
+                'message': app_status['message']}
+    else:
+        return typing.cast('_StatusDict', content)
+
+
+def status_set(status: str, message: str = '', *, is_app: bool = False) -> None:
+    """Set a status of a unit or an application.
+
+    Args:
+        status: The status to set.
+        message: The message to set in the status.
+        is_app: A boolean indicating whether the status should be set for a unit or an
+                application.
+    """
+    if not isinstance(is_app, bool):
+        raise TypeError('is_app parameter must be boolean')
+    _run('status-set', f'--application={is_app}', status, message)
+
+
+def storage_list(name: str) -> List[int]:
+    storages = _run('storage-list', name, return_output=True, use_json=True)
+    storages = typing.cast(List[str], storages)
+    return [int(s.split('/')[1]) for s in storages]
+
+
+def storage_get(storage_name_id: str, attribute: str) -> str:
+    if not len(attribute) > 0:  # assume it's an empty string.
+        raise RuntimeError('calling storage_get with `attribute=""` will return a dict '
+                           'and not a string. This usage is not supported.')
+    out = _run('storage-get', '-s', storage_name_id, attribute,
+               return_output=True, use_json=True)
+    return typing.cast(str, out)
+
+
+def storage_add(name: str, count: int = 1) -> None:
+    if not isinstance(count, int) or isinstance(count, bool):
+        raise TypeError(f'storage count must be integer, got: {count} ({type(count)})')
+    _run('storage-add', f'{name}={count}')
+
+
+def action_get() -> Dict[str, Any]:
+    out = _run('action-get', return_output=True, use_json=True)
+    return typing.cast(Dict[str, Any], out)
+
+
+def action_set(results: Dict[str, Any]) -> None:
+    # The Juju action-set hook tool cannot interpret nested dicts, so we use a helper to
+    # flatten out any nested dict structures into a dotted notation, and validate keys.
+    flat_results = _format_action_result_dict(results)
+    _run('action-set', *[f"{k}={v}" for k, v in flat_results.items()])
+
+
+def action_log(message: str) -> None:
+    _run('action-log', message)
+
+
+def action_fail(message: str = '') -> None:
+    _run('action-fail', message)
+
+
+def application_version_set(version: str) -> None:
+    _run('application-version-set', '--', version)
+
+
+def juju_log(level: str, message: str) -> None:
+    """Pass a log message on to the juju logger."""
+    _run('juju-log', '--log-level', level, "--", message)
+
+
+def network_get(binding_name: str, relation_id: Optional[int] = None) -> '_NetworkDict':
+    """Return network info provided by network-get for a given binding.
+
+    Args:
+        binding_name: A name of a binding (relation name or extra-binding name).
+        relation_id: An optional relation id to get network info for.
+    """
+    cmd = ['network-get', binding_name]
+    if relation_id is not None:
+        cmd.extend(['-r', str(relation_id)])
+    network = _run(*cmd, return_output=True, use_json=True)
+    return typing.cast('_NetworkDict', network)
+
+
+def add_metrics(metrics: Mapping[str, Union[int, float]],
+                labels: Optional[Mapping[str, str]] = None) -> None:
+    cmd: List[str] = ['add-metric']
+    if labels:
+        label_args: List[str] = []
+        for k, v in labels.items():
+            _Validator.validate_metric_label(k)
+            _Validator.validate_label_value(k, v)
+            label_args.append(f'{k}={v}')
+        cmd.extend(['--labels', ','.join(label_args)])
+
+    metric_args: List[str] = []
+    for k, v in metrics.items():
+        _Validator.validate_metric_key(k)
+        metric_value = _Validator.format_metric_value(v)
+        metric_args.append(f'{k}={metric_value}')
+    cmd.extend(metric_args)
+    _run(*cmd)
+
+
+def goal_state() -> Dict[str, Dict[str, Any]]:
+    app_state = _run('goal-state', return_output=True, use_json=True)
+    return typing.cast(Dict[str, Dict[str, Any]], app_state)
+
+
+def secret_get(*,
+               id: Optional[str] = None,
+               label: Optional[str] = None,
+               refresh: bool = False,
+               peek: bool = False) -> Dict[str, str]:
+    args: List[str] = []
+    if id is not None:
+        args.append(id)
+    if label is not None:
+        args.extend(['--label', label])
+    if refresh:
+        args.append('--refresh')
+    if peek:
+        args.append('--peek')
+    # IMPORTANT: Don't call shared _run_for_secret method here; we want to
+    # be extra sensitive inside secret_get to ensure we never
+    # accidentally log or output secrets, even if _run_for_secret changes.
+    result = _run('secret-get', *args, return_output=True, use_json=True)
+    return typing.cast(Dict[str, str], result)
+
+
+def secret_info_get(*,
+                    id: Optional[str] = None,
+                    label: Optional[str] = None) -> Dict[str, Any]:
+    args: List[str] = []
+    if id is not None:
+        args.append(id)
+    elif label is not None:  # elif because Juju secret-info-get doesn't allow id and label
+        args.extend(['--label', label])
+    result = _run('secret-info-get', *args, return_output=True, use_json=True)
+    return typing.cast(Dict[str, Any], result)
+
+
+def secret_set(id: str, *,
+               content: Optional[Dict[str, str]] = None,
+               label: Optional[str] = None,
+               description: Optional[str] = None,
+               expire: Optional[datetime.datetime] = None,
+               rotate: Optional[str] = None):
+    args = [id]
+    if label is not None:
+        args.extend(['--label', label])
+    if description is not None:
+        args.extend(['--description', description])
+    if expire is not None:
+        args.extend(['--expire', expire.isoformat()])
+    if rotate is not None:
+        args += ['--rotate', rotate]
+    if content is not None:
+        # The content has already been validated with Secret._validate_content
+        for k, v in content.items():
+            args.append(f'{k}={v}')
+    _run('secret-set', *args, return_output=False, use_json=False)
+
+
+def secret_add(content: Dict[str, str], *,
+               label: Optional[str] = None,
+               description: Optional[str] = None,
+               expire: Optional[datetime.datetime] = None,
+               rotate: Optional[str] = None,
+               owner: Optional[str] = None) -> str:
+    args: List[str] = []
+    if label is not None:
+        args.extend(['--label', label])
+    if description is not None:
+        args.extend(['--description', description])
+    if expire is not None:
+        args.extend(['--expire', expire.isoformat()])
+    if rotate is not None:
+        args += ['--rotate', rotate]
+    if owner is not None:
+        args += ['--owner', owner]
+    # The content has already been validated with Secret._validate_content
+    for k, v in content.items():
+        args.append(f'{k}={v}')
+    result = _run('secret-add', *args, return_output=True, use_json=False)
+    secret_id = typing.cast(str, result)
+    return secret_id.strip()
+
+
+def secret_grant(id: str, relation_id: int, *, unit: Optional[str] = None):
+    args = [id, '--relation', str(relation_id)]
+    if unit is not None:
+        args += ['--unit', str(unit)]
+    _run('secret-grant', *args, return_output=False, use_json=False)
+
+
+def secret_revoke(id: str, relation_id: int, *, unit: Optional[str] = None):
+    args = [id, '--relation', str(relation_id)]
+    if unit is not None:
+        args += ['--unit', str(unit)]
+    _run('secret-revoke', *args, return_output=False, use_json=False)
+
+
+def secret_remove(id: str, *, revision: Optional[int] = None):
+    args = [id]
+    if revision is not None:
+        args.extend(['--revision', str(revision)])
+    _run('secret-remove', *args, return_output=False, use_json=False)
+
+
+def open_port(protocol: str, port: Optional[int] = None):
+    arg = f'{port}/{protocol}' if port is not None else protocol
+    _run('open-port', arg)
+
+
+def close_port(protocol: str, port: Optional[int] = None):
+    arg = f'{port}/{protocol}' if port is not None else protocol
+    _run('close-port', arg)
+
+
+def opened_ports() -> Set[str]:
+    # We could use "opened-ports --format=json", but it's not really
+    # structured; it's just an array of strings which are the lines of the
+    # text output, like ["icmp","8081/udp"]. So it's probably just as
+    # likely to change as the text output, and doesn't seem any better.
+    output = typing.cast(str, _run('opened-ports', return_output=True))
+    ports: Set[str] = set()
+    for line in output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        ports.add(line)
+    return ports

--- a/ops/model.py
+++ b/ops/model.py
@@ -18,15 +18,11 @@ import dataclasses
 import datetime
 import enum
 import ipaddress
-import json
 import logging
-import math
 import os
 import re
 import shutil
 import stat
-import subprocess
-import tempfile
 import time
 import typing
 import weakref
@@ -53,7 +49,8 @@ from typing import (
 
 import ops
 import ops.pebble as pebble
-from ops._private import timeconv, yaml
+from ops import hook_tools
+from ops._private import timeconv
 from ops.jujuversion import JujuVersion
 
 # a k8s spec is a mapping from names/"types" to json/yaml spec objects
@@ -2576,67 +2573,6 @@ class SecretNotFoundError(ModelError):
     """Raised when the specified secret does not exist."""
 
 
-_ACTION_RESULT_KEY_REGEX = re.compile(r'^[a-z0-9](([a-z0-9-.]+)?[a-z0-9])?$')
-
-
-def _format_action_result_dict(input: Dict[str, Any],
-                               parent_key: Optional[str] = None,
-                               output: Optional[Dict[str, str]] = None
-                               ) -> Dict[str, str]:
-    """Turn a nested dictionary into a flattened dictionary, using '.' as a key seperator.
-
-    This is used to allow nested dictionaries to be translated into the dotted format required by
-    the Juju `action-set` hook tool in order to set nested data on an action.
-
-    Additionally, this method performs some validation on keys to ensure they only use permitted
-    characters.
-
-    Example::
-
-        >>> test_dict = {'a': {'b': 1, 'c': 2}}
-        >>> _format_action_result_dict(test_dict)
-        {'a.b': 1, 'a.c': 2}
-
-    Arguments:
-        input: The dictionary to flatten
-        parent_key: The string to prepend to dictionary's keys
-        output: The current dictionary to be returned, which may or may not yet be completely flat
-
-    Returns:
-        A flattened dictionary with validated keys
-
-    Raises:
-        ValueError: if the dict is passed with a mix of dotted/non-dotted keys that expand out to
-            result in duplicate keys. For example: {'a': {'b': 1}, 'a.b': 2}. Also raised if a dict
-            is passed with a key that fails to meet the format requirements.
-    """
-    output_: Dict[str, str] = output or {}
-
-    for key, value in input.items():
-        # Ensure the key is of a valid format, and raise a ValueError if not
-        if not isinstance(key, str):
-            # technically a type error, but for consistency with the
-            # other exceptions raised on key validation...
-            raise ValueError(f'invalid key {key!r}; must be a string')
-        if not _ACTION_RESULT_KEY_REGEX.match(key):
-            raise ValueError("key '{!r}' is invalid: must be similar to 'key', 'some-key2', or "
-                             "'some.key'".format(key))
-
-        if parent_key:
-            key = f"{parent_key}.{key}"
-
-        if isinstance(value, MutableMapping):
-            value = typing.cast(Dict[str, Any], value)
-            output_ = _format_action_result_dict(value, key, output_)
-        elif key in output_:
-            raise ValueError("duplicate key detected in dictionary passed to 'action-set': {!r}"
-                             .format(key))
-        else:
-            output_[key] = value  # type: ignore
-
-    return output_
-
-
 class _ModelBackend:
     """Represents the connection between the Model representation and talking to Juju.
 
@@ -2669,34 +2605,6 @@ class _ModelBackend:
         self._leader_check_time = None
         self._hook_is_running = ''
 
-    def _run(self, *args: str, return_output: bool = False,
-             use_json: bool = False, input_stream: Optional[str] = None
-             ) -> Union[str, Any, None]:
-        kwargs = dict(stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, encoding='utf-8')
-        if input_stream:
-            kwargs.update({"input": input_stream})
-        which_cmd = shutil.which(args[0])
-        if which_cmd is None:
-            raise RuntimeError(f'command not found: {args[0]}')
-        args = (which_cmd,) + args[1:]
-        if use_json:
-            args += ('--format=json',)
-        # TODO(benhoyt): all the "type: ignore"s below kinda suck, but I've
-        #                been fighting with Pyright for half an hour now...
-        try:
-            result = subprocess.run(args, **kwargs)  # type: ignore
-        except subprocess.CalledProcessError as e:
-            raise ModelError(e.stderr)
-        if return_output:
-            if result.stdout is None:  # type: ignore
-                return ''
-            else:
-                text: str = result.stdout  # type: ignore
-                if use_json:
-                    return json.loads(text)  # type: ignore
-                else:
-                    return text  # type: ignore
-
     @staticmethod
     def _is_relation_not_found(model_error: Exception) -> bool:
         return 'relation not found' in str(model_error)
@@ -2710,19 +2618,18 @@ class _ModelBackend:
         pass
 
     def relation_ids(self, relation_name: str) -> List[int]:
-        relation_ids = self._run('relation-ids', relation_name, return_output=True, use_json=True)
-        relation_ids = typing.cast(Iterable[str], relation_ids)
-        return [int(relation_id.split(':')[-1]) for relation_id in relation_ids]
+        try:
+            return hook_tools.relation_ids(relation_name)
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def relation_list(self, relation_id: int) -> List[str]:
         try:
-            rel_list = self._run('relation-list', '-r', str(relation_id),
-                                 return_output=True, use_json=True)
-            return typing.cast(List[str], rel_list)
-        except ModelError as e:
+            return hook_tools.relation_list(relation_id)
+        except hook_tools.HookError as e:
             if self._is_relation_not_found(e):
                 raise RelationNotFoundError() from e
-            raise
+            raise ModelError from e
 
     def relation_remote_app_name(self, relation_id: int) -> Optional[str]:
         """Return remote app name for given relation ID, or None if not known."""
@@ -2735,19 +2642,16 @@ class _ModelBackend:
         # If caller is asking for information about another relation, use
         # "relation-list --app" to get it.
         try:
-            rel_id = self._run('relation-list', '-r', str(relation_id), '--app',
-                               return_output=True, use_json=True)
-            # if it returned anything at all, it's a str.
-            return typing.cast(str, rel_id)
+            return hook_tools.relation_list_app(relation_id)
 
-        except ModelError as e:
+        except hook_tools.HookError as e:
             if self._is_relation_not_found(e):
                 return None
             if 'option provided but not defined: --app' in str(e):
                 # "--app" was introduced to relation-list in Juju 2.8.1, so
                 # handle previous versions of Juju gracefully
                 return None
-            raise
+            raise ModelError from e
 
     def relation_get(self, relation_id: int, member_name: str, is_app: bool
                      ) -> '_RelationDataContent_Raw':
@@ -2760,17 +2664,12 @@ class _ModelBackend:
                 raise RuntimeError(
                     f'getting application data is not supported on Juju version {version}')
 
-        args = ['relation-get', '-r', str(relation_id), '-', member_name]
-        if is_app:
-            args.append('--app')
-
         try:
-            raw_data_content = self._run(*args, return_output=True, use_json=True)
-            return typing.cast('_RelationDataContent_Raw', raw_data_content)
-        except ModelError as e:
+            return hook_tools.relation_get(relation_id, member_name, is_app)
+        except hook_tools.HookError as e:
             if self._is_relation_not_found(e):
-                raise RelationNotFoundError() from e
-            raise
+                raise RelationNotFoundError() from ModelError(e)
+            raise ModelError from e
 
     def relation_set(self, relation_id: int, key: str, value: str, is_app: bool) -> None:
         if not isinstance(is_app, bool):
@@ -2782,22 +2681,18 @@ class _ModelBackend:
                 raise RuntimeError(
                     f'setting application data is not supported on Juju version {version}')
 
-        args = ['relation-set', '-r', str(relation_id)]
-        if is_app:
-            args.append('--app')
-        args.extend(["--file", "-"])
-
         try:
-            content = yaml.safe_dump({key: value})
-            self._run(*args, input_stream=content)
-        except ModelError as e:
+            hook_tools.relation_set(relation_id, key, value, is_app)
+        except hook_tools.HookError as e:
             if self._is_relation_not_found(e):
-                raise RelationNotFoundError() from e
-            raise
+                raise RelationNotFoundError() from ModelError(e)
+            raise ModelError from e
 
     def config_get(self) -> Dict[str, '_ConfigOption']:
-        out = self._run('config-get', return_output=True, use_json=True)
-        return typing.cast(Dict[str, '_ConfigOption'], out)
+        try:
+            return hook_tools.config_get()
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def is_leader(self) -> bool:
         """Obtain the current leadership status for the unit the charm code is executing on.
@@ -2814,32 +2709,26 @@ class _ModelBackend:
             # Current time MUST be saved before running is-leader to ensure the cache
             # is only used inside the window that is-leader itself asserts.
             self._leader_check_time = now
-            is_leader = self._run('is-leader', return_output=True, use_json=True)
-            self._is_leader = typing.cast(bool, is_leader)
+            try:
+                self._is_leader = hook_tools.is_leader()
+            except hook_tools.HookError as e:
+                raise ModelError from e
 
         # we can cast to bool now since if we're here it means we checked.
         return typing.cast(bool, self._is_leader)
 
     def resource_get(self, resource_name: str) -> str:
-        out = self._run('resource-get', resource_name, return_output=True)
-        return typing.cast(str, out).strip()
+        try:
+            return hook_tools.resource_get(resource_name)
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def pod_spec_set(self, spec: Mapping[str, Any],
                      k8s_resources: Optional[Mapping[str, Any]] = None):
-        tmpdir = Path(tempfile.mkdtemp('-pod-spec-set'))
         try:
-            spec_path = tmpdir / 'spec.yaml'
-            with spec_path.open("wt", encoding="utf8") as f:
-                yaml.safe_dump(spec, stream=f)
-            args = ['--file', str(spec_path)]
-            if k8s_resources:
-                k8s_res_path = tmpdir / 'k8s-resources.yaml'
-                with k8s_res_path.open("wt", encoding="utf8") as f:
-                    yaml.safe_dump(k8s_resources, stream=f)
-                args.extend(['--k8s-resources', str(k8s_res_path)])
-            self._run('pod-spec-set', *args)
-        finally:
-            shutil.rmtree(str(tmpdir))
+            hook_tools.pod_spec_set(spec, k8s_resources)
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def status_get(self, *, is_app: bool = False) -> '_StatusDict':
         """Get a status of a unit or an application.
@@ -2848,32 +2737,10 @@ class _ModelBackend:
             is_app: A boolean indicating whether the status should be retrieved for a unit
                 or an application.
         """
-        content = self._run(
-            'status-get', '--include-data', f'--application={is_app}',
-            use_json=True,
-            return_output=True)
-        # Unit status looks like (in YAML):
-        # message: 'load: 0.28 0.26 0.26'
-        # status: active
-        # status-data: {}
-        # Application status looks like (in YAML):
-        # application-status:
-        #   message: 'load: 0.28 0.26 0.26'
-        #   status: active
-        #   status-data: {}
-        #   units:
-        #     uo/0:
-        #       message: 'load: 0.28 0.26 0.26'
-        #       status: active
-        #       status-data: {}
-
-        if is_app:
-            content = typing.cast(Dict[str, Dict[str, str]], content)
-            app_status = content['application-status']
-            return {'status': app_status['status'],
-                    'message': app_status['message']}
-        else:
-            return typing.cast('_StatusDict', content)
+        try:
+            return hook_tools.status_get(is_app=is_app)
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def status_set(self, status: str, message: str = '', *, is_app: bool = False) -> None:
         """Set a status of a unit or an application.
@@ -2884,17 +2751,21 @@ class _ModelBackend:
             is_app: A boolean indicating whether the status should be set for a unit or an
                     application.
         """
-        if not isinstance(is_app, bool):
-            raise TypeError('is_app parameter must be boolean')
-        self._run('status-set', f'--application={is_app}', status, message)
+        try:
+            hook_tools.status_set(status, message, is_app=is_app)
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def storage_list(self, name: str) -> List[int]:
-        storages = self._run('storage-list', name, return_output=True, use_json=True)
-        storages = typing.cast(List[str], storages)
-        return [int(s.split('/')[1]) for s in storages]
+        try:
+            return hook_tools.storage_list(name)
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def _storage_event_details(self) -> Tuple[int, str]:
-        output = self._run('storage-get', '--help', return_output=True)
+        # TODO why do we have `--help` here?
+        #  Doesn't make sense from the output of `juju exec ... storage-get`.
+        output = hook_tools._run('storage-get', '--help', return_output=True)
         output = typing.cast(str, output)
         # Match the entire string at once instead of going line by line
         match = self._STORAGE_KEY_RE.match(output)
@@ -2907,36 +2778,46 @@ class _ModelBackend:
         return index, location
 
     def storage_get(self, storage_name_id: str, attribute: str) -> str:
-        if not len(attribute) > 0:  # assume it's an empty string.
-            raise RuntimeError('calling storage_get with `attribute=""` will return a dict '
-                               'and not a string. This usage is not supported.')
-        out = self._run('storage-get', '-s', storage_name_id, attribute,
-                        return_output=True, use_json=True)
-        return typing.cast(str, out)
+        try:
+            return hook_tools.storage_get(storage_name_id, attribute)
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def storage_add(self, name: str, count: int = 1) -> None:
-        if not isinstance(count, int) or isinstance(count, bool):
-            raise TypeError(f'storage count must be integer, got: {count} ({type(count)})')
-        self._run('storage-add', f'{name}={count}')
+        try:
+            hook_tools.storage_add(name, count)
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def action_get(self) -> Dict[str, Any]:
-        out = self._run('action-get', return_output=True, use_json=True)
-        return typing.cast(Dict[str, Any], out)
+        try:
+            return hook_tools.action_get()
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def action_set(self, results: Dict[str, Any]) -> None:
-        # The Juju action-set hook tool cannot interpret nested dicts, so we use a helper to
-        # flatten out any nested dict structures into a dotted notation, and validate keys.
-        flat_results = _format_action_result_dict(results)
-        self._run('action-set', *[f"{k}={v}" for k, v in flat_results.items()])
+        try:
+            hook_tools.action_set(results)
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def action_log(self, message: str) -> None:
-        self._run('action-log', message)
+        try:
+            hook_tools.action_log(message)
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def action_fail(self, message: str = '') -> None:
-        self._run('action-fail', message)
+        try:
+            hook_tools.action_fail(message)
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def application_version_set(self, version: str) -> None:
-        self._run('application-version-set', '--', version)
+        try:
+            hook_tools.application_version_set(version)
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     @classmethod
     def log_split(cls, message: str, max_len: int = MAX_LOG_LINE_LEN
@@ -2956,7 +2837,10 @@ class _ModelBackend:
     def juju_log(self, level: str, message: str) -> None:
         """Pass a log message on to the juju logger."""
         for line in self.log_split(message):
-            self._run('juju-log', '--log-level', level, "--", line)
+            try:
+                hook_tools.juju_log(level, line)
+            except hook_tools.HookError as e:
+                raise ModelError from e
 
     def network_get(self, binding_name: str, relation_id: Optional[int] = None) -> '_NetworkDict':
         """Return network info provided by network-get for a given binding.
@@ -2965,35 +2849,19 @@ class _ModelBackend:
             binding_name: A name of a binding (relation name or extra-binding name).
             relation_id: An optional relation id to get network info for.
         """
-        cmd = ['network-get', binding_name]
-        if relation_id is not None:
-            cmd.extend(['-r', str(relation_id)])
         try:
-            network = self._run(*cmd, return_output=True, use_json=True)
-            return typing.cast('_NetworkDict', network)
-        except ModelError as e:
+            return hook_tools.network_get(binding_name, relation_id)
+        except hook_tools.HookError as e:
             if self._is_relation_not_found(e):
-                raise RelationNotFoundError() from e
-            raise
+                raise RelationNotFoundError() from ModelError(e)
+            raise ModelError from e
 
     def add_metrics(self, metrics: Mapping[str, Union[int, float]],
                     labels: Optional[Mapping[str, str]] = None) -> None:
-        cmd: List[str] = ['add-metric']
-        if labels:
-            label_args: List[str] = []
-            for k, v in labels.items():
-                _ModelBackendValidator.validate_metric_label(k)
-                _ModelBackendValidator.validate_label_value(k, v)
-                label_args.append(f'{k}={v}')
-            cmd.extend(['--labels', ','.join(label_args)])
-
-        metric_args: List[str] = []
-        for k, v in metrics.items():
-            _ModelBackendValidator.validate_metric_key(k)
-            metric_value = _ModelBackendValidator.format_metric_value(v)
-            metric_args.append(f'{k}={metric_value}')
-        cmd.extend(metric_args)
-        self._run(*cmd)
+        try:
+            hook_tools.add_metrics(metrics, labels)
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def get_pebble(self, socket_path: str) -> pebble.Client:
         """Create a pebble.Client instance from given socket path."""
@@ -3009,8 +2877,10 @@ class _ModelBackend:
         # The goal-state tool will return the information that we need. Goal state as a general
         # concept is being deprecated, however, in favor of approaches such as the one that we use
         # here.
-        app_state = self._run('goal-state', return_output=True, use_json=True)
-        app_state = typing.cast(Dict[str, Dict[str, Any]], app_state)
+        try:
+            app_state = hook_tools.goal_state()
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
         # Planned units can be zero. We don't need to do error checking here.
         # But we need to filter out dying units as they may be reported before being deleted
@@ -3020,52 +2890,42 @@ class _ModelBackend:
 
     def update_relation_data(self, relation_id: int, _entity: Union['Unit', 'Application'],
                              key: str, value: str):
-        self.relation_set(relation_id, key, value, isinstance(_entity, Application))
+        try:
+            self.relation_set(relation_id, key, value, isinstance(_entity, Application))
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def secret_get(self, *,
                    id: Optional[str] = None,
                    label: Optional[str] = None,
                    refresh: bool = False,
                    peek: bool = False) -> Dict[str, str]:
-        args: List[str] = []
-        if id is not None:
-            args.append(id)
-        if label is not None:
-            args.extend(['--label', label])
-        if refresh:
-            args.append('--refresh')
-        if peek:
-            args.append('--peek')
-        # IMPORTANT: Don't call shared _run_for_secret method here; we want to
-        # be extra sensitive inside secret_get to ensure we never
-        # accidentally log or output secrets, even if _run_for_secret changes.
         try:
-            result = self._run('secret-get', *args, return_output=True, use_json=True)
-        except ModelError as e:
+            return hook_tools.secret_get(id=id, label=label, refresh=refresh, peek=peek)
+        except hook_tools.HookError as e:
             if 'not found' in str(e):
-                raise SecretNotFoundError() from e
-            raise
-        return typing.cast(Dict[str, str], result)
+                raise SecretNotFoundError() from ModelError(e)
+            raise ModelError from e
 
     def _run_for_secret(self, *args: str, return_output: bool = False,
                         use_json: bool = False) -> Union[str, Any, None]:
         try:
-            return self._run(*args, return_output=return_output, use_json=use_json)
-        except ModelError as e:
+            return hook_tools._run(*args, return_output=return_output, use_json=use_json)
+        except hook_tools.HookError as e:
             if 'not found' in str(e):
                 raise SecretNotFoundError() from e
-            raise
+            raise ModelError from e
 
     def secret_info_get(self, *,
                         id: Optional[str] = None,
                         label: Optional[str] = None) -> SecretInfo:
-        args: List[str] = []
-        if id is not None:
-            args.append(id)
-        elif label is not None:  # elif because Juju secret-info-get doesn't allow id and label
-            args.extend(['--label', label])
-        result = self._run_for_secret('secret-info-get', *args, return_output=True, use_json=True)
-        info_dicts = typing.cast(Dict[str, Any], result)
+        try:
+            info_dicts = hook_tools.secret_info_get(id=id, label=label)
+        except hook_tools.HookError as e:
+            if 'not found' in str(e):
+                raise SecretNotFoundError() from ModelError(e)
+            raise ModelError from e
+
         id = list(info_dicts)[0]  # Juju returns dict of {secret_id: {info}}
         return SecretInfo.from_dict(id, typing.cast(Dict[str, Any], info_dicts[id]))
 
@@ -3075,20 +2935,18 @@ class _ModelBackend:
                    description: Optional[str] = None,
                    expire: Optional[datetime.datetime] = None,
                    rotate: Optional[SecretRotate] = None):
-        args = [id]
-        if label is not None:
-            args.extend(['--label', label])
-        if description is not None:
-            args.extend(['--description', description])
-        if expire is not None:
-            args.extend(['--expire', expire.isoformat()])
-        if rotate is not None:
-            args += ['--rotate', rotate.value]
-        if content is not None:
-            # The content has already been validated with Secret._validate_content
-            for k, v in content.items():
-                args.append(f'{k}={v}')
-        self._run_for_secret('secret-set', *args)
+        try:
+            hook_tools.secret_set(
+                id,
+                content=content,
+                label=label,
+                description=description,
+                expire=expire,
+                rotate=rotate.value if rotate else None)
+        except hook_tools.HookError as e:
+            if 'not found' in str(e):
+                raise SecretNotFoundError() from ModelError(e)
+            raise ModelError from e
 
     def secret_add(self, content: Dict[str, str], *,
                    label: Optional[str] = None,
@@ -3096,65 +2954,61 @@ class _ModelBackend:
                    expire: Optional[datetime.datetime] = None,
                    rotate: Optional[SecretRotate] = None,
                    owner: Optional[str] = None) -> str:
-        args: List[str] = []
-        if label is not None:
-            args.extend(['--label', label])
-        if description is not None:
-            args.extend(['--description', description])
-        if expire is not None:
-            args.extend(['--expire', expire.isoformat()])
-        if rotate is not None:
-            args += ['--rotate', rotate.value]
-        if owner is not None:
-            args += ['--owner', owner]
-        # The content has already been validated with Secret._validate_content
-        for k, v in content.items():
-            args.append(f'{k}={v}')
-        result = self._run('secret-add', *args, return_output=True)
-        secret_id = typing.cast(str, result)
-        return secret_id.strip()
+        try:
+            return hook_tools.secret_add(
+                content,
+                label=label,
+                description=description,
+                expire=expire,
+                rotate=rotate.value if rotate else None,
+                owner=owner)
+        except hook_tools.HookError as e:
+            if 'not found' in str(e):
+                raise SecretNotFoundError() from ModelError(e)
+            raise ModelError from e
 
     def secret_grant(self, id: str, relation_id: int, *, unit: Optional[str] = None):
-        args = [id, '--relation', str(relation_id)]
-        if unit is not None:
-            args += ['--unit', str(unit)]
-        self._run_for_secret('secret-grant', *args)
+        try:
+            hook_tools.secret_grant(id, relation_id, unit=unit)
+        except hook_tools.HookError as e:
+            if 'not found' in str(e):
+                raise SecretNotFoundError() from ModelError(e)
+            raise ModelError from e
 
     def secret_revoke(self, id: str, relation_id: int, *, unit: Optional[str] = None):
-        args = [id, '--relation', str(relation_id)]
-        if unit is not None:
-            args += ['--unit', str(unit)]
-        self._run_for_secret('secret-revoke', *args)
+        try:
+            hook_tools.secret_revoke(id, relation_id, unit=unit)
+        except hook_tools.HookError as e:
+            if 'not found' in str(e):
+                raise SecretNotFoundError() from ModelError(e)
+            raise ModelError from e
 
     def secret_remove(self, id: str, *, revision: Optional[int] = None):
-        args = [id]
-        if revision is not None:
-            args.extend(['--revision', str(revision)])
-        self._run_for_secret('secret-remove', *args)
+        try:
+            hook_tools.secret_remove(id, revision=revision)
+        except hook_tools.HookError as e:
+            if 'not found' in str(e):
+                raise SecretNotFoundError() from ModelError(e)
+            raise ModelError from e
 
     def open_port(self, protocol: str, port: Optional[int] = None):
-        arg = f'{port}/{protocol}' if port is not None else protocol
-        self._run('open-port', arg)
+        try:
+            hook_tools.open_port(protocol, port)
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def close_port(self, protocol: str, port: Optional[int] = None):
-        arg = f'{port}/{protocol}' if port is not None else protocol
-        self._run('close-port', arg)
+        try:
+            hook_tools.close_port(protocol, port)
+        except hook_tools.HookError as e:
+            raise ModelError from e
 
     def opened_ports(self) -> Set[OpenedPort]:
-        # We could use "opened-ports --format=json", but it's not really
-        # structured; it's just an array of strings which are the lines of the
-        # text output, like ["icmp","8081/udp"]. So it's probably just as
-        # likely to change as the text output, and doesn't seem any better.
-        output = typing.cast(str, self._run('opened-ports', return_output=True))
-        ports: Set[OpenedPort] = set()
-        for line in output.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            port = self._parse_opened_port(line)
-            if port is not None:
-                ports.add(port)
-        return ports
+        try:
+            output = hook_tools.opened_ports()
+        except hook_tools.HookError as e:
+            raise ModelError from e
+        return {port for port in map(self._parse_opened_port, output) if port is not None}
 
     @classmethod
     def _parse_opened_port(cls, port_str: str) -> Optional[OpenedPort]:
@@ -3169,45 +3023,3 @@ class _ModelBackend:
             logger.warning('Ignoring opened-ports port range: %s', port_str)
         protocol_lit = typing.cast(typing.Literal['tcp', 'udp'], protocol)
         return OpenedPort(protocol_lit, int(port))
-
-
-class _ModelBackendValidator:
-    """Provides facilities for validating inputs and formatting them for model backends."""
-
-    METRIC_KEY_REGEX = re.compile(r'^[a-zA-Z](?:[a-zA-Z0-9-_]*[a-zA-Z0-9])?$')
-
-    @classmethod
-    def validate_metric_key(cls, key: str):
-        if cls.METRIC_KEY_REGEX.match(key) is None:
-            raise ModelError(
-                f'invalid metric key {key!r}: must match {cls.METRIC_KEY_REGEX.pattern}')
-
-    @classmethod
-    def validate_metric_label(cls, label_name: str):
-        if cls.METRIC_KEY_REGEX.match(label_name) is None:
-            raise ModelError(
-                'invalid metric label name {!r}: must match {}'.format(
-                    label_name, cls.METRIC_KEY_REGEX.pattern))
-
-    @classmethod
-    def format_metric_value(cls, value: Union[int, float]):
-        if not isinstance(value, (int, float)):  # pyright: ignore[reportUnnecessaryIsInstance]
-            raise ModelError('invalid metric value {!r} provided:'
-                             ' must be a positive finite float'.format(value))
-
-        if math.isnan(value) or math.isinf(value) or value < 0:
-            raise ModelError('invalid metric value {!r} provided:'
-                             ' must be a positive finite float'.format(value))
-        return str(value)
-
-    @classmethod
-    def validate_label_value(cls, label: str, value: str):
-        # Label values cannot be empty, contain commas or equal signs as those are
-        # used by add-metric as separators.
-        if not value:
-            raise ModelError(
-                f'metric label {label} has an empty value, which is not allowed')
-        v = str(value)
-        if re.search('[,=]', v) is not None:
-            raise ModelError(
-                f'metric label values must not contain "," or "=": {label}={value!r}')


### PR DESCRIPTION
In essence, hook tools are independent of ops.
This PR improves separation between the model and the hook tools.

This gains us:
- Clearer separation of the stack's components.
- More freedom in growing the hook tools API without bloating core model code.
