### PR TITLE
docs: add workflow badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The `ops` library
 
 ![CI Status](https://github.com/canonical/operator/actions/workflows/framework-tests.yaml/badge.svg)
-![Publish](https://github.com/canonical/operator/actions/workflows/publish.yaml/badge.svg)
+![Publish](https://github.com/canonical/operator/actions/workflows/publish.yml/badge.svg)
 
 The `ops` library is a Python framework for developing and testing Kubernetes and machine [charms](https://juju.is/docs/sdk/charmed-operators). While charms can be written in any language, `ops` defines the latest standard, and charmers are encouraged to use Python with `ops` for all charms. The library is an official component of the Charm SDK, itself a part of [the Juju universe](https://juju.is/).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # The `ops` library
 
+![Charmcraft pack](https://github.com/canonical/actions/workflows/charmcraft.yml/badge.svg)
+![Compatibility: DB charms](https://github.com/canonical/actions/workflows/db-charm-tests.yml/badge.svg)
+![Compatibility: Basic charms](https://github.com/canonical/actions/workflows/hello-charm-tests.yml/badge.svg)
+![Compatibility: Observability charms](https://github.com/canonical/actions/workflows/observability-charm-tests.yml/badge.svg)
+![CI Status](https://github.com/canonical/actions/workflows/framework-tests.yml/badge.svg)
 
 The `ops` library is a Python framework for developing and testing Kubernetes and machine [charms](https://juju.is/docs/sdk/charmed-operators). While charms can be written in any language, `ops` defines the latest standard, and charmers are encouraged to use Python with `ops` for all charms. The library is an official component of the Charm SDK, itself a part of [the Juju universe](https://juju.is/).
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # The `ops` library
 
-![Charmcraft pack](https://github.com/canonical/actions/workflows/charmcraft.yml/badge.svg)
-![Compatibility: DB charms](https://github.com/canonical/actions/workflows/db-charm-tests.yml/badge.svg)
-![Compatibility: Basic charms](https://github.com/canonical/actions/workflows/hello-charm-tests.yml/badge.svg)
-![Compatibility: Observability charms](https://github.com/canonical/actions/workflows/observability-charm-tests.yml/badge.svg)
-![CI Status](https://github.com/canonical/actions/workflows/framework-tests.yml/badge.svg)
+![Charmcraft pack](https://github.com/canonical/operator/actions/workflows/charmcraft-pack.yaml/badge.svg)
+![Compatibility: DB charms](https://github.com/canonical/operator/actions/workflows/db-charm-tests.yaml/badge.svg)
+![Compatibility: Basic charms](https://github.com/canonical/operator/actions/workflows/hello-charm-tests.yaml/badge.svg)
+![Compatibility: Observability charms](https://github.com/canonical/operator/actions/workflows/observability-charm-tests.yaml/badge.svg)
+![CI Status](https://github.com/canonical/operator/actions/workflows/framework-tests.yaml/badge.svg)
 
 The `ops` library is a Python framework for developing and testing Kubernetes and machine [charms](https://juju.is/docs/sdk/charmed-operators). While charms can be written in any language, `ops` defines the latest standard, and charmers are encouraged to use Python with `ops` for all charms. The library is an official component of the Charm SDK, itself a part of [the Juju universe](https://juju.is/).
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # The `ops` library
 
-![Charmcraft pack](https://github.com/canonical/operator/actions/workflows/charmcraft-pack.yaml/badge.svg)
-![Compatibility: DB charms](https://github.com/canonical/operator/actions/workflows/db-charm-tests.yaml/badge.svg)
-![Compatibility: Basic charms](https://github.com/canonical/operator/actions/workflows/hello-charm-tests.yaml/badge.svg)
-![Compatibility: Observability charms](https://github.com/canonical/operator/actions/workflows/observability-charm-tests.yaml/badge.svg)
 ![CI Status](https://github.com/canonical/operator/actions/workflows/framework-tests.yaml/badge.svg)
+![Publish](https://github.com/canonical/operator/actions/workflows/publish.yaml/badge.svg)
 
 The `ops` library is a Python framework for developing and testing Kubernetes and machine [charms](https://juju.is/docs/sdk/charmed-operators). While charms can be written in any language, `ops` defines the latest standard, and charmers are encouraged to use Python with `ops` for all charms. The library is an official component of the Charm SDK, itself a part of [the Juju universe](https://juju.is/).
 


### PR DESCRIPTION
Add badges for the Github workflows (except publish) to the README.

These will show when viewing the README in a markdown reader that loads external images (e.g. on Github itself) but more importantly also show the CI status on [the Juju releases page](https://releases.juju.is).