### PR TITLE
ci: use Go 1.20 for real Pebble tests

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -67,10 +67,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set up Go 1.17
+      - name: Set up Go 1.20
         uses: actions/setup-go@v1
         with:
-          go-version: "1.17"
+          go-version: "1.20"
 
       - name: Install tox
         run: pip install tox


### PR DESCRIPTION
Pebble uses Go as of canonical/pebble#/171, so we need to adjust the ops CI to also do so for the real Pebble tests.