### PR TITLE
test: add type hints for test_storage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ include = ["ops/*.py", "ops/_private/*.py",
     "test/test_lib.py",
     "test/test_model.py",
     "test/test_testing.py",
+    "test/test_storage.py",
 ]
 pythonVersion = "3.8" # check no python > 3.8 features are used
 pythonPlatform = "All"


### PR DESCRIPTION
* Ignore the `None`s passed when creating the framework - passing real values would be a lot of extra noise without actually gaining any value in the test
* Add dummy methods to make the `Serializable` protocol match
* Ignore types when replacing a (when type checking) property
* Inherit from StoredStateData rather than Object to match the type of the `Framework.save_snapshot` method - the additional methods seem harmless in this case, and the meaning of the test seems unchanged
* Sprinkle enough type hints so that pyright can tell what's happening

Partially addresses #1007