### PR TITLE
feat: provide a clearer exception when the Pebble socket is missing

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -20,6 +20,7 @@ For a command-line interface for local testing, see test/pebble_cli.py.
 import binascii
 import copy
 import datetime
+import errno
 import email.message
 import email.parser
 import enum
@@ -1623,6 +1624,10 @@ class Client:
                 message = f'{type(e2).__name__} - {e2}'
             raise APIError(body, code, status, message)
         except urllib.error.URLError as e:
+            if e.errno == errno.ENOENT:
+                raise ConnectionError(
+                    f"Could not connect to Pebble: socket not found at '{self.socket_path}' "
+                    "(container restarted?)") from None
             raise ConnectionError(e.reason)
 
         return response

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1626,7 +1626,7 @@ class Client:
         except urllib.error.URLError as e:
             if e.errno == errno.ENOENT:
                 raise ConnectionError(
-                    f"Could not connect to Pebble: socket not found at '{self.socket_path}' "
+                    f"Could not connect to Pebble: socket not found at {self.socket_path!r} "
                     "(container restarted?)") from None
             raise ConnectionError(e.reason)
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -23,7 +23,6 @@ import datetime
 import email.message
 import email.parser
 import enum
-import errno
 import http.client
 import io
 import json
@@ -1624,7 +1623,7 @@ class Client:
                 message = f'{type(e2).__name__} - {e2}'
             raise APIError(body, code, status, message)
         except urllib.error.URLError as e:
-            if e.errno == errno.ENOENT:
+            if e.args and isinstance(e.args[0], FileNotFoundError):
                 raise ConnectionError(
                     f"Could not connect to Pebble: socket not found at {self.socket_path!r} "
                     "(container restarted?)") from None

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -20,10 +20,10 @@ For a command-line interface for local testing, see test/pebble_cli.py.
 import binascii
 import copy
 import datetime
-import errno
 import email.message
 import email.parser
 import enum
+import errno
 import http.client
 import io
 import json

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -2579,6 +2579,7 @@ class TestSocketClient(unittest.TestCase):
         with self.assertRaises(pebble.ConnectionError) as cm:
             client.get_system_info()
         self.assertIsInstance(cm.exception, pebble.Error)
+        self.assertIn("Could not connect to Pebble", str(cm.exception))
 
     def test_real_client(self):
         shutdown, socket_path = fake_pebble.start_server()

--- a/test/test_real_pebble.py
+++ b/test/test_real_pebble.py
@@ -260,11 +260,6 @@ class TestRealPebble(unittest.TestCase):
 
         self.assertEqual(reads, [b'one\n', b'2\n', b'THREE\n'])
 
-    def test_missing_socket(self):
-        bad_client = pebble.Client(socket_path="/not-a-real-pebble-socket")
-        with self.assertRaises(pebble.ConnectionError):
-            bad_client.get_system_info()
-
 
 @unittest.skipUnless(os.getenv('RUN_REAL_PEBBLE_TESTS'), 'RUN_REAL_PEBBLE_TESTS not set')
 class TestPebbleStorageAPIsUsingRealPebble(unittest.TestCase, PebbleStorageAPIsTestMixin):

--- a/test/test_real_pebble.py
+++ b/test/test_real_pebble.py
@@ -260,6 +260,11 @@ class TestRealPebble(unittest.TestCase):
 
         self.assertEqual(reads, [b'one\n', b'2\n', b'THREE\n'])
 
+    def test_missing_socket(self):
+        bad_client = pebble.Client(socket_path="/not-a-real-pebble-socket")
+        with self.assertRaises(pebble.ConnectionError):
+            bad_client.get_system_info()
+
 
 @unittest.skipUnless(os.getenv('RUN_REAL_PEBBLE_TESTS'), 'RUN_REAL_PEBBLE_TESTS not set')
 class TestPebbleStorageAPIsUsingRealPebble(unittest.TestCase, PebbleStorageAPIsTestMixin):


### PR DESCRIPTION
Filter the 'pebble socket does not exist' case from the existing try/except block and raise a more helpful exception in that case.

Although the content of the exception message is not really part of the API contract, since we're deliberately changing it, extend the unit test to check that the message has been changed.

Fixes #844