### PR TITLE
Fix type of StatusBase.name

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1548,8 +1548,8 @@ class StatusBase:
 
     _statuses: Dict[str, Type['StatusBase']] = {}
 
-    # Subclasses should override this attribute and make it a string.
-    name = NotImplemented
+    # Subclasses should override this attribute
+    name = ''
 
     def __init__(self, message: str = ''):
         if self.__class__ is StatusBase:


### PR DESCRIPTION
This also fixes the type of a subclass's .name attribute, such as BlockedStatus.name, so that a "# type: ignore" comment is not required in such things as "status_str == BlockedStatus.name".

See https://github.com/canonical/github-runner-operator/pull/79#discussion_r1274376165

Please describe the *why* and the *how* of your change here.
