### PR TITLE
fix: pin macaroonbakery version

### DIFF
--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -11,8 +11,9 @@ jobs:
         charm-repo:
           - "canonical/postgresql-operator"
           - "canonical/postgresql-k8s-operator"
-          - "canonical/mysql-operator"
-          - "canonical/mysql-k8s-operator"
+# TODO: uncomment once secrets issues are fixed in these charms (eg: https://github.com/canonical/mysql-operator/issues/367)
+#          - "canonical/mysql-operator"
+#          - "canonical/mysql-k8s-operator"
 
     steps:
       - name: Checkout the ${{ matrix.charm-repo }} repository

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,4 +11,6 @@ pytest-operator~=0.23
 coverage[toml]~=7.0
 typing_extensions~=4.2
 
+macaroonbakery != 1.3.3  # TODO: remove once this is fixed: https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
+
 -r requirements.txt


### PR DESCRIPTION
This addresses the dependency issues with protobuf detailed here: https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94

Also comment out mysql charm tests as they're broken at the moment.