### PR TITLE
Add kill-delay to pebble ServiceDict type

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -85,6 +85,7 @@ ServiceDict = typing.TypedDict('ServiceDict',
                                 'backoff-delay': str,
                                 'backoff-factor': Optional[int],
                                 'backoff-limit': str,
+                                'kill-delay': Optional[str],
                                 },
                                total=False)
 
@@ -806,6 +807,7 @@ class Service:
         self.backoff_delay = dct.get('backoff-delay', '')
         self.backoff_factor = dct.get('backoff-factor')
         self.backoff_limit = dct.get('backoff-limit', '')
+        self.kill_delay = dct.get('kill-delay', '')
 
     def to_dict(self) -> 'ServiceDict':
         """Convert this service object to its dict representation."""
@@ -829,6 +831,7 @@ class Service:
             ('backoff-delay', self.backoff_delay),
             ('backoff-factor', self.backoff_factor),
             ('backoff-limit', self.backoff_limit),
+            ('kill-delay', self.kill_delay),
         ]
         dct = {name: value for name, value in fields if value}
         return typing.cast('ServiceDict', dct)

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -687,6 +687,7 @@ class TestService(unittest.TestCase):
         self.assertEqual(service.backoff_delay, '')
         self.assertIs(service.backoff_factor, None)
         self.assertEqual(service.backoff_limit, '')
+        self.assertIs(service.kill_delay, '')
         self.assertEqual(service.to_dict(), {})
 
     def test_name_only(self):
@@ -717,6 +718,7 @@ class TestService(unittest.TestCase):
             'backoff-delay': '1s',
             'backoff-factor': 4,
             'backoff-limit': '10s',
+            'kill-delay': '420s',
         }
         s = pebble.Service('Name 2', d)
         self.assertEqual(s.name, 'Name 2')
@@ -738,6 +740,7 @@ class TestService(unittest.TestCase):
         self.assertEqual(s.backoff_delay, '1s')
         self.assertEqual(s.backoff_factor, 4)
         self.assertEqual(s.backoff_limit, '10s')
+        self.assertEqual(s.kill_delay, '420s')
 
         self.assertEqual(s.to_dict(), d)
 


### PR DESCRIPTION
Pebble [merged/released](https://github.com/canonical/pebble/pull/190/files) `kill-delay` support, but ops did not yet picked that up.

This PR adds it.

Closes #974 