### PR TITLE
ci: reinstate prometheus-k8s-operator tests as it's been fixed

### DIFF
--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -11,8 +11,7 @@ jobs:
       matrix:
         charm-repo:
           - "canonical/alertmanager-k8s-operator"
-# TODO: currently failing
-#          - "canonical/prometheus-k8s-operator"
+          - "canonical/prometheus-k8s-operator"
           - "canonical/grafana-k8s-operator"
 
     steps:


### PR DESCRIPTION
I believe this was the fix on their side: https://github.com/canonical/prometheus-k8s-operator/pull/513