### PR TITLE
fix(testing): reset collected statuses in Harness.evaluate_status

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -860,7 +860,7 @@ class CollectStatusEvent(EventBase):
 
     The framework will trigger these events after the hook code runs
     successfully (``collect_app_status`` will only be triggered on the leader
-    unit). If any statuses were added by the event handlers using
+    unit). If any statuses were added by the event handler using
     :meth:`add_status`, the framework will choose the highest-priority status
     and set that as the status (application status for ``collect_app_status``,
     or unit status for ``collect_unit_status``).

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1632,8 +1632,10 @@ class Harness(Generic[CharmType]):
         statuses were added.
 
         Tests should normally call this and then assert that ``self.model.app.status``
-        or ``self.model.unit.status`` is the value expected. This method resets the
-        added statuses before triggering the collect-status events.
+        or ``self.model.unit.status`` is the value expected.
+
+        Evaluation is not "additive"; this method resets the added statuses before
+        triggering each collect-status event.
         """
         self.charm.app._collected_statuses = []
         self.charm.unit._collected_statuses = []

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1634,6 +1634,9 @@ class Harness(Generic[CharmType]):
         Tests should normally call this and then assert that ``self.model.app.status``
         or ``self.model.unit.status`` is the value expected.
         """
+        if self._backend._is_leader:
+            self.charm.app._collected_statuses = []
+        self.charm.unit._collected_statuses = []
         charm._evaluate_status(self.charm)
 
     def handle_exec(self,

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1632,10 +1632,10 @@ class Harness(Generic[CharmType]):
         statuses were added.
 
         Tests should normally call this and then assert that ``self.model.app.status``
-        or ``self.model.unit.status`` is the value expected.
+        or ``self.model.unit.status`` is the value expected. This method resets the
+        added statuses before triggering the collect-status events.
         """
-        if self._backend._is_leader:
-            self.charm.app._collected_statuses = []
+        self.charm.app._collected_statuses = []
         self.charm.unit._collected_statuses = []
         charm._evaluate_status(self.charm)
 


### PR DESCRIPTION
Currently you can't really call `Harness.evaluate_status()` twice in one test because it keeps the previous collected statuses around. Reset them before evaluating.

I believe this addresses https://github.com/canonical/operator/issues/736#issuecomment-1762094066
