### PR TITLE
docs: reduce the amount of detail in the open/close port methods

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -600,7 +600,7 @@ class Unit:
         Some behaviour, such as whether the port is opened externally without
         using "juju expose" and whether the opened ports are per-unit, differs
         between Kubernetes and machine charms. See the
-        `Juju documentation <https://juju.is/docs/sdk/hook-tool#heading--open-port>`_
+        `Juju documentation <https://juju.is/docs/sdk/hook-tool#heading--open-port>`__
         for more detail.
 
         Args:
@@ -619,7 +619,7 @@ class Unit:
         Some behaviour, such as whether the port is closed externally without
         using "juju unexpose", differs between Kubernetes and machine charms.
         See the
-        `Juju documentation <https://juju.is/docs/sdk/hook-tool#heading--close-port>`_
+        `Juju documentation <https://juju.is/docs/sdk/hook-tool#heading--close-port>`__
         for more detail.
 
         Args:

--- a/ops/model.py
+++ b/ops/model.py
@@ -597,7 +597,7 @@ class Unit:
                   port: Optional[int] = None):
         """Open a port with the given protocol for this unit.
 
-        Some behaviour, such as whether the post is opened externally without
+        Some behaviour, such as whether the port is opened externally without
         using "juju expose" and whether the opened ports are per-unit, differs
         between Kubernetes and machine charms. See the
         `Juju documentation <https://juju.is/docs/sdk/hook-tool#heading--open-port>`_

--- a/ops/model.py
+++ b/ops/model.py
@@ -597,14 +597,11 @@ class Unit:
                   port: Optional[int] = None):
         """Open a port with the given protocol for this unit.
 
-        Calling this registers intent with Juju that the application should be
-        accessed on the given port, but the port isn't actually opened
-        externally until the admin runs "juju expose".
-
-        On Kubernetes sidecar charms, the ports opened are not strictly
-        per-unit: Juju will open the union of ports from all units.
-        However, normally charms should make the same open_port() call from
-        every unit.
+        Some behaviour, such as whether the post is opened externally without
+        using "juju expose" and whether the opened ports are per-unit, differs
+        between Kubernetes and machine charms. See the
+        `Juju documentation <https://juju.is/docs/sdk/hook-tool#heading--open-port>`_
+        for more detail.
 
         Args:
             protocol: String representing the protocol; must be one of
@@ -619,10 +616,11 @@ class Unit:
                    port: Optional[int] = None):
         """Close a port with the given protocol for this unit.
 
-        On Kubernetes sidecar charms, Juju will only close the port once the
-        last unit that opened that port has closed it. However, this is
-        usually not an issue; normally charms should make the same
-        close_port() call from every unit.
+        Some behaviour, such as whether the post is closed externally without
+        using "juju unexpose", differs between Kubernetes and machine charms.
+        See the
+        `Juju documentation <https://juju.is/docs/sdk/hook-tool#heading--close-port>`_
+        for more detail.
 
         Args:
             protocol: String representing the protocol; must be one of

--- a/ops/model.py
+++ b/ops/model.py
@@ -616,7 +616,7 @@ class Unit:
                    port: Optional[int] = None):
         """Close a port with the given protocol for this unit.
 
-        Some behaviour, such as whether the post is closed externally without
+        Some behaviour, such as whether the port is closed externally without
         using "juju unexpose", differs between Kubernetes and machine charms.
         See the
         `Juju documentation <https://juju.is/docs/sdk/hook-tool#heading--close-port>`_


### PR DESCRIPTION
Simplify the `open_port()` and `close_port()` documentation:

* Link to the Juju documentation ([soon to also be updated](https://chat.charmhub.io/charmhub/pl/heqdxrtrkjyotdn8iikcpegbxh)) to minimise the amount of syncing required
* Note that the behaviour differs between K8s sidecar and machine charms
* Remove the note that `juju expose`/`juju unexpose` is required (true for machine, not true for k8s sidecar)

Fixes #918