### PR TITLE
fix: non-leaders can only view app secrets

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2482,7 +2482,12 @@ class _TestingModelBackend:
         return None
 
     def _ensure_secret_owner(self, secret: _Secret):
-        if secret.owner_name not in [self.app_name, self.unit_name]:
+        # For unit secrets, the owner unit has manage permissions. For app
+        # secrets, the leader has manage permissions and other units only have
+        # view permissions.
+        # https://discourse.charmhub.io/t/secret-access-permissions/12627
+        if (secret.owner_name != self.unit_name
+                and (secret.owner_name != self.app_name or not self.is_leader())):
             raise model.SecretNotFoundError(
                 f'You must own secret {secret.id!r} to perform this operation')
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2486,10 +2486,13 @@ class _TestingModelBackend:
         # secrets, the leader has manage permissions and other units only have
         # view permissions.
         # https://discourse.charmhub.io/t/secret-access-permissions/12627
-        if (secret.owner_name != self.unit_name
-                and (secret.owner_name != self.app_name or not self.is_leader())):
-            raise model.SecretNotFoundError(
-                f'You must own secret {secret.id!r} to perform this operation')
+        unit_secret = secret.owner_name == self.unit_name
+        app_secret = secret.owner_name == self.app_name
+
+        if unit_secret or (app_secret and self.is_leader()):
+            return
+        raise model.SecretNotFoundError(
+            f'You must own secret {secret.id!r} to perform this operation')
 
     def secret_info_get(self, *,
                         id: Optional[str] = None,

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -4915,10 +4915,11 @@ class TestSecrets(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             harness.trigger_secret_removal('nosecret', 1)
 
-    def test_secret_permissions(self):
+    def test_secret_permissions_unit(self):
         harness = ops.testing.Harness(ops.CharmBase, meta='name: database')
         self.addCleanup(harness.cleanup)
         harness.begin()
+
         # The charm can always manage a local unit secret.
         secret_id = harness.charm.unit.add_secret({"password": "1234"}).id
         secret = harness.charm.model.get_secret(id=secret_id)
@@ -4927,6 +4928,12 @@ class TestSecrets(unittest.TestCase):
         self.assertEqual(info.id, secret_id)
         secret.set_content({"password": "5678"})
         secret.remove_all_revisions()
+
+    def test_secret_permissions_leader(self):
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: database')
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+
         # The leader can manage an application secret.
         harness.set_leader(True)
         secret_id = harness.charm.app.add_secret({"password": "1234"}).id
@@ -4936,6 +4943,12 @@ class TestSecrets(unittest.TestCase):
         self.assertEqual(info.id, secret_id)
         secret.set_content({"password": "5678"})
         secret.remove_all_revisions()
+
+    def test_secret_permissions_nonleader(self):
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: database')
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+
         # Non-leaders can only view an application secret.
         harness.set_leader(False)
         secret_id = harness.charm.app.add_secret({"password": "1234"}).id

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -4819,6 +4819,7 @@ class TestSecrets(unittest.TestCase):
         harness.add_relation_unit(relation_id, 'webapp/0')
         assert harness is not None
 
+        harness.set_leader(True)
         secret = harness.model.app.add_secret({'foo': 'x'})
         assert secret.id is not None
         self.assertEqual(harness.get_secret_grants(secret.id, relation_id), set())
@@ -4913,6 +4914,39 @@ class TestSecrets(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             harness.trigger_secret_removal('nosecret', 1)
+
+    def test_secret_permissions(self):
+        harness = ops.testing.Harness(ops.CharmBase, meta='name: database')
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        # The charm can always manage a local unit secret.
+        secret_id = harness.charm.unit.add_secret({"password": "1234"}).id
+        secret = harness.charm.model.get_secret(id=secret_id)
+        self.assertEqual(secret.get_content(), {"password": "1234"})
+        info = secret.get_info()
+        self.assertEqual(info.id, secret_id)
+        secret.set_content({"password": "5678"})
+        secret.remove_all_revisions()
+        # The leader can manage an application secret.
+        harness.set_leader(True)
+        secret_id = harness.charm.app.add_secret({"password": "1234"}).id
+        secret = harness.charm.model.get_secret(id=secret_id)
+        self.assertEqual(secret.get_content(), {"password": "1234"})
+        info = secret.get_info()
+        self.assertEqual(info.id, secret_id)
+        secret.set_content({"password": "5678"})
+        secret.remove_all_revisions()
+        # Non-leaders can only view an application secret.
+        harness.set_leader(False)
+        secret_id = harness.charm.app.add_secret({"password": "1234"}).id
+        secret = harness.charm.model.get_secret(id=secret_id)
+        self.assertEqual(secret.get_content(), {"password": "1234"})
+        with self.assertRaises(ops.model.SecretNotFoundError):
+            secret.get_info()
+        with self.assertRaises(ops.model.SecretNotFoundError):
+            secret.set_content({"password": "5678"})
+        with self.assertRaises(ops.model.SecretNotFoundError):
+            secret.remove_all_revisions()
 
 
 class EventRecorder(ops.CharmBase):


### PR DESCRIPTION
A charm that owns a unit secret always has manage permissions, regardless of which unit is executing the charm. However, an app secret has manage permissions if the charm is executing on the leader, and view permissions otherwise ([the matrix in this WIP documentation](https://discourse.charmhub.io/t/secret-access-permissions/12627) has been verified by @wallyworld).

This PR adjusts the Harness permission check (used by get-info, set, grant, revoke, remove, etc) so that if the secret is an app secret, then the leader flag must be set for access to be allowed.

Fixes #1071