### PR TITLE
docs: correct the version that Harness.run_action was added

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,12 @@
+# 2.9.0
+
+* Added `Harness.run_action()`, `testing.ActionOutput`, and `testing.ActionFailed`
+
 # 2.8.0
 
 * Added `Unit.reboot()` and `Harness.reboot_count``
 * Added `RelationMeta.optional`
 * The type of a `Handle`'s `key` was expanded from `str` to `str|None`
-* Added `Harness.run_action()`, `testing.ActionOutput`, and `testing.ActionFailed`
 * Narrowed types of `app` and `unit` in relation events to exclude `None` where applicable
 
 # 2.7.0

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1799,7 +1799,7 @@ class Harness(Generic[CharmType]):
                 ...
             harness.run_action("action-name", params)
 
-        *New in version 2.8*
+        *New in version 2.9*
 
         Args:
             action_name: the name of the action to run, as found in ``actions.yaml``.


### PR DESCRIPTION
When I opened the original PR, I assumed it would squeeze into 2.8, but then forgot to update that to 2.9 before we merged, sorry.