### PR TITLE
ci: remove the temporary mysql-k8s-operator unit tests workaround

### DIFF
--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -43,8 +43,3 @@ jobs:
 
       - name: Run the charm's unit tests
         run: tox -vve unit
-        # TODO: remove this once https://github.com/canonical/mysql-k8s-operator/pull/316 is fixed
-        env:
-          # This env var is only to indicate Juju version to "simulate" in the mysqk-k8s-operator
-          # unit tests. No libjuju is being actually used in unit testing.
-          LIBJUJU_VERSION_SPECIFIER: 3.1


### PR DESCRIPTION
With [canonical/mysql-k8s-operator#320](https://github.com/canonical/mysql-k8s-operator/pull/320) merged, we should no longer require the temporary workaround from #1036.