### PR TITLE
ci: add a workflow to check for exclusive language

### DIFF
--- a/.github/workflows/inclusivity.yaml
+++ b/.github/workflows/inclusivity.yaml
@@ -1,0 +1,10 @@
+name: Inclusive naming PR check
+on: pull_request
+
+jobs:
+  call-inclusive-naming-check:
+    name: Inclusive naming
+    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    with:
+      fail-on-error: 'true'
+      woke-args: '. /home/runner/work/_actions/canonical-web-and-design/inclusive-naming/main/config.yml -c .woke.yaml'

--- a/.woke.yaml
+++ b/.woke.yaml
@@ -1,0 +1,6 @@
+rules:
+ - name: dummy
+   enabled: false
+ - name: sanity
+   enabled: false
+

--- a/tox.ini
+++ b/tox.ini
@@ -82,8 +82,7 @@ commands =
 
 [testenv:smoke]
 description = Run a smoke test against a Juju controller.
-# wokeignore:rule=whitelist
-whitelist_externals = juju
+allowlist_externals = juju
                       charmcraft
                       bash
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -82,6 +82,7 @@ commands =
 
 [testenv:smoke]
 description = Run a smoke test against a Juju controller.
+# wokeignore:rule=whitelist
 whitelist_externals = juju
                       charmcraft
                       bash


### PR DESCRIPTION
This adds the [standard Canonical workflow](https://github.com/canonical/Inclusive-naming) for detecting non-inclusive language (and suggesting alternatives).

Only one language change is made: tox supports `allowlist_externals`  instead of `whitelist_externals` (and likely will remove the old option eventually), so switch to that.

There are two terms that occur across the code base that fail the default config: "dummy" and "sanity". I think debating whether we should replace those can be done in a different PR.

For now, this should prevent any non-inclusive language accidentally making it into the code.