### PR TITLE
ci: Pass LIBJUJU_VERSION_SPECIFIER to the mysql-k8s-operator unit tests

### DIFF
--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Run the charm's unit tests
         run: tox -vve unit
+        # TODO: remove this once https://github.com/canonical/mysql-k8s-operator/pull/316 is fixed
         env:
           # This env var is only to indicate Juju version to "simulate" in the mysqk-k8s-operator
           # unit tests. No libjuju is being actually used in unit testing.

--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -43,3 +43,7 @@ jobs:
 
       - name: Run the charm's unit tests
         run: tox -vve unit
+        env:
+          # This env var is only to indicate Juju version to "simulate" in the mysqk-k8s-operator
+          # unit tests. No libjuju is being actually used in unit testing.
+          LIBJUJU_VERSION_SPECIFIER: 3.1


### PR DESCRIPTION
In canonical/mysql-k8s-operator#313, the unit tests were changed to expect a LIBJUJU_VERSION_SPECIFIER envvar to be present when the tests are run. This is used in those tests to run the tests simulating Juju 2.9 and 3.1.

Adjust our running of the mysql-k8s-operator tests to also provide this value, fixed at 3.1. (This is also present for the other 3 DB operators, but that should do no harm).