### PR TITLE
feat: expose the ability to set Pebble log targets

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -77,7 +77,7 @@ jobs:
         run: pip install tox~=4.2
 
       - name: Install Pebble
-        run: go install github.com/canonical/pebble/cmd/pebble@latest
+        run: go install github.com/canonical/pebble/cmd/pebble@master
 
       - name: Start Pebble
         run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # 2.9.0
 
+* Added log target support to `ops.pebble` layers and plans.
 * Added `Harness.run_action()`, `testing.ActionOutput`, and `testing.ActionFailed`
 
 # 2.8.0

--- a/HACKING.md
+++ b/HACKING.md
@@ -55,7 +55,7 @@ pytest
 The framework has some tests that interact with a real/live Pebble server.  To
 run these tests, you must have [pebble](https://github.com/canonical/pebble)
 installed and available in your path.  If you have the Go toolchain installed,
-you can run `go install github.com/canonical/pebble/cmd/pebble@latest`.  This will
+you can run `go install github.com/canonical/pebble/cmd/pebble@master`.  This will
 install pebble to `$GOBIN` if it is set or `$HOME/go/bin` otherwise.  Add
 `$GOBIN` to your path (e.g. `export PATH=$PATH:$GOBIN` or `export
 PATH=$PATH:$HOME/go/bin` in your `.bashrc`) and you are ready to run the real
@@ -78,10 +78,6 @@ tox -e unit -- test/test_real_pebble.py
 source .tox/unit/bin/activate
 pytest -v test/test_real_pebble.py
 ```
-
-To test Pebble functionality that has been merged but not yet released, you can run
-`go install github.com/canonical/pebble/cmd/pebble@master`. This otherwise works in
-the same way as the install described above.
 
 # Documentation
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -52,20 +52,20 @@ pytest
 
 ## Pebble Tests
 
-The framework has some tests that interact with a real/live pebble server.  To
+The framework has some tests that interact with a real/live Pebble server.  To
 run these tests, you must have [pebble](https://github.com/canonical/pebble)
 installed and available in your path.  If you have the Go toolchain installed,
 you can run `go install github.com/canonical/pebble/cmd/pebble@latest`.  This will
 install pebble to `$GOBIN` if it is set or `$HOME/go/bin` otherwise.  Add
 `$GOBIN` to your path (e.g. `export PATH=$PATH:$GOBIN` or `export
 PATH=$PATH:$HOME/go/bin` in your `.bashrc`) and you are ready to run the real
-pebble tests:
+Pebble tests:
 
 ```sh
 tox -e pebble
 ```
 
-To do this even more manually, you could start the pebble server yourself:
+To do this even more manually, you could start the Pebble server yourself:
 
 ```sh
 export PEBBLE=$HOME/pebble
@@ -78,6 +78,10 @@ tox -e unit -- test/test_real_pebble.py
 source .tox/unit/bin/activate
 pytest -v test/test_real_pebble.py
 ```
+
+To test Pebble functionality that has been merged but not yet released, you can run
+`go install github.com/canonical/pebble/cmd/pebble@master`. This otherwise works in
+the same way as the install described above.
 
 # Documentation
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -751,7 +751,7 @@ class Plan:
 
     @property
     def log_targets(self) -> Dict[str, 'LogTarget']:
-        """This plan's log targets mapping (maps log targer name to :class:`LogTarget`).
+        """This plan's log targets mapping (maps log target name to :class:`LogTarget`).
 
         This property is currently read-only.
         """

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -129,8 +129,8 @@ LogTargetDict = typing.TypedDict('LogTargetDict',
                                  {'override': Union[Literal['merge'], Literal['replace']],
                                   'type': Literal['loki'],
                                   'location': str,
-                                  'services': Optional[List[str]],
-                                  'labels': Optional[Dict[str, str]]},
+                                  'services': List[str],
+                                  'labels': Dict[str, str]},
                                  total=False)
 
 LayerDict = typing.TypedDict('LayerDict',
@@ -1063,12 +1063,9 @@ class LogTarget:
         self.name = name
         dct: LogTargetDict = raw or {}
         self.override: str = dct.get('override', '')
-        self.type_ = dct.get('type', '')
+        self.type = dct.get('type', '')
         self.location = dct.get('location', '')
-        services = dct.get('services')
-        if services:
-            services = services[:]
-        self.services: Optional[List[str]] = services
+        self.services: List[str] = list(dct.get('services', []))
         labels = dct.get('labels')
         if labels is not None:
             labels = copy.deepcopy(labels)
@@ -1078,7 +1075,7 @@ class LogTarget:
         """Convert this log target object to its dict representation."""
         fields = [
             ('override', self.override),
-            ('type', self.type_),
+            ('type', self.type),
             ('location', self.location),
             ('services', self.services),
             ('labels', self.labels),

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -124,16 +124,27 @@ CheckDict = typing.TypedDict('CheckDict',
                               'threshold': Optional[int]},
                              total=False)
 
+# In Python 3.11+ 'services' and 'labels' should be NotRequired, and total=True.
+LogTargetDict = typing.TypedDict('LogTargetDict',
+                                 {'override': Union[Literal['merge'], Literal['replace']],
+                                  'type': Literal['loki'],
+                                  'location': str,
+                                  'services': Optional[List[str]],
+                                  'labels': Optional[Dict[str, str]]},
+                                 total=False)
+
 LayerDict = typing.TypedDict('LayerDict',
                              {'summary': str,
                               'description': str,
                               'services': Dict[str, ServiceDict],
-                              'checks': Dict[str, CheckDict]},
+                              'checks': Dict[str, CheckDict],
+                              'log-targets': Dict[str, LogTargetDict]},
                              total=False)
 
 PlanDict = typing.TypedDict('PlanDict',
                             {'services': Dict[str, ServiceDict],
-                             'checks': Dict[str, CheckDict]},
+                             'checks': Dict[str, CheckDict],
+                             'log-targets': Dict[str, LogTargetDict]},
                             total=False)
 
 _AuthDict = TypedDict('_AuthDict',
@@ -718,6 +729,9 @@ class Plan:
                                               for name, service in d.get('services', {}).items()}
         self._checks: Dict[str, Check] = {name: Check(name, check)
                                           for name, check in d.get('checks', {}).items()}
+        self._log_targets: Dict[str, LogTarget] = {
+            name: LogTarget(name, target)
+            for name, target in d.get('log-targets', {}).items()}
 
     @property
     def services(self) -> Dict[str, 'Service']:
@@ -735,11 +749,20 @@ class Plan:
         """
         return self._checks
 
+    @property
+    def log_targets(self) -> Dict[str, 'LogTarget']:
+        """This plan's log targets mapping (maps log targer name to :class:`LogTarget`).
+
+        This property is currently read-only.
+        """
+        return self._log_targets
+
     def to_dict(self) -> 'PlanDict':
         """Convert this plan to its dict representation."""
         fields = [
             ('services', {name: service.to_dict() for name, service in self._services.items()}),
             ('checks', {name: check.to_dict() for name, check in self._checks.items()}),
+            ('log-targets', {name: target.to_dict() for name, target in self._log_targets.items()})
         ]
         dct = {name: value for name, value in fields if value}
         return typing.cast('PlanDict', dct)
@@ -766,6 +789,8 @@ class Layer:
     services: Dict[str, 'Service']
     #: Mapping of check to :class:`Check` defined by this layer.
     checks: Dict[str, 'Check']
+    #: Mapping of target to :class:`LogTarget` defined by this layer.
+    log_targets: Dict[str, 'LogTarget']
 
     def __init__(self, raw: Optional[Union[str, 'LayerDict']] = None):
         if isinstance(raw, str):
@@ -780,6 +805,8 @@ class Layer:
                          for name, service in d.get('services', {}).items()}
         self.checks = {name: Check(name, check)
                        for name, check in d.get('checks', {}).items()}
+        self.log_targets = {name: LogTarget(name, target)
+                            for name, target in d.get('log-targets', {}).items()}
 
     def to_yaml(self) -> str:
         """Convert this layer to its YAML representation."""
@@ -792,6 +819,7 @@ class Layer:
             ('description', self.description),
             ('services', {name: service.to_dict() for name, service in self.services.items()}),
             ('checks', {name: check.to_dict() for name, check in self.checks.items()}),
+            ('log-targets', {name: target.to_dict() for name, target in self.log_targets.items()})
         ]
         dct = {name: value for name, value in fields if value}
         return typing.cast('LayerDict', dct)
@@ -1026,6 +1054,48 @@ class CheckStatus(enum.Enum):
 
     UP = 'up'
     DOWN = 'down'
+
+
+class LogTarget:
+    """Represents a log target in a Pebble configuration layer."""
+
+    def __init__(self, name: str, raw: Optional['LogTargetDict'] = None):
+        self.name = name
+        dct: LogTargetDict = raw or {}
+        self.override: str = dct.get('override', '')
+        self.type_ = dct.get('type', '')
+        self.location = dct.get('location', '')
+        services = dct.get('services')
+        if services:
+            services = services[:]
+        self.services: Optional[List[str]] = services
+        labels = dct.get('labels')
+        if labels is not None:
+            labels = copy.deepcopy(labels)
+        self.labels: Optional[Dict[str, str]] = labels
+
+    def to_dict(self) -> 'LogTargetDict':
+        """Convert this log target object to its dict representation."""
+        fields = [
+            ('override', self.override),
+            ('type', self.type_),
+            ('location', self.location),
+            ('services', self.services),
+            ('labels', self.labels),
+        ]
+        dct = {name: value for name, value in fields if value}
+        return typing.cast('LogTargetDict', dct)
+
+    def __repr__(self):
+        return f'LogTarget({self.to_dict()!r})'
+
+    def __eq__(self, other: Union['LogTargetDict', 'LogTarget']):
+        if isinstance(other, dict):
+            return self.to_dict() == other
+        elif isinstance(other, LogTarget):
+            return self.to_dict() == other.to_dict()
+        else:
+            return NotImplemented
 
 
 class FileType(enum.Enum):

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -479,6 +479,25 @@ class TestPlan(unittest.TestCase):
         with self.assertRaises(AttributeError):
             plan.checks = {}  # type: ignore
 
+    def test_log_targets(self):
+        plan = pebble.Plan('')
+        self.assertEqual(plan.log_targets, {})
+
+        location = "https://example.com:3100/loki/api/v1/push"
+        plan = pebble.Plan(
+            'log-targets:\n baz:\n  override: replace\n  type: loki\n  '
+            f'location: {location}')
+
+        self.assertEqual(len(plan.log_targets), 1)
+        self.assertEqual(plan.log_targets['baz'].name, 'baz')
+        self.assertEqual(plan.log_targets['baz'].override, 'replace')
+        self.assertEqual(plan.log_targets['baz'].type_, "loki")
+        self.assertEqual(plan.log_targets['baz'].location, location)
+
+        # Should be read-only ("can't set attribute")
+        with self.assertRaises(AttributeError):
+            plan.log_targets = {}  # type: ignore
+
     def test_yaml(self):
         # Starting with nothing, we get the empty result
         plan = pebble.Plan('')
@@ -496,6 +515,12 @@ checks:
  bar:
   http:
    https://example.com/
+
+log-targets:
+ baz:
+  override: replace
+  type: loki
+  location: https://example.com:3100/loki/api/v1/push
 '''
         plan = pebble.Plan(raw)
         reformed = yaml.safe_dump(yaml.safe_load(raw))
@@ -524,6 +549,8 @@ class TestLayer(unittest.TestCase):
         self.assertEqual(layer.summary, '')
         self.assertEqual(layer.description, '')
         self.assertEqual(layer.services, {})
+        self.assertEqual(layer.checks, {})
+        self.assertEqual(layer.log_targets, {})
         self.assertEqual(layer.to_dict(), {})
 
     def test_no_args(self):
@@ -546,6 +573,17 @@ class TestLayer(unittest.TestCase):
                     'summary': 'Bar',
                     'command': 'echo bar',
                 },
+            },
+            'log-targets': {
+                'baz': {
+                    'override': 'merge',
+                    'type': 'loki',
+                    'location': 'https://example.com',
+                    'services': ['foo'],
+                    'labels': {
+                        'key': 'value $VAR',
+                    }
+                },
             }
         }
         s = pebble.Layer(d)
@@ -557,6 +595,12 @@ class TestLayer(unittest.TestCase):
         self.assertEqual(s.services['bar'].name, 'bar')
         self.assertEqual(s.services['bar'].summary, 'Bar')
         self.assertEqual(s.services['bar'].command, 'echo bar')
+        self.assertEqual(s.log_targets['baz'].name, 'baz')
+        self.assertEqual(s.log_targets['baz'].override, 'merge')
+        self.assertEqual(s.log_targets['baz'].type_, 'loki')
+        self.assertEqual(s.log_targets['baz'].location, 'https://example.com')
+        self.assertEqual(s.log_targets['baz'].services, ['foo'])
+        self.assertEqual(s.log_targets['baz'].labels, {'key': 'value $VAR'})
 
         self.assertEqual(s.to_dict(), d)
 
@@ -569,6 +613,11 @@ class TestLayer(unittest.TestCase):
     http:
       url: https://example.com/
 description: The quick brown fox!
+log-targets:
+  baz:
+    location: https://example.com:3100
+    override: replace
+    type: loki
 services:
   bar:
     command: echo bar
@@ -603,6 +652,10 @@ summary: Sum Mary
 
         self.assertEqual(s.checks['chk'].name, 'chk')
         self.assertEqual(s.checks['chk'].http, {'url': 'https://example.com/'})
+
+        self.assertEqual(s.log_targets['baz'].name, 'baz')
+        self.assertEqual(s.log_targets['baz'].override, 'replace')
+        self.assertEqual(s.log_targets['baz'].location, 'https://example.com:3100')
 
         self.assertEqual(s.to_yaml(), yaml)
         self.assertEqual(str(s), yaml)
@@ -881,6 +934,65 @@ class TestCheck(unittest.TestCase):
         d['level'] = 'ready'
         self.assertNotEqual(one, d)
 
+        self.assertNotEqual(one, 5)
+
+
+class TestLogTarget(unittest.TestCase):
+    def _assert_empty(self, target: pebble.LogTarget, name: str):
+        self.assertEqual(target.name, name)
+        self.assertEqual(target.override, '')
+        self.assertEqual(target.type_, '')
+        self.assertEqual(target.location, '')
+        self.assertIs(target.services, None)
+        self.assertIs(target.labels, None)
+
+    def test_name_only(self):
+        target = pebble.LogTarget('tgt')
+        self._assert_empty(target, 'tgt')
+
+    def test_dict(self):
+        d: pebble.LogTargetDict = {
+            'override': 'replace',
+            'type': 'loki',
+            'location': 'https://example.com:3100/loki/api/v1/push',
+            'services': ['+all'],
+            'labels': {'key': 'val', 'key2': 'val2'}
+        }
+        target = pebble.LogTarget('tgt', d)
+        self.assertEqual(target.name, 'tgt')
+        self.assertEqual(target.override, 'replace')
+        self.assertEqual(target.type_, 'loki')
+        self.assertEqual(target.location, 'https://example.com:3100/loki/api/v1/push')
+        self.assertEqual(target.services, ['+all'])
+        self.assertEqual(target.labels, {'key': 'val', 'key2': 'val2'})
+
+        self.assertEqual(target.to_dict(), d)
+
+        # Ensure pebble.Target has made copies of mutable objects.
+        assert target.services is not None and target.labels is not None
+        target.services[0] = '-all'
+        self.assertEqual(d['services'], ['+all'])
+        target.labels['key'] = 'val3'
+        assert d['labels'] is not None
+        self.assertEqual(d['labels']['key'], 'val')
+
+    def test_equality(self):
+        d: pebble.LogTargetDict = {
+            'override': 'replace',
+            'type': 'loki',
+            'location': 'https://example.com',
+            'services': ['foo', 'bar'],
+            'labels': {'k': 'v'}
+        }
+        one = pebble.LogTarget('one', d)
+        two = pebble.LogTarget('two', d)
+        self.assertEqual(one, two)
+        self.assertEqual(one, d)
+        self.assertEqual(two, d)
+        self.assertEqual(one, one.to_dict())
+        self.assertEqual(two, two.to_dict())
+        d['override'] = 'merge'
+        self.assertNotEqual(one, d)
         self.assertNotEqual(one, 5)
 
 

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -452,7 +452,12 @@ class TestPlan(unittest.TestCase):
         plan = pebble.Plan('')
         self.assertEqual(plan.services, {})
 
-        plan = pebble.Plan('services:\n foo:\n  override: replace\n  command: echo foo')
+        plan = pebble.Plan("""
+services:
+  foo:
+    override: replace
+    command: echo foo
+""")
 
         self.assertEqual(len(plan.services), 1)
         self.assertEqual(plan.services['foo'].name, 'foo')
@@ -467,8 +472,13 @@ class TestPlan(unittest.TestCase):
         plan = pebble.Plan('')
         self.assertEqual(plan.checks, {})
 
-        plan = pebble.Plan(
-            'checks:\n bar:\n  override: replace\n  http:\n   url: https://example.com/')
+        plan = pebble.Plan("""
+checks:
+  bar:
+    override: replace
+    http:
+      url: https://example.com/
+""")
 
         self.assertEqual(len(plan.checks), 1)
         self.assertEqual(plan.checks['bar'].name, 'bar')
@@ -484,14 +494,18 @@ class TestPlan(unittest.TestCase):
         self.assertEqual(plan.log_targets, {})
 
         location = "https://example.com:3100/loki/api/v1/push"
-        plan = pebble.Plan(
-            'log-targets:\n baz:\n  override: replace\n  type: loki\n  '
-            f'location: {location}')
+        plan = pebble.Plan(f"""
+log-targets:
+  baz:
+    override: replace
+    type: loki
+    location: {location}
+""")
 
         self.assertEqual(len(plan.log_targets), 1)
         self.assertEqual(plan.log_targets['baz'].name, 'baz')
         self.assertEqual(plan.log_targets['baz'].override, 'replace')
-        self.assertEqual(plan.log_targets['baz'].type_, "loki")
+        self.assertEqual(plan.log_targets['baz'].type, "loki")
         self.assertEqual(plan.log_targets['baz'].location, location)
 
         # Should be read-only ("can't set attribute")
@@ -528,7 +542,12 @@ log-targets:
         self.assertEqual(str(plan), reformed)
 
     def test_service_equality(self):
-        plan = pebble.Plan('services:\n foo:\n  override: replace\n  command: echo foo')
+        plan = pebble.Plan("""
+services:
+  foo:
+    override: replace
+    command: echo foo
+""")
 
         old_service = pebble.Service(name="foo",
                                      raw={
@@ -597,7 +616,7 @@ class TestLayer(unittest.TestCase):
         self.assertEqual(s.services['bar'].command, 'echo bar')
         self.assertEqual(s.log_targets['baz'].name, 'baz')
         self.assertEqual(s.log_targets['baz'].override, 'merge')
-        self.assertEqual(s.log_targets['baz'].type_, 'loki')
+        self.assertEqual(s.log_targets['baz'].type, 'loki')
         self.assertEqual(s.log_targets['baz'].location, 'https://example.com')
         self.assertEqual(s.log_targets['baz'].services, ['foo'])
         self.assertEqual(s.log_targets['baz'].labels, {'key': 'value $VAR'})
@@ -941,9 +960,9 @@ class TestLogTarget(unittest.TestCase):
     def _assert_empty(self, target: pebble.LogTarget, name: str):
         self.assertEqual(target.name, name)
         self.assertEqual(target.override, '')
-        self.assertEqual(target.type_, '')
+        self.assertEqual(target.type, '')
         self.assertEqual(target.location, '')
-        self.assertIs(target.services, None)
+        self.assertEqual(target.services, [])
         self.assertIs(target.labels, None)
 
     def test_name_only(self):
@@ -961,7 +980,7 @@ class TestLogTarget(unittest.TestCase):
         target = pebble.LogTarget('tgt', d)
         self.assertEqual(target.name, 'tgt')
         self.assertEqual(target.override, 'replace')
-        self.assertEqual(target.type_, 'loki')
+        self.assertEqual(target.type, 'loki')
         self.assertEqual(target.location, 'https://example.com:3100/loki/api/v1/push')
         self.assertEqual(target.services, ['+all'])
         self.assertEqual(target.labels, {'key': 'val', 'key2': 'val2'})

--- a/test/test_real_pebble.py
+++ b/test/test_real_pebble.py
@@ -259,6 +259,33 @@ class TestRealPebble(unittest.TestCase):
 
         self.assertEqual(reads, [b'one\n', b'2\n', b'THREE\n'])
 
+    def test_log_forwarding(self):
+        self.client.add_layer("log-forwarder", {
+            "services": {
+                "tired": {
+                    "override": "replace",
+                    "command": "sleep 1",
+                },
+            },
+            "log-targets": {
+                "pretend-loki": {
+                    "type": "loki",
+                    "override": "replace",
+                    "location": "https://example.com",
+                    "services": ["all"],
+                    "labels": {"foo": "bar"},
+                },
+            },
+        }, combine=True)
+        self.client.replan_services()
+        plan = self.client.get_plan()
+        self.assertEqual(len(plan.log_targets), 1)
+        self.assertEqual(plan.log_targets["pretend-loki"].type, "loki")
+        self.assertEqual(plan.log_targets["pretend-loki"].override, "replace")
+        self.assertEqual(plan.log_targets["pretend-loki"].location, "https://example.com")
+        self.assertEqual(plan.log_targets["pretend-loki"].services, ["all"])
+        self.assertEqual(plan.log_targets["pretend-loki"].labels, {"foo": "bar"})
+
 
 @unittest.skipUnless(os.getenv('RUN_REAL_PEBBLE_TESTS'), 'RUN_REAL_PEBBLE_TESTS not set')
 class TestPebbleStorageAPIsUsingRealPebble(unittest.TestCase, PebbleStorageAPIsTestMixin):

--- a/test/test_real_pebble.py
+++ b/test/test_real_pebble.py
@@ -277,7 +277,6 @@ class TestRealPebble(unittest.TestCase):
                 },
             },
         }, combine=True)
-        self.client.replan_services()
         plan = self.client.get_plan()
         self.assertEqual(len(plan.log_targets), 1)
         self.assertEqual(plan.log_targets["pretend-loki"].type, "loki")


### PR DESCRIPTION
Exposes the `log-targets` section of the Pebble layer spec, to allow charms to configure log forwarding in Pebble without having to provide layers as plain YAML.

New types:

* `LogTargetDict`: a typed dictionary similar to `ServiceDict` and `CheckDict`.
* `LogTarget`: similar to `Service` and `Check`.

Changed types:

* `LayerDict` and `PlanDict` have (not required) `log-targets` keys.
* `Layer` and `Plan` have `log_targets` attributes (`Plan` is read-only, as with `checks` and `services`).

Fixes #1073