### PR TITLE
test: add type hinting to test_testing

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2793,7 +2793,7 @@ class _TestingPebbleClient:
             )
 
     def pull(self, path: str, *,
-             encoding: str = 'utf-8') -> Union[BinaryIO, TextIO]:
+             encoding: Optional[str] = 'utf-8') -> Union[BinaryIO, TextIO]:
         self._check_connection()
         self._check_absolute_path(path)
         file_path = self._root / path[1:]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ include = ["ops/*.py", "ops/_private/*.py",
     "test/test_log.py",
     "test/test_helpers.py",
     "test/test_lib.py",
+    "test/test_testing.py",
 ]
 pythonVersion = "3.8" # check no python > 3.8 features are used
 pythonPlatform = "All"

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -5031,7 +5031,7 @@ class TestHandleExec(unittest.TestCase):
     def test_register_with_result(self):
         self.harness.handle_exec(self.container, ["foo"], result=10)
 
-        with self.assertRaises(pebble.ExecError[str]) as exc:
+        with self.assertRaises(pebble.ExecError) as exc:
             self.container.exec(["foo"]).wait()
         self.assertEqual(exc.exception.exit_code, 10)
 
@@ -5182,13 +5182,12 @@ class TestHandleExec(unittest.TestCase):
             "group-id": 2,
             "environment": {"foo": "bar", "foobar": "barfoo"}
         }
-        layer = ops.pebble.Layer(
-            ops.pebble.LayerDict(
-                summary="",
-                description="",
-                services={
-                    "test": service}))
-        self.container.add_layer(label="test", layer=layer)
+        layer: ops.pebble.LayerDict = {
+            'summary': "",
+            'description': "",
+            'services': {
+                "test": service}}
+        self.container.add_layer(label="test", layer=ops.pebble.Layer(layer))
         args_history: typing.List[ops.testing.ExecArgs] = []
 
         def handler(args: ops.testing.ExecArgs):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -5031,9 +5031,9 @@ class TestHandleExec(unittest.TestCase):
     def test_register_with_result(self):
         self.harness.handle_exec(self.container, ["foo"], result=10)
 
-        with self.assertRaises(pebble.ExecError) as exc:  # type: ignore
+        with self.assertRaises(pebble.ExecError[str]) as exc:
             self.container.exec(["foo"]).wait()
-        self.assertEqual(exc.exception.exit_code, 10)  # type: ignore
+        self.assertEqual(exc.exception.exit_code, 10)
 
         self.harness.handle_exec(self.container, ["foo"], result="hello")
         stdout, stderr = self.container.exec(["foo"]).wait_output()

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -56,8 +56,7 @@ class SetLeaderErrorTester(ops.CharmBase):
 
     def _on_leader_elected(self, event: ops.EventBase):
         peers = self.model.get_relation(self._peer_name)
-        if typing.TYPE_CHECKING:
-            assert peers is not None
+        assert peers is not None
         peers.data[self.app]["foo"] = "bar"
 
 
@@ -500,8 +499,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(backend.relation_list(rel_id), ['postgresql/0'])
         harness.charm.get_changes(reset=True)  # ignore relation created events
         relation = harness.charm.model.get_relation('db')
-        if typing.TYPE_CHECKING:
-            assert relation is not None
+        assert relation is not None
         self.assertEqual(len(relation.units), 1)
         # Check relation data is correct
         rel_unit = harness.charm.model.get_unit('postgresql/0')
@@ -516,8 +514,7 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(backend.relation_list(rel_id), [])
         # Check the unit is actually removed from the relations the model knows about
         rel = harness.charm.model.get_relation('db')
-        if typing.TYPE_CHECKING:
-            assert rel is not None
+        assert rel is not None
         self.assertEqual(len(rel.units), 0)
         self.assertFalse(rel_unit in rel.data)
         # Check relation departed was raised with correct data
@@ -830,8 +827,7 @@ class TestHarness(unittest.TestCase):
         helper = DBRelationChangedHelper(harness.charm, "helper")
         rel_id = harness.add_relation('db', 'postgresql')
         rel = harness.charm.model.get_relation('db')
-        if typing.TYPE_CHECKING:
-            assert rel is not None
+        assert rel is not None
         rel.data[harness.charm.model.unit]['key'] = 'value'
         # there should be no event for updating our own data
         harness.update_relation_data(rel_id, 'my-charm/0', {'new': 'other'})
@@ -858,12 +854,10 @@ class TestHarness(unittest.TestCase):
         rel_id = harness.add_relation('db', 'postgresql')
 
         rel = harness.charm.model.get_relation('db')
-        if typing.TYPE_CHECKING:
-            assert rel is not None
+        assert rel is not None
         rel.data[harness.charm.model.unit]['key'] = 'value'
         rel = harness.charm.model.get_relation('db')
-        if typing.TYPE_CHECKING:
-            assert rel is not None
+        assert rel is not None
         harness.update_relation_data(rel_id, 'postgresql/0', {'key': 'v1'})
         self.assertEqual({'key': 'v1'}, rel.data[harness.charm.model.unit])
         # Make sure there was no event
@@ -914,8 +908,7 @@ class TestHarness(unittest.TestCase):
         helper = DBRelationChangedHelper(harness.charm, "helper")
         rel_id = harness.add_relation('db', 'postgresql')
         rel = harness.charm.model.get_relation('db')
-        if typing.TYPE_CHECKING:
-            assert rel is not None
+        assert rel is not None
         rel.data[harness.charm.app]['key'] = 'value'
         harness.update_relation_data(rel_id, 'postgresql', {'key': 'v1'})
         self.assertEqual({'key': 'v1'}, rel.data[harness.charm.app])
@@ -952,8 +945,7 @@ class TestHarness(unittest.TestCase):
 
         harness.update_relation_data(rel_id, 'my-charm', {'new': 'value'})
         rel = harness.charm.model.get_relation('db')
-        if typing.TYPE_CHECKING:
-            assert rel is not None
+        assert rel is not None
         self.assertEqual(rel.data[harness.charm.app]['new'], 'value')
 
         # Our app data bag got updated.
@@ -1192,8 +1184,7 @@ class TestHarness(unittest.TestCase):
         rel_id = harness.add_relation('db', 'postgresql')
         harness.add_relation_unit(rel_id, 'postgresql/0')
         rel = harness.charm.model.get_relation('db')
-        if typing.TYPE_CHECKING:
-            assert rel is not None
+        assert rel is not None
         with harness._event_context('foo'):
             with self.assertRaises(ops.ModelError):
                 rel.data[harness.charm.app]['foo'] = 'bar'
@@ -1898,8 +1889,7 @@ class TestHarness(unittest.TestCase):
         class MyCharm(ops.CharmBase):
             def event_handler(self, evt: ops.RelationEvent):
                 rel = evt.relation
-                if typing.TYPE_CHECKING:
-                    assert rel is not None and rel.app is not None
+                assert rel is not None and rel.app is not None
                 rel.data[rel.app]['foo'] = 'bar'
 
         harness = ops.testing.Harness(MyCharm, meta='''
@@ -1941,20 +1931,17 @@ class TestHarness(unittest.TestCase):
         def mock_join_db(event: ops.EventBase):
             # the harness thinks we're inside a db_relation_joined hook
             # but we want to mock the remote data here:
-            if typing.TYPE_CHECKING:
-                assert isinstance(event, ops.RelationEvent)
+            assert isinstance(event, ops.RelationEvent)
             with harness._event_context(''):
                 # pretend for a moment we're not in a hook context,
                 # so the harness will let us:
-                print(event.relation.app)
                 event.relation.data[harness.charm.app]['foo'] = 'bar'
 
         harness.charm._join_db = mock_join_db
         rel_id = harness.add_relation('db', 'remote')
         harness.add_relation_unit(rel_id, 'remote/0')
         rel = harness.charm.model.get_relation('db', rel_id)
-        if typing.TYPE_CHECKING:
-            assert rel is not None
+        assert rel is not None
         self.assertEqual({'foo': 'bar'},
                          harness.get_relation_data(rel_id, 'test-charm'))
 
@@ -1976,8 +1963,7 @@ class TestHarness(unittest.TestCase):
         harness.update_relation_data(rel_id, 'test-charm/0', {'foo': 'bar'})
         harness.add_relation_unit(rel_id, 'postgresql/0')
         rel = harness.charm.model.get_relation('db', rel_id)
-        if typing.TYPE_CHECKING:
-            assert rel is not None
+        assert rel is not None
         del rel.data[harness.charm.model.unit]['foo']
         self.assertEqual({}, harness.get_relation_data(rel_id, 'test-charm/0'))
 
@@ -2373,8 +2359,7 @@ class TestHarness(unittest.TestCase):
         harness.begin_with_initial_hooks()
         self.assertIsNotNone(harness.charm)
         rel = harness.model.get_relation('peer')
-        if typing.TYPE_CHECKING:
-            assert rel is not None
+        assert rel is not None
         rel_id = rel.id
         self.assertEqual(
             harness.charm.changes,
@@ -2874,8 +2859,7 @@ class TestNetwork(unittest.TestCase):
         self.harness.add_network('10.0.0.10')
 
         binding = self.harness.model.get_binding('db')
-        if typing.TYPE_CHECKING:
-            assert binding is not None
+        assert binding is not None
         self.assertEqual(binding.name, 'db')
         network = binding.network
         self.assertEqual(network.bind_address, ipaddress.IPv4Address('10.0.0.10'))
@@ -2899,11 +2883,9 @@ class TestNetwork(unittest.TestCase):
                                  egress_subnets=['10.0.0.0/8', '10.10.0.0/16'])
 
         relation = self.harness.model.get_relation('db', relation_id)
-        if typing.TYPE_CHECKING:
-            assert relation is not None
+        assert relation is not None
         binding = self.harness.model.get_binding(relation)
-        if typing.TYPE_CHECKING:
-            assert binding is not None
+        assert binding is not None
         self.assertEqual(binding.name, 'db')
         network = binding.network
         self.assertEqual(network.bind_address, ipaddress.IPv4Address('10.0.0.10'))
@@ -2924,16 +2906,14 @@ class TestNetwork(unittest.TestCase):
         self.harness.add_network('10.0.2.1', endpoint='db')
 
         binding = self.harness.model.get_binding('db')
-        if typing.TYPE_CHECKING:
-            assert binding is not None
+        assert binding is not None
         self.assertEqual(binding.name, 'db')
         network = binding.network
         self.assertEqual(network.bind_address, ipaddress.IPv4Address('10.0.2.1'))
 
         # Ensure binding for the other interface is still on the default value
         foo_binding = self.harness.model.get_binding('foo')
-        if typing.TYPE_CHECKING:
-            assert foo_binding is not None
+        assert foo_binding is not None
         self.assertEqual(foo_binding.network.bind_address,
                          ipaddress.IPv4Address('10.0.0.1'))
 
@@ -2944,19 +2924,16 @@ class TestNetwork(unittest.TestCase):
         self.harness.add_network('35.0.0.1', endpoint='db', relation_id=relation_id)
 
         relation = self.harness.model.get_relation('db', relation_id)
-        if typing.TYPE_CHECKING:
-            assert relation is not None
+        assert relation is not None
         binding = self.harness.model.get_binding(relation)
-        if typing.TYPE_CHECKING:
-            assert binding is not None
+        assert binding is not None
         self.assertEqual(binding.name, 'db')
         network = binding.network
         self.assertEqual(network.bind_address, ipaddress.IPv4Address('35.0.0.1'))
 
         # Ensure binding for the other interface is still on the default value
         foo_binding = self.harness.model.get_binding('foo')
-        if typing.TYPE_CHECKING:
-            assert foo_binding is not None
+        assert foo_binding is not None
         self.assertEqual(foo_binding.network.bind_address,
                          ipaddress.IPv4Address('10.0.0.1'))
 
@@ -2965,11 +2942,9 @@ class TestNetwork(unittest.TestCase):
         self.harness.add_network('10.0.0.10', endpoint='db')
 
         relation = self.harness.model.get_relation('db', relation_id)
-        if typing.TYPE_CHECKING:
-            assert relation is not None
+        assert relation is not None
         binding = self.harness.model.get_binding(relation)
-        if typing.TYPE_CHECKING:
-            assert binding is not None
+        assert binding is not None
         self.assertEqual(binding.name, 'db')
         network = binding.network
         self.assertEqual(network.bind_address, ipaddress.IPv4Address('10.0.0.10'))
@@ -2978,8 +2953,7 @@ class TestNetwork(unittest.TestCase):
         self.harness.add_network('10.0.0.10')
 
         binding = self.harness.model.get_binding('db')
-        if typing.TYPE_CHECKING:
-            assert binding is not None
+        assert binding is not None
         self.assertEqual(binding.name, 'db')
         network = binding.network
         self.assertEqual(network.bind_address, ipaddress.IPv4Address('10.0.0.10'))
@@ -2988,8 +2962,7 @@ class TestNetwork(unittest.TestCase):
         self.harness.add_network('2001:0db8::a:0:0:1')
 
         binding = self.harness.model.get_binding('db')
-        if typing.TYPE_CHECKING:
-            assert binding is not None
+        assert binding is not None
         self.assertEqual(binding.name, 'db')
         network = binding.network
         self.assertEqual(network.bind_address, ipaddress.IPv6Address('2001:0db8::a:0:0:1'))
@@ -3005,8 +2978,7 @@ class TestNetwork(unittest.TestCase):
     def test_network_get_relation_not_found(self):
         with self.assertRaises(ops.RelationNotFoundError):
             binding = self.harness.model.get_binding('db')
-            if typing.TYPE_CHECKING:
-                assert binding is not None
+            assert binding is not None
             binding.network
 
     def test_add_network_endpoint_not_in_meta(self):
@@ -3040,8 +3012,7 @@ class DBRelationChangedHelper(ops.Object):
             self.changes.append((event.relation.id, event.unit.name))
         else:
             app = event.app
-            if typing.TYPE_CHECKING:
-                assert app is not None
+            assert app is not None
             self.changes.append((event.relation.id, app.name))
 
 
@@ -3058,8 +3029,7 @@ class RelationChangedViewer(ops.Object):
             data = event.relation.data[event.unit]
         else:
             app = event.app
-            if typing.TYPE_CHECKING:
-                assert app is not None
+            assert app is not None
             data = event.relation.data[app]
         self.changes.append(dict(data))
 
@@ -3171,8 +3141,7 @@ class RelationEventCharm(RecordingCharm):
 
         data = dict(app=app_name, unit=unit_name, relation_id=event.relation.id)
         if isinstance(event, ops.RelationDepartedEvent):
-            if typing.TYPE_CHECKING:
-                assert event.departing_unit is not None
+            assert event.departing_unit is not None
             data['departing_unit'] = event.departing_unit.name
 
         recording: RecordedChange = {
@@ -3194,9 +3163,8 @@ class RelationBrokenTester(RelationEventCharm):
 
     def _on_relation_broken(self, event: ops.RelationBrokenEvent):
         rel = event.relation
-        if typing.TYPE_CHECKING:
-            assert rel is not None and rel.app is not None
-        print(rel.data[rel.app]['bar'])
+        assert rel is not None and rel.app is not None
+        rel.data[rel.app]['bar']  # invalid access to app data
 
 
 class ContainerEventCharm(RecordingCharm):
@@ -4789,8 +4757,7 @@ class TestSecrets(unittest.TestCase):
 
         secret = harness.model.app.add_secret({'foo': 'bar'})
         with self.assertRaises(RuntimeError):
-            if typing.TYPE_CHECKING:
-                assert secret.id is not None
+            assert secret.id is not None
             harness.set_secret_content(secret.id, {'bar': 'foo'})
 
     def test_set_secret_content_invalid_secret_id(self):
@@ -4860,16 +4827,13 @@ class TestSecrets(unittest.TestCase):
 
         relation_id = harness.add_relation('db', 'webapp')
         harness.add_relation_unit(relation_id, 'webapp/0')
-        if typing.TYPE_CHECKING:
-            assert harness is not None
+        assert harness is not None
 
         secret = harness.model.app.add_secret({'foo': 'x'})
-        if typing.TYPE_CHECKING:
-            assert secret.id is not None
+        assert secret.id is not None
         self.assertEqual(harness.get_secret_grants(secret.id, relation_id), set())
         rel = harness.model.get_relation('db')
-        if typing.TYPE_CHECKING:
-            assert rel is not None
+        assert rel is not None
         secret.grant(rel)
         self.assertEqual(harness.get_secret_grants(secret.id, relation_id), {'webapp'})
 
@@ -4883,8 +4847,7 @@ class TestSecrets(unittest.TestCase):
         self.addCleanup(harness.cleanup)
 
         secret = harness.model.app.add_secret({'foo': 'x'}, label='lbl')
-        if typing.TYPE_CHECKING:
-            assert secret.id is not None
+        assert secret.id is not None
         harness.begin()
         harness.framework.observe(harness.charm.on.secret_rotate, harness.charm.record_event)
         harness.trigger_secret_rotation(secret.id)
@@ -4910,8 +4873,7 @@ class TestSecrets(unittest.TestCase):
         self.addCleanup(harness.cleanup)
 
         secret = harness.model.app.add_secret({'foo': 'x'}, label='lbl')
-        if typing.TYPE_CHECKING:
-            assert secret.id is not None
+        assert secret.id is not None
         harness.begin()
         harness.framework.observe(harness.charm.on.secret_remove, harness.charm.record_event)
         harness.trigger_secret_removal(secret.id, 1)
@@ -4939,8 +4901,7 @@ class TestSecrets(unittest.TestCase):
         self.addCleanup(harness.cleanup)
 
         secret = harness.model.app.add_secret({'foo': 'x'}, label='lbl')
-        if typing.TYPE_CHECKING:
-            assert secret.id is not None
+        assert secret.id is not None
         harness.begin()
         harness.framework.observe(harness.charm.on.secret_remove, harness.charm.record_event)
         harness.trigger_secret_removal(secret.id, 1)

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -27,6 +27,7 @@ import shutil
 import sys
 import tempfile
 import textwrap
+import typing
 import unittest
 import uuid
 from unittest.mock import MagicMock
@@ -47,45 +48,47 @@ is_linux = platform.system() == 'Linux'
 class SetLeaderErrorTester(ops.CharmBase):
     """Sets peer relation data inside leader-elected."""
 
-    def __init__(self, framework):
+    def __init__(self, framework: ops.Framework):
         super().__init__(framework)
         self._peer_name = 'peer'
         self.framework.observe(self.on.leader_elected,
                                self._on_leader_elected)
 
-    def _on_leader_elected(self, event):
+    def _on_leader_elected(self, event: ops.EventBase):
         peers = self.model.get_relation(self._peer_name)
+        if typing.TYPE_CHECKING:
+            assert peers is not None
         peers.data[self.app]["foo"] = "bar"
 
 
 class StorageTester(ops.CharmBase):
     """Record the relation-changed events."""
 
-    def __init__(self, framework):
+    def __init__(self, framework: ops.Framework):
         super().__init__(framework)
-        self.observed_events = []
+        self.observed_events: typing.List[ops.EventBase] = []
         self.framework.observe(self.on.test_storage_attached,
                                self._on_test_storage_attached)
         self.framework.observe(self.on.test_storage_detaching,
                                self._on_test_storage_detaching)
 
-    def _on_test_storage_attached(self, event):
+    def _on_test_storage_attached(self, event: ops.EventBase):
         self.observed_events.append(event)
 
-    def _on_test_storage_detaching(self, event):
+    def _on_test_storage_detaching(self, event: ops.EventBase):
         self.observed_events.append(event)
 
 
 class StorageWithHyphensHelper(ops.Object):
-    def __init__(self, parent, key):
+    def __init__(self, parent: ops.Object, key: str):
         super().__init__(parent, key)
-        self.changes = []
+        self.changes: typing.List[ops.EventBase] = []
         parent.framework.observe(parent.on.test_with_hyphens_storage_attached,
                                  self.on_storage_changed)
         parent.framework.observe(parent.on.test_with_hyphens_storage_detaching,
                                  self.on_storage_changed)
 
-    def on_storage_changed(self, event):
+    def on_storage_changed(self, event: ops.EventBase):
         self.changes.append(event)
 
 
@@ -167,10 +170,10 @@ class TestHarness(unittest.TestCase):
         c.get_plan()  # shouldn't raise ConnectionError
 
     def test_can_connect_begin_with_initial_hooks(self):
-        pebble_ready_calls = collections.defaultdict(int)
+        pebble_ready_calls: collections.defaultdict[str, int] = collections.defaultdict(int)
 
         class MyCharm(ops.CharmBase):
-            def __init__(self, *args):
+            def __init__(self, *args: typing.Any):
                 super().__init__(*args)
                 self.framework.observe(self.on.foo_pebble_ready, self._on_pebble_ready)
                 self.framework.observe(self.on.bar_pebble_ready, self._on_pebble_ready)
@@ -243,12 +246,12 @@ class TestHarness(unittest.TestCase):
         class InitialDataTester(ops.CharmBase):
             """Record the relation-changed events."""
 
-            def __init__(self, framework):
+            def __init__(self, framework: ops.Framework):
                 super().__init__(framework)
-                self.observed_events = []
+                self.observed_events: typing.List[ops.EventBase] = []
                 self.framework.observe(self.on.db_relation_changed, self._on_db_relation_changed)
 
-            def _on_db_relation_changed(self, event):
+            def _on_db_relation_changed(self, event: ops.EventBase):
                 self.observed_events.append(event)
 
         # language=YAML
@@ -293,13 +296,13 @@ class TestHarness(unittest.TestCase):
         class InitialDataTester(ops.CharmBase):
             """Record the relation-changed events."""
 
-            def __init__(self, framework):
+            def __init__(self, framework: ops.Framework):
                 super().__init__(framework)
-                self.observed_events = []
+                self.observed_events: typing.List[ops.EventBase] = []
                 self.framework.observe(self.on.cluster_relation_changed,
                                        self._on_cluster_relation_changed)
 
-            def _on_cluster_relation_changed(self, event):
+            def _on_cluster_relation_changed(self, event: ops.EventBase):
                 self.observed_events.append(event)
 
         # language=YAML
@@ -354,7 +357,7 @@ class TestHarness(unittest.TestCase):
 
         # relation remote app is None to mirror production Juju behavior where Juju doesn't
         # communicate the remote app to ops.
-        rel_id = harness.add_relation('foo', None)
+        rel_id = harness.add_relation('foo', None)  # type: ignore
 
         with pytest.raises(KeyError, match='trying to access remote app data'):
             harness.remove_relation(rel_id)
@@ -497,6 +500,8 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(backend.relation_list(rel_id), ['postgresql/0'])
         harness.charm.get_changes(reset=True)  # ignore relation created events
         relation = harness.charm.model.get_relation('db')
+        if typing.TYPE_CHECKING:
+            assert relation is not None
         self.assertEqual(len(relation.units), 1)
         # Check relation data is correct
         rel_unit = harness.charm.model.get_unit('postgresql/0')
@@ -510,8 +515,11 @@ class TestHarness(unittest.TestCase):
         # Check removed unit does not exist
         self.assertEqual(backend.relation_list(rel_id), [])
         # Check the unit is actually removed from the relations the model knows about
-        self.assertEqual(len(harness.charm.model.get_relation('db').units), 0)
-        self.assertFalse(rel_unit in harness.charm.model.get_relation('db').data)
+        rel = harness.charm.model.get_relation('db')
+        if typing.TYPE_CHECKING:
+            assert rel is not None
+        self.assertEqual(len(rel.units), 0)
+        self.assertFalse(rel_unit in rel.data)
         # Check relation departed was raised with correct data
         self.assertEqual({'name': 'relation-departed',
                           'relation': 'db',
@@ -577,7 +585,7 @@ class TestHarness(unittest.TestCase):
         harness.remove_relation(rel_id)
         self.assertIsNone(self._find_relation_in_model_by_id(harness, rel_id))
 
-    def _find_relation_in_model_by_id(self, harness, rel_id):
+    def _find_relation_in_model_by_id(self, harness: ops.testing.Harness['RelationEventCharm'], rel_id: int):
         for relations in harness.charm.model.relations.values():
             for relation in relations:
                 if rel_id == relation.id:
@@ -744,13 +752,14 @@ class TestHarness(unittest.TestCase):
             harness.get_relation_data(99, 'postgresql')
 
         meta = yaml.safe_load(charm_meta)
-        t_app = ops.Application('test-app', meta, harness._backend, None)
-        t_unit0 = ops.Unit('test-app/0', meta, harness._backend, {ops.Application: t_app})
-        t_unit1 = ops.Unit('test-app/1', meta, harness._backend, {ops.Application: t_app})
+        t_cache = ops.model._ModelCache(meta, harness._backend)
+        t_app = ops.Application('test-app', meta, harness._backend, t_cache)
+        t_unit0 = ops.Unit('test-app/0', meta, harness._backend, t_cache)
+        t_unit1 = ops.Unit('test-app/1', meta, harness._backend, t_cache)
         self.assertEqual(harness.get_relation_data(rel_id, t_app), {})
         self.assertEqual(harness.get_relation_data(rel_id, t_unit0), {})
         self.assertEqual(harness.get_relation_data(rel_id, t_unit1), None)
-        pg_app = ops.Application('postgresql', meta, harness._backend, None)
+        pg_app = ops.Application('postgresql', meta, harness._backend, t_cache)
         self.assertEqual(harness.get_relation_data(rel_id, pg_app), {'remote': 'data'})
 
     def test_create_harness_twice(self):
@@ -818,6 +827,8 @@ class TestHarness(unittest.TestCase):
         helper = DBRelationChangedHelper(harness.charm, "helper")
         rel_id = harness.add_relation('db', 'postgresql')
         rel = harness.charm.model.get_relation('db')
+        if typing.TYPE_CHECKING:
+            assert rel is not None
         rel.data[harness.charm.model.unit]['key'] = 'value'
         # there should be no event for updating our own data
         harness.update_relation_data(rel_id, 'my-charm/0', {'new': 'other'})
@@ -844,8 +855,12 @@ class TestHarness(unittest.TestCase):
         rel_id = harness.add_relation('db', 'postgresql')
 
         rel = harness.charm.model.get_relation('db')
+        if typing.TYPE_CHECKING:
+            assert rel is not None
         rel.data[harness.charm.model.unit]['key'] = 'value'
         rel = harness.charm.model.get_relation('db')
+        if typing.TYPE_CHECKING:
+            assert rel is not None
         harness.update_relation_data(rel_id, 'postgresql/0', {'key': 'v1'})
         self.assertEqual({'key': 'v1'}, rel.data[harness.charm.model.unit])
         # Make sure there was no event
@@ -896,6 +911,8 @@ class TestHarness(unittest.TestCase):
         helper = DBRelationChangedHelper(harness.charm, "helper")
         rel_id = harness.add_relation('db', 'postgresql')
         rel = harness.charm.model.get_relation('db')
+        if typing.TYPE_CHECKING:
+            assert rel is not None
         rel.data[harness.charm.app]['key'] = 'value'
         harness.update_relation_data(rel_id, 'postgresql', {'key': 'v1'})
         self.assertEqual({'key': 'v1'}, rel.data[harness.charm.app])
@@ -932,6 +949,8 @@ class TestHarness(unittest.TestCase):
 
         harness.update_relation_data(rel_id, 'my-charm', {'new': 'value'})
         rel = harness.charm.model.get_relation('db')
+        if typing.TYPE_CHECKING:
+            assert rel is not None
         self.assertEqual(rel.data[harness.charm.app]['new'], 'value')
 
         # Our app data bag got updated.
@@ -1170,6 +1189,8 @@ class TestHarness(unittest.TestCase):
         rel_id = harness.add_relation('db', 'postgresql')
         harness.add_relation_unit(rel_id, 'postgresql/0')
         rel = harness.charm.model.get_relation('db')
+        if typing.TYPE_CHECKING:
+            assert rel is not None
         with harness._event_context('foo'):
             with self.assertRaises(ops.ModelError):
                 rel.data[harness.charm.app]['foo'] = 'bar'
@@ -1765,7 +1786,7 @@ class TestHarness(unittest.TestCase):
         self.assertIn(self._extract_storage_index(stor_ids[0]), attached_storage_ids)
         self.assertNotIn(self._extract_storage_index(stor_ids[1]), attached_storage_ids)
 
-    def _extract_storage_index(self, stor_id):
+    def _extract_storage_index(self, stor_id: str):
         return int(stor_id.split('/')[-1])
 
     def test_remove_detached_storage(self):
@@ -1830,14 +1851,14 @@ class TestHarness(unittest.TestCase):
         # The charm_dir also gets set
         self.assertEqual(harness.framework.charm_dir, tmp)
 
-    def _get_dummy_charm_harness(self, tmp):
+    def _get_dummy_charm_harness(self, tmp: pathlib.Path):
         self._write_dummy_charm(tmp)
         charm_mod = importlib.import_module('testcharm')
         harness = ops.testing.Harness(charm_mod.MyTestingCharm)
         self.addCleanup(harness.cleanup)
         return harness
 
-    def _write_dummy_charm(self, tmp):
+    def _write_dummy_charm(self, tmp: pathlib.Path):
         srcdir = tmp / 'src'
         srcdir.mkdir(0o755)
         charm_filename = srcdir / 'testcharm.py'
@@ -1872,8 +1893,11 @@ class TestHarness(unittest.TestCase):
 
     def test_event_context(self):
         class MyCharm(ops.CharmBase):
-            def event_handler(self, evt):
-                evt.relation.data[evt.relation.app]['foo'] = 'bar'
+            def event_handler(self, evt: ops.RelationEvent):
+                rel = evt.relation
+                if typing.TYPE_CHECKING:
+                    assert rel is not None and rel.app is not None
+                rel.data[rel.app]['foo'] = 'bar'
 
         harness = ops.testing.Harness(MyCharm, meta='''
             name: test-charm
@@ -1899,7 +1923,7 @@ class TestHarness(unittest.TestCase):
                 self.framework.observe(self.on.db_relation_joined,
                                        self._join_db)
 
-            def _join_db(self, event):
+            def _join_db(self, event: ops.EventBase) -> None:
                 # do things with APIs we cannot easily mock
                 raise NotImplementedError
 
@@ -1911,9 +1935,11 @@ class TestHarness(unittest.TestCase):
             ''')
         harness.begin()
 
-        def mock_join_db(event):
+        def mock_join_db(event: ops.EventBase):
             # the harness thinks we're inside a db_relation_joined hook
             # but we want to mock the remote data here:
+            if typing.TYPE_CHECKING:
+                assert isinstance(event, ops.RelationEvent)
             with harness._event_context(''):
                 # pretend for a moment we're not in a hook context,
                 # so the harness will let us:
@@ -1924,6 +1950,8 @@ class TestHarness(unittest.TestCase):
         rel_id = harness.add_relation('db', 'remote')
         harness.add_relation_unit(rel_id, 'remote/0')
         rel = harness.charm.model.get_relation('db', rel_id)
+        if typing.TYPE_CHECKING:
+            assert rel is not None
         self.assertEqual({'foo': 'bar'},
                          harness.get_relation_data(rel_id, 'test-charm'))
 
@@ -1945,6 +1973,8 @@ class TestHarness(unittest.TestCase):
         harness.update_relation_data(rel_id, 'test-charm/0', {'foo': 'bar'})
         harness.add_relation_unit(rel_id, 'postgresql/0')
         rel = harness.charm.model.get_relation('db', rel_id)
+        if typing.TYPE_CHECKING:
+            assert rel is not None
         del rel.data[harness.charm.model.unit]['foo']
         self.assertEqual({}, harness.get_relation_data(rel_id, 'test-charm/0'))
 
@@ -1959,10 +1989,10 @@ class TestHarness(unittest.TestCase):
         harness.begin()
         harness.set_leader(False)
         rel_id = harness.add_relation('db', 'postgresql')
-        for invalid_value in (1, 1.2, {}, [], set(), True, object(), type):
+        for invalid_value in (1, 1.2, {}, [], set(), True, object(), type):  # type: ignore
             with self.assertRaises(ops.RelationDataError):
                 harness.update_relation_data(rel_id, 'test-charm/0',
-                                             {'foo': invalid_value})
+                                             {'foo': invalid_value})  # type: ignore
 
     def test_set_workload_version(self):
         harness = ops.testing.Harness(ops.CharmBase, meta='''
@@ -2319,7 +2349,7 @@ class TestHarness(unittest.TestCase):
 
     def test_begin_with_initial_hooks_with_peer_relation(self):
         class PeerCharm(RelationEventCharm):
-            def __init__(self, framework):
+            def __init__(self, framework: ops.Framework):
                 super().__init__(framework)
                 self.observe_relation_events('peer')
         harness = ops.testing.Harness(PeerCharm, meta='''
@@ -2339,7 +2369,10 @@ class TestHarness(unittest.TestCase):
             _ = harness.charm
         harness.begin_with_initial_hooks()
         self.assertIsNotNone(harness.charm)
-        rel_id = harness.model.get_relation('peer').id
+        rel = harness.model.get_relation('peer')
+        if typing.TYPE_CHECKING:
+            assert rel is not None
+        rel_id = rel.id
         self.assertEqual(
             harness.charm.changes,
             [
@@ -2359,7 +2392,7 @@ class TestHarness(unittest.TestCase):
 
     def test_begin_with_initial_hooks_peer_relation_pre_defined(self):
         class PeerCharm(RelationEventCharm):
-            def __init__(self, framework):
+            def __init__(self, framework: ops.Framework):
                 super().__init__(framework)
                 self.observe_relation_events('peer')
         harness = ops.testing.Harness(PeerCharm, meta='''
@@ -2391,7 +2424,7 @@ class TestHarness(unittest.TestCase):
 
     def test_begin_with_initial_hooks_relation_charm_with_no_relation(self):
         class CharmWithDB(RelationEventCharm):
-            def __init__(self, framework):
+            def __init__(self, framework: ops.Framework):
                 super().__init__(framework)
                 self.observe_relation_events('db')
         harness = ops.testing.Harness(CharmWithDB, meta='''
@@ -2414,7 +2447,7 @@ class TestHarness(unittest.TestCase):
 
     def test_begin_with_initial_hooks_with_one_relation(self):
         class CharmWithDB(RelationEventCharm):
-            def __init__(self, framework):
+            def __init__(self, framework: ops.Framework):
                 super().__init__(framework)
                 self.observe_relation_events('db')
         harness = ops.testing.Harness(CharmWithDB, meta='''
@@ -2461,7 +2494,7 @@ class TestHarness(unittest.TestCase):
 
     def test_begin_with_initial_hooks_with_application_data(self):
         class CharmWithDB(RelationEventCharm):
-            def __init__(self, framework):
+            def __init__(self, framework: ops.Framework):
                 super().__init__(framework)
                 self.observe_relation_events('db')
         harness = ops.testing.Harness(CharmWithDB, meta='''
@@ -2516,7 +2549,7 @@ class TestHarness(unittest.TestCase):
 
     def test_begin_with_initial_hooks_with_multiple_units(self):
         class CharmWithDB(RelationEventCharm):
-            def __init__(self, framework):
+            def __init__(self, framework: ops.Framework):
                 super().__init__(framework)
                 self.observe_relation_events('db')
         harness = ops.testing.Harness(CharmWithDB, meta='''
@@ -2579,7 +2612,7 @@ class TestHarness(unittest.TestCase):
 
     def test_begin_with_initial_hooks_multiple_relation_same_endpoint(self):
         class CharmWithDB(RelationEventCharm):
-            def __init__(self, framework):
+            def __init__(self, framework: ops.Framework):
                 super().__init__(framework)
                 self.observe_relation_events('db')
         harness = ops.testing.Harness(CharmWithDB, meta='''
@@ -2625,7 +2658,7 @@ class TestHarness(unittest.TestCase):
                                          expected_relation_created[0]]
         self.assertEqual(changes[:2], expected_relation_created)
         changes = changes[2:]
-        expected_middle = [
+        expected_middle: typing.List[RecordedChange] = [
             {'name': 'leader-elected'},
             {'name': 'config-changed', 'data': {}},
             {'name': 'start'},
@@ -2802,15 +2835,15 @@ class TestHarness(unittest.TestCase):
 
     def test_evaluate_status(self):
         class TestCharm(ops.CharmBase):
-            def __init__(self, framework):
+            def __init__(self, framework: ops.Framework):
                 super().__init__(framework)
                 self.framework.observe(self.on.collect_app_status, self._on_collect_app_status)
                 self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
 
-            def _on_collect_app_status(self, event):
+            def _on_collect_app_status(self, event: ops.CollectStatusEvent):
                 event.add_status(ops.ActiveStatus())
 
-            def _on_collect_unit_status(self, event):
+            def _on_collect_unit_status(self, event: ops.CollectStatusEvent):
                 event.add_status(ops.BlockedStatus('bar'))
 
         harness = ops.testing.Harness(TestCharm)
@@ -2838,6 +2871,8 @@ class TestNetwork(unittest.TestCase):
         self.harness.add_network('10.0.0.10')
 
         binding = self.harness.model.get_binding('db')
+        if typing.TYPE_CHECKING:
+            assert binding is not None
         self.assertEqual(binding.name, 'db')
         network = binding.network
         self.assertEqual(network.bind_address, ipaddress.IPv4Address('10.0.0.10'))
@@ -2861,7 +2896,11 @@ class TestNetwork(unittest.TestCase):
                                  egress_subnets=['10.0.0.0/8', '10.10.0.0/16'])
 
         relation = self.harness.model.get_relation('db', relation_id)
+        if typing.TYPE_CHECKING:
+            assert relation is not None
         binding = self.harness.model.get_binding(relation)
+        if typing.TYPE_CHECKING:
+            assert binding is not None
         self.assertEqual(binding.name, 'db')
         network = binding.network
         self.assertEqual(network.bind_address, ipaddress.IPv4Address('10.0.0.10'))
@@ -2882,12 +2921,17 @@ class TestNetwork(unittest.TestCase):
         self.harness.add_network('10.0.2.1', endpoint='db')
 
         binding = self.harness.model.get_binding('db')
+        if typing.TYPE_CHECKING:
+            assert binding is not None
         self.assertEqual(binding.name, 'db')
         network = binding.network
         self.assertEqual(network.bind_address, ipaddress.IPv4Address('10.0.2.1'))
 
         # Ensure binding for the other interface is still on the default value
-        self.assertEqual(self.harness.model.get_binding('foo').network.bind_address,
+        foo_binding = self.harness.model.get_binding('foo')
+        if typing.TYPE_CHECKING:
+            assert foo_binding is not None
+        self.assertEqual(foo_binding.network.bind_address,
                          ipaddress.IPv4Address('10.0.0.1'))
 
     def test_add_network_specific_relation(self):
@@ -2897,13 +2941,20 @@ class TestNetwork(unittest.TestCase):
         self.harness.add_network('35.0.0.1', endpoint='db', relation_id=relation_id)
 
         relation = self.harness.model.get_relation('db', relation_id)
+        if typing.TYPE_CHECKING:
+            assert relation is not None
         binding = self.harness.model.get_binding(relation)
+        if typing.TYPE_CHECKING:
+            assert binding is not None
         self.assertEqual(binding.name, 'db')
         network = binding.network
         self.assertEqual(network.bind_address, ipaddress.IPv4Address('35.0.0.1'))
 
         # Ensure binding for the other interface is still on the default value
-        self.assertEqual(self.harness.model.get_binding('foo').network.bind_address,
+        foo_binding = self.harness.model.get_binding('foo')
+        if typing.TYPE_CHECKING:
+            assert foo_binding is not None
+        self.assertEqual(foo_binding.network.bind_address,
                          ipaddress.IPv4Address('10.0.0.1'))
 
     def test_add_network_endpoint_fallback(self):
@@ -2911,7 +2962,11 @@ class TestNetwork(unittest.TestCase):
         self.harness.add_network('10.0.0.10', endpoint='db')
 
         relation = self.harness.model.get_relation('db', relation_id)
+        if typing.TYPE_CHECKING:
+            assert relation is not None
         binding = self.harness.model.get_binding(relation)
+        if typing.TYPE_CHECKING:
+            assert binding is not None
         self.assertEqual(binding.name, 'db')
         network = binding.network
         self.assertEqual(network.bind_address, ipaddress.IPv4Address('10.0.0.10'))
@@ -2920,6 +2975,8 @@ class TestNetwork(unittest.TestCase):
         self.harness.add_network('10.0.0.10')
 
         binding = self.harness.model.get_binding('db')
+        if typing.TYPE_CHECKING:
+            assert binding is not None
         self.assertEqual(binding.name, 'db')
         network = binding.network
         self.assertEqual(network.bind_address, ipaddress.IPv4Address('10.0.0.10'))
@@ -2928,6 +2985,8 @@ class TestNetwork(unittest.TestCase):
         self.harness.add_network('2001:0db8::a:0:0:1')
 
         binding = self.harness.model.get_binding('db')
+        if typing.TYPE_CHECKING:
+            assert binding is not None
         self.assertEqual(binding.name, 'db')
         network = binding.network
         self.assertEqual(network.bind_address, ipaddress.IPv6Address('2001:0db8::a:0:0:1'))
@@ -2942,7 +3001,10 @@ class TestNetwork(unittest.TestCase):
 
     def test_network_get_relation_not_found(self):
         with self.assertRaises(ops.RelationNotFoundError):
-            self.harness.model.get_binding('db').network
+            binding = self.harness.model.get_binding('db')
+            if typing.TYPE_CHECKING:
+                assert binding is not None
+            binding.network
 
     def test_add_network_endpoint_not_in_meta(self):
         with self.assertRaises(ops.ModelError):
@@ -2965,40 +3027,57 @@ class TestNetwork(unittest.TestCase):
 
 
 class DBRelationChangedHelper(ops.Object):
-    def __init__(self, parent, key):
+    def __init__(self, parent: ops.Object, key: str):
         super().__init__(parent, key)
-        self.changes = []
+        self.changes: typing.List[typing.Tuple[int, str]] = []
         parent.framework.observe(parent.on.db_relation_changed, self.on_relation_changed)
 
-    def on_relation_changed(self, event):
+    def on_relation_changed(self, event: ops.RelationEvent):
         if event.unit is not None:
             self.changes.append((event.relation.id, event.unit.name))
         else:
-            self.changes.append((event.relation.id, event.app.name))
+            app = event.app
+            if typing.TYPE_CHECKING:
+                assert app is not None
+            self.changes.append((event.relation.id, app.name))
 
 
 class RelationChangedViewer(ops.Object):
     """Track relation_changed events and saves the data seen in the relation bucket."""
 
-    def __init__(self, charm, relation_name):
+    def __init__(self, charm: ops.CharmBase, relation_name: str):
         super().__init__(charm, relation_name)
-        self.changes = []
+        self.changes: typing.List[typing.Dict[str, str]] = []
         charm.framework.observe(charm.on[relation_name].relation_changed, self.on_relation_changed)
 
-    def on_relation_changed(self, event):
+    def on_relation_changed(self, event: ops.RelationEvent):
         if event.unit is not None:
             data = event.relation.data[event.unit]
         else:
-            data = event.relation.data[event.app]
+            app = event.app
+            if typing.TYPE_CHECKING:
+                assert app is not None
+            data = event.relation.data[app]
         self.changes.append(dict(data))
+
+
+if typing.TYPE_CHECKING:
+    # In Python 3.11+ replace this with Required/NotRequired.
+    class BaseRecordedChange(typing.TypedDict):
+        name: str
+    
+    class RecordedChange(BaseRecordedChange, total=False):
+        data: typing.Dict[str, typing.Any]
+        relation: str
+        container: str
 
 
 class RecordingCharm(ops.CharmBase):
     """Record the events that we see, and any associated data."""
 
-    def __init__(self, framework):
+    def __init__(self, framework: ops.Framework):
         super().__init__(framework)
-        self.changes = []
+        self.changes: typing.List[RecordedChange] = []
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.leader_elected, self._on_leader_elected)
         self.framework.observe(self.on.leader_settings_changed, self._on_leader_settings_changed)
@@ -3009,53 +3088,53 @@ class RecordingCharm(ops.CharmBase):
         self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
         self.framework.observe(self.on.update_status, self._on_update_status)
 
-    def get_changes(self, reset=True):
+    def get_changes(self, reset: bool = True):
         changes = self.changes
         if reset:
             self.changes = []
         return changes
 
-    def _on_install(self, _):
+    def _on_install(self, _: ops.InstallEvent):
         if self.config.get('set_status'):
             self.unit.status = ops.MaintenanceStatus("Status set on install")
-        self.changes.append(dict(name='install'))
+        self.changes.append({'name': 'install'})
 
-    def _on_start(self, _):
-        self.changes.append(dict(name='start'))
+    def _on_start(self, _: ops.StartEvent):
+        self.changes.append({'name': 'start'})
 
-    def _on_stop(self, _):
-        self.changes.append(dict(name='stop'))
+    def _on_stop(self, _: ops.StopEvent):
+        self.changes.append({'name': 'stop'})
 
-    def _on_remove(self, _):
-        self.changes.append(dict(name='remove'))
+    def _on_remove(self, _: ops.RemoveEvent):
+        self.changes.append({'name': 'remove'})
 
-    def _on_config_changed(self, _):
-        self.changes.append(dict(name='config-changed', data=dict(self.framework.model.config)))
+    def _on_config_changed(self, _: ops.ConfigChangedEvent):
+        self.changes.append({'name': 'config-changed', 'data': dict(self.framework.model.config)})
 
-    def _on_leader_elected(self, _):
-        self.changes.append(dict(name='leader-elected'))
+    def _on_leader_elected(self, _: ops.LeaderElectedEvent):
+        self.changes.append({'name': 'leader-elected'})
 
-    def _on_leader_settings_changed(self, _):
-        self.changes.append(dict(name='leader-settings-changed'))
+    def _on_leader_settings_changed(self, _: ops.LeaderSettingsChangedEvent):
+        self.changes.append({'name': 'leader-settings-changed'})
 
-    def _on_upgrade_charm(self, _):
-        self.changes.append(dict(name='upgrade-charm'))
+    def _on_upgrade_charm(self, _: ops.UpgradeCharmEvent):
+        self.changes.append({'name': 'upgrade-charm'})
 
-    def _on_update_status(self, _):
-        self.changes.append(dict(name='update-status'))
+    def _on_update_status(self, _: ops.UpdateStatusEvent):
+        self.changes.append({'name': 'update-status'})
 
 
 class RelationEventCharm(RecordingCharm):
     """Record events related to relation lifecycles."""
 
-    def __init__(self, framework):
+    def __init__(self, framework: ops.Framework):
         super().__init__(framework)
         # When set, this instructs the charm to include a 'relation_data' field in the 'data'
         # section of each change it logs, which allows us to test which relation data was available
         # in each hook invocation
         self.record_relation_data_on_events = False
 
-    def observe_relation_events(self, relation_name):
+    def observe_relation_events(self, relation_name: str):
         self.relation_name = relation_name
         self.framework.observe(self.on[relation_name].relation_created, self._on_relation_created)
         self.framework.observe(self.on[relation_name].relation_joined, self._on_relation_joined)
@@ -3064,22 +3143,22 @@ class RelationEventCharm(RecordingCharm):
                                self._on_relation_departed)
         self.framework.observe(self.on[relation_name].relation_broken, self._on_relation_broken)
 
-    def _on_relation_created(self, event):
+    def _on_relation_created(self, event: ops.RelationCreatedEvent):
         self._observe_relation_event('relation-created', event)
 
-    def _on_relation_joined(self, event):
+    def _on_relation_joined(self, event: ops.RelationJoinedEvent):
         self._observe_relation_event('relation-joined', event)
 
-    def _on_relation_changed(self, event):
+    def _on_relation_changed(self, event: ops.RelationChangedEvent):
         self._observe_relation_event('relation-changed', event)
 
-    def _on_relation_departed(self, event):
+    def _on_relation_departed(self, event: ops.RelationDepartedEvent):
         self._observe_relation_event('relation-departed', event)
 
-    def _on_relation_broken(self, event):
+    def _on_relation_broken(self, event: ops.RelationBrokenEvent):
         self._observe_relation_event('relation-broken', event)
 
-    def _observe_relation_event(self, event_name, event):
+    def _observe_relation_event(self, event_name: str, event: ops.RelationEvent):
         unit_name = None
         if event.unit is not None:
             unit_name = event.unit.name
@@ -3089,9 +3168,11 @@ class RelationEventCharm(RecordingCharm):
 
         data = dict(app=app_name, unit=unit_name, relation_id=event.relation.id)
         if isinstance(event, ops.RelationDepartedEvent):
+            if typing.TYPE_CHECKING:
+                assert event.departing_unit is not None
             data['departing_unit'] = event.departing_unit.name
 
-        recording = dict(name=event_name, relation=event.relation.name, data=data)
+        recording: RecordedChange = {'name': event_name, 'relation': event.relation.name, 'data': data}
 
         if self.record_relation_data_on_events:
             recording["data"].update({'relation_data': {
@@ -3105,36 +3186,33 @@ class RelationEventCharm(RecordingCharm):
 class RelationBrokenTester(RelationEventCharm):
     """Access inaccessible relation data."""
 
-    def __init__(self, framework):
-        super().__init__(framework)
-
-    def _on_relation_broken(self, event):
-        print(event.relation.data[event.relation.app]['bar'])
+    def _on_relation_broken(self, event: ops.RelationBrokenEvent):
+        rel = event.relation
+        if typing.TYPE_CHECKING:
+            assert rel is not None and rel.app is not None
+        print(rel.data[rel.app]['bar'])
 
 
 class ContainerEventCharm(RecordingCharm):
     """Record events related to container lifecycles."""
 
-    def __init__(self, framework):
-        super().__init__(framework)
-
-    def observe_container_events(self, container_name):
+    def observe_container_events(self, container_name: str):
         self.framework.observe(self.on[container_name].pebble_ready, self._on_pebble_ready)
 
-    def _on_pebble_ready(self, event):
+    def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
         self._observe_container_event('pebble-ready', event)
 
-    def _observe_container_event(self, event_name, event: ops.PebbleReadyEvent):
+    def _observe_container_event(self, event_name: str, event: ops.PebbleReadyEvent):
         container_name = None
         if event.workload is not None:
             container_name = event.workload.name
         self.changes.append(
-            dict(name=event_name, container=container_name))
+            {'name': event_name, 'container': container_name})
 
 
-def get_public_methods(obj):
+def get_public_methods(obj: object):
     """Get the public attributes of obj to compare to another object."""
-    public = set()
+    public: typing.Set[str] = set()
     members = inspect.getmembers(obj)
     for name, member in members:
         if name.startswith('_'):
@@ -3297,7 +3375,7 @@ class _TestingPebbleClientMixin:
             containers:
               mycontainer: {}
             ''')
-        self.addCleanup(harness.cleanup)
+        self.addCleanup(harness.cleanup)  # type: ignore
         backend = harness._backend
 
         client = backend.get_pebble('/charm/containers/mycontainer/pebble.socket')
@@ -4002,7 +4080,24 @@ class TestTestingPebbleClient(unittest.TestCase, _TestingPebbleClientMixin):
 class _PebbleStorageAPIsTestMixin:
     # Override this in classes using this mixin.
     # This should be set to any non-empty path, but without a trailing /.
-    prefix = None
+    prefix: str = None  # type: ignore
+
+    # Override this in classes using this mixin.
+    client: ops.pebble.Client = None  # type: ignore
+
+    if typing.TYPE_CHECKING:
+        # Provide these in classes using this mixin, generally by mixing with a TestCase.
+        def assertEqual(self, first: typing.Any, second: typing.Any, msg: typing.Optional[str] = None):
+            ...
+
+        def assertRaises(self, exception: typing.Type[BaseException], *, msg: typing.Optional[str] = None):
+            ...
+        
+        def assertIsInstance(self, obj: typing.Any, cls: typing.Type[object], msg: typing.Optional[str] = None):
+            ...
+
+        def assertIn(self, member: typing.Any, container: typing.Container[typing.Any], msg: typing.Optional[str] = None):
+            ...
 
     def test_push_and_pull_bytes(self):
         self._test_push_and_pull_data(
@@ -4016,7 +4111,7 @@ class _PebbleStorageAPIsTestMixin:
             encoding='sjis',
             stream_class=io.StringIO)
 
-    def _test_push_and_pull_data(self, original_data, encoding, stream_class):
+    def _test_push_and_pull_data(self, original_data: typing.Union[str, bytes], encoding: typing.Optional[str], stream_class: typing.Union[typing.Type[io.BytesIO], typing.Type[io.StringIO]]):
         client = self.client
         client.push(f"{self.prefix}/test", original_data, encoding=encoding)
         with client.pull(f"{self.prefix}/test", encoding=encoding) as infile:
@@ -4640,6 +4735,7 @@ class TestSecrets(unittest.TestCase):
         self.assertEqual(len(harness.charm.events), 1)
         event = harness.charm.events[0]
         self.assertIsInstance(event, ops.SecretChangedEvent)
+        assert isinstance(event, ops.SecretChangedEvent)  # Dupes previous line for type checkers.
         self.assertEqual(event.secret.get_content(), {'foo': '1'})
         self.assertEqual(event.secret.get_content(refresh=True), {'foo': '2'})
         self.assertEqual(event.secret.get_content(), {'foo': '2'})
@@ -4652,6 +4748,8 @@ class TestSecrets(unittest.TestCase):
 
         secret = harness.model.app.add_secret({'foo': 'bar'})
         with self.assertRaises(RuntimeError):
+            if typing.TYPE_CHECKING:
+                assert secret.id is not None
             harness.set_secret_content(secret.id, {'bar': 'foo'})
 
     def test_set_secret_content_invalid_secret_id(self):
@@ -4721,8 +4819,12 @@ class TestSecrets(unittest.TestCase):
 
         relation_id = harness.add_relation('db', 'webapp')
         harness.add_relation_unit(relation_id, 'webapp/0')
+        if typing.TYPE_CHECKING:
+            assert harness is not None
 
         secret = harness.model.app.add_secret({'foo': 'x'})
+        if typing.TYPE_CHECKING:
+            assert secret.id is not None
         self.assertEqual(harness.get_secret_grants(secret.id, relation_id), set())
         secret.grant(harness.model.get_relation('db'))
         self.assertEqual(harness.get_secret_grants(secret.id, relation_id), {'webapp'})
@@ -4737,6 +4839,8 @@ class TestSecrets(unittest.TestCase):
         self.addCleanup(harness.cleanup)
 
         secret = harness.model.app.add_secret({'foo': 'x'}, label='lbl')
+        if typing.TYPE_CHECKING:
+            assert secret.id is not None
         harness.begin()
         harness.framework.observe(harness.charm.on.secret_rotate, harness.charm.record_event)
         harness.trigger_secret_rotation(secret.id)
@@ -4745,10 +4849,12 @@ class TestSecrets(unittest.TestCase):
         self.assertEqual(len(harness.charm.events), 2)
         event = harness.charm.events[0]
         self.assertIsInstance(event, ops.SecretRotateEvent)
+        assert isinstance(event, ops.SecretRotateEvent)  # Dupes previous line for type checkers.
         self.assertEqual(event.secret.label, 'lbl')
         self.assertEqual(event.secret.get_content(), {'foo': 'x'})
         event = harness.charm.events[1]
         self.assertIsInstance(event, ops.SecretRotateEvent)
+        assert isinstance(event, ops.SecretRotateEvent)  # Dupes previous line for type checkers.
         self.assertEqual(event.secret.label, 'override')
         self.assertEqual(event.secret.get_content(), {'foo': 'x'})
 
@@ -4760,6 +4866,8 @@ class TestSecrets(unittest.TestCase):
         self.addCleanup(harness.cleanup)
 
         secret = harness.model.app.add_secret({'foo': 'x'}, label='lbl')
+        if typing.TYPE_CHECKING:
+            assert secret.id is not None
         harness.begin()
         harness.framework.observe(harness.charm.on.secret_remove, harness.charm.record_event)
         harness.trigger_secret_removal(secret.id, 1)
@@ -4768,11 +4876,13 @@ class TestSecrets(unittest.TestCase):
         self.assertEqual(len(harness.charm.events), 2)
         event = harness.charm.events[0]
         self.assertIsInstance(event, ops.SecretRemoveEvent)
+        assert isinstance(event, ops.SecretRemoveEvent)  # Dupes previous line for type checkers.
         self.assertEqual(event.secret.label, 'lbl')
         self.assertEqual(event.revision, 1)
         self.assertEqual(event.secret.get_content(), {'foo': 'x'})
         event = harness.charm.events[1]
         self.assertIsInstance(event, ops.SecretRemoveEvent)
+        assert isinstance(event, ops.SecretRemoveEvent)  # Dupes previous line for type checkers.
         self.assertEqual(event.secret.label, 'override')
         self.assertEqual(event.revision, 42)
         self.assertEqual(event.secret.get_content(), {'foo': 'x'})
@@ -4785,6 +4895,8 @@ class TestSecrets(unittest.TestCase):
         self.addCleanup(harness.cleanup)
 
         secret = harness.model.app.add_secret({'foo': 'x'}, label='lbl')
+        if typing.TYPE_CHECKING:
+            assert secret.id is not None
         harness.begin()
         harness.framework.observe(harness.charm.on.secret_remove, harness.charm.record_event)
         harness.trigger_secret_removal(secret.id, 1)
@@ -4793,11 +4905,13 @@ class TestSecrets(unittest.TestCase):
         self.assertEqual(len(harness.charm.events), 2)
         event = harness.charm.events[0]
         self.assertIsInstance(event, ops.SecretRemoveEvent)
+        assert isinstance(event, ops.SecretRemoveEvent)  # Dupes previous line for type checkers.
         self.assertEqual(event.secret.label, 'lbl')
         self.assertEqual(event.revision, 1)
         self.assertEqual(event.secret.get_content(), {'foo': 'x'})
         event = harness.charm.events[1]
         self.assertIsInstance(event, ops.SecretRemoveEvent)
+        assert isinstance(event, ops.SecretRemoveEvent)  # Dupes previous line for type checkers.
         self.assertEqual(event.secret.label, 'override')
         self.assertEqual(event.revision, 42)
         self.assertEqual(event.secret.get_content(), {'foo': 'x'})
@@ -4807,11 +4921,11 @@ class TestSecrets(unittest.TestCase):
 
 
 class EventRecorder(ops.CharmBase):
-    def __init__(self, framework):
+    def __init__(self, framework: ops.Framework):
         super().__init__(framework)
-        self.events = []
+        self.events: typing.List[ops.EventBase] = []
 
-    def record_event(self, event):
+    def record_event(self, event: ops.EventBase):
         self.events.append(event)
 
 
@@ -4863,7 +4977,7 @@ class TestPorts(unittest.TestCase):
         with self.assertRaises(ops.ModelError):
             unit.open_port('icmp', 8080)  # icmp cannot have port
         with self.assertRaises(ops.ModelError):
-            unit.open_port('ftp', 8080)  # invalid protocol
+            unit.open_port('ftp', 8080)  # invalid protocol  # type: ignore
         with self.assertRaises(ops.ModelError):
             unit.open_port('tcp')  # tcp must have port
         with self.assertRaises(ops.ModelError):
@@ -4956,10 +5070,10 @@ class TestHandleExec(unittest.TestCase):
         self.assertEqual(stderr, "")
 
     def test_register_with_handler(self):
-        args_history = []
+        args_history: typing.List[ops.testing.ExecArgs] = []
         return_value = None
 
-        def handler(args):
+        def handler(args: ops.testing.ExecArgs):
             args_history.append(args)
             return return_value
 
@@ -4997,7 +5111,7 @@ class TestHandleExec(unittest.TestCase):
         self.assertEqual(args_history[-1].group_id, 2)
 
     def test_exec_timeout(self):
-        def handler(_):
+        def handler(_: ops.testing.ExecArgs):
             raise TimeoutError
 
         self.harness.handle_exec(self.container, [], handler=handler)
@@ -5018,9 +5132,9 @@ class TestHandleExec(unittest.TestCase):
             self.container.exec(["ls"], combine_stderr=True).wait_output()
 
     def test_exec_stdin(self):
-        args_history = []
+        args_history: typing.List[ops.testing.ExecArgs] = []
 
-        def handler(args):
+        def handler(args: ops.testing.ExecArgs):
             args_history.append(args)
 
         self.harness.handle_exec(self.container, [], handler=handler)
@@ -5040,14 +5154,18 @@ class TestHandleExec(unittest.TestCase):
         stderr = io.StringIO()
         proc = self.container.exec(["ls"], stderr=stderr, stdout=stdout)
         self.assertIsNone(proc.stdout)
+        assert proc.stdout is not None  # Dupes the previous line for type checking
         self.assertIsNone(proc.stderr)
+        assert proc.stderr is not None  # Dupes the previous line for type checking
         proc.wait()
         self.assertEqual(stdout.getvalue(), "output")
         self.assertEqual(stderr.getvalue(), "error")
 
         proc = self.container.exec(["ls"])
         self.assertIsNotNone(proc.stdout)
+        assert proc.stdout is not None  # Dupes the previous line for type checking
         self.assertIsNotNone(proc.stderr)
+        assert proc.stderr is not None  # Dupes the previous line for type checking
         proc.wait()
         self.assertEqual(proc.stdout.read(), "output")
         self.assertEqual(proc.stderr.read(), "error")
@@ -5061,6 +5179,10 @@ class TestHandleExec(unittest.TestCase):
         self.assertEqual(stdout.getvalue(), "output")
         self.assertEqual(stderr.getvalue(), "error")
         proc = self.container.exec(["ls"])
+        self.assertIsNotNone(proc.stdout)
+        assert proc.stdout is not None  # Dupes the previous line for type checking
+        self.assertIsNotNone(proc.stderr)
+        assert proc.stderr is not None  # Dupes the previous line for type checking
         self.assertEqual(proc.stdout.read(), "output")
         self.assertEqual(proc.stderr.read(), "error")
 
@@ -5070,6 +5192,10 @@ class TestHandleExec(unittest.TestCase):
         self.assertEqual(stdout.getvalue(), b"output")
         self.assertEqual(stderr.getvalue(), b"error")
         proc = self.container.exec(["ls"], encoding=None)
+        self.assertIsNotNone(proc.stdout)
+        assert proc.stdout is not None  # Dupes the previous line for type checking
+        self.assertIsNotNone(proc.stderr)
+        assert proc.stderr is not None  # Dupes the previous line for type checking
         self.assertEqual(proc.stdout.read(), b"output")
         self.assertEqual(proc.stderr.read(), b"error")
 
@@ -5086,9 +5212,9 @@ class TestHandleExec(unittest.TestCase):
         self.container.add_layer(label="test", layer={
             "summary": "", "description": "", "services": {"test": service}
         })
-        args_history = []
+        args_history: typing.List[ops.testing.ExecArgs] = []
 
-        def handler(args):
+        def handler(args: ops.testing.ExecArgs):
             args_history.append(args)
 
         os.environ["JUJU_VERSION"] = "3.2.1"


### PR DESCRIPTION
One minor (type) change to ops.testing: the harness `pull()` signature is changed to allow `encoding==None`, which matches the actual `pebble.Client` method.

Otherwise, changes are in test_testing:
* Explicitly ignore types where we are testing invalid type behaviour
* Use `assert`s to show type checkers that `obj|None` is always `obj` in a few places - this seems better tn tests than `cast(obj_type, obj)` and pyright doesn't understand that this is the case with `assertIsNotNone(obj)`
* Remove two `print()` calls, one of which seems to be a debugging print that slipped in, and one that's not required although the expression being printed is
* Replace a few `dict(a=b, c=d)` with `{'a': b, 'c': d}` as pyright seems to understand the latter much more easily (plus it's insignificantly faster and generally more recommended style)
* Fix `test_push_with_permission_mask` where the exception's `kind` attribute was (presumably in error) only being tested for one of the test cases
* In the `_PebbleStorageAPIsTestMixin` class make it clear (especially for type checkers, but also in general) that a `client` attribute must be provided by the eventual class
* In the `_PebbleStorageAPIsTestMixin` class make it clear to type checkers that various TestCase methods will be provided (via mixing with `unittest.TestCase`)
* Sprinkle type hints where required for pyright to be happy

Partially addresses #1007