### PR TITLE
fix: handle users/groups with no names in push_path

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -2467,6 +2467,16 @@ class Container:
         import grp
         import pwd
         info = path.lstat()
+        try:
+            pw_name = pwd.getpwuid(info.st_uid).pw_name
+        except KeyError:
+            logger.warning("Could not get name for user %s", info.st_uid)
+            pw_name = None
+        try:
+            gr_name = grp.getgrgid(info.st_gid).gr_name
+        except KeyError:
+            logger.warning("Could not get name for group %s", info.st_gid)
+            gr_name = None
         return pebble.FileInfo(
             path=str(path),
             name=path.name,
@@ -2475,9 +2485,9 @@ class Container:
             permissions=stat.S_IMODE(info.st_mode),
             last_modified=datetime.datetime.fromtimestamp(info.st_mtime),
             user_id=info.st_uid,
-            user=pwd.getpwuid(info.st_uid).pw_name,
+            user=pw_name,
             group_id=info.st_gid,
-            group=grp.getgrgid(info.st_gid).gr_name)
+            group=gr_name)
 
     @staticmethod
     def _list_recursive(list_func: Callable[[Path], Iterable[pebble.FileInfo]],

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -988,7 +988,7 @@ class TestModel(unittest.TestCase):
             push_path = pathlib.Path(push_src) / 'src.txt'
             push_path.write_text('hello')
             container.push_path(push_path, "/")
-        assert container.exists("/src.txt"), 'push_path failed: file "src.txt" missing at destination'
+        assert container.exists("/src.txt"), 'push_path failed: file "src.txt" missing'
 
 
 class PushPullCase:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -982,14 +982,13 @@ class TestModel(unittest.TestCase):
             ''')
         harness.begin()
         harness.set_can_connect('foo', True)
-        c = harness.model.unit.containers['foo']
+        container = harness.model.unit.containers['foo']
 
         with tempfile.TemporaryDirectory() as push_src:
             push_path = pathlib.Path(push_src) / 'src.txt'
-            with push_path.open('w') as f:
-                f.write('hello')
-            c.push_path(push_path, "/")
-        assert c.exists("/src.txt"), 'push_path failed: file "src.txt" missing at destination'
+            push_path.write_text('hello')
+            container.push_path(push_path, "/")
+        assert container.exists("/src.txt"), 'push_path failed: file "src.txt" missing at destination'
 
 
 class PushPullCase:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -969,8 +969,8 @@ class TestModel(unittest.TestCase):
         self.assertEqual(str(cm.exception), 'ERROR cannot get status\n')
         self.assertEqual(cm.exception.args[0], 'ERROR cannot get status\n')
 
-    @patch("pwd.getpwuid")
     @patch("grp.getgrgid")
+    @patch("pwd.getpwuid")
     def test_push_path_unnamed(self, getpwuid: MagicMock, getgrgid: MagicMock):
         getpwuid.side_effect = KeyError
         getgrgid.side_effect = KeyError


### PR DESCRIPTION
[Ned Batchelder noticed that the unit tests failed on his machine](https://hachyderm.io/@coveragepy/111477098431251147), which was because the temporary folder returned by `TemporaryDirectory()` belonged to a group with no name.

In theory, this could happen outside of the tests as well - someone could do a `push_path()` on a path that has files that have owners/groups that do not have names (e.g. because they have been removed). This is presumably quite uncommon (which makes sense: it seems unlikely that the charm container would often have a user or group removed) but it's also simple to fix, so it seems like we might as well do that.