### PR TITLE
chore: pin the dev requirements to major.minor compatible

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -99,6 +99,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Python 3
         uses: actions/setup-python@v2
+        with:
+          python-version: '3.11'
 
       - name: Build
         run: python setup.py sdist

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -10,7 +10,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Python 3
         uses: actions/setup-python@v2
-
+        with:
+          python-version: '3.11'
       - name: Install tox
         run: pip install tox~=4.2
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1855,7 +1855,7 @@ class _TestingConfig(Dict[str, Union[str, int, float, bool]]):
                 'Incorrectly formatted `options.yaml`: `type` needs to be one '
                 'of [{}], not {}.'.format(', '.join(self._supported_types), declared_type))
 
-        if type(value) != self._supported_types[declared_type]:
+        if type(value) is not self._supported_types[declared_type]:
             raise RuntimeError('Config option {} is supposed to be of type '
                                '{}, not `{}`.'.format(key, declared_type,
                                                       type(value).__name__))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ pytest~=7.2
 pyright==1.1.317
 pytest-operator~=0.23
 coverage[toml]~=7.0
+setuptools~=68.2
 typing_extensions~=4.2
 
 -r requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 isort~=5.11
 autopep8~=1.6
-flake8~=4.0
-flake8-docstrings~=1.6
+flake8~=6.1
+flake8-docstrings~=1.7
 flake8-builtins~=2.1
-pyproject-flake8~=4.0
+pyproject-flake8~=6.1
 pep8-naming~=0.13
 pytest~=7.2
 pyright==1.1.317

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,6 @@ pytest~=7.2
 pyright==1.1.317
 pytest-operator~=0.23
 coverage[toml]~=7.0
-setuptools~=68.2
 typing_extensions~=4.2
 
 -r requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,14 +1,14 @@
-isort==5.11.4
-autopep8==1.6.0
-flake8==4.0.1
-flake8-docstrings==1.6.0
-flake8-builtins==2.1.0
-pyproject-flake8==4.0.1
-pep8-naming==0.13.2
-pytest==7.2.1
+isort~=5.11
+autopep8~=1.6
+flake8~=4.0
+flake8-docstrings~=1.6
+flake8-builtins~=2.1
+pyproject-flake8~=4.0
+pep8-naming~=0.13
+pytest~=7.2
 pyright==1.1.317
-pytest-operator==0.23.0
-coverage[toml]==7.0.5
-typing_extensions==4.2.0
+pytest-operator~=0.23
+coverage[toml]~=7.0
+typing_extensions~=4.2
 
 -r requirements.txt


### PR DESCRIPTION
Adjust the dev requirements to be pinned to the latest compatible version of the currently used major.minor version.

This should make breakage like the current issue with flake8 & Python 3 less common, and generally encourage developing using the latest versions of the dev tools (picking up bug fixes and security fixes in particular).

Pyright doesn't use semvar and newer versions have issues with some of the hinting we use (it's unclear whether this is limitations in Python, or a pyright bug, or something we should fix ourselves) so leave it tightly pinned to the same version.

Changes one line of (ops.testing) code to avoid an issue raised by newer flake8 (using `!=` to compare types, rather than `is not` for an exact match or `not isinstance` for looser checks).

Temporarily use Python 3.11 for the CI linting check (rather than whatever the setup-python tool provides by default, currently 3.12), to work around an incompatibility between pyproject-flake8 and Python 3.12. This should be reverted when (a) we move away from flake8, or (b) pyproject-flake8 has a fix in a released version.

Temporarily use Python 3.11 for the CI `build sdist` check. We need to either explicitly install `setuptools` in that action, or modernise the `setup.py` to not require it (since we're considering moving to be more purely pyproject.toml, that might end up the solution).