### PR TITLE
test: fix type hint warnings in test_private tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ per-file-ignores = ["test/*:D100,D101,D102,D103,D104"]
 docstring-convention = "google"
 
 [tool.pyright]
-include = ["ops/*.py", "ops/_private/*.py"]
+include = ["ops/*.py", "ops/_private/*.py",
+    "test/test_private.py",
+]
 pythonVersion = "3.8" # check no python > 3.8 features are used
 pythonPlatform = "All"
 typeCheckingMode = "strict"

--- a/test/test_private.py
+++ b/test/test_private.py
@@ -90,9 +90,7 @@ class TestStrconv(unittest.TestCase):
             timeconv.parse_rfc3339('2021-99-99T04:36:22Z')
 
         with self.assertRaises(ValueError):
-            timeconv.parse_rfc3339(
-                timeconv.parse_rfc3339('2021-02-10T04:36:22.118970777x'))  # type: ignore
+            timeconv.parse_rfc3339('2021-02-10T04:36:22.118970777x')
 
         with self.assertRaises(ValueError):
-            timeconv.parse_rfc3339(
-                timeconv.parse_rfc3339('2021-02-10T04:36:22.118970777-99:99'))  # type: ignore
+            timeconv.parse_rfc3339('2021-02-10T04:36:22.118970777-99:99')

--- a/test/test_private.py
+++ b/test/test_private.py
@@ -91,8 +91,8 @@ class TestStrconv(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             timeconv.parse_rfc3339(
-                timeconv.parse_rfc3339('2021-02-10T04:36:22.118970777x'))
+                timeconv.parse_rfc3339('2021-02-10T04:36:22.118970777x'))  # type: ignore
 
         with self.assertRaises(ValueError):
             timeconv.parse_rfc3339(
-                timeconv.parse_rfc3339('2021-02-10T04:36:22.118970777-99:99'))
+                timeconv.parse_rfc3339('2021-02-10T04:36:22.118970777-99:99'))  # type: ignore


### PR DESCRIPTION
It looks like there's an accidental double-call in these two tests. They still pass, since the ValueError isn't caught in the second call, but that means that the second call isn't doing anything at all. It would also be weird if the code changed and allowed the values being tested because instead of the test failing in the expected way (the assertRaises failing) it would fail because a TypeError would be raised instead of ValueError.

This also makes pyright happy because we're not (theoretically) passing a datetime.datetime when a string is expected.

test_private is otherwise fine:

```
$ env PYTHONPATH=.tox/static/lib/python3.10/site-packages/ .tox/static/bin/pyright test/test_private.py 
WARNING: there is a new pyright version available (v1.1.317 -> v1.1.327).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`

0 errors, 0 warnings, 0 informations 
```

Partial fix for #1007