### PR TITLE
feat: add Unit.reboot for machine charms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # 2.8.0
 
-* Added `Unit.reboot()` and `Harness.last_rebooted``
+* Added `Unit.reboot()` and `Harness.reboot_count``
 * Added `RelationMeta.optional`
 * The type of a `Handle`'s `key` was expanded from `str` to `str|None`
 * Narrowed types of `app` and `unit` in relation events to exclude `None` where applicable

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 # 2.8.0
 
-* Added Unit.reboot() and Harness.last_rebooted
+* Added `Unit.reboot()` and `Harness.last_rebooted``
+* Added `RelationMeta.optional`
 * The type of a `Handle`'s `key` was expanded from `str` to `str|None`
+* Narrowed types of `app` and `unit` in relation events to exclude `None` where applicable
 
 # 2.7.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # 2.8.0
 
-* Added Unit.reboot()
+* Added Unit.reboot() and Harness.last_rebooted
 * The type of a `Handle`'s `key` was expanded from `str` to `str|None`
 
 # 2.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # 2.8.0
 
+* Added Unit.reboot()
 * The type of a `Handle`'s `key` was expanded from `str` to `str|None`
 
 # 2.7.0

--- a/ops/model.py
+++ b/ops/model.py
@@ -692,7 +692,7 @@ class Unit:
             self._backend.open_port(protocol, port)
 
     def reboot(self, now: bool = False) -> None:
-        """Reboot the host machine, after stopping all containers hosted on the machine.
+        """Reboot the host machine.
 
         Normally, the reboot will only take place after the current hook successfully
         completes. Use ``now=True`` to reboot immediately without waiting for the

--- a/ops/model.py
+++ b/ops/model.py
@@ -26,6 +26,7 @@ import re
 import shutil
 import stat
 import subprocess
+import sys
 import tempfile
 import time
 import typing
@@ -3388,6 +3389,10 @@ class _ModelBackend:
     def reboot(self, now: bool = False):
         if now:
             self._run("juju-reboot", "--now")
+            # Juju will kill the Charm process, and in testing no code after
+            # this point would execute. However, we want to guarantee that for
+            # Charmers, so we force that to be the case.
+            sys.exit()
         else:
             self._run("juju-reboot")
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -673,6 +673,8 @@ class Unit:
         Use :meth:`open_port` and :meth:`close_port` to manage ports
         individually.
 
+        *New in version 2.7*
+
         Args:
             ports: The ports to open. Provide an int to open a TCP port, or
                 a :class:`Port` to open a port for another protocol.
@@ -701,6 +703,8 @@ class Unit:
 
         This is not supported on Kubernetes charms, can only be called for the current unit,
         and cannot be used in an action hook.
+
+        *New in version 2.8*
 
         Args:
             now: terminate immediately without waiting for the current hook to complete,

--- a/ops/model.py
+++ b/ops/model.py
@@ -699,10 +699,8 @@ class Unit:
         hook to complete; this is useful when multiple restarts are required (Juju
         will re-run the hook after rebooting).
 
-        This will silently fail for Kubernetes charms.
-
-        This can only be called for the current unit, and cannot be used in an action
-        hook.
+        This is not supported on Kubernetes charms, can only be called for the current unit,
+        and cannot be used in an action hook.
 
         Args:
             now: terminate immediately without waiting for the current hook to complete,

--- a/ops/model.py
+++ b/ops/model.py
@@ -695,9 +695,9 @@ class Unit:
         """Reboot the host machine, after stopping all containers hosted on the machine.
 
         Normally, the reboot will only take place after the current hook successfully
-        completes. Use the ``now`` argument when multiple reboots are required, to
-        reboot immediately without waiting for the hook to complete, and to restart the
-        hook after rebooting.
+        completes. Use ``now=True`` to reboot immediately without waiting for the
+        hook to complete; this is useful when multiple restarts are required (Juju
+        will re-run the hook after rebooting).
 
         This will silently fail for Kubernetes charms.
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1882,6 +1882,10 @@ class _Secret:
     grants: Dict[int, Set[str]] = dataclasses.field(default_factory=dict)
 
 
+class RebootingMachineError(Exception):
+    """Raised when the machine would reboot."""
+
+
 @_copy_docstrings(model._ModelBackend)
 @_record_calls
 class _TestingModelBackend:
@@ -2502,6 +2506,14 @@ class _TestingModelBackend:
                 raise model.ModelError(f'ERROR port range bounds must be between 1 and 65535, got {port}-{port}\n')  # NOQA: test_quote_backslashes
         else:
             raise model.ModelError(f'ERROR invalid protocol "{protocol}", expected "tcp", "udp", or "icmp"\n')  # NOQA: test_quote_backslashes
+
+    def reboot(self, now: bool = False):
+        if not now:
+            # We can't simulate the reboot, so just do nothing.
+            return
+        # This should exit, reboot, and re-emit the event, but we'll need the caller
+        # to handle that. We raise an exception so that they can simulate the exit.
+        raise RebootingMachineError()
 
 
 @_copy_docstrings(pebble.ExecProcess)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1733,12 +1733,9 @@ class Harness(Generic[CharmType]):
         )
 
     @property
-    def last_rebooted(self) -> Optional[datetime.datetime]:
-        """The time that the charm last called :meth:`ops.Unit.reboot` (with or without *now*).
-
-        Returns ``None`` if :meth:`ops.Unit.reboot` has not been called.
-        """
-        return self._backend._last_reboot
+    def reboot_count(self) -> int:
+        """Count of times that the charm has called :meth:`ops.Unit.reboot`."""
+        return self._backend._reboot_count
 
 
 def _get_app_or_unit_name(app_or_unit: AppUnitOrName) -> str:
@@ -1974,7 +1971,7 @@ class _TestingModelBackend:
         self._secrets: List[_Secret] = []
         self._opened_ports: Set[model.Port] = set()
         self._networks: Dict[Tuple[Optional[str], Optional[int]], _NetworkDict] = {}
-        self._last_reboot = None
+        self._reboot_count = 0
 
     def _validate_relation_access(self, relation_name: str, relations: List[model.Relation]):
         """Ensures that the named relation exists/has been added.
@@ -2536,7 +2533,7 @@ class _TestingModelBackend:
             raise model.ModelError(f'ERROR invalid protocol "{protocol}", expected "tcp", "udp", or "icmp"\n')  # NOQA: test_quote_backslashes
 
     def reboot(self, now: bool = False):
-        self._last_reboot = datetime.datetime.now(datetime.timezone.utc)
+        self._reboot_count += 1
         if not now:
             return
         # This should exit, reboot, and re-emit the event, but we'll need the caller

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1883,7 +1883,21 @@ class _Secret:
 
 
 class RebootingMachineError(Exception):
-    """Raised when the machine would reboot."""
+    """Raised when the machine would reboot.
+    
+    When :meth:`Unit.reboot` is called with ``now=True`` in a machine charm, the
+    unit's machine is rebooted, interrupting the execution of the event hook. To
+    simulate that when using the testing harness, write a test that expects a
+    ``RebootingMachineError`` to be raised, for example::
+
+        def test_installation(self):
+            self.harness.begin()
+            with self.assertRaises(ops.testing.RebootMachineError):
+                self.harness.charm.on.install.emit()
+                # More asserts here that the first part of installation was done.
+            self.harness.charm.on.install.emit()
+            # More asserts here that the installation continued appropriately.
+    """
 
 
 @_copy_docstrings(model._ModelBackend)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1888,7 +1888,7 @@ class RebootingMachineError(Exception):
     When :meth:`Unit.reboot` is called with ``now=True`` in a machine charm, the
     unit's machine is rebooted, interrupting the execution of the event hook. To
     simulate that when using the testing harness, write a test that expects a
-    ``RebootingMachineError`` to be raised, for example::
+    this exception to be raised, for example::
 
         def test_installation(self):
             self.harness.begin()

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1892,24 +1892,6 @@ class _Secret:
     grants: Dict[int, Set[str]] = dataclasses.field(default_factory=dict)
 
 
-class RebootNow(Exception):  # noqa
-    """Raised when the machine would reboot.
-
-    When :meth:`ops.Unit.reboot` is called with ``now=True`` in a machine charm, the
-    unit's machine is rebooted, interrupting the execution of the event hook. To
-    simulate that when using the testing harness, write a test that expects this
-    exception to be raised, for example::
-
-        def test_installation(self):
-            self.harness.begin()
-            with self.assertRaises(ops.testing.RebootNow):
-                self.harness.charm.on.install.emit()
-                # More asserts here that the first part of installation was done.
-            self.harness.charm.on.install.emit()
-            # More asserts here that the installation continued appropriately.
-    """
-
-
 @_copy_docstrings(model._ModelBackend)
 @_record_calls
 class _TestingModelBackend:
@@ -2537,11 +2519,8 @@ class _TestingModelBackend:
         if not now:
             return
         # This should exit, reboot, and re-emit the event, but we'll need the caller
-        # to handle that. We raise an exception so that they can simulate the exit.
-        # We have a custom exception, rather than using SystemExit like the real call
-        # does, because we don't want to terminate someone's tests if they miss
-        # catching it, or if it happens unexpectedly.
-        raise RebootNow()
+        # to handle everything after the exit.
+        raise SystemExit()
 
 
 @_copy_docstrings(pebble.ExecProcess)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1882,7 +1882,7 @@ class _Secret:
     grants: Dict[int, Set[str]] = dataclasses.field(default_factory=dict)
 
 
-class RebootNow(Exception):
+class RebootNow(Exception):  # noqa
     """Raised when the machine would reboot.
 
     When :meth:`ops.Unit.reboot` is called with ``now=True`` in a machine charm, the

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1884,7 +1884,7 @@ class _Secret:
 
 class RebootingMachineError(Exception):
     """Raised when the machine would reboot.
-    
+
     When :meth:`Unit.reboot` is called with ``now=True`` in a machine charm, the
     unit's machine is rebooted, interrupting the execution of the event hook. To
     simulate that when using the testing harness, write a test that expects a

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1882,10 +1882,10 @@ class _Secret:
     grants: Dict[int, Set[str]] = dataclasses.field(default_factory=dict)
 
 
-class RebootingMachineError(Exception):
+class RebootNow(Exception):
     """Raised when the machine would reboot.
 
-    When :meth:`Unit.reboot` is called with ``now=True`` in a machine charm, the
+    When :meth:`ops.Unit.reboot` is called with ``now=True`` in a machine charm, the
     unit's machine is rebooted, interrupting the execution of the event hook. To
     simulate that when using the testing harness, write a test that expects a
     this exception to be raised, for example::
@@ -2527,10 +2527,10 @@ class _TestingModelBackend:
             return
         # This should exit, reboot, and re-emit the event, but we'll need the caller
         # to handle that. We raise an exception so that they can simulate the exit.
-        raise RebootingMachineError()
+        raise RebootNow()
 
 
-@_copy_docstrings(pebble.ExecProcess)
+@_copy_docstrings(pebble.ExecProcRebootingMachineErroress)
 class _TestingExecProcess:
     def __init__(self,
                  command: List[str],

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2538,6 +2538,9 @@ class _TestingModelBackend:
             return
         # This should exit, reboot, and re-emit the event, but we'll need the caller
         # to handle that. We raise an exception so that they can simulate the exit.
+        # We have a custom exception, rather than using SystemExit like the real call
+        # does, because we don't want to terminate someone's tests if they miss
+        # catching it, or if it happens unexpectedly.
         raise RebootNow()
 
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1900,7 +1900,7 @@ class RebootNow(Exception):  # noqa
 
         def test_installation(self):
             self.harness.begin()
-            with self.assertRaises(ops.testing.RebootMachineError):
+            with self.assertRaises(ops.testing.RebootNow):
                 self.harness.charm.on.install.emit()
                 # More asserts here that the first part of installation was done.
             self.harness.charm.on.install.emit()

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1734,7 +1734,7 @@ class Harness(Generic[CharmType]):
 
     @property
     def reboot_count(self) -> int:
-        """Count of times that the charm has called :meth:`ops.Unit.reboot`."""
+        """Number of times the charm has called :meth:`ops.Unit.reboot`."""
         return self._backend._reboot_count
 
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2530,7 +2530,7 @@ class _TestingModelBackend:
         raise RebootNow()
 
 
-@_copy_docstrings(pebble.ExecProcRebootingMachineErroress)
+@_copy_docstrings(pebble.ExecProcess)
 class _TestingExecProcess:
     def __init__(self,
                  command: List[str],

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1895,8 +1895,8 @@ class RebootNow(Exception):  # noqa
 
     When :meth:`ops.Unit.reboot` is called with ``now=True`` in a machine charm, the
     unit's machine is rebooted, interrupting the execution of the event hook. To
-    simulate that when using the testing harness, write a test that expects a
-    this exception to be raised, for example::
+    simulate that when using the testing harness, write a test that expects this
+    exception to be raised, for example::
 
         def test_installation(self):
             self.harness.begin()

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1731,7 +1731,7 @@ class Harness(Generic[CharmType]):
     def last_rebooted(self) -> Optional[datetime.datetime]:
         """The time that the charm last called :meth:`ops.Unit.reboot` (with or without *now*).
 
-        Returns None if :meth:`ops.Unit.reboot` has not been called.
+        Returns ``None`` if :meth:`ops.Unit.reboot` has not been called.
         """
         return self._backend._last_reboot
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -3607,7 +3607,8 @@ class TestUnit(unittest.TestCase):
         self.assertEqual(fake_script_calls(self, clear=True), [
             ['juju-reboot', ''],
         ])
-        self.unit.reboot(now=True)
+        with self.assertRaises(SystemExit):
+            self.unit.reboot(now=True)
         self.assertEqual(fake_script_calls(self, clear=True), [
             ['juju-reboot', '--now'],
         ])

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -3596,5 +3596,27 @@ class TestPorts(unittest.TestCase):
         ])
 
 
+class TestContainer(unittest.TestCase):
+    def setUp(self):
+        self.model = ops.model.Model(ops.charm.CharmMeta(), ops.model._ModelBackend('myapp/0'))
+        self.unit = self.model.unit
+
+    def test_reboot(self):
+        fake_script(self, 'juju-reboot', 'exit 0')
+        self.unit.reboot()
+        self.assertEqual(fake_script_calls(self, clear=True), [
+            ['juju-reboot', ''],
+        ])
+        self.unit.reboot(now=True)
+        self.assertEqual(fake_script_calls(self, clear=True), [
+            ['juju-reboot', '--now'],
+        ])
+
+        with self.assertRaises(RuntimeError):
+            self.model.get_unit('other').reboot()
+        with self.assertRaises(RuntimeError):
+            self.model.get_unit('other').reboot(now=True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -3596,7 +3596,7 @@ class TestPorts(unittest.TestCase):
         ])
 
 
-class TestContainer(unittest.TestCase):
+class TestUnit(unittest.TestCase):
     def setUp(self):
         self.model = ops.model.Model(ops.charm.CharmMeta(), ops.model._ModelBackend('myapp/0'))
         self.unit = self.model.unit

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3339,8 +3339,8 @@ class TestTestingModelBackend(unittest.TestCase):
 
     def test_reboot(self):
         class RebootingCharm(ops.CharmBase):
-            def __init__(self, *args, **kwargs):  # type: ignore
-                super().__init__(*args, **kwargs)  # type: ignore
+            def __init__(self, framework: ops.Framework):
+                super().__init__(framework)
                 self.framework.observe(self.on.install, self._reboot_now)
                 self.framework.observe(self.on.remove, self._reboot)
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3356,11 +3356,11 @@ class TestTestingModelBackend(unittest.TestCase):
         self.addCleanup(harness.cleanup)
         backend = harness._backend
         backend.reboot()
-        with self.assertRaises(ops.testing.RebootingMachineError):
+        with self.assertRaises(ops.testing.RebootNow):
             backend.reboot(now=True)
         harness.begin()
         harness.charm.on.install.emit()
-        with self.assertRaises(ops.testing.RebootingMachineError):
+        with self.assertRaises(ops.testing.RebootNow):
             harness.charm.on.remove.emit()
 
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3362,27 +3362,19 @@ class TestTestingModelBackend(unittest.TestCase):
             name: test-app
             ''')
         self.addCleanup(harness.cleanup)
-        self.assertIsNone(harness.last_rebooted)
+        self.assertEqual(harness.reboot_count, 0)
         backend = harness._backend
         backend.reboot()
-        reboot1 = harness.last_rebooted
-        assert reboot1 is not None
-        self.assertTrue(reboot1)
+        self.assertEqual(harness.reboot_count, 1)
         with self.assertRaises(ops.testing.RebootNow):
             backend.reboot(now=True)
-        reboot2 = harness.last_rebooted
-        assert reboot2 is not None
-        self.assertGreater(reboot2, reboot1)
+        self.assertEqual(harness.reboot_count, 2)
         harness.begin()
         with self.assertRaises(ops.testing.RebootNow):
             harness.charm.on.install.emit()
-        reboot3 = harness.last_rebooted
-        assert reboot3 is not None
-        self.assertGreater(reboot3, reboot2)
+        self.assertEqual(harness.reboot_count, 3)
         harness.charm.on.remove.emit()
-        reboot4 = harness.last_rebooted
-        assert reboot4 is not None
-        self.assertGreater(reboot4, reboot3)
+        self.assertEqual(harness.reboot_count, 4)
 
 
 class _TestingPebbleClientMixin:

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3366,11 +3366,11 @@ class TestTestingModelBackend(unittest.TestCase):
         backend = harness._backend
         backend.reboot()
         self.assertEqual(harness.reboot_count, 1)
-        with self.assertRaises(ops.testing.RebootNow):
+        with self.assertRaises(SystemExit):
             backend.reboot(now=True)
         self.assertEqual(harness.reboot_count, 2)
         harness.begin()
-        with self.assertRaises(ops.testing.RebootNow):
+        with self.assertRaises(SystemExit):
             harness.charm.on.install.emit()
         self.assertEqual(harness.reboot_count, 3)
         harness.charm.on.remove.emit()

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3341,14 +3341,14 @@ class TestTestingModelBackend(unittest.TestCase):
         class RebootingCharm(ops.CharmBase):
             def __init__(self, *args, **kwargs):  # type: ignore
                 super().__init__(*args, **kwargs)  # type: ignore
-                self.framework.observe(self.on.install, self._reboot)
-                self.framework.observe(self.on.remove, self._reboot_now)
-
-            def _reboot(self, event: ops.RemoveEvent):
-                self.unit.reboot()
+                self.framework.observe(self.on.install, self._reboot_now)
+                self.framework.observe(self.on.remove, self._reboot)
 
             def _reboot_now(self, event: ops.InstallEvent):
                 self.unit.reboot(now=True)
+
+            def _reboot(self, event: ops.RemoveEvent):
+                self.unit.reboot()
 
         harness = ops.testing.Harness(RebootingCharm, meta='''
             name: test-app
@@ -3359,9 +3359,9 @@ class TestTestingModelBackend(unittest.TestCase):
         with self.assertRaises(ops.testing.RebootNow):
             backend.reboot(now=True)
         harness.begin()
-        harness.charm.on.install.emit()
         with self.assertRaises(ops.testing.RebootNow):
-            harness.charm.on.remove.emit()
+            harness.charm.on.install.emit()
+        harness.charm.on.remove.emit()
 
 
 class _TestingPebbleClientMixin:

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3354,14 +3354,27 @@ class TestTestingModelBackend(unittest.TestCase):
             name: test-app
             ''')
         self.addCleanup(harness.cleanup)
+        self.assertIsNone(harness.last_rebooted)
         backend = harness._backend
         backend.reboot()
+        reboot1 = harness.last_rebooted
+        assert reboot1 is not None
+        self.assertTrue(reboot1)
         with self.assertRaises(ops.testing.RebootNow):
             backend.reboot(now=True)
+        reboot2 = harness.last_rebooted
+        assert reboot2 is not None
+        self.assertGreater(reboot2, reboot1)
         harness.begin()
         with self.assertRaises(ops.testing.RebootNow):
             harness.charm.on.install.emit()
+        reboot3 = harness.last_rebooted
+        assert reboot3 is not None
+        self.assertGreater(reboot3, reboot2)
         harness.charm.on.remove.emit()
+        reboot4 = harness.last_rebooted
+        assert reboot4 is not None
+        self.assertGreater(reboot4, reboot3)
 
 
 class _TestingPebbleClientMixin:


### PR DESCRIPTION
Adds a new `reboot` method to `Unit`, that's a wrapper around the `juju-reboot` command.

`juju-reboot` is only available for machine charms. When it's run for a K8s charm, Juju logs an error message but doesn't return an response with the error (or have a non-zero exit), which means that we have to fail silently.

Adds a corresponding `reboot()` method to the harness backend.

From the point of view of the harness, we assume that everything is essentially the same after rebooting without `--now`, so this is a no-op. The most likely change that would impact the harness would be a leadership change, but it seems better to let the Charmer model that explicitly in their tests.

When rebooting with `--now`, what should happen is that everything after that point in the event handler is skipped, there's a simulated reboot (again, roughly a no-op), and then the event is re-emitted. I went down a long rabbit-hole trying to get the harness to do this, but it ended up way too messy for minimal benefit. Instead, a `SystemExit` exception is raised and the Charmer is expected to handle it in their tests, for example:

```python
def test_installation(self):
    self.harness.begin()
    with self.assertRaises(SystemExit):
        self.harness.charm.on.install.emit()
        # More asserts here that the first part of installation was done.
    self.harness.charm.on.install.emit()
    # More asserts here that the installation continued appropriately.
```

Fixes #929