### PR TITLE
docs: document limitations with pushing locked or bind-mount files

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -2252,6 +2252,11 @@ class Container:
              group: Optional[str] = None):
         """Write content to a given file path on the remote system.
 
+        Note that if another process has the file open on the remote system,
+        or if the remote file is a bind mount, pushing will fail with a
+        :class:`pebble.PathError`. Use :meth:`Container.exec` for full
+        control.
+
         Args:
             path: Path of the file to write to on the remote system.
             source: Source of data to write. This is either a concrete str or


### PR DESCRIPTION
Adds documentation to `Container.push` to explain that it will fail if the remote file is locked or is a bind-mount.

Fixes #752