### PR TITLE
Simplify Harness.add_relation by adding app_data and unit_data args

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,15 @@ a full deployment. Our [API documentation](https://ops.readthedocs.io/en/latest/
 has the details, including this example:
 
 ```python
+# Initial setup
 harness = Harness(MyCharm)
-# Do initial setup here
-relation_id = harness.add_relation('db', 'postgresql')
+self.addCleanup(harness.cleanup)  # always clean up after ourselves
+
 # Now instantiate the charm to see events as the model changes
 harness.begin()
-harness.add_relation_unit(relation_id, 'postgresql/0')
-harness.update_relation_data(relation_id, 'postgresql/0', {'key': 'val'})
-# Check that charm has properly handled the relation_joined event for postgresql/0
+harness.add_relation('db', 'postgresql', unit_data={'key': 'val'})
+
+# Check that charm has properly handled relation_joined or relation_changed
 self.assertEqual(harness.charm. ...)
 ```
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -108,6 +108,38 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(backend.relation_get(rel_id, 'test-app', is_app=True), {})
         self.assertEqual(backend.relation_get(rel_id, 'test-app/0', is_app=False), {})
 
+    def test_add_relation_with_app_data(self):
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            ''')
+        self.addCleanup(harness.cleanup)
+        rel_id = harness.add_relation('db', 'postgresql', app_data={'x': '1', 'y': '2'})
+        self.assertIsInstance(rel_id, int)
+        backend = harness._backend
+        self.assertEqual(backend.relation_ids('db'), [rel_id])
+        self.assertEqual(backend.relation_list(rel_id), ['postgresql/0'])
+        self.assertEqual(harness.get_relation_data(rel_id, 'postgresql'), {'x': '1', 'y': '2'})
+        self.assertEqual(harness.get_relation_data(rel_id, 'postgresql/0'), {})
+
+    def test_add_relation_with_unit_data(self):
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
+            name: test-app
+            requires:
+                db:
+                    interface: pgsql
+            ''')
+        self.addCleanup(harness.cleanup)
+        rel_id = harness.add_relation('db', 'postgresql', unit_data={'a': '1', 'b': '2'})
+        self.assertIsInstance(rel_id, int)
+        backend = harness._backend
+        self.assertEqual(backend.relation_ids('db'), [rel_id])
+        self.assertEqual(backend.relation_list(rel_id), ['postgresql/0'])
+        self.assertEqual(harness.get_relation_data(rel_id, 'postgresql'), {})
+        self.assertEqual(harness.get_relation_data(rel_id, 'postgresql/0'), {'a': '1', 'b': '2'})
+
     def test_can_connect_default(self):
         harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: test-app


### PR DESCRIPTION
When using testing.Harness, it's very common to see these two or three calls in a row: add relation, (often) add relation unit, and (often) update relation data. This addition simplifies those patterns down to just a single call, and without the need for the relation_id return value in most cases.

See additional justification and discussion at #992.

Fixes #992
