### PR TITLE
chore: update framework tests to pass under Python 3.12

### DIFF
--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -537,16 +537,26 @@ class TestFramework(BaseTestCase):
         with self.assertRaises(RuntimeError) as cm:
             class OtherEvents(ops.ObjectEvents):  # type: ignore
                 foo = event
+        # Python 3.12+ raises the original exception with a note, but earlier
+        # Python chains the exceptions.
+        if hasattr(cm.exception, "__notes__"):
+            cause = str(cm.exception)
+        else:
+            cause = str(cm.exception.__cause__)
         self.assertEqual(
-            str(cm.exception.__cause__),
+            cause,
             "EventSource(MyEvent) reused as MyEvents.foo and OtherEvents.foo")
 
         with self.assertRaises(RuntimeError) as cm:
             class MyNotifier(ops.Object):  # type: ignore
                 on = MyEvents()  # type: ignore
                 bar = event
+        if hasattr(cm.exception, "__notes__"):
+            cause = str(cm.exception)
+        else:
+            cause = str(cm.exception.__cause__)
         self.assertEqual(
-            str(cm.exception.__cause__),
+            cause,
             "EventSource(MyEvent) reused as MyEvents.foo and MyNotifier.bar")
 
     def test_reemit_ignores_unknown_event_type(self):


### PR DESCRIPTION
The behaviour of descriptors changed in 3.12, so that when `__set_name__` raises an exception, that exception reaches the code that did the name setting, with a note attached, unlike earlier Python where the exception was chained.

<details>
<summary>Minimal code</summary>

```python
import sys
print(sys.version)
class Foo:
    def __init__(self):
        self.name = None
    def __set_name__(self, owner, name):
        if self.name is not None:
            raise RuntimeError("hello world!")
        self.name = name

f = Foo()
class A:
    x = f
try:
    class B:
        x = f
except Exception as e:
    if hasattr(e, "__notes__"):
        print(f"notes: {e.__notes__!r}")
    print(f"cause: {e.__cause__!r}")
    print(f"context: {e.__context__!r}")
    print(f"str: {e}")
```

</details>

<details>
<summary>Python 3.11</summary>

```
3.11.5 (main, Oct  2 2023, 11:58:32) [GCC 11.4.0]
cause: RuntimeError('hello world!')
context: RuntimeError('hello world!')
str: Error calling __set_name__ on 'Foo' instance 'x' in 'B'
```

</details>

<details>
<summary>Python 3.12</summary>

```
3.12.0 (main, Oct  3 2023, 10:11:00) [GCC 11.4.0]
notes: ["Error calling __set_name__ on 'Foo' instance 'x' in 'B'"]
cause: None
context: None
str: hello world!
```

</details>

In the framework tests, we verify that the event source is not being reused by checking the `str` of the causing exception, but that doesn't work in both 3.12 and earlier Python because of this Python change.

I couldn't find a way to use exactly the same code in Python 3.12 and earlier, so have checked for the presence of the `__notes__` attribute - if it is there, then the "Error calling __set_name__" piece will be in in the notes, and so we look at the exception itself; if it is not there, then we assume the earlier behaviour and look at the causing exception. This could be a check against `sys.version_info` instead if that was preferred.