### PR TITLE
feat(charm): add RelationMeta.optional

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
         '_RelationMetaDict', {
             'interface': Required[str],
             'limit': int,
+            'optional': bool,
             'scope': _Scopes},
         total=False)
 
@@ -1300,6 +1301,14 @@ class RelationMeta:
     Will be either ``"global"`` or ``"container"``.
     """
 
+    optional: bool
+    """If True, the relation is considered optional.
+
+    This value is informational only and is not used by Juju itself (all
+    relations are optional from Juju's perspective), but it may be set in
+    ``metadata.yaml`` and used by the charm code if appropriate.
+    """
+
     VALID_SCOPES = ['global', 'container']
 
     def __init__(self, role: RelationRole, relation_name: str, raw: '_RelationMetaDict'):
@@ -1318,6 +1327,8 @@ class RelationMeta:
         if self.scope not in self.VALID_SCOPES:
             raise TypeError("scope should be one of {}; not '{}'".format(
                 ', '.join(f"'{s}'" for s in self.VALID_SCOPES), self.scope))
+
+        self.optional = raw.get('optional', False)
 
 
 class StorageMeta:

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -362,7 +362,6 @@ containers:
         self.assertEqual(charm.count, 2)
 
     def test_relations_meta(self):
-
         # language=YAML
         self.meta = ops.CharmMeta.from_yaml('''
 name: my-charm
@@ -373,15 +372,18 @@ requires:
     scope: container
   metrics:
     interface: prometheus-scraping
+    optional: true
 ''')
 
         self.assertEqual(self.meta.requires['database'].interface_name, 'mongodb')
         self.assertEqual(self.meta.requires['database'].limit, 1)
         self.assertEqual(self.meta.requires['database'].scope, 'container')
+        self.assertFalse(self.meta.requires['database'].optional)
 
         self.assertEqual(self.meta.requires['metrics'].interface_name, 'prometheus-scraping')
         self.assertIsNone(self.meta.requires['metrics'].limit)
         self.assertEqual(self.meta.requires['metrics'].scope, 'global')  # Default value
+        self.assertTrue(self.meta.requires['metrics'].optional)
 
     def test_relations_meta_limit_type_validation(self):
         with self.assertRaisesRegex(TypeError, "limit should be an int, not <class 'str'>"):


### PR DESCRIPTION
This field is already supported in `metadata.yaml` but just not exposed in `RelationMeta`. Expose it. Further discussion in #799.

Fixes #799