### PR TITLE
docs: document more of the exceptions that may be raised

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -105,6 +105,8 @@ Currently we don't publish separate versions of documentation for separate relea
 
 next to the relevant content (e.g. headings, etc.).
 
+Noteworthy changes should also get a new entry in [CHANGES.md](CHANGES.md).
+
 
 ## Dependencies
 

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -939,9 +939,6 @@ class CollectStatusEvent(EventBase):
         """Add a status for evaluation.
 
         See :class:`CollectStatusEvent` for a description of how to use this.
-
-        Raises:
-            TypeError: if ``status`` is not a :class:`model.StatusBase` instance.
         """
         if not isinstance(status, model.StatusBase):
             raise TypeError(f'status should be a StatusBase, not {type(status).__name__}')

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -25,6 +25,7 @@ from typing import (
     List,
     Literal,
     Mapping,
+    NoReturn,  # Use Never in Python 3.11+
     Optional,
     TextIO,
     Tuple,
@@ -120,11 +121,14 @@ class ActionEvent(EventBase):
     params: Dict[str, Any]
     """The parameters passed to the action."""
 
-    def defer(self) -> None:
+    def defer(self) -> NoReturn:
         """Action events are not deferrable like other events.
 
         This is because an action runs synchronously and the administrator
         is waiting for the result.
+
+        Raises:
+            RuntimeError: always.
         """
         raise RuntimeError('cannot defer action events')
 
@@ -175,6 +179,12 @@ class ActionEvent(EventBase):
 
         Args:
             results: The result of the action as a Dict
+
+        Raises:
+            :class:`ops.ModelError`: if a reserved key is used.
+            ValueError: if ``results`` has a mix of dotted/non-dotted keys that expand out to
+                result in duplicate keys, for example: {'a': {'b': 1}, 'a.b': 2}. Also raised if
+                a dict is passed with a key that fails to meet the format requirements.
         """
         self.framework.model._backend.action_set(results)
 
@@ -359,8 +369,11 @@ class CollectMetricsEvent(HookEvent):
         Args:
             metrics: Key-value mapping of metrics that have been gathered.
             labels: Key-value labels applied to the metrics.
+
+        Raises:
+            :class:`ops.ModelError`: if invalid keys or values are provided.
         """
-        self.framework.model._backend.add_metrics(metrics, labels)  # type:ignore
+        self.framework.model._backend.add_metrics(metrics, labels)
 
 
 class RelationEvent(HookEvent):
@@ -762,8 +775,12 @@ class SecretRotateEvent(SecretEvent):
     revision by calling :meth:`event.secret.set_content() <ops.Secret.set_content>`.
     """
 
-    def defer(self) -> None:
-        """Secret rotation events are not deferrable (Juju handles re-invocation)."""
+    def defer(self) -> NoReturn:
+        """Secret rotation events are not deferrable (Juju handles re-invocation).
+
+        Raises:
+            RuntimeError: always.
+        """
         raise RuntimeError(
             'Cannot defer secret rotation events. Juju will keep firing this '
             'event until you create a new revision.')
@@ -842,8 +859,12 @@ class SecretExpiredEvent(SecretEvent):
         super().restore(snapshot)
         self._revision = cast(int, snapshot['revision'])
 
-    def defer(self) -> None:
-        """Secret expiration events are not deferrable (Juju handles re-invocation)."""
+    def defer(self) -> NoReturn:
+        """Secret expiration events are not deferrable (Juju handles re-invocation).
+
+        Raises:
+            RuntimeError: always.
+        """
         raise RuntimeError(
             'Cannot defer secret expiration events. Juju will keep firing '
             'this event until you create a new revision.')
@@ -912,6 +933,10 @@ class CollectStatusEvent(EventBase):
         """Add a status for evaluation.
 
         See :class:`CollectStatusEvent` for a description of how to use this.
+
+        Raises:
+            TypeError: if ``status`` is not a :class:`model.StatusBase` instance.
+
         """
         if not isinstance(status, model.StatusBase):
             raise TypeError(f'status should be a StatusBase, not {type(status).__name__}')

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -18,7 +18,6 @@ import enum
 import logging
 import os
 import pathlib
-from typing import NoReturn  # Use Never in Python 3.11+
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -26,6 +25,7 @@ from typing import (
     List,
     Literal,
     Mapping,
+    NoReturn,
     Optional,
     TextIO,
     Tuple,

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -181,10 +181,10 @@ class ActionEvent(EventBase):
             results: The result of the action as a Dict
 
         Raises:
-            :class:`ops.ModelError`: if a reserved key is used.
+            ModelError: if a reserved key is used.
             ValueError: if ``results`` has a mix of dotted/non-dotted keys that expand out to
-                result in duplicate keys, for example: {'a': {'b': 1}, 'a.b': 2}. Also raised if
-                a dict is passed with a key that fails to meet the format requirements.
+                result in duplicate keys, for example: :code:`{'a': {'b': 1}, 'a.b': 2}`. Also
+                raised if a dict is passed with a key that fails to meet the format requirements.
             OSError: if extremely large (>100KB) results are provided.
         """
         self.framework.model._backend.action_set(results)
@@ -372,7 +372,7 @@ class CollectMetricsEvent(HookEvent):
             labels: Key-value labels applied to the metrics.
 
         Raises:
-            :class:`ops.ModelError`: if invalid keys or values are provided.
+            ModelError: if invalid keys or values are provided.
         """
         self.framework.model._backend.add_metrics(metrics, labels)
 

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -18,6 +18,7 @@ import enum
 import logging
 import os
 import pathlib
+from typing import NoReturn  # Use Never in Python 3.11+
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -25,7 +26,6 @@ from typing import (
     List,
     Literal,
     Mapping,
-    NoReturn,  # Use Never in Python 3.11+
     Optional,
     TextIO,
     Tuple,
@@ -185,6 +185,7 @@ class ActionEvent(EventBase):
             ValueError: if ``results`` has a mix of dotted/non-dotted keys that expand out to
                 result in duplicate keys, for example: {'a': {'b': 1}, 'a.b': 2}. Also raised if
                 a dict is passed with a key that fails to meet the format requirements.
+            OSError: if extremely large (>100KB) results are provided.
         """
         self.framework.model._backend.action_set(results)
 

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -937,7 +937,6 @@ class CollectStatusEvent(EventBase):
 
         Raises:
             TypeError: if ``status`` is not a :class:`model.StatusBase` instance.
-
         """
         if not isinstance(status, model.StatusBase):
             raise TypeError(f'status should be a StatusBase, not {type(status).__name__}')

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -263,11 +263,11 @@ class EventSource:
 
     It is generally used as::
 
-        class SomethingHappened(EventBase):
+        class SomethingHappened(ops.EventBase):
             pass
 
         class SomeObject(Object):
-            something_happened = EventSource(SomethingHappened)
+            something_happened = ops.EventSource(SomethingHappened)
 
     With that, instances of that type will offer the ``someobj.something_happened``
     attribute which is a :class:`BoundEvent`, and may be used to emit and observe
@@ -1106,15 +1106,15 @@ class StoredState:
 
     Example::
 
-        class MyClass(Object):
-            _stored = StoredState()
+        class MyClass(ops.Object):
+            _stored = ops.StoredState()
 
     Instances of ``MyClass`` can transparently save state between invocations by
     setting attributes on ``_stored``. Initial state should be set with
     ``set_default`` on the bound object, that is::
 
-        class MyClass(Object):
-            _stored = StoredState()
+        class MyClass(ops.Object):
+            _stored = ops.StoredState()
 
             def __init__(self, parent, key):
                 super().__init__(parent, key)

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -445,6 +445,10 @@ class ObjectEvents(Object):
                         event. Must be a valid Python identifier, not be a keyword
                         or an existing attribute.
             event_type: A type of the event to define.
+
+        Raises:
+            RuntimeError: if the same event is defined twice, or if ``event_kind``
+                is an invalid name.
         """
         prefix = 'unable to define an event with event_kind that '
         if not event_kind.isidentifier():
@@ -710,7 +714,7 @@ class Framework(Object):
             marshal.dumps(data)
         except ValueError:
             msg = "unable to save the data for {}, it must contain only simple types: {!r}"
-            raise ValueError(msg.format(value.__class__.__name__, data))
+            raise ValueError(msg.format(value.__class__.__name__, data)) from None
 
         self._storage.save_snapshot(value.handle.path, data)
 
@@ -954,6 +958,9 @@ class Framework(Object):
         stop execution when a hook event is about to be handled.
 
         For those reasons, the "all" and "hook" breakpoint names are reserved.
+
+        Raises:
+            ValueError: if the breakpoint name is invalid.
         """
         # If given, validate the name comply with all the rules
         if name is not None:

--- a/ops/model.py
+++ b/ops/model.py
@@ -2008,10 +2008,10 @@ class Container:
     This class should not be instantiated directly, instead use :meth:`Unit.get_container`
     or :attr:`Unit.containers`.
 
-    :class:`ChangeError` and :class:`TimeoutError` may be raised by Pebble
+    :class:`ops.pebble.ChangeError` and :class:`ops.pebble.TimeoutError` may be raised by Pebble
     operations that wait for changes such as :meth:`start` and :meth:`replan`.
     If Pebble cannot be reached, or an error occurred communicating with Pebble,
-    :class:`ConnectionError` or :class:`APIError` may be raised.
+    :class:`ops.pebble.ConnectionError` or :class:`ops.pebble.APIError` may be raised.
     """
 
     name: str

--- a/ops/model.py
+++ b/ops/model.py
@@ -1318,9 +1318,6 @@ class Secret:
             expire: New expiration time (or timedelta from now) to apply.
             rotate: New rotation policy to apply. The new policy will take
                 effect only after the currently-scheduled rotation.
-
-        Raises:
-            TypeError: if no information is provided (all of the arguments are ``None``).
         """
         if label is None and description is None and expire is None and rotate is None:
             raise TypeError('Must provide a label, description, expiration time, '
@@ -1844,7 +1841,7 @@ class Resources:
         on disk, otherwise it raises a :class:`NameError`.
 
         Raises:
-            NameError: if the resource’s path cannot be fetched.
+            NameError: if the resource's path cannot be fetched.
         """
         if name not in self._paths:
             raise NameError(f'invalid resource name: {name}')
@@ -2719,14 +2716,16 @@ class Container:
         See :meth:`ops.pebble.Client.exec` for documentation of the parameters
         and return value, as well as examples.
 
+        Note that older versions of Juju do not support the ``service_content`` parameter, so if
+        the Charm is to be used on those versions, then
+        :meth:`JujuVersion.supports_exec_service_context` should be used as a guard.
+
         Raises:
             ConnectionError: if pebble cannot be reached.
             APIError: if an error occurred communicating with pebble, or if the command is not
                 found.
             ChangeError: if the command did not execute in time.
             ExecError: if the command exits with a non-zero exit code.
-            RuntimeError: if ``service_context`` is used with a version of Juju that does have this
-                functionality.
             ValueError: If no command is provided, or if ``combine_stderr`` is true, and a value is
                 provided for ``stderr``.
         """
@@ -2764,7 +2763,6 @@ class Container:
             APIError: if any of the services are not in the plan or are not currently running.
             ConnectionError: if pebble cannot be reached.
             APIError: if an error occurred communicating with pebble.
-            TypeError: if no service names are provided.
         """
         if not service_names:
             raise TypeError('send_signal expected at least 1 service name, got 0')

--- a/ops/model.py
+++ b/ops/model.py
@@ -2210,6 +2210,7 @@ class Container:
                 are specified, return checks with any name.
             level: Optional check level to query for. If not specified, fetch
                 all checks.
+
         Raises:
             ConnectionError: if pebble cannot be reached.
             APIError: if an error occurred communicating with pebble.
@@ -2720,7 +2721,8 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble, or if the command is not found.
+            APIError: if an error occurred communicating with pebble, or if the command is not
+                found.
             ChangeError: if the command did not execute in time.
             ExecError: if the command exits with a non-zero exit code.
             RuntimeError: if ``service_context`` is used with a version of Juju that does have this

--- a/ops/model.py
+++ b/ops/model.py
@@ -436,7 +436,6 @@ class Application:
 
         Raises:
             ValueError: if the secret is empty, or the secret key is invalid.
-
         """
         Secret._validate_content(content)
         id = self._backend.secret_add(
@@ -1845,7 +1844,7 @@ class Resources:
         on disk, otherwise it raises a :class:`NameError`.
 
         Raises:
-            NameError: if the resource's path cannot be fetched.
+            NameError: if the resource’s path cannot be fetched.
         """
         if name not in self._paths:
             raise NameError(f'invalid resource name: {name}')
@@ -1917,7 +1916,7 @@ class StorageMapping(Mapping[str, List['Storage']]):
         via ``<storage-name>-storage-attached`` events when it becomes available.
 
         Raises:
-            ModelError: if the storage is not in the charm's metadata.
+            ModelError: if the storage is not in the charm’s metadata.
         """
         if storage_name not in self._storage_map:
             raise ModelError(('cannot add storage {!r}:'
@@ -2065,8 +2064,8 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
-            ChangeError: if one or more of the services didn't stop/start in time.
+            APIError: if an error occurred communicating with pebble.
+            ChangeError: if one or more of the services didn’t stop/start in time.
             TimeoutError: if pebble did not respond in time.
         """
         self._pebble.autostart_services()
@@ -2076,8 +2075,8 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
-            ChangeError: if one or more of the services didn't stop/start in time.
+            APIError: if an error occurred communicating with pebble.
+            ChangeError: if one or more of the services didn’t stop/start in time.
             TimeoutError: if pebble did not respond in time.
         """
         self._pebble.replan_services()
@@ -2087,8 +2086,8 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
-            ChangeError: if one or more of the services didn't stop/start in time.
+            APIError: if an error occurred communicating with pebble.
+            ChangeError: if one or more of the services didn’t stop/start in time.
             TimeoutError: if pebble did not respond in time.
             TypeError: if no services are specified.
         """
@@ -2102,8 +2101,8 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
-            ChangeError: if one or more of the services didn't stop/start in time.
+            APIError: if an error occurred communicating with pebble.
+            ChangeError: if one or more of the services didn’t stop/start in time.
             TimeoutError: if pebble did not respond in time.
             TypeError: if no services are specified.
         """
@@ -2127,8 +2126,8 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
-            ChangeError: if one or more of the services didn't stop/start in time.
+            APIError: if an error occurred communicating with pebble.
+            ChangeError: if one or more of the services didn’t stop/start in time.
             TimeoutError: if pebble did not respond in time.
             TypeError: if no services are specified.
         """
@@ -2154,7 +2153,7 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble, or if the layer is invalid
+            APIError: if an error occurred communicating with pebble, or if the layer is invalid
         """
         self._pebble.add_layer(label, layer, combine=combine)
 
@@ -2167,7 +2166,7 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         return self._pebble.get_plan()
 
@@ -2179,7 +2178,7 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         names = service_names or None
         services = self._pebble.get_services(names)
@@ -2191,7 +2190,7 @@ class Container:
         Raises:
             ModelError: if service_name is not found.
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         services = self.get_services(service_name)
         if not services:
@@ -2213,7 +2212,7 @@ class Container:
                 all checks.
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         checks = self._pebble.get_checks(names=check_names or None, level=level)
         return CheckInfoMapping(checks)
@@ -2224,7 +2223,7 @@ class Container:
         Raises:
             ModelError: if ``check_name`` is not found.
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         checks = self.get_checks(check_name)
         if not checks:
@@ -2259,7 +2258,7 @@ class Container:
             PathError: If there was an error reading the file at path, for example, if the file
                 doesn't exist or is a directory.
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         return self._pebble.pull(str(path), encoding=encoding)
 
@@ -2295,7 +2294,7 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         self._pebble.push(str(path), source, encoding=encoding,
                           make_dirs=make_dirs,
@@ -2320,7 +2319,7 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         return self._pebble.list_files(str(path),
                                        pattern=pattern, itself=itself)
@@ -2376,7 +2375,7 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         if hasattr(source_path, '__iter__') and not isinstance(source_path, str):
             source_paths = typing.cast(Iterable[Union[str, Path]], source_path)
@@ -2465,7 +2464,7 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         if hasattr(source_path, '__iter__') and not isinstance(source_path, str):
             source_paths = typing.cast(Iterable[Union[str, Path]], source_path)
@@ -2576,7 +2575,7 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         try:
             self._pebble.list_files(str(path), itself=True)
@@ -2591,7 +2590,7 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         try:
             files = self._pebble.list_files(str(path), itself=True)
@@ -2627,7 +2626,7 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         self._pebble.make_dir(str(path), make_parents=make_parents,
                               permissions=permissions,
@@ -2648,7 +2647,7 @@ class Container:
             PathError: If a relative path is provided, or if `recursive` is False and the file or
                 directory cannot be removed (it does not exist or is not empty).
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         self._pebble.remove_path(str(path), recursive=recursive)
 
@@ -2721,7 +2720,7 @@ class Container:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble, or if the command is not found.
+            APIError: if an error occurred communicating with pebble, or if the command is not found.
             ChangeError: if the command did not execute in time.
             ExecError: if the command exits with a non-zero exit code.
             RuntimeError: if ``service_context`` is used with a version of Juju that does have this
@@ -2762,7 +2761,7 @@ class Container:
         Raises:
             APIError: if any of the services are not in the plan or are not currently running.
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
             TypeError: if no service names are provided.
         """
         if not service_names:

--- a/ops/model.py
+++ b/ops/model.py
@@ -2007,6 +2007,11 @@ class Container:
 
     This class should not be instantiated directly, instead use :meth:`Unit.get_container`
     or :attr:`Unit.containers`.
+
+    :class:`ChangeError` and :class:`TimeoutError` may be raised by Pebble
+    operations that wait for changes such as :meth:`start` and :meth:`replan`.
+    If Pebble cannot be reached, or an error occurred communicating with Pebble,
+    :class:`ConnectionError` or :class:`APIError` may be raised.
     """
 
     name: str
@@ -2057,52 +2062,22 @@ class Container:
         return True
 
     def autostart(self) -> None:
-        """Autostart all services marked as ``startup: enabled``.
-
-        Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
-            ChangeError: if one or more of the services didn’t stop/start in time.
-            TimeoutError: if pebble did not respond in time.
-        """
+        """Autostart all services marked as ``startup: enabled``."""
         self._pebble.autostart_services()
 
     def replan(self) -> None:
-        """Replan all services: restart changed services and start startup-enabled services.
-
-        Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
-            ChangeError: if one or more of the services didn’t stop/start in time.
-            TimeoutError: if pebble did not respond in time.
-        """
+        """Replan all services: restart changed services and start startup-enabled services."""
         self._pebble.replan_services()
 
     def start(self, *service_names: str):
-        """Start given service(s) by name.
-
-        Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
-            ChangeError: if one or more of the services didn’t stop/start in time.
-            TimeoutError: if pebble did not respond in time.
-            TypeError: if no services are specified.
-        """
+        """Start given service(s) by name."""
         if not service_names:
             raise TypeError('start expected at least 1 argument, got 0')
 
         self._pebble.start_services(service_names)
 
     def restart(self, *service_names: str):
-        """Restart the given service(s) by name.
-
-        Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
-            ChangeError: if one or more of the services didn’t stop/start in time.
-            TimeoutError: if pebble did not respond in time.
-            TypeError: if no services are specified.
-        """
+        """Restart the given service(s) by name."""
         if not service_names:
             raise TypeError('restart expected at least 1 argument, got 0')
 
@@ -2119,15 +2094,7 @@ class Container:
             self._pebble.start_services(service_names)
 
     def stop(self, *service_names: str):
-        """Stop given service(s) by name.
-
-        Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
-            ChangeError: if one or more of the services didn’t stop/start in time.
-            TimeoutError: if pebble did not respond in time.
-            TypeError: if no services are specified.
-        """
+        """Stop given service(s) by name."""
         if not service_names:
             raise TypeError('stop expected at least 1 argument, got 0')
 
@@ -2149,8 +2116,7 @@ class Container:
                 rules; if the layer doesn't exist, it is added as usual.
 
         Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble, or if the layer is invalid
+            APIError: if an error occurred communicating with pebble, or if the layer is invalid.
         """
         self._pebble.add_layer(label, layer, combine=combine)
 
@@ -2160,10 +2126,6 @@ class Container:
         This will immediately reflect changes from any previous
         :meth:`add_layer` calls, regardless of whether :meth:`replan` or
         :meth:`restart` have been called.
-
-        Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
         """
         return self._pebble.get_plan()
 
@@ -2172,10 +2134,6 @@ class Container:
 
         If no service names are specified, return status information for all
         services, otherwise return information for only the given services.
-
-        Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
         """
         names = service_names or None
         services = self._pebble.get_services(names)
@@ -2186,8 +2144,6 @@ class Container:
 
         Raises:
             ModelError: if service_name is not found.
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
         """
         services = self.get_services(service_name)
         if not services:
@@ -2207,10 +2163,6 @@ class Container:
                 are specified, return checks with any name.
             level: Optional check level to query for. If not specified, fetch
                 all checks.
-
-        Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
         """
         checks = self._pebble.get_checks(names=check_names or None, level=level)
         return CheckInfoMapping(checks)
@@ -2220,8 +2172,6 @@ class Container:
 
         Raises:
             ModelError: if ``check_name`` is not found.
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
         """
         checks = self.get_checks(check_name)
         if not checks:
@@ -2255,8 +2205,6 @@ class Container:
         Raises:
             PathError: If there was an error reading the file at path, for example, if the file
                 doesn't exist or is a directory.
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
         """
         return self._pebble.pull(str(path), encoding=encoding)
 
@@ -2289,10 +2237,6 @@ class Container:
             group_id: Group ID (GID) for file.
             group: Group name for file. Group's GID must match group_id if
                 both are specified.
-
-        Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
         """
         self._pebble.push(str(path), source, encoding=encoding,
                           make_dirs=make_dirs,
@@ -2314,10 +2258,6 @@ class Container:
                 for example ``*.txt``.
             itself: If path refers to a directory, return information about the
                 directory itself, rather than its contents.
-
-        Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
         """
         return self._pebble.list_files(str(path),
                                        pattern=pattern, itself=itself)
@@ -2370,10 +2310,6 @@ class Container:
                 *contents* placed inside the destination directory.
             dest_dir: Remote destination directory inside which the source
                 dir/files will be placed. This must be an absolute path.
-
-        Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
         """
         if hasattr(source_path, '__iter__') and not isinstance(source_path, str):
             source_paths = typing.cast(Iterable[Union[str, Path]], source_path)
@@ -2459,10 +2395,6 @@ class Container:
                 destination directory.
             dest_dir: Local destination directory inside which the source
                 dir/files will be placed.
-
-        Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
         """
         if hasattr(source_path, '__iter__') and not isinstance(source_path, str):
             source_paths = typing.cast(Iterable[Union[str, Path]], source_path)
@@ -2569,12 +2501,7 @@ class Container:
         return dest_dir / path_suffix
 
     def exists(self, path: Union[str, PurePath]) -> bool:
-        """Report whether a path exists on the container filesystem.
-
-        Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
-        """
+        """Report whether a path exists on the container filesystem."""
         try:
             self._pebble.list_files(str(path), itself=True)
         except pebble.APIError as err:
@@ -2584,12 +2511,7 @@ class Container:
         return True
 
     def isdir(self, path: Union[str, PurePath]) -> bool:
-        """Report whether a directory exists at the given path on the container filesystem.
-
-        Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
-        """
+        """Report whether a directory exists at the given path on the container filesystem."""
         try:
             files = self._pebble.list_files(str(path), itself=True)
         except pebble.APIError as err:
@@ -2621,10 +2543,6 @@ class Container:
             group_id: Group ID (GID) for directory.
             group: Group name for directory. Group's GID must match group_id
                 if both are specified.
-
-        Raises:
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
         """
         self._pebble.make_dir(str(path), make_parents=make_parents,
                               permissions=permissions,
@@ -2644,8 +2562,6 @@ class Container:
         Raises:
             PathError: If a relative path is provided, or if `recursive` is False and the file or
                 directory cannot be removed (it does not exist or is not empty).
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
         """
         self._pebble.remove_path(str(path), recursive=recursive)
 
@@ -2721,13 +2637,9 @@ class Container:
         :meth:`JujuVersion.supports_exec_service_context` should be used as a guard.
 
         Raises:
-            ConnectionError: if pebble cannot be reached.
             APIError: if an error occurred communicating with pebble, or if the command is not
                 found.
-            ChangeError: if the command did not execute in time.
             ExecError: if the command exits with a non-zero exit code.
-            ValueError: If no command is provided, or if ``combine_stderr`` is true, and a value is
-                provided for ``stderr``.
         """
         if service_context is not None:
             version = JujuVersion.from_environ()
@@ -2761,8 +2673,6 @@ class Container:
 
         Raises:
             APIError: if any of the services are not in the plan or are not currently running.
-            ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble.
         """
         if not service_names:
             raise TypeError('send_signal expected at least 1 service name, got 0')

--- a/ops/model.py
+++ b/ops/model.py
@@ -2114,9 +2114,6 @@ class Container:
                 combine is True and the label already exists, the two layers
                 are combined into a single one considering the layer override
                 rules; if the layer doesn't exist, it is added as usual.
-
-        Raises:
-            APIError: if an error occurred communicating with Pebble, or if the layer is invalid.
         """
         self._pebble.add_layer(label, layer, combine=combine)
 
@@ -2637,8 +2634,6 @@ class Container:
         :meth:`JujuVersion.supports_exec_service_context` should be used as a guard.
 
         Raises:
-            APIError: if an error occurred communicating with Pebble, or if the command is not
-                found.
             ExecError: if the command exits with a non-zero exit code.
         """
         if service_context is not None:

--- a/ops/model.py
+++ b/ops/model.py
@@ -1913,7 +1913,7 @@ class StorageMapping(Mapping[str, List['Storage']]):
         via ``<storage-name>-storage-attached`` events when it becomes available.
 
         Raises:
-            ModelError: if the storage is not in the charm’s metadata.
+            ModelError: if the storage is not in the charm's metadata.
         """
         if storage_name not in self._storage_map:
             raise ModelError(('cannot add storage {!r}:'
@@ -2116,7 +2116,7 @@ class Container:
                 rules; if the layer doesn't exist, it is added as usual.
 
         Raises:
-            APIError: if an error occurred communicating with pebble, or if the layer is invalid.
+            APIError: if an error occurred communicating with Pebble, or if the layer is invalid.
         """
         self._pebble.add_layer(label, layer, combine=combine)
 
@@ -2203,8 +2203,8 @@ class Container:
             encoding is ``None``.
 
         Raises:
-            PathError: If there was an error reading the file at path, for example, if the file
-                doesn't exist or is a directory.
+            pebble.PathError: If there was an error reading the file at path,
+                for example, if the file doesn't exist or is a directory.
         """
         return self._pebble.pull(str(path), encoding=encoding)
 
@@ -2560,8 +2560,8 @@ class Container:
                        exist. Behaviourally similar to ``rm -rf <file|dir>``.
 
         Raises:
-            PathError: If a relative path is provided, or if `recursive` is False and the file or
-                directory cannot be removed (it does not exist or is not empty).
+            pebble.PathError: If a relative path is provided, or if `recursive` is False
+                and the file or directory cannot be removed (it does not exist or is not empty).
         """
         self._pebble.remove_path(str(path), recursive=recursive)
 
@@ -2672,7 +2672,8 @@ class Container:
             service_names: Name(s) of the service(s) to send the signal to.
 
         Raises:
-            APIError: if any of the services are not in the plan or are not currently running.
+            pebble.APIError: if any of the services are not in the plan or are
+                not currently running.
         """
         if not service_names:
             raise TypeError('send_signal expected at least 1 service name, got 0')

--- a/ops/model.py
+++ b/ops/model.py
@@ -1917,7 +1917,7 @@ class StorageMapping(Mapping[str, List['Storage']]):
         via ``<storage-name>-storage-attached`` events when it becomes available.
 
         Raises:
-            :class:`ModelError`: if the storage is not in the charm's metadata.
+            ModelError: if the storage is not in the charm's metadata.
         """
         if storage_name not in self._storage_map:
             raise ModelError(('cannot add storage {!r}:'
@@ -2064,11 +2064,10 @@ class Container:
         """Autostart all services marked as ``startup: enabled``.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
-            :class:`ops.pebble.ChangeError`: if one or more of the services didn't stop/start in
-                time.
-            :class:`ops.pebble.TimeoutError`: if pebble did not respond in time.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
+            ChangeError: if one or more of the services didn't stop/start in time.
+            TimeoutError: if pebble did not respond in time.
         """
         self._pebble.autostart_services()
 
@@ -2076,11 +2075,10 @@ class Container:
         """Replan all services: restart changed services and start startup-enabled services.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
-            :class:`ops.pebble.ChangeError`: if one or more of the services didn't stop/start in
-                time.
-            :class:`ops.pebble.TimeoutError`: if pebble did not respond in time.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
+            ChangeError: if one or more of the services didn't stop/start in time.
+            TimeoutError: if pebble did not respond in time.
         """
         self._pebble.replan_services()
 
@@ -2088,11 +2086,10 @@ class Container:
         """Start given service(s) by name.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
-            :class:`ops.pebble.ChangeError`: if one or more of the services didn't stop/start in
-                time.
-            :class:`ops.pebble.TimeoutError`: if pebble did not respond in time.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
+            ChangeError: if one or more of the services didn't stop/start in time.
+            TimeoutError: if pebble did not respond in time.
             TypeError: if no services are specified.
         """
         if not service_names:
@@ -2104,11 +2101,10 @@ class Container:
         """Restart the given service(s) by name.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
-            :class:`ops.pebble.ChangeError`: if one or more of the services didn't stop/start in
-                time.
-            :class:`ops.pebble.TimeoutError`: if pebble did not respond in time.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
+            ChangeError: if one or more of the services didn't stop/start in time.
+            TimeoutError: if pebble did not respond in time.
             TypeError: if no services are specified.
         """
         if not service_names:
@@ -2130,11 +2126,10 @@ class Container:
         """Stop given service(s) by name.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
-            :class:`ops.pebble.ChangeError`: if one or more of the services didn't stop/start in
-                time.
-            :class:`ops.pebble.TimeoutError`: if pebble did not respond in time.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
+            ChangeError: if one or more of the services didn't stop/start in time.
+            TimeoutError: if pebble did not respond in time.
             TypeError: if no services are specified.
         """
         if not service_names:
@@ -2158,9 +2153,8 @@ class Container:
                 rules; if the layer doesn't exist, it is added as usual.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble, or if the
-                layer is invalid
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble, or if the layer is invalid
         """
         self._pebble.add_layer(label, layer, combine=combine)
 
@@ -2172,8 +2166,8 @@ class Container:
         :meth:`restart` have been called.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         return self._pebble.get_plan()
 
@@ -2184,8 +2178,8 @@ class Container:
         services, otherwise return information for only the given services.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         names = service_names or None
         services = self._pebble.get_services(names)
@@ -2195,9 +2189,9 @@ class Container:
         """Get status information for a single named service.
 
         Raises:
-            :class:`ModelError`: if service_name is not found.
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            ModelError: if service_name is not found.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         services = self.get_services(service_name)
         if not services:
@@ -2218,8 +2212,8 @@ class Container:
             level: Optional check level to query for. If not specified, fetch
                 all checks.
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         checks = self._pebble.get_checks(names=check_names or None, level=level)
         return CheckInfoMapping(checks)
@@ -2228,9 +2222,9 @@ class Container:
         """Get check information for a single named check.
 
         Raises:
-            :class:`ModelError`: if ``check_name`` is not found.
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            ModelError: if ``check_name`` is not found.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         checks = self.get_checks(check_name)
         if not checks:
@@ -2262,10 +2256,10 @@ class Container:
             encoding is ``None``.
 
         Raises:
-            :class:`ops.pebble.PathError`: If there was an error reading the file at path,
-                for example, if the file doesn't exist or is a directory.
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            PathError: If there was an error reading the file at path, for example, if the file
+                doesn't exist or is a directory.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         return self._pebble.pull(str(path), encoding=encoding)
 
@@ -2300,8 +2294,8 @@ class Container:
                 both are specified.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         self._pebble.push(str(path), source, encoding=encoding,
                           make_dirs=make_dirs,
@@ -2325,8 +2319,8 @@ class Container:
                 directory itself, rather than its contents.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         return self._pebble.list_files(str(path),
                                        pattern=pattern, itself=itself)
@@ -2381,8 +2375,8 @@ class Container:
                 dir/files will be placed. This must be an absolute path.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         if hasattr(source_path, '__iter__') and not isinstance(source_path, str):
             source_paths = typing.cast(Iterable[Union[str, Path]], source_path)
@@ -2470,8 +2464,8 @@ class Container:
                 dir/files will be placed.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         if hasattr(source_path, '__iter__') and not isinstance(source_path, str):
             source_paths = typing.cast(Iterable[Union[str, Path]], source_path)
@@ -2581,8 +2575,8 @@ class Container:
         """Report whether a path exists on the container filesystem.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         try:
             self._pebble.list_files(str(path), itself=True)
@@ -2596,8 +2590,8 @@ class Container:
         """Report whether a directory exists at the given path on the container filesystem.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         try:
             files = self._pebble.list_files(str(path), itself=True)
@@ -2632,8 +2626,8 @@ class Container:
                 if both are specified.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         self._pebble.make_dir(str(path), make_parents=make_parents,
                               permissions=permissions,
@@ -2651,11 +2645,10 @@ class Container:
                        exist. Behaviourally similar to ``rm -rf <file|dir>``.
 
         Raises:
-            :class:`ops.pebble.PathError`: If a relative path is provided, or if `recursive` is
-                False and the file or directory cannot be removed (it does not exist or is not
-                empty).
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            PathError: If a relative path is provided, or if `recursive` is False and the file or
+                directory cannot be removed (it does not exist or is not empty).
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         self._pebble.remove_path(str(path), recursive=recursive)
 
@@ -2727,11 +2720,10 @@ class Container:
         and return value, as well as examples.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble, or if the
-                command is not found.
-            :class:`ops.pebble.ChangeError`: if the command did not execute in time.
-            :class:`ops.pebble.ExecError`: if the command exits with a non-zero exit code.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble, or if the command is not found.
+            ChangeError: if the command did not execute in time.
+            ExecError: if the command exits with a non-zero exit code.
             RuntimeError: if ``service_context`` is used with a version of Juju that does have this
                 functionality.
             ValueError: If no command is provided, or if ``combine_stderr`` is true, and a value is
@@ -2768,10 +2760,9 @@ class Container:
             service_names: Name(s) of the service(s) to send the signal to.
 
         Raises:
-            :class:`ops.pebble.APIError`: if any of the services are not in the plan or are
-                not currently running.
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            APIError: if any of the services are not in the plan or are not currently running.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
             TypeError: if no service names are provided.
         """
         if not service_names:

--- a/ops/model.py
+++ b/ops/model.py
@@ -2637,7 +2637,7 @@ class Container:
         :meth:`JujuVersion.supports_exec_service_context` should be used as a guard.
 
         Raises:
-            APIError: if an error occurred communicating with pebble, or if the command is not
+            APIError: if an error occurred communicating with Pebble, or if the command is not
                 found.
             ExecError: if the command exits with a non-zero exit code.
         """
@@ -2672,7 +2672,7 @@ class Container:
             service_names: Name(s) of the service(s) to send the signal to.
 
         Raises:
-            pebble.APIError: if any of the services are not in the plan or are
+            pebble.APIError: If any of the services are not in the plan or are
                 not currently running.
         """
         if not service_names:

--- a/ops/model.py
+++ b/ops/model.py
@@ -2008,10 +2008,16 @@ class Container:
     This class should not be instantiated directly, instead use :meth:`Unit.get_container`
     or :attr:`Unit.containers`.
 
-    :class:`ops.pebble.ChangeError` and :class:`ops.pebble.TimeoutError` may be raised by Pebble
-    operations that wait for changes such as :meth:`start` and :meth:`replan`.
-    If Pebble cannot be reached, or an error occurred communicating with Pebble,
-    :class:`ops.pebble.ConnectionError` or :class:`ops.pebble.APIError` may be raised.
+    For methods that make changes to the container, if the change fails or times out, then a
+    :class:`ops.pebble.ChangeError` or :class:`ops.pebble.TimeoutError` will be raised.
+
+    Interactions with the container use Pebble, so all methods may raise exceptions when there are
+    problems communicating with Pebble. Problems connecting to or transferring data with Pebble
+    will raise a :class:`ops.pebble.ConnectionError` - generally you can guard against these by
+    first checking :meth:`can_connect`, but it is possible for problems to occur after
+    :meth:`can_connect` has succeeded. When an error occurs executing the request, such as trying
+    to add an invalid layer or execute a command that does not exist, an
+    :class:`ops.pebble.APIError` is raised.
     """
 
     name: str

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1530,10 +1530,14 @@ class Client:
     Defaults to using a Unix socket at socket_path (which must be specified
     unless a custom opener is provided).
 
-    :class:`ChangeError` and :class:`TimeoutError` may be raised by Pebble
-    operations that wait for changes such as :meth:`start_services` and :meth:`replan_services`.
-    If Pebble cannot be reached, or an error occurred communicating with Pebble,
-    :class:`ConnectionError` or :class:`APIError` may be raised.
+    For methods that wait for changes, such as :meth:`start_services` and :meth:`replan_services`,
+    if the change fails or times out, then a :class:`ChangeError` or :class:`TimeoutError` will be
+    raised.
+
+    All methods may raise exceptions when there are problems communicating with Pebble. Problems
+    connecting to or transferring data with Pebble will raise a :class:`ConnectionError`. When an
+    error occurs executing the request, such as trying to add an invalid layer or execute a command
+    that does not exist, an :class:`APIError` is raised.
     """
 
     _chunk_size = 8192

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1344,7 +1344,7 @@ class ExecProcess(Generic[AnyStr]):
         Raises:
             ChangeError: if there was an error starting or running the process.
             ExecError: if the process exits with a non-zero exit code.
-            TypeError: if :meth:`exec` was called with the ``stdout`` argument.
+            TypeError: if :meth:`Client.exec` was called with the ``stdout`` argument.
         """
         if self.stdout is None:
             raise TypeError(

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -2528,7 +2528,8 @@ class Client:
             services: Non-empty list of service names to send the signal to.
 
         Raises:
-            APIError: If any of the services are not in the plan or are not currently running.
+            APIError: If any of the services are not in the plan or are not
+                currently running.
         """
         if isinstance(services, (str, bytes)) or not hasattr(services, '__iter__'):
             raise TypeError('services must be of type Iterable[str], '

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1632,8 +1632,8 @@ class Client:
         """Get system info.
 
         Raises:
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         resp = self._request('GET', '/v1/system-info')
         return SystemInfo.from_dict(resp['result'])
@@ -1642,8 +1642,8 @@ class Client:
         """Get list of warnings in given state (pending or all).
 
         Raises:
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         query = {'select': select.value}
         resp = self._request('GET', '/v1/warnings', query)
@@ -1653,8 +1653,8 @@ class Client:
         """Acknowledge warnings up to given timestamp, return number acknowledged.
 
         Raises:
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         body = {'action': 'okay', 'timestamp': timestamp.isoformat()}
         resp = self._request('POST', '/v1/warnings', body=body)
@@ -1666,8 +1666,8 @@ class Client:
         """Get list of changes in given state, filter by service name if given.
 
         Raises:
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         query: Dict[str, Union[str, int]] = {'select': select.value}
         if service is not None:
@@ -1679,8 +1679,8 @@ class Client:
         """Get single change by ID.
 
         Raises:
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         resp = self._request('GET', f'/v1/changes/{change_id}')
         return Change.from_dict(resp['result'])
@@ -1689,8 +1689,8 @@ class Client:
         """Abort change with given ID.
 
         Raises:
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         body = {'action': 'abort'}
         resp = self._request('POST', f'/v1/changes/{change_id}', body=body)
@@ -1700,18 +1700,18 @@ class Client:
         """Start the startup-enabled services and wait (poll) for them to be started.
 
         Args:
-            timeout: Seconds before autostart change is considered timed out (float).
+            timeout: Seconds before autostart change is considered timed out (float). If
+                timeout is 0, submit the action but don't wait; just return the change ID
+                immediately.
             delay: Seconds before executing the autostart change (float).
 
         Returns:
             ChangeID of the autostart change.
 
         Raises:
-            :class:`ChangeError`: if one or more of the services didn't start. If
-                timeout is 0, submit the action but don't wait; just return the change
-                ID immediately.
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            ChangeError: if one or more of the services didn't start, and ``timeout`` is non-zero.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         return self._services_action('autostart', [], timeout, delay)
 
@@ -1719,18 +1719,19 @@ class Client:
         """Replan by (re)starting changed and startup-enabled services and wait for them to start.
 
         Args:
-            timeout: Seconds before replan change is considered timed out (float).
+            timeout: Seconds before replan change is considered timed out (float). If
+                timeout is 0, submit the action but don't wait; just return the change
+                ID immediately.
             delay: Seconds before executing the replan change (float).
 
         Returns:
             ChangeID of the replan change.
 
         Raises:
-            :class:`ChangeError`: if one or more of the services didn't stop/start. If
-                timeout is 0, submit the action but don't wait; just return the change
-                ID immediately.
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            ChangeError: if one or more of the services didn't stop/start, and ``timeout`` is
+                non-zero.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         return self._services_action('replan', [], timeout, delay)
 
@@ -1741,20 +1742,19 @@ class Client:
 
         Args:
             services: Non-empty list of services to start.
-            timeout: Seconds before start change is considered timed out (float).
+            timeout: Seconds before start change is considered timed out (float). If
+                timeout is 0, submit the action but don't wait; just return the change
+                ID immediately.
             delay: Seconds before executing the start change (float).
 
         Returns:
             ChangeID of the start change.
 
         Raises:
-            :class:`ChangeError`: if one or more of the services didn't stop/start. If
-                timeout is 0, submit the action but don't wait; just return the change
-                ID immediately.
-
-        Raises:
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            ChangeError: if one or more of the services didn't stop/start, and ``timeout`` is
+                non-zero.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         return self._services_action('start', services, timeout, delay)
 
@@ -1765,20 +1765,19 @@ class Client:
 
         Args:
             services: Non-empty list of services to stop.
-            timeout: Seconds before stop change is considered timed out (float).
+            timeout: Seconds before stop change is considered timed out (float). If
+                timeout is 0, submit the action but don't wait; just return the change
+                ID immediately.
             delay: Seconds before executing the stop change (float).
 
         Returns:
             ChangeID of the stop change.
 
         Raises:
-            :class:`ChangeError`: if one or more of the services didn't stop/start. If
-                timeout is 0, submit the action but don't wait; just return the change
-                ID immediately.
-
-        Raises:
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            ChangeError: if one or more of the services didn't stop/start and ``timeout`` is
+                non-zero.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         return self._services_action('stop', services, timeout, delay)
 
@@ -1796,13 +1795,11 @@ class Client:
             ChangeID of the restart change.
 
         Raises:
-            :class:`ChangeError`: if one or more of the services didn't stop/start. If
+            ChangeError: if one or more of the services didn't stop/start. If
                 timeout is 0, submit the action but don't wait; just return the change
                 ID immediately.
-
-        Raises:
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         return self._services_action('restart', services, timeout, delay)
 
@@ -1922,8 +1919,8 @@ class Client:
         layer override rules; if the layer doesn't exist, it is added as usual.
 
         Raises:
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         if not isinstance(label, str):
             raise TypeError(f'label must be a str, not {type(label).__name__}')
@@ -1951,8 +1948,8 @@ class Client:
         """Get the Pebble plan (contains combined layer configuration).
 
         Raises:
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         resp = self._request('GET', '/v1/plan', {'format': 'yaml'})
         return Plan(resp['result'])
@@ -1964,8 +1961,8 @@ class Client:
         named.
 
         Raises:
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         query = None
         if names is not None:
@@ -1998,10 +1995,10 @@ class Client:
             encoding is None.
 
         Raises:
-            :class:`PathError`: If there was an error reading the file at path, for
+            PathError: If there was an error reading the file at path, for
                 example, if the file doesn't exist or is a directory.
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         query = {
             'action': 'read',
@@ -2081,10 +2078,10 @@ class Client:
                 both are specified.
 
         Raises:
-            :class:`PathError`: if the destination path does not exist, and ``make_dirs`` is not
-                used.
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            PathError: If there was an error writing the file to the path, for example, if the
+                destination path doesn’t exist and ``make_dirs`` is not used.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         info = self._make_auth_dict(permissions, user_id, user, group_id, group)
         info['path'] = path
@@ -2184,9 +2181,10 @@ class Client:
                 directory itself, rather than its contents.
 
         Raises:
-            :class:`PathError`: if the path does not exist.
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            PathError: if there was an error listing the directory, for example, if the directory
+                does not exist.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         query = {
             'action': 'list',
@@ -2222,10 +2220,10 @@ class Client:
                 if both are specified.
 
         Raises:
-            :class:`PathError`: if the parent path does not exist, and ``make_parents`` is not
-                used.
-            :class:`ConnectionError`: if pebble cannot be reached.
-            :class:`APIError`: if an error occured communicating with pebble.
+            PathError: if there was an error making the directory, for example, if the parent path
+                does not exist, and ``make_parents`` is not used.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         info = self._make_auth_dict(permissions, user_id, user, group_id, group)
         info['path'] = path
@@ -2444,11 +2442,10 @@ class Client:
             not.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble, or if the
-                command is not found.
-            :class:`ops.pebble.ChangeError`: if the command did not execute in time.
-            :class:`ops.pebble.ExecError`: if the command exits with a non-zero exit code.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble, or if the command is not found.
+            ChangeError: if the command did not execute in time.
+            ExecError: if the command exits with a non-zero exit code.
             RuntimeError: if ``service_context`` is used with a version of Juju that does have this
                 functionality.
             ValueError: If no command is provided, or if ``combine_stderr`` is true, and a value is
@@ -2591,9 +2588,8 @@ class Client:
             services: Non-empty list of service names to send the signal to.
 
         Raises:
-            :class:`APIError`: If any of the services are not in the plan or are not
-                currently running.
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
+            APIError: If any of the services are not in the plan or are not currently running.
+            ConnectionError: if pebble cannot be reached.
         """
         if isinstance(services, (str, bytes)) or not hasattr(services, '__iter__'):
             raise TypeError('services must be of type Iterable[str], '
@@ -2627,8 +2623,8 @@ class Client:
             List of :class:`CheckInfo` objects.
 
         Raises:
-            :class:`ops.pebble.ConnectionError`: if pebble cannot be reached.
-            :class:`ops.pebble.APIError`: if an error occured communicating with pebble.
+            ConnectionError: if pebble cannot be reached.
+            APIError: if an error occured communicating with pebble.
         """
         query = {}
         if level is not None:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -2033,7 +2033,7 @@ class Client:
                 both are specified.
 
         Raises:
-            PathError: If there was an error writing the file to the path, for example, if the
+            PathError: If there was an error writing the file to the path; for example, if the
                 destination path doesn't exist and ``make_dirs`` is not used.
         """
         info = self._make_auth_dict(permissions, user_id, user, group_id, group)
@@ -2134,7 +2134,7 @@ class Client:
                 directory itself, rather than its contents.
 
         Raises:
-            PathError: if there was an error listing the directory, for example, if the directory
+            PathError: if there was an error listing the directory; for example, if the directory
                 does not exist.
         """
         query = {
@@ -2171,7 +2171,7 @@ class Client:
                 if both are specified.
 
         Raises:
-            PathError: if there was an error making the directory, for example, if the parent path
+            PathError: if there was an error making the directory; for example, if the parent path
                 does not exist, and ``make_parents`` is not used.
         """
         info = self._make_auth_dict(permissions, user_id, user, group_id, group)

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1633,7 +1633,7 @@ class Client:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         resp = self._request('GET', '/v1/system-info')
         return SystemInfo.from_dict(resp['result'])
@@ -1643,7 +1643,7 @@ class Client:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         query = {'select': select.value}
         resp = self._request('GET', '/v1/warnings', query)
@@ -1654,7 +1654,7 @@ class Client:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         body = {'action': 'okay', 'timestamp': timestamp.isoformat()}
         resp = self._request('POST', '/v1/warnings', body=body)
@@ -1667,7 +1667,7 @@ class Client:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         query: Dict[str, Union[str, int]] = {'select': select.value}
         if service is not None:
@@ -1680,7 +1680,7 @@ class Client:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         resp = self._request('GET', f'/v1/changes/{change_id}')
         return Change.from_dict(resp['result'])
@@ -1690,7 +1690,7 @@ class Client:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         body = {'action': 'abort'}
         resp = self._request('POST', f'/v1/changes/{change_id}', body=body)
@@ -1709,9 +1709,9 @@ class Client:
             ChangeID of the autostart change.
 
         Raises:
-            ChangeError: if one or more of the services didn't start, and ``timeout`` is non-zero.
+            ChangeError: if one or more of the services didn’t start, and ``timeout`` is non-zero.
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         return self._services_action('autostart', [], timeout, delay)
 
@@ -1728,10 +1728,10 @@ class Client:
             ChangeID of the replan change.
 
         Raises:
-            ChangeError: if one or more of the services didn't stop/start, and ``timeout`` is
+            ChangeError: if one or more of the services didn’t stop/start, and ``timeout`` is
                 non-zero.
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         return self._services_action('replan', [], timeout, delay)
 
@@ -1751,10 +1751,10 @@ class Client:
             ChangeID of the start change.
 
         Raises:
-            ChangeError: if one or more of the services didn't stop/start, and ``timeout`` is
+            ChangeError: if one or more of the services didn’t stop/start, and ``timeout`` is
                 non-zero.
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         return self._services_action('start', services, timeout, delay)
 
@@ -1774,10 +1774,10 @@ class Client:
             ChangeID of the stop change.
 
         Raises:
-            ChangeError: if one or more of the services didn't stop/start and ``timeout`` is
+            ChangeError: if one or more of the services didn’t stop/start and ``timeout`` is
                 non-zero.
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         return self._services_action('stop', services, timeout, delay)
 
@@ -1795,11 +1795,11 @@ class Client:
             ChangeID of the restart change.
 
         Raises:
-            ChangeError: if one or more of the services didn't stop/start. If
+            ChangeError: if one or more of the services didn’t stop/start. If
                 timeout is 0, submit the action but don't wait; just return the change
                 ID immediately.
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         return self._services_action('restart', services, timeout, delay)
 
@@ -1920,7 +1920,7 @@ class Client:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         if not isinstance(label, str):
             raise TypeError(f'label must be a str, not {type(label).__name__}')
@@ -1949,7 +1949,7 @@ class Client:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         resp = self._request('GET', '/v1/plan', {'format': 'yaml'})
         return Plan(resp['result'])
@@ -1962,7 +1962,7 @@ class Client:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         query = None
         if names is not None:
@@ -1998,7 +1998,7 @@ class Client:
             PathError: If there was an error reading the file at path, for
                 example, if the file doesn't exist or is a directory.
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         query = {
             'action': 'read',
@@ -2081,7 +2081,7 @@ class Client:
             PathError: If there was an error writing the file to the path, for example, if the
                 destination path doesn’t exist and ``make_dirs`` is not used.
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         info = self._make_auth_dict(permissions, user_id, user, group_id, group)
         info['path'] = path
@@ -2184,7 +2184,7 @@ class Client:
             PathError: if there was an error listing the directory, for example, if the directory
                 does not exist.
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         query = {
             'action': 'list',
@@ -2223,7 +2223,7 @@ class Client:
             PathError: if there was an error making the directory, for example, if the parent path
                 does not exist, and ``make_parents`` is not used.
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         info = self._make_auth_dict(permissions, user_id, user, group_id, group)
         info['path'] = path
@@ -2443,7 +2443,7 @@ class Client:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble, or if the command is not found.
+            APIError: if an error occurred communicating with pebble, or if the command is not found.
             ChangeError: if the command did not execute in time.
             ExecError: if the command exits with a non-zero exit code.
             RuntimeError: if ``service_context`` is used with a version of Juju that does have this
@@ -2624,7 +2624,7 @@ class Client:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occured communicating with pebble.
+            APIError: if an error occurred communicating with pebble.
         """
         query = {}
         if level is not None:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -2443,7 +2443,8 @@ class Client:
 
         Raises:
             ConnectionError: if pebble cannot be reached.
-            APIError: if an error occurred communicating with pebble, or if the command is not found.
+            APIError: if an error occurred communicating with pebble, or if the command is not
+                found.
             ChangeError: if the command did not execute in time.
             ExecError: if the command exits with a non-zero exit code.
             RuntimeError: if ``service_context`` is used with a version of Juju that does have this

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1531,7 +1531,7 @@ class Client:
     unless a custom opener is provided).
 
     :class:`ChangeError` and :class:`TimeoutError` may be raised by Pebble
-    operations that wait for changes such as :meth:`start` and :meth:`replan`.
+    operations that wait for changes such as :meth:`start_services` and :meth:`replan_services`.
     If Pebble cannot be reached, or an error occurred communicating with Pebble,
     :class:`ConnectionError` or :class:`APIError` may be raised.
     """
@@ -1764,7 +1764,7 @@ class Client:
             ChangeID of the restart change.
 
         Raises:
-            ChangeError: if one or more of the services didn't stop/start and ``timeout is
+            ChangeError: if one or more of the services didn't stop/start and ``timeout`` is
                 non-zero.
         """
         return self._services_action('restart', services, timeout, delay)

--- a/ops/storage.py
+++ b/ops/storage.py
@@ -220,9 +220,6 @@ class JujuStorage:
             handle_path: The string identifying the snapshot.
             snapshot_data: The data to be persisted. (as returned by Object.snapshot()). This
                 might be a dict/tuple/int, but must only contain 'simple' python types.
-
-        Raises:
-            :class:`CalledProcessError`: if Juju returns an error.
         """
         self._backend.set(handle_path, snapshot_data)
 
@@ -234,7 +231,6 @@ class JujuStorage:
 
         Raises:
             :class:`NoSnapshotError`: if there is no snapshot for the given handle_path.
-            :class:`CalledProcessError`: if Juju returns an error.
         """
         try:
             content = self._backend.get(handle_path)
@@ -246,17 +242,11 @@ class JujuStorage:
         """Part of the Storage API, remove a snapshot that was previously saved.
 
         Dropping a snapshot that doesn't exist is treated as a no-op.
-
-        Raises:
-            :class:`CalledProcessError`: if Juju returns an error.
         """
         self._backend.delete(handle_path)
 
     def save_notice(self, event_path: str, observer_path: str, method_name: str):
         """Part of the Storage API, record a notice (event and observer).
-
-        Raises:
-            :class:`CalledProcessError`: if Juju returns an error.
         """
         notice_list = self._load_notice_list()
         notice_list.append((event_path, observer_path, method_name))
@@ -264,9 +254,6 @@ class JujuStorage:
 
     def drop_notice(self, event_path: str, observer_path: str, method_name: str):
         """Part of the Storage API, remove a notice that was previously recorded.
-
-        Raises:
-            :class:`CalledProcessError`: if Juju returns an error.
         """
         notice_list = self._load_notice_list()
         notice_list.remove((event_path, observer_path, method_name))
@@ -281,9 +268,6 @@ class JujuStorage:
 
         Returns:
             Iterable of (event_path, observer_path, method_name) tuples
-
-        Raises:
-            :class:`CalledProcessError`: if Juju returns an error.
         """
         notice_list = self._load_notice_list()
         for row in notice_list:

--- a/ops/storage.py
+++ b/ops/storage.py
@@ -104,7 +104,7 @@ class SQLiteStorage:
         Args:
             handle_path: The string identifying the snapshot.
             snapshot_data: The data to be persisted. (as returned by Object.snapshot()). This
-            might be a dict/tuple/int, but must only contain 'simple' python types.
+            might be a dict/tuple/int, but must only contain 'simple' Python types.
         """
         # Use pickle for serialization, so the value remains portable.
         raw_data = pickle.dumps(snapshot_data)
@@ -220,6 +220,9 @@ class JujuStorage:
             handle_path: The string identifying the snapshot.
             snapshot_data: The data to be persisted. (as returned by Object.snapshot()). This
                 might be a dict/tuple/int, but must only contain 'simple' python types.
+
+        Raises:
+            :class:`CalledProcessError`: if Juju returns an error.
         """
         self._backend.set(handle_path, snapshot_data)
 
@@ -230,29 +233,41 @@ class JujuStorage:
             handle_path: The string identifying the snapshot.
 
         Raises:
-            NoSnapshotError: if there is no snapshot for the given handle_path.
+            :class:`NoSnapshotError`: if there is no snapshot for the given handle_path.
+            :class:`CalledProcessError`: if Juju returns an error.
         """
         try:
             content = self._backend.get(handle_path)
         except KeyError:
-            raise NoSnapshotError(handle_path)
+            raise NoSnapshotError(handle_path) from None
         return content
 
     def drop_snapshot(self, handle_path: str):
         """Part of the Storage API, remove a snapshot that was previously saved.
 
         Dropping a snapshot that doesn't exist is treated as a no-op.
+
+        Raises:
+            :class:`CalledProcessError`: if Juju returns an error.
         """
         self._backend.delete(handle_path)
 
     def save_notice(self, event_path: str, observer_path: str, method_name: str):
-        """Part of the Storage API, record a notice (event and observer)."""
+        """Part of the Storage API, record a notice (event and observer).
+
+        Raises:
+            :class:`CalledProcessError`: if Juju returns an error.
+        """
         notice_list = self._load_notice_list()
         notice_list.append((event_path, observer_path, method_name))
         self._save_notice_list(notice_list)
 
     def drop_notice(self, event_path: str, observer_path: str, method_name: str):
-        """Part of the Storage API, remove a notice that was previously recorded."""
+        """Part of the Storage API, remove a notice that was previously recorded.
+
+        Raises:
+            :class:`CalledProcessError`: if Juju returns an error.
+        """
         notice_list = self._load_notice_list()
         notice_list.remove((event_path, observer_path, method_name))
         self._save_notice_list(notice_list)
@@ -266,6 +281,9 @@ class JujuStorage:
 
         Returns:
             Iterable of (event_path, observer_path, method_name) tuples
+
+        Raises:
+            :class:`CalledProcessError`: if Juju returns an error.
         """
         notice_list = self._load_notice_list()
         for row in notice_list:

--- a/ops/storage.py
+++ b/ops/storage.py
@@ -230,7 +230,7 @@ class JujuStorage:
             handle_path: The string identifying the snapshot.
 
         Raises:
-            :class:`NoSnapshotError`: if there is no snapshot for the given handle_path.
+            NoSnapshotError: if there is no snapshot for the given handle_path.
         """
         try:
             content = self._backend.get(handle_path)
@@ -246,15 +246,13 @@ class JujuStorage:
         self._backend.delete(handle_path)
 
     def save_notice(self, event_path: str, observer_path: str, method_name: str):
-        """Part of the Storage API, record a notice (event and observer).
-        """
+        """Part of the Storage API, record a notice (event and observer)."""
         notice_list = self._load_notice_list()
         notice_list.append((event_path, observer_path, method_name))
         self._save_notice_list(notice_list)
 
     def drop_notice(self, event_path: str, observer_path: str, method_name: str):
-        """Part of the Storage API, remove a notice that was previously recorded.
-        """
+        """Part of the Storage API, remove a notice that was previously recorded."""
         notice_list = self._load_notice_list()
         notice_list.remove((event_path, observer_path, method_name))
         self._save_notice_list(notice_list)

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1066,7 +1066,7 @@ class Harness(Generic[CharmType]):
 
         Raises:
             KeyError: if no Pebble client exists for that container name (should only happen if
-            container is not present in ``metadata.yaml``).
+                container is not present in ``metadata.yaml``).
         """
         client = self._backend._pebble_clients.get(container_name)
         if client is None:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -284,9 +284,6 @@ class Harness(Generic[CharmType]):
 
         Note that the Charm is not instantiated until :meth:`.begin()` is called.
         Until then, attempting to access this property will raise an exception.
-
-        Raises:
-            RuntimeError: if :meth:`begin` has not been called.
         """
         if self._charm is None:
             raise RuntimeError('The charm instance is not available yet. '
@@ -309,8 +306,7 @@ class Harness(Generic[CharmType]):
         Before calling :meth:`begin`, there is no Charm instance, so changes to the Model won't
         emit events. Call :meth:`.begin` for :attr:`.charm` to be valid.
 
-        Raises:
-            RuntimeError: if called multiple times.
+        Should only be called once.
         """
         if self._charm is not None:
             raise RuntimeError('cannot call the begin method on the harness more than once')
@@ -694,12 +690,12 @@ class Harness(Generic[CharmType]):
         It will trigger a storage-detaching hook if the storage unit in question exists
         and is presently marked as attached.
 
+        Note that the Charm is not instantiated until :meth:`begin` is called.
+        Until then, attempting to use this method will raise an exception.
+
         Args:
             storage_id: The full storage ID of the storage unit being detached, including the
                 storage key, e.g. my-storage/0.
-
-        Raises:
-            RuntimeError: if called before the harness is initialised.
         """
         if self._charm is None:
             raise RuntimeError('cannot detach storage before Harness is initialised')
@@ -1111,9 +1107,6 @@ class Harness(Generic[CharmType]):
 
         Cannot be called once :meth:`begin` has been called. Use it to set the
         value that will be returned by :attr:`Model.name <ops.Model.name>`.
-
-        Raises:
-            RuntimeError: if called after :meth:`begin`.
         """
         if self._charm is not None:
             raise RuntimeError('cannot set the Model name after begin()')
@@ -1124,9 +1117,6 @@ class Harness(Generic[CharmType]):
 
         Cannot be called once :meth:`begin` has been called. Use it to set the
         value that will be returned by :attr:`Model.uuid <ops.Model.uuid>`.
-
-        Raises:
-            RuntimeError: if called after :meth:`begin`.
         """
         if self._charm is not None:
             raise RuntimeError('cannot set the Model uuid after begin()')

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -544,18 +544,15 @@ class Harness(Generic[CharmType]):
 
     def add_oci_resource(self, resource_name: str,
                          contents: Optional[Mapping[str, str]] = None) -> None:
-        """Add oci resources to the backend.
+        """Add OCI resources to the backend.
 
-        This will register an oci resource and create a temporary file for processing metadata
+        This will register an OCI resource and create a temporary file for processing metadata
         about the resource. A default set of values will be used for all the file contents
         unless a specific contents dict is provided.
 
         Args:
             resource_name: Name of the resource to add custom contents to.
             contents: Optional custom dict to write for the named resource.
-
-        Raises:
-            RuntimeError: if the resource is not defined, or is not an OCI image.
         """
         if not contents:
             contents = {'registrypath': 'registrypath',
@@ -580,9 +577,6 @@ class Harness(Generic[CharmType]):
             resource_name: The name of the resource being added
             content: Either string or bytes content, which will be the content of the filename
                 returned by resource-get. If contents is a string, it will be encoded in utf-8
-
-        Raises:
-            RuntimeError: if the resource is not defined, or is not a file.
         """
         if resource_name not in self._meta.resources.keys():
             raise RuntimeError(f'Resource {resource_name} is not a defined resource')
@@ -665,9 +659,6 @@ class Harness(Generic[CharmType]):
 
         Return:
             A list of storage IDs, e.g. ["my-storage/1", "my-storage/2"].
-
-        Raises:
-            RuntimeError: if the storage is missing from the metadata.
         """
         if storage_name not in self._meta.storages:
             raise RuntimeError(
@@ -910,12 +901,6 @@ class Harness(Generic[CharmType]):
         Args:
             relation_id: The integer relation identifier (as returned by :meth:`add_relation`).
             remote_unit_name: A string representing the remote unit that is being added.
-
-        Return:
-            None
-
-        Raises:
-            RuntimeError: if no matching relation is found.
         """
         self._backend._relation_list_map[relation_id].append(remote_unit_name)
         # we can write remote unit data iff we are not in a hook env
@@ -968,9 +953,6 @@ class Harness(Generic[CharmType]):
         Args:
             relation_id: The integer relation identifier (as returned by :meth:`add_relation`).
             remote_unit_name: A string representing the remote unit that is being removed.
-
-        Raises:
-            RuntimeError: if no matching relation is found.
         """
         relation_name = self._backend._relation_names[relation_id]
 
@@ -1141,9 +1123,6 @@ class Harness(Generic[CharmType]):
             app_or_unit: The unit or application name that is being updated.
                 This can be the local or remote application.
             key_values: Each key/value will be updated in the relation data.
-
-        Raises:
-            RuntimeError: if no matching relation is found.
         """
         relation_name = self._backend._relation_names[relation_id]
         relation = self._model.get_relation(relation_name, relation_id)
@@ -1310,9 +1289,6 @@ class Harness(Generic[CharmType]):
         event. Typically, a charm author would check planned units during a
         config or install hook, or after receiving a peer relation joined
         event.
-
-        Raises:
-            TypeError: if ``num_units`` is not 0 or a positive integer.
         """
         if num_units < 0:
             raise TypeError("num_units must be 0 or a positive integer.")
@@ -1461,9 +1437,6 @@ class Harness(Generic[CharmType]):
             secret_id: The ID of the secret to update. This should normally be
                 the return value of :meth:`add_model_secret`.
             content: A key-value mapping containing the new payload.
-
-        Raises:
-            RuntimeError: if the secret is owned by the charm under test.
         """
         model.Secret._validate_content(content)
         secret = self._ensure_secret(secret_id)
@@ -1489,9 +1462,6 @@ class Harness(Generic[CharmType]):
             observer: The name of the application (or specific unit) to grant
                 access to. A relation between this application and the charm
                 under test must already have been created.
-
-        Raises:
-            RuntimeError: if the secret is owned by the charm under test.
         """
         secret = self._ensure_secret(secret_id)
         if secret.owner_name in [self.model.app.name, self.model.unit.name]:
@@ -1515,9 +1485,6 @@ class Harness(Generic[CharmType]):
             observer: The name of the application (or specific unit) to revoke
                 access to. A relation between this application and the charm under
                 test must have already been created.
-
-        Raises:
-            RuntimeError: if the secret is owned by the charm under test.
         """
         secret = self._ensure_secret(secret_id)
         if secret.owner_name in [self.model.app.name, self.model.unit.name]:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2042,7 +2042,7 @@ class _TestingModelBackend:
     def relation_ids(self, relation_name: str) -> List[int]:
         try:
             return self._relation_ids_map[relation_name]
-        except KeyError as e:
+        except KeyError:
             if relation_name not in self._meta.relations:
                 raise model.ModelError(f'{relation_name} is not a known relation') from None
             no_ids: List[int] = []
@@ -2051,7 +2051,7 @@ class _TestingModelBackend:
     def relation_list(self, relation_id: int):
         try:
             return self._relation_list_map[relation_id]
-        except KeyError as e:
+        except KeyError:
             raise model.RelationNotFoundError from None
 
     def relation_remote_app_name(self, relation_id: int) -> Optional[str]:


### PR DESCRIPTION
### More extensively document the exceptions that Charmers should be aware of and potentially catching

If we raise an exception when checking an argument's type, and the type hinting covers this, I have not included it in the `Raises` list. I feel that the docs (and a type checker) cover this already, and the `Raises` section should be more focused on exceptions that the Charmer should consider handling.

#908 goes back-and-forth on documenting very common exceptions (like `APIError` and `CommunicationError` in nearly all pebble `Client` methods), and I have as well. ~I'm currently +0 on documenting them, and it seems like it's simpler to add them all in the PR and them remove them than decide to add them after the initial PR, so they are included at the moment. I could easily be convinced that they should be removed and a central doc note added (but I'm not sure where that would be best).~ These have been removed and are centralised in the `Container` and `pebble.Client` docstrings.

Exceptions that are possible but should be rare and indicate a broken system (such as Juju or Pebble returning invalid data or being unresponsive) are not included. It feels like this tips *too* far in the "document everything" direction, and I don't feel like it would be worth Charmers trying to handle these exceptional (no pun intended) circumstances.

Where it was unclear whether it was worth documenting a potential exception - such as not providing any commands in `exec`, which seems more likely to be a coding error than something the Charm should handle, but I could see happening with quite dynamic code - I have generally taken the more defensive approach of including the potential raise.

I wrote a terrible, horrible, no good, very bad charm that causes a large number of these errors, and examined the pebble & Juju code to find information about what might cause issues. However, since I'm still only lightly familiar with Juju/ops, I could have missed some cases.

### Minor tweaks to exception chaining

* If we are raising an exception in an exception handler but the original exception is just an implementation detail, `raise x from None`
* If we are converting an exception to a more specific/localised one and the original exception is relevant, `raise x from e`
* If we are filtering an exception and then re-raising, `raise` or `raise e` (preferably the former, but leaving the latter if already in place)

### Miscellanous

One minor type hinting improvement: if an exception is always raised, use `typing.NoReturn` as the return type.

Drive-bys:
 * Remove one `type: ignore` that is no longer required.
 * Add `ops.` to a couple of examples in the docstrings that were missed in #921

Fixes #908, #1043