### PR TITLE
test: add type hints to test_framework

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,9 @@
+# 2.8.0
+
+* The type of a `Handle`'s `key` was expanded from `str` to `str|None`
+
+# 2.7.0
+
+* Added Unit.set_ports()
+* Type checks now allow comparing a `JujuVersion` to a `str`
+* Renamed `OpenPort` to `Port` (`OpenPort` remains as an alias)

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -101,7 +101,7 @@ class Handle:
     under the same parent and kind may have the same key.
     """
 
-    def __init__(self, parent: Optional[Union['Handle', 'Object']], kind: str, key: str):
+    def __init__(self, parent: Optional[Union['Handle', 'Object']], kind: str, key: Optional[str]):
         if isinstance(parent, Object):
             # if it's not an Object, it will be either a Handle (good) or None (no parent)
             parent = parent.handle
@@ -119,7 +119,7 @@ class Handle:
             else:
                 self._path = f"{kind}"  # don't need f-string, but consistent with above
 
-    def nest(self, kind: str, key: str) -> 'Handle':
+    def nest(self, kind: str, key: Optional[str]) -> 'Handle':
         """Create a new handle as child of the current one."""
         return Handle(self, kind, key)
 
@@ -143,7 +143,7 @@ class Handle:
         return self._kind
 
     @property
-    def key(self) -> str:
+    def key(self) -> Optional[str]:
         """Return the handle's key."""
         return self._key
 

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -1061,13 +1061,17 @@ class BoundStoredState:
 
     if TYPE_CHECKING:
         @typing.overload
-        def __getattr__(self, key: Literal['on']) -> ObjectEvents:  # type: ignore
+        def __getattr__(self, key: Literal['on']) -> ObjectEvents:
+            pass
+
+        @typing.overload
+        def __getattr__(self, key: str) -> Any:
             pass
 
     def __getattr__(self, key: str) -> Any:
         # "on" is the only reserved key that can't be used in the data map.
         if key == "on":
-            return self._data.on  # type: ignore  # casting won't work for some reason
+            return self._data.on
         if key not in self._data:
             raise AttributeError(f"attribute '{key}' is not stored")
         return _wrap_stored(self._data, self._data[key])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ include = ["ops/*.py", "ops/_private/*.py",
     "test/test_model.py",
     "test/test_testing.py",
     "test/test_charm.py",
+    "test/test_framework.py",
 ]
 pythonVersion = "3.8" # check no python > 3.8 features are used
 pythonPlatform = "All"

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -1276,10 +1276,8 @@ class TestStoredState(BaseTestCase):
 
         class WrappedFramework(ops.Framework):
             def __init__(self,
-                         store: typing.Union[SQLiteStorage,
-                                             JujuStorage],
-                         charm_dir: typing.Union[str,
-                                                 Path],
+                         store: typing.Union[SQLiteStorage, JujuStorage],
+                         charm_dir: typing.Union[str, Path],
                          meta: ops.CharmMeta,
                          model: ops.Model,
                          event_name: str):

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -887,20 +887,14 @@ class TestStoredState(BaseTestCase):
     def test_stored_dict_repr(self):
         self.assertEqual(repr(ops.StoredDict(None, {})),  # type: ignore
                          "ops.framework.StoredDict()")
-        self.assertEqual(
-            repr(
-                ops.StoredDict(
-                    None, {  # type: ignore
-                        "a": 1})), "ops.framework.StoredDict({'a': 1})")
+        self.assertEqual(repr(ops.StoredDict(None, {"a": 1})),  # type: ignore
+                         "ops.framework.StoredDict({'a': 1})")
 
     def test_stored_list_repr(self):
         self.assertEqual(repr(ops.StoredList(None, [])),  # type: ignore
                          "ops.framework.StoredList()")
-        self.assertEqual(
-            repr(
-                ops.StoredList(
-                    None, [  # type: ignore
-                        1, 2, 3])), 'ops.framework.StoredList([1, 2, 3])')
+        self.assertEqual(repr(ops.StoredList(None, [1, 2, 3])),  # type: ignore
+                         'ops.framework.StoredList([1, 2, 3])')
 
     def test_stored_set_repr(self):
         self.assertEqual(repr(ops.StoredSet(None, set())),  # type: ignore

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -52,10 +52,9 @@ class TestFramework(BaseTestCase):
 
     def test_handle_path(self):
         cases = [
-            (ops.Handle(None, "root", 'test1'), "root[test1]"),
+            (ops.Handle(None, "root", None), "root"),
             (ops.Handle(None, "root", "1"), "root[1]"),
-            (ops.Handle(ops.Handle(None, "root", 'test2'), "child", 'test3'),
-             "root[test2]/child[test3]"),
+            (ops.Handle(ops.Handle(None, "root", None), "child", None), "root/child"),
             (ops.Handle(ops.Handle(None, "root", "1"), "child", "2"), "root[1]/child[2]"),
         ]
         for handle, path in cases:

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -1104,7 +1104,7 @@ class TestStoredState(BaseTestCase):
         framework.commit()
 
     def test_mutable_types(self):
-        # Test and validation functions in a list of 2-tuples.
+        # Test and validation functions in a list of tuples.
         # Assignment and keywords like del are not supported in lambdas
         #  so functions are used instead.
         test_case = typing.Tuple[

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -345,7 +345,7 @@ class TestFramework(BaseTestCase):
             def snapshot(self):
                 return {"My N!": self.my_n}
 
-            def restore(self, snapshot: typing.Dict[str, int]):
+            def restore(self, snapshot: typing.Dict[str, typing.Any]):
                 super().restore(snapshot)
                 self.my_n = snapshot["My N!"] + 1
 


### PR DESCRIPTION
* Change the type of `Handle`'s `key` (in `__init__` and `nest()` and the property) to explicitly allow `None
* Add a CHANGES.md file to document changes (backfilled only to 2.7)
* Tidy up the type hinting of `BoundStoredState.__getattr__` - multiple overloads need to be provided, and once that's done the ignores can be removed (and a bunch of type issues in the tests get resolved)
* Ignore type where creating an object that's only partially complete, but the test only requires that much and fully creating it would be a lot of extra code for no real gain
* Where's it's simple to do, pass the required attributes rather than `None`
* Ignore types where we're checking handling of invalid types
* Add casts around the very dynamic snapshot/restore functionality
* For a couple of the "list of test cases" situations, move the documentation of what each element in the test case is to a new type definition that covers both what was there before and the (rough) expected type
* Sprinkle type hints where required for pyright to be happy

Partially addresses #1007