### PR TITLE
Remove the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,0 @@
-Please describe the *why* and the *how* of your change here.


### PR DESCRIPTION
It just gets in the way. You have to manually select and delete it from the PR description -- and that's easy to miss when you have a single commit and GitHub puts this text at the bottom of the nice commit message.

More trouble than it's worth -- just delete it. You can be sure I'll ask the PR creator if it needs a better description. :-)
