### PR TITLE
Add `Unit.ordinal`

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -469,12 +469,16 @@ class Unit:
     app: Application
     """Application the unit is part of."""
 
+    number: int
+    """Unit ID number, for example 0."""
+
     def __init__(self, name: str, meta: 'ops.charm.CharmMeta',
                  backend: '_ModelBackend', cache: '_ModelCache'):
         self.name = name
 
         app_name = name.split('/')[0]
         self.app = cache.get(Application, app_name)
+        self.number = int(name.split('/')[1])
 
         self._backend = backend
         self._cache = cache

--- a/ops/model.py
+++ b/ops/model.py
@@ -469,16 +469,16 @@ class Unit:
     app: Application
     """Application the unit is part of."""
 
-    number: int
+    ordinal: int
     """Unit ID number, for example 0."""
 
     def __init__(self, name: str, meta: 'ops.charm.CharmMeta',
                  backend: '_ModelBackend', cache: '_ModelCache'):
         self.name = name
 
-        app_name = name.split('/')[0]
+        app_name, ordinal = name.split('/')
         self.app = cache.get(Application, app_name)
-        self.number = int(name.split('/')[1])
+        self.ordinal = int(ordinal)
 
         self._backend = backend
         self._cache = cache

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -3596,5 +3596,15 @@ class TestPorts(unittest.TestCase):
         ])
 
 
+@pytest.mark.parametrize("name,ordinal", [("foo/3", 3), ("my-app-name/0", 0)])
+def test_unit_ordinal(name, ordinal):
+    meta = ops.CharmMeta.from_yaml("""
+    name: charm
+    """)
+    backend = _ModelBackend(name)
+    model = ops.Model(meta, backend)
+    assert model.unit.ordinal == ordinal
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1443,7 +1443,7 @@ containers:
             containers['c3']
 
         with self.assertRaises(RuntimeError):
-            other_unit = self.model.get_unit('other')
+            other_unit = self.model.get_unit('other/0')
             other_unit.containers
 
     def test_unit_get_container(self):
@@ -1457,7 +1457,7 @@ containers:
             unit.get_container('c3')
 
         with self.assertRaises(RuntimeError):
-            other_unit = self.model.get_unit('other')
+            other_unit = self.model.get_unit('other/0')
             other_unit.get_container('foo')
 
 
@@ -3349,7 +3349,7 @@ class TestSecretClass(unittest.TestCase):
         backend = ops.model._ModelBackend('test', 'test', 'test')
         meta = ops.CharmMeta()
         cache = ops.model._ModelCache(meta, backend)
-        unit = ops.Unit('test', meta, backend, cache)
+        unit = ops.Unit('test/0', meta, backend, cache)
         rel123 = ops.Relation('test', 123, True, unit, backend, cache)
         rel234 = ops.Relation('test', 234, True, unit, backend, cache)
         secret.grant(rel123)
@@ -3379,7 +3379,7 @@ class TestSecretClass(unittest.TestCase):
         fake_script(self, 'secret-info-get', """echo '{"z": {"label": "y", "revision": 7}}'""")
 
         secret = self.make_secret(id='x')
-        unit = ops.Unit('test', ops.CharmMeta(), self.model._backend, self.model._cache)
+        unit = ops.Unit('test/0', ops.CharmMeta(), self.model._backend, self.model._cache)
         rel123 = ops.Relation('test', 123, True, unit, self.model._backend, self.model._cache)
         rel234 = ops.Relation('test', 234, True, unit, self.model._backend, self.model._cache)
         secret.revoke(rel123)


### PR DESCRIPTION
Many of our charms use `ops.Unit.name.split("/")[1]` or `ops.Unit.name.split("/")[-1]` to parse the unit ordinal

The unit ordinal appears to be part of Juju's official API:

> `A unit is always named on the pattern <application>/<unit ID>, where <application> is the name of the application and the <unit ID> is its ID number`

https://juju.is/docs/juju/unit