### PR TITLE
fix: handle parsing ISO datetimes where the microseconds round up to more than 1s

### DIFF
--- a/ops/_private/timeconv.py
+++ b/ops/_private/timeconv.py
@@ -32,7 +32,8 @@ def parse_rfc3339(s: str) -> datetime.datetime:
     that Go's encoding/json package produces for time.Time values.
 
     Unfortunately we can't use datetime.fromisoformat(), as that does not
-    support more than 6 digits for the fractional second, nor the 'Z' for UTC.
+    support more than 6 digits for the fractional second, nor the 'Z' for UTC,
+    in Python 3.8 (Python 3.11+ has the required functionality).
     """
     match = _TIMESTAMP_RE.match(s)
     if not match:
@@ -50,6 +51,8 @@ def parse_rfc3339(s: str) -> datetime.datetime:
         tz = datetime.timezone(tz_delta if sign == '+' else -tz_delta)
 
     microsecond = round(float(sfrac or '0') * 1000000)
+    carry, microsecond = divmod(microsecond, 1000000)
+    ss = int(ss) + carry
 
-    return datetime.datetime(int(y), int(m), int(d), int(hh), int(mm), int(ss),
+    return datetime.datetime(int(y), int(m), int(d), int(hh), int(mm), ss,
                              microsecond=microsecond, tzinfo=tz)

--- a/test/test_private.py
+++ b/test/test_private.py
@@ -72,6 +72,9 @@ class TestStrconv(unittest.TestCase):
         self.assertEqual(timeconv.parse_rfc3339('2020-12-25T13:45:50.123456789+00:00'),
                          datetime.datetime(2020, 12, 25, 13, 45, 50, 123457, tzinfo=utc))
 
+        self.assertEqual(timeconv.parse_rfc3339('2006-08-28T13:20:00.99999999Z'),
+                         datetime.datetime(2006, 8, 28, 13, 20, 1, 0, tzinfo=utc))
+
         tzinfo = datetime.timezone(datetime.timedelta(hours=-11, minutes=-30))
         self.assertEqual(timeconv.parse_rfc3339('2020-12-25T13:45:50.123456789-11:30'),
                          datetime.datetime(2020, 12, 25, 13, 45, 50, 123457, tzinfo=tzinfo))


### PR DESCRIPTION
We handle microseconds with more than 6 digits if the number of microseconds can be rounded to a number < 1M, for example:

```python
>>> timeconv.parse_rfc3339("2006-08-28T13:20:00.9999991+12:00")
datetime.datetime(2006, 8, 28, 13, 20, 0, 999999, tzinfo=datetime.timezone(datetime.timedelta(seconds=43200)))
```

However, if rounding takes us to the next second, we fail, for example:

```python
>>> timeconv.parse_rfc3339("2006-08-28T13:20:00.9999999+12:00")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/tameyer/code/operator/ops/_private/timeconv.py", line 54, in parse_rfc3339
    return datetime.datetime(int(y), int(m), int(d), int(hh), int(mm), int(ss),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: microsecond must be in 0..999999
```

Handle this case by carrying the result over to the second field.

Note that it looks like the Python 3.11+ standard library (which includes this functionality) [https://github.com/python/cpython/blob/48dfd74a9db9d4aa9c6f23b4a67b461e5d977173/Lib/_pydatetime.py#L413 truncates] instead of rounds (at least in the Python `_pydatetime` - I haven't looked at the C implementation). Rounding seems more correct to me, but I can understand an argument that we should duplicate the stdlib behaviour since we'll presumably move to using that once we have Python 3.11 as a minimum Python version.