### PR TITLE
fix(model): make Secret.set_content invalidate local cache

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1225,6 +1225,7 @@ class Secret:
         if self._id is None:
             self._id = self.get_info().id
         self._backend.secret_set(typing.cast(str, self.id), content=content)
+        self._content = None  # invalidate cache so it's refetched next get_content()
 
     def set_info(self, *,
                  label: Optional[str] = None,


### PR DESCRIPTION
This is so that if get_content() is called after, it fetches and returns the expected new content. We could also set self._content to the new content, but re-fetching it from Juju seems better.