### PR TITLE
effectively disable type checking on ObjectEvent namespace

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -489,6 +489,13 @@ class ObjectEvents(Object):
         event_kinds = ', '.join(sorted(self._event_kinds()))
         return f'<{k.__module__}.{k.__qualname__}: {event_kinds}>'
 
+    def __getattr__(self, name: str):
+        """This tells type checkers to suspend judgement on this type's attributes.
+
+        This allows charms to freely write `self.on.foobar_baz` without mypy/pyright whining.
+        """
+        return super().__getattribute__(name)
+
 
 class PrefixedEvents:
     """Events to be found in all events using a specific prefix."""

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -489,10 +489,11 @@ class ObjectEvents(Object):
         event_kinds = ', '.join(sorted(self._event_kinds()))
         return f'<{k.__module__}.{k.__qualname__}: {event_kinds}>'
 
-    def __getattr__(self, name: str):
-        """This tells type checkers to suspend judgement on this type's attributes.
+    def __getattr__(self, name: str) -> Any:
+        """The existence of this method tells type checkers to allow dynamic attributes.
 
-        This allows charms to freely write `self.on.foobar_baz` without mypy/pyright whining.
+        This allows charms to access dynamically-defined events such as
+        ``self.on.db_relation_joined`` without Mypy/Pyright whining.
         """
         return super().__getattribute__(name)
 


### PR DESCRIPTION
Fixes #981

This PR tells type checkers to make no assumptions about the names that will be found in ObjectEvents.

- pros: type checkers will no longer complain on `self.on.dynamically_defined_name_action`
- cons: type checkers will no longer give type hints for events names that we do know to exist in subclasses, e.g. `start, stop, install`...