### PR TITLE
test: add type hints to the test_infra tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ show_missing = true
 # Formatting tools configuration
 [tool.autopep8]
 max-line-length = 99
-ignore = ["E203", "W503"]
+ignore = ["W503"]
 recursive = true
 jobs = -1
 aggressive = 3
@@ -22,7 +22,7 @@ max-line-length = 99
 max-doc-length = 99
 exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-ignore = ["D105", "D107", "E203", "W503"]
+ignore = ["D105", "D107", "W503"]
 # D100, D101, D102, D103, D104: Ignore missing docstrings in tests
 per-file-ignores = ["test/*:D100,D101,D102,D103,D104"]
 docstring-convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ per-file-ignores = ["test/*:D100,D101,D102,D103,D104"]
 docstring-convention = "google"
 
 [tool.pyright]
-include = ["ops/*.py", "ops/_private/*.py"]
+include = ["ops/*.py", "ops/_private/*.py",
+    "test/test_infra.py",
+]
 pythonVersion = "3.8" # check no python > 3.8 features are used
 pythonPlatform = "All"
 typeCheckingMode = "strict"

--- a/test/test_infra.py
+++ b/test/test_infra.py
@@ -19,19 +19,20 @@ import re
 import subprocess
 import sys
 import tempfile
+import typing
 import unittest
 
 import ops
 
 
-def get_python_filepaths(include_tests=True):
+def get_python_filepaths(include_tests: bool = True):
     """Helper to retrieve paths of Python files."""
     python_paths = ['setup.py']
     roots = ['ops']
     if include_tests:
         roots.append('test')
     for root in roots:
-        for dirpath, dirnames, filenames in os.walk(root):
+        for dirpath, _, filenames in os.walk(root):
             for filename in filenames:
                 if filename.endswith(".py"):
                     python_paths.append(os.path.join(dirpath, filename))
@@ -42,7 +43,7 @@ class InfrastructureTests(unittest.TestCase):
 
     def test_quote_backslashes(self):
         # ensure we're not using unneeded backslash to escape strings
-        issues = []
+        issues : typing.List[typing.Tuple[str, int, str]] = []
         for filepath in get_python_filepaths():
             with open(filepath, "rt", encoding="utf8") as fh:
                 for idx, line in enumerate(fh, 1):
@@ -54,7 +55,7 @@ class InfrastructureTests(unittest.TestCase):
 
     def test_ensure_copyright(self):
         # all non-empty Python files must have a proper copyright somewhere in the first 5 lines
-        issues = []
+        issues : typing.List[str] = []
         regex = re.compile(r"# Copyright \d\d\d\d(-\d\d\d\d)? Canonical Ltd.\n")
         for filepath in get_python_filepaths():
             if os.stat(filepath).st_size == 0:
@@ -69,7 +70,7 @@ class InfrastructureTests(unittest.TestCase):
         if issues:
             self.fail("Please add copyright headers to the following files:\n" + "\n".join(issues))
 
-    def _run_setup(self, *args):
+    def _run_setup(self, *args: str) -> str:
         proc = subprocess.run(
             (sys.executable, 'setup.py') + args,
             stdout=subprocess.PIPE,
@@ -101,7 +102,7 @@ class InfrastructureTests(unittest.TestCase):
 
         # For some reason "setup.py --requires" doesn't work, so do this the hard way
         with open('setup.py', encoding='utf-8') as f:
-            lines = []
+            lines : typing.List[str] = []
             for line in f:
                 if 'install_requires=[' in line:
                     break
@@ -131,7 +132,7 @@ class ImportersTestCase(unittest.TestCase):
             with self.subTest(name=name):
                 self.check(name)
 
-    def check(self, name):
+    def check(self, name : str):
         """Helper function to run the test."""
         fd, testfile = tempfile.mkstemp()
         self.addCleanup(os.unlink, testfile)

--- a/test/test_infra.py
+++ b/test/test_infra.py
@@ -43,7 +43,7 @@ class InfrastructureTests(unittest.TestCase):
 
     def test_quote_backslashes(self):
         # ensure we're not using unneeded backslash to escape strings
-        issues : typing.List[typing.Tuple[str, int, str]] = []
+        issues: typing.List[typing.Tuple[str, int, str]] = []
         for filepath in get_python_filepaths():
             with open(filepath, "rt", encoding="utf8") as fh:
                 for idx, line in enumerate(fh, 1):
@@ -55,7 +55,7 @@ class InfrastructureTests(unittest.TestCase):
 
     def test_ensure_copyright(self):
         # all non-empty Python files must have a proper copyright somewhere in the first 5 lines
-        issues : typing.List[str] = []
+        issues: typing.List[str] = []
         regex = re.compile(r"# Copyright \d\d\d\d(-\d\d\d\d)? Canonical Ltd.\n")
         for filepath in get_python_filepaths():
             if os.stat(filepath).st_size == 0:
@@ -102,7 +102,7 @@ class InfrastructureTests(unittest.TestCase):
 
         # For some reason "setup.py --requires" doesn't work, so do this the hard way
         with open('setup.py', encoding='utf-8') as f:
-            lines : typing.List[str] = []
+            lines: typing.List[str] = []
             for line in f:
                 if 'install_requires=[' in line:
                     break
@@ -132,7 +132,7 @@ class ImportersTestCase(unittest.TestCase):
             with self.subTest(name=name):
                 self.check(name)
 
-    def check(self, name : str):
+    def check(self, name: str):
         """Helper function to run the test."""
         fd, testfile = tempfile.mkstemp()
         self.addCleanup(os.unlink, testfile)


### PR DESCRIPTION
Minor type hinting to make pyright happy:

```
$ env PYTHONPATH=.tox/static/lib/python3.10/site-packages/ .tox/static/bin/pyright test/test_infra.py 
WARNING: there is a new pyright version available (v1.1.317 -> v1.1.327).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`

0 errors, 0 warnings, 0 informations 
```

Also renames an unused variable to `_` to get rid of an IDE warning.

Partial fix for #1007.