### PR TITLE
test: add type hinting to test_lib

### DIFF
--- a/ops/lib/__init__.py
+++ b/ops/lib/__init__.py
@@ -23,6 +23,7 @@ import logging
 import os
 import re
 import sys
+import typing
 import warnings
 from ast import literal_eval
 from importlib.machinery import ModuleSpec
@@ -117,7 +118,7 @@ def autoimport():
         versions.sort(reverse=True)
 
 
-def _find_all_specs(path):
+def _find_all_specs(path: typing.Iterable[str]) -> typing.Iterator[ModuleSpec]:
     for sys_dir in path:
         if sys_dir == "":
             sys_dir = "."
@@ -192,7 +193,7 @@ class _Missing:
         return f"got {_join_and(sorted(got))}, but missing {_join_and(sorted(exp - got))}"
 
 
-def _parse_lib(spec):
+def _parse_lib(spec: ModuleSpec) -> typing.Optional["_Lib"]:
     if spec.origin is None:
         # "can't happen"
         logger.warning("No origin for %r (no idea why; please report)", spec.name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ include = ["ops/*.py", "ops/_private/*.py",
     "test/test_infra.py",
     "test/test_jujuversion.py",
     "test/test_log.py",
+    "test/test_lib.py",
 ]
 pythonVersion = "3.8" # check no python > 3.8 features are used
 pythonPlatform = "All"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 isort==5.11.4
-logassert==7
 autopep8==1.6.0
 flake8==4.0.1
 flake8-docstrings==1.6.0

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -1486,9 +1486,16 @@ class BreakpointTests(BaseTestCase):
             os.environ.pop('JUJU_DEBUG_AT', None)
             framework = self.create_framework()
 
-        with self.assertNoLogs(level="WARNING"):
-            with patch('pdb.Pdb.set_trace') as mock:
-                framework.breakpoint()
+        with patch('pdb.Pdb.set_trace') as mock:
+            # We want to verify that there are *no* logs at warning level.
+            # However, assertNoLogs is Python 3.10+.
+            try:
+                with self.assertLogs(level="WARNING"):
+                    framework.breakpoint()
+            except AssertionError:
+                pass
+            else:
+                self.fail("No warning logs should be generated")
         self.assertEqual(mock.call_count, 0)
         self.assertEqual(fake_stderr.getvalue(), "")
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -25,8 +25,6 @@ from pathlib import Path
 from test.test_helpers import BaseTestCase, fake_script
 from unittest.mock import patch
 
-import logassert
-
 import ops
 from ops.framework import _BREAKPOINT_WELCOME_MESSAGE, _event_regex
 from ops.storage import NoSnapshotError, SQLiteStorage
@@ -41,13 +39,14 @@ class TestFramework(BaseTestCase):
         patcher = patch('ops.storage.SQLiteStorage.DB_LOCK_TIMEOUT', datetime.timedelta(0))
         patcher.start()
         self.addCleanup(patcher.stop)
-        logassert.setup(self, 'ops')
 
     def test_deprecated_init(self):
         # For 0.7, this still works, but it is deprecated.
-        framework = ops.Framework(':memory:', None, None, None)
-        self.assertLoggedWarning(
-            "deprecated: Framework now takes a Storage not a path")
+        with self.assertLogs(level="WARNING") as cm:
+            framework = ops.Framework(':memory:', None, None, None)
+        self.assertIn(
+            "WARNING:ops.framework:deprecated: Framework now takes a Storage not a path",
+            cm.output)
         self.assertIsInstance(framework._storage, SQLiteStorage)
 
     def test_handle_path(self):
@@ -356,12 +355,7 @@ class TestFramework(BaseTestCase):
         obs = MyObserver(framework, "1")
 
         framework.observe(pub.foo, obs._on_foo)
-
-        self.assertNotLogged("Deferring")
         pub.foo.emit(1)
-        self.assertLogged("Deferring <MyEvent via MyNotifier[1]/foo[1]>.")
-        self.assertNotLogged("Re-emitting")
-
         framework.reemit()
 
         # Two things being checked here:
@@ -375,7 +369,6 @@ class TestFramework(BaseTestCase):
         #    we'd get a foo=3).
         #
         self.assertEqual(obs.seen, ["on_foo:foo=2", "on_foo:foo=2"])
-        self.assertLoggedDebug("Re-emitting deferred event <MyEvent via MyNotifier[1]/foo[1]>.")
 
     def test_weak_observer(self):
         framework = self.create_framework()
@@ -1487,21 +1480,17 @@ class GenericObserver(ops.Object):
 @patch('sys.stderr', new_callable=io.StringIO)
 class BreakpointTests(BaseTestCase):
 
-    def setUp(self):
-        super().setUp()
-        logassert.setup(self, 'ops')
-
     def test_ignored(self, fake_stderr):
         # It doesn't do anything really unless proper environment is there.
         with patch.dict(os.environ):
             os.environ.pop('JUJU_DEBUG_AT', None)
             framework = self.create_framework()
 
-        with patch('pdb.Pdb.set_trace') as mock:
-            framework.breakpoint()
+        with self.assertNoLogs(level="WARNING"):
+            with patch('pdb.Pdb.set_trace') as mock:
+                framework.breakpoint()
         self.assertEqual(mock.call_count, 0)
         self.assertEqual(fake_stderr.getvalue(), "")
-        self.assertNotLoggedWarning("Breakpoint", "skipped")
 
     def test_pdb_properly_called(self, fake_stderr):
         # The debugger needs to leave the user in the frame where the breakpoint is executed,
@@ -1658,17 +1647,20 @@ class BreakpointTests(BaseTestCase):
 
     def test_named_indicated_unnamed(self, fake_stderr):
         # Some breakpoint was indicated, but the framework call was unnamed
-        self.check_trace_set('some-breakpoint', None, 0)
-        self.assertLoggedWarning(
-            "Breakpoint None skipped",
-            "not found in the requested breakpoints: {'some-breakpoint'}")
+        with self.assertLogs(level="WARNING") as cm:
+            self.check_trace_set('some-breakpoint', None, 0)
+        self.assertEqual(cm.output, [
+            "WARNING:ops.framework:Breakpoint None skipped "
+            "(not found in the requested breakpoints: {'some-breakpoint'})"
+        ])
 
     def test_named_indicated_somethingelse(self, fake_stderr):
         # Some breakpoint was indicated, but the framework call was with a different name
-        self.check_trace_set('some-breakpoint', 'other-name', 0)
-        self.assertLoggedWarning(
-            "Breakpoint 'other-name' skipped",
-            "not found in the requested breakpoints: {'some-breakpoint'}")
+        with self.assertLogs(level="WARNING") as cm:
+            self.check_trace_set('some-breakpoint', 'other-name', 0)
+        self.assertEqual(cm.output, [
+            "WARNING:ops.framework:Breakpoint 'other-name' skipped "
+            "(not found in the requested breakpoints: {'some-breakpoint'})"])
 
     def test_named_indicated_ingroup(self, fake_stderr):
         # A multiple breakpoint was indicated, and the framework call used a name among those.

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -27,8 +27,6 @@ import warnings
 from pathlib import Path
 from unittest.mock import patch
 
-import logassert
-
 import ops
 from ops.main import CHARM_STATE_FILE, _should_use_controller_storage
 from ops.storage import SQLiteStorage
@@ -1137,26 +1135,20 @@ class TestMainWithDispatchAsScript(_TestMainWithDispatch, unittest.TestCase):
 
 
 class TestStorageHeuristics(unittest.TestCase):
-    def setUp(self):
-        logassert.setup(self, '')
-
     def test_fallback_to_current_juju_version__too_old(self):
         meta = ops.CharmMeta.from_yaml("series: [kubernetes]")
         with patch.dict(os.environ, {"JUJU_VERSION": "1.0"}):
             self.assertFalse(_should_use_controller_storage(Path("/xyzzy"), meta))
-            self.assertLogged('Using local storage: JUJU_VERSION=1.0.0')
 
     def test_fallback_to_current_juju_version__new_enough(self):
         meta = ops.CharmMeta.from_yaml("series: [kubernetes]")
         with patch.dict(os.environ, {"JUJU_VERSION": "2.8"}):
             self.assertTrue(_should_use_controller_storage(Path("/xyzzy"), meta))
-            self.assertLogged('Using controller storage: JUJU_VERSION=2.8.0')
 
     def test_not_if_not_in_k8s(self):
         meta = ops.CharmMeta.from_yaml("series: [ecs]")
         with patch.dict(os.environ, {"JUJU_VERSION": "2.8"}):
             self.assertFalse(_should_use_controller_storage(Path("/xyzzy"), meta))
-            self.assertLogged('Using local storage: not a Kubernetes podspec charm')
 
     def test_not_if_already_local(self):
         meta = ops.CharmMeta.from_yaml("series: [kubernetes]")


### PR DESCRIPTION
Extends the type hinting for tests:

* Stop testing the debug level log output (this also removes the need for the logassert package)
* Pass a dummy spec object rather than None to avoid type errors
* Ignore type checks when the purpose of the test is to test what happens when bad types are used
* Minor type hinting where required for pyright to be happy

Partially addresses #1007.