### PR TITLE
docs: add instructions on how to use a custom version of ops in a Charm

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -91,7 +91,7 @@ in `requirements.txt` (or `pyproject.toml`) with a reference to the branch, like
 
 ```
 #ops ~= 2.9
-git+https://github.com/{your-username}}/operator@{your-branch-name}}
+git+https://github.com/{your-username}/operator@{your-branch-name}
 ```
 
 `git` is not normally available when `charmcraft` is packing the charm, so you'll

--- a/HACKING.md
+++ b/HACKING.md
@@ -149,7 +149,7 @@ your charm to a controller using that version of Juju. For example, with microk8
 
 1. [Build Juju and its dependencies](https://github.com/juju/juju/blob/3.4/CONTRIBUTING.md#build-juju-and-its-dependencies)
 2. Run `make microk8s-operator-update`
-3. Run `GOBIN=/path/to/your/juju/_build/bin:$GOBIN /path/to/your/juju bootstrap`
+3. Run `GOBIN=/path/to/your/juju/_build/linux_amd64/bin:$GOBIN /path/to/your/juju bootstrap`
 4. Add a model and deploy your charm as normal
 
 # Documentation


### PR DESCRIPTION
Figuring out how to test changes to `ops` locally (without just monkeypatching everything) wasn't straightforward when I started - this should make it easier for new people going forward.

I've included two variants:

* If the code is in a Git branch then I find it's simplest to just have the `charmcraft.yaml` file make `git` available and use standard Python dependency specification.
* If the code isn't easily installable by `pip`, then editing the `.charm` zip file is probably simplest - I've included @benhoyt's `inject-ops.sh` script to make it easy for people.

I've also added a small note about running in custom Juju versions, since that was something I had to learn today and seems like it might also come up for other people working on `ops`.