### PR TITLE
test: fix type hinting on test_jujuversion tests

### DIFF
--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -71,7 +71,7 @@ class JujuVersion:
             and self.build == other.build
             and self.patch == other.patch)
 
-    def __lt__(self, other: 'JujuVersion') -> bool:
+    def __lt__(self, other: Union[str, 'JujuVersion']) -> bool:
         if self is other:
             return False
         if isinstance(other, str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ per-file-ignores = ["test/*:D100,D101,D102,D103,D104"]
 docstring-convention = "google"
 
 [tool.pyright]
-include = ["ops/*.py", "ops/_private/*.py"]
+include = ["ops/*.py", "ops/_private/*.py",
+    "test/test_jujuversion.py",
+]
 pythonVersion = "3.8" # check no python > 3.8 features are used
 pythonPlatform = "All"
 typeCheckingMode = "strict"

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -41,7 +41,7 @@ class TestJujuVersion(unittest.TestCase):
             self.assertEqual(v.patch, patch)
             self.assertEqual(v.build, build)
 
-    @unittest.mock.patch('os.environ', new={})
+    @unittest.mock.patch('os.environ', new={})  # type: ignore
     def test_from_environ(self):
         # JUJU_VERSION is not set
         v = ops.JujuVersion.from_environ()


### PR DESCRIPTION
JujuVersion's comparisons can be done against strings as well as other JujuVersions, so the type hints should reflect that.

For mocking the os.environ response, the type is dict(str, str) but I think to declare that we would need to define the dict, e.g:

```
    _mockenv : typing.Dict[str, str] = {}
    @unittest.mock.patch("os.environ", new=_mockenv)
```

And that looks considerably messier to my eyes and doesn't seem to really add value (so I've ignored the warning).

Partially fixes #1007