### PR TITLE
Raise error in wait_output if stdout is already being consumed

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1338,6 +1338,11 @@ class ExecProcess(Generic[AnyStr]):
             out = io.BytesIO()
             err = io.BytesIO() if self.stderr is not None else None
 
+        if self.stdout is None:
+            raise TypeError(
+                "stdout is already being consumed by another object provided to the exec function"
+            )
+
         t = _start_thread(shutil.copyfileobj, self.stdout, out)
         self._threads.append(t)
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1331,17 +1331,18 @@ class ExecProcess(Generic[AnyStr]):
             ChangeError: if there was an error starting or running the process.
             ExecError: if the process exits with a non-zero exit code.
         """
+        if self.stdout is None:
+            raise TypeError(
+                "can't use wait_output() when exec was called with the stdout argument; "
+                "use wait() instead"
+            )
+
         if self._encoding is not None:
             out = io.StringIO()
             err = io.StringIO() if self.stderr is not None else None
         else:
             out = io.BytesIO()
             err = io.BytesIO() if self.stderr is not None else None
-
-        if self.stdout is None:
-            raise TypeError(
-                "stdout is already being consumed by another object provided to the exec function"
-            )
 
         t = _start_thread(shutil.copyfileobj, self.stdout, out)
         self._threads.append(t)

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -2925,6 +2925,15 @@ class TestExec(unittest.TestCase):
             ('TXT', '{"command":"end"}'),
         ])
 
+    def test_wait_output_no_stdout(self):
+        stdio, stderr, _ = self.add_responses('123', 0)
+        stdio.receives.append('{"command":"end"}')
+        stderr.receives.append('{"command":"end"}')
+        stdout_buffer = io.BytesIO()
+        process = self.client.exec(["echo", "FOOBAR"], stdout=stdout_buffer, encoding=None)
+        with self.assertRaises(TypeError):
+            process.wait_output()
+
     def test_wait_output_bad_command(self):
         stdio, stderr, _ = self.add_responses('123', 0)
         stdio.receives.append(b'Python 3.8.10\n')


### PR DESCRIPTION
When the `stdout` argument is provided to `ops.Container.exec` for capturing the stdout stream, the `ExecProcess` will have a `stdout` attribute of `None`. To prevent potential null safety issues, an error is now raised in such cases within `wait_output`.