### PR TITLE
Ignore push() encoding if source is a binary file or stream

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -19,6 +19,7 @@ import dataclasses
 import datetime
 import fnmatch
 import inspect
+import io
 import ipaddress
 import os
 import pathlib
@@ -2592,7 +2593,11 @@ class _TestingPebbleClient:
             elif isinstance(source, bytes):
                 file_path.write_bytes(source)
             else:
-                with file_path.open('wb' if encoding is None else 'w', encoding=encoding) as f:
+                # If source is binary, open file in binary mode and ignore encoding param
+                is_binary = isinstance(source, (io.RawIOBase, io.BufferedIOBase))
+                open_mode = 'wb' if is_binary else 'w'
+                open_encoding = None if is_binary else encoding
+                with file_path.open(open_mode, encoding=open_encoding) as f:
                     shutil.copyfileobj(cast(IOBase, source), cast(IOBase, f))
             os.chmod(file_path, permissions)
         except FileNotFoundError as e:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2594,7 +2594,7 @@ class _TestingPebbleClient:
                 file_path.write_bytes(source)
             else:
                 # If source is binary, open file in binary mode and ignore encoding param
-                is_binary = isinstance(source, (io.RawIOBase, io.BufferedIOBase))
+                is_binary = isinstance(source.read(0), bytes)
                 open_mode = 'wb' if is_binary else 'w'
                 open_encoding = None if is_binary else encoding
                 with file_path.open(open_mode, encoding=open_encoding) as f:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -19,7 +19,6 @@ import dataclasses
 import datetime
 import fnmatch
 import inspect
-import io
 import ipaddress
 import os
 import pathlib

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3998,6 +3998,22 @@ class _PebbleStorageAPIsTestMixin:
             received_data = infile.read()
         self.assertEqual(original_data, received_data)
 
+    def test_push_bytes_ignore_encoding(self):
+        # push() encoding param should be ignored if source is bytes
+        client = self.client
+        client.push(f"{self.prefix}/test", b'\x00\x01', encoding='utf-8')
+        with client.pull(f"{self.prefix}/test", encoding=None) as infile:
+            received_data = infile.read()
+        self.assertEqual(received_data, b'\x00\x01')
+
+    def test_push_bytesio_ignore_encoding(self):
+        # push() encoding param should be ignored if source is binary stream
+        client = self.client
+        client.push(f"{self.prefix}/test", io.BytesIO(b'\x00\x01'), encoding='utf-8')
+        with client.pull(f"{self.prefix}/test", encoding=None) as infile:
+            received_data = infile.read()
+        self.assertEqual(received_data, b'\x00\x01')
+
     def test_push_and_pull_larger_file(self):
         # Intent: to ensure things work appropriately with larger files.
         # Larger files may be sent/received in multiple chunks; this should help for


### PR DESCRIPTION
The [push() docs](https://ops.readthedocs.io/en/latest/#ops.Container.push) explicitly say that the "encoding" param is ignored if the source is bytes or a binary stream. This is useful because the default is encoding='utf-8'; but we should already know the source stream is binary, so let that override the default.

Also add a test that "encoding" is ignored in these cases.

Fixes #990
