### PR TITLE
feat: Harness support for Pebble notices

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -2744,7 +2744,6 @@ class Container:
         user_id: Optional[int] = None,
         types: Optional[Iterable[Union[pebble.NoticeType, str]]] = None,
         keys: Optional[Iterable[str]] = None,
-        after: Optional[datetime.datetime] = None,
     ) -> List[pebble.Notice]:
         """Query for notices that match all of the provided filters.
 
@@ -2756,7 +2755,6 @@ class Container:
             user_id=user_id,
             types=types,
             keys=keys,
-            after=after,
         )
 
     # Define this last to avoid clashes with the imported "pebble" module

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -2750,11 +2750,11 @@ class Client:
         """Record an occurrence of a notice with the specified options.
 
         Args:
-            type: Notice type (currently only "custom" notices are supported)
-            key: Notice key; must be in "example.com/path" format
-            data: Data fields for this notice
-            repeat_after: Prevent notice with same type and key from
-                repeating within this duration
+            type: Notice type (currently only "custom" notices are supported).
+            key: Notice key; must be in "example.com/path" format.
+            data: Data fields for this notice.
+            repeat_after: Only allow this notice to repeat after this duration
+                has elapsed (the default is to always repeat).
 
         Returns:
             The notice's ID.
@@ -2804,12 +2804,12 @@ class Client:
         type has nanosecond precision).
 
         Args:
-            select: select which notices to return (instead of returning
-                notices for the current user)
-            user_id: filter for notices for the specified user, including
-                public notices (only works for Pebble admins)
-            types: filter for notices with any of the specified types
-            keys: filter for notices with any of the specified keys
+            select: Select which notices to return (instead of returning
+                notices for the current user).
+            user_id: Filter for notices for the specified user, including
+                public notices (only works for Pebble admins).
+            types: Filter for notices with any of the specified types.
+            keys: Filter for notices with any of the specified keys.
         """
         query: Dict[str, Union[str, List[str]]] = {}
         if select is not None:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -2751,7 +2751,7 @@ class Client:
 
         Args:
             type: Notice type (currently only "custom" notices are supported)
-            key: Notice key; must be in "domain.com/path" format
+            key: Notice key; must be in "example.com/path" format
             data: Data fields for this notice
             repeat_after: Prevent notice with same type and key from
                 reoccurring within this duration

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1308,7 +1308,7 @@ class NoticesSelect(enum.Enum):
     """
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Notice:
     """Information about a single notice."""
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -2754,7 +2754,7 @@ class Client:
             key: Notice key; must be in "example.com/path" format
             data: Data fields for this notice
             repeat_after: Prevent notice with same type and key from
-                reoccurring within this duration
+                repeating within this duration
 
         Returns:
             The notice's ID.

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1308,7 +1308,7 @@ class NoticesSelect(enum.Enum):
     """
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class Notice:
     """Information about a single notice."""
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -3295,7 +3295,7 @@ class _TestingPebbleClient:
 
         # The shape of the code below is taken from State.AddNotice in Pebble.
         now = datetime.datetime.now(tz=datetime.timezone.utc)
-        uid = 0  # hard-code UID as root (Pebble and charms ran as root for now)
+        uid = 0  # Hard-code UID as root (Pebble and charms run as root for now).
 
         new_or_repeated = False
         unique_key = (uid, type.value, key)
@@ -3306,7 +3306,7 @@ class _TestingPebbleClient:
             notice = pebble.Notice(
                 id=str(self._last_notice_id),
                 user_id=uid,
-                type=pebble.NoticeType(type),
+                type=type,
                 key=key,
                 first_occurred=now,
                 last_occurred=now,
@@ -3365,25 +3365,22 @@ class _TestingPebbleClient:
             filter_user_id = None
 
         if types is not None:
-            types = [(t.value if isinstance(t, pebble.NoticeType) else t) for t in types]
+            types = {(t.value if isinstance(t, pebble.NoticeType) else t) for t in types}
         if keys is not None:
-            keys = list(keys)
+            keys = set(keys)
 
-        notices: List[pebble.Notice] = []
-        for notice in self._notices.values():
-            if not self._notice_matches(notice, filter_user_id, types, keys):
-                continue
-            notices.append(notice)
-
+        notices = [notice for notice in self._notices.values() if
+                   self._notice_matches(notice, filter_user_id, types, keys)]
         notices.sort(key=lambda notice: notice.last_repeated)
         return notices
 
     @staticmethod
     def _notice_matches(notice: pebble.Notice,
                         user_id: Optional[int] = None,
-                        types: Optional[List[str]] = None,
-                        keys: Optional[List[str]] = None) -> bool:
+                        types: Optional[Set[str]] = None,
+                        keys: Optional[Set[str]] = None) -> bool:
         # Same logic as NoticeFilter.matches in Pebble.
+        # For example: if user_id filter is set and it doesn't match, return False.
         if user_id is not None and not (notice.user_id is None or user_id == notice.user_id):
             return False
         if types is not None and notice.type not in types:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1110,12 +1110,12 @@ class Harness(Generic[CharmType]):
         :class:`ops.PebbleCustomNoticeEvent`.
 
         Args:
-            container_name: Name of workload container
-            key: Notice key; must be in "example.com/path" format
-            data: Data fields for this notice
-            repeat_after: Prevent notice with same type and key from
-                reoccurring within this duration
-            type: Notice type (currently only "custom" notices are supported)
+            container_name: Name of workload container.
+            key: Notice key; must be in "example.com/path" format.
+            data: Data fields for this notice.
+            repeat_after: Only allow this notice to repeat after this duration
+                has elapsed (the default is to always repeat).
+            type: Notice type (currently only "custom" notices are supported).
 
         Returns:
             The notice's ID.
@@ -2755,7 +2755,7 @@ class _TestingPebbleClient:
         self._root = container_root
         self._backend = backend
         self._exec_handlers: Dict[Tuple[str, ...], ExecHandler] = {}
-        self._notices: Dict[Tuple[Optional[int], str, str], pebble.Notice] = {}
+        self._notices: Dict[Tuple[str, str], pebble.Notice] = {}
         self._last_notice_id = 0
 
     def _handle_exec(self, command_prefix: Sequence[str], handler: ExecHandler):
@@ -3295,17 +3295,16 @@ class _TestingPebbleClient:
 
         # The shape of the code below is taken from State.AddNotice in Pebble.
         now = datetime.datetime.now(tz=datetime.timezone.utc)
-        uid = 0  # Hard-code UID as root (Pebble and charms run as root for now).
 
         new_or_repeated = False
-        unique_key = (uid, type.value, key)
+        unique_key = (type.value, key)
         notice = self._notices.get(unique_key)
         if notice is None:
             # First occurrence of this notice uid+type+key
             self._last_notice_id += 1
             notice = pebble.Notice(
                 id=str(self._last_notice_id),
-                user_id=uid,
+                user_id=0,  # Charm should always be able to read pebble_notify notices.
                 type=type,
                 key=key,
                 first_occurred=now,

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1111,7 +1111,7 @@ class Harness(Generic[CharmType]):
 
         Args:
             container_name: Name of workload container
-            key: Notice key; must be in "domain.com/path" format
+            key: Notice key; must be in "example.com/path" format
             data: Data fields for this notice
             repeat_after: Prevent notice with same type and key from
                 reoccurring within this duration
@@ -3036,7 +3036,7 @@ class _TestingPebbleClient:
         self._check_absolute_path(path)
         file_path = self._root / path[1:]
         if not file_path.exists():
-            raise self._api_error(404, f"stat {path}: no such file or directory") from None
+            raise self._api_error(404, f"stat {path}: no such file or directory")
         files = [file_path]
         if not itself:
             try:
@@ -3165,13 +3165,13 @@ class _TestingPebbleClient:
         handler = self._find_exec_handler(command)
         if handler is None:
             message = "execution handler not found, please register one using Harness.handle_exec"
-            raise self._api_error(500, message) from None
+            raise self._api_error(500, message)
         environment = {} if environment is None else environment
         if service_context is not None:
             plan = self.get_plan()
             if service_context not in plan.services:
                 message = f'context service "{service_context}" not found'
-                raise self._api_error(500, message) from None
+                raise self._api_error(500, message)
             service = plan.services[service_context]
             environment = {**service.environment, **environment}
             working_dir = service.working_dir if working_dir is None else working_dir
@@ -3262,7 +3262,7 @@ class _TestingPebbleClient:
             if service not in plan.services or not self.get_services([service])[0].is_running():
                 # conform with the real pebble api
                 message = f'cannot send signal to "{service}": service is not running'
-                raise self._api_error(500, message) from None
+                raise self._api_error(500, message)
 
         # Check if signal name is valid
         try:
@@ -3271,7 +3271,7 @@ class _TestingPebbleClient:
             # conform with the real pebble api
             first_service = next(iter(service_names))
             message = f'cannot send signal to "{first_service}": invalid signal name "{sig}"'
-            raise self._api_error(500, message) from None
+            raise self._api_error(500, message)
 
     def get_checks(self, level=None, names=None):  # type:ignore
         raise NotImplementedError(self.get_checks)  # type:ignore
@@ -3291,7 +3291,7 @@ class _TestingPebbleClient:
         """
         if type != pebble.NoticeType.CUSTOM:
             message = f'invalid type "{type.value}" (can only add "custom" notices)'
-            raise self._api_error(400, message) from None
+            raise self._api_error(400, message)
 
         # The shape of the code below is taken from State.AddNotice in Pebble.
         now = datetime.datetime.now(tz=datetime.timezone.utc)
@@ -3344,7 +3344,7 @@ class _TestingPebbleClient:
         for notice in self._notices.values():
             if notice.id == id:
                 return notice
-        raise self._api_error(404, f'cannot find notice with ID "{id}"') from None
+        raise self._api_error(404, f'cannot find notice with ID "{id}"')
 
     def get_notices(
         self,
@@ -3361,7 +3361,7 @@ class _TestingPebbleClient:
             filter_user_id = user_id
         if select is not None:
             if user_id is not None:
-                raise self._api_error(400, 'cannot use both "select" and "user_id"') from None
+                raise self._api_error(400, 'cannot use both "select" and "user_id"')
             filter_user_id = None
 
         if types is not None:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -3313,20 +3313,27 @@ class _TestingPebbleClient:
                 last_repeated=now,
                 expire_after=datetime.timedelta(days=7),
                 occurrences=1,
+                last_data=data or {},
+                repeat_after=repeat_after,
             )
             self._notices[unique_key] = notice
             new_or_repeated = True
         else:
             # Additional occurrence, update existing notice
-            notice.occurrences += 1
+            last_repeated = notice.last_repeated
             if repeat_after is None or now > notice.last_repeated + repeat_after:
                 # Update last repeated time if repeat-after time has elapsed (or is None)
-                notice.last_repeated = now
+                last_repeated = now
                 new_or_repeated = True
-
-        notice.last_occurred = now
-        notice.last_data = data or {}
-        notice.repeat_after = repeat_after
+            notice = dataclasses.replace(
+                notice,
+                last_occurred=now,
+                last_repeated=last_repeated,
+                occurrences=notice.occurrences + 1,
+                last_data=data or {},
+                repeat_after=repeat_after,
+            )
+            self._notices[unique_key] = notice
 
         return notice.id, new_or_repeated
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -1106,12 +1106,14 @@ class Harness(Generic[CharmType]):
         """Record a Pebble notice with the specified key and data.
 
         If the notice is new or was repeated, this will trigger a notice event
-        of the appropriate type, for example :class:`PebbleCustomNoticeEvent`.
+        of the appropriate type, for example :class:`ops.PebbleCustomNoticeEvent`.
 
         Args:
             container_name: Name of workload container
             key: Notice key; must be in "domain.com/path" format
             data: Data fields for this notice
+            repeat_after: Prevent notice with same type and key from
+                reoccurring within this duration
             type: Notice type; should normally be "custom" means a custom notice
         """
         # TODO: behaviour if begin() has not been called?
@@ -1119,7 +1121,7 @@ class Harness(Generic[CharmType]):
         container = self.model.unit.get_container(container_name)
         client = self._backend._pebble_clients[container.name]
 
-        id, new_or_repeated = client._notify(type, key, data=data)
+        id, new_or_repeated = client._notify(type, key, data=data, repeat_after=repeat_after)
         if type == 'custom' and new_or_repeated:
             self.charm.on[container_name].pebble_custom_notice.emit(container, id, type, key)
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1980,7 +1980,6 @@ containers:
             select=pebble.NoticesSelect.ALL,
             types=[pebble.NoticeType.CUSTOM],
             keys=['example.com/a', 'example.com/b'],
-            after=datetime.datetime(2023, 12, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(len(notices), 1)
         self.assertEqual(notices[0].id, '124')
@@ -1992,7 +1991,6 @@ containers:
             select=pebble.NoticesSelect.ALL,
             types=[pebble.NoticeType.CUSTOM],
             keys=['example.com/a', 'example.com/b'],
-            after=datetime.datetime(2023, 12, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc),
         ))])
 
 

--- a/test/test_real_pebble.py
+++ b/test/test_real_pebble.py
@@ -306,3 +306,5 @@ class TestPebbleStorageAPIsUsingRealPebble(unittest.TestCase, PebbleStorageAPIsT
     @unittest.skip('pending resolution of https://github.com/canonical/pebble/issues/80')
     def test_make_dir_with_permission_mask(self):
         pass
+
+# TODO(benhoyt): add some real Pebble tests for Notices here

--- a/test/test_real_pebble.py
+++ b/test/test_real_pebble.py
@@ -12,6 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Run (some) unit tests against a real Pebble server.
+
+Set the RUN_REAL_PEBBLE_TESTS environment variable to run these tests
+against a real Pebble server. For example, in one terminal, run Pebble:
+
+$ PEBBLE=~/pebble pebble run --http=:4000
+2021-09-20T04:10:34.934Z [pebble] Started daemon
+
+In another terminal, run the tests:
+
+$ source .tox/unit/bin/activate
+$ RUN_REAL_PEBBLE_TESTS=1 PEBBLE=~/pebble pytest test/test_real_pebble.py -v
+$ deactivate
+"""
+
 import json
 import os
 import shutil
@@ -26,32 +41,23 @@ import uuid
 
 from ops import pebble
 
-from .test_testing import PebbleStorageAPIsTestMixin
+from .test_testing import PebbleNoticesMixin, PebbleStorageAPIsTestMixin
 
 
-# Set the RUN_REAL_PEBBLE_TESTS environment variable to run these tests
-# against a real Pebble server. For example, in one terminal, run Pebble:
-#
-# $ PEBBLE=~/pebble pebble run --http=:4000
-# 2021-09-20T04:10:34.934Z [pebble] Started daemon
-#
-# In another terminal, run the tests:
-#
-# $ source .tox/unit/bin/activate
-# $ RUN_REAL_PEBBLE_TESTS=1 PEBBLE=~/pebble pytest test/test_real_pebble.py -v
-# $ deactivate
-#
+def get_socket_path() -> str:
+    socket_path = os.getenv('PEBBLE_SOCKET')
+    pebble_path = os.getenv('PEBBLE')
+    if not socket_path and pebble_path:
+        assert isinstance(pebble_path, str)
+        socket_path = os.path.join(pebble_path, '.pebble.socket')
+    assert socket_path, 'PEBBLE or PEBBLE_SOCKET must be set if RUN_REAL_PEBBLE_TESTS set'
+    return socket_path
+
+
 @unittest.skipUnless(os.getenv('RUN_REAL_PEBBLE_TESTS'), 'RUN_REAL_PEBBLE_TESTS not set')
 class TestRealPebble(unittest.TestCase):
     def setUp(self):
-        socket_path = os.getenv('PEBBLE_SOCKET')
-        pebble_path = os.getenv('PEBBLE')
-        if not socket_path and pebble_path:
-            assert isinstance(pebble_path, str)
-            socket_path = os.path.join(pebble_path, '.pebble.socket')
-        assert socket_path, 'PEBBLE or PEBBLE_SOCKET must be set if RUN_REAL_PEBBLE_TESTS set'
-
-        self.client = pebble.Client(socket_path=socket_path)
+        self.client = pebble.Client(socket_path=get_socket_path())
 
     def test_checks_and_health(self):
         self.client.add_layer('layer', {
@@ -289,14 +295,10 @@ class TestRealPebble(unittest.TestCase):
 @unittest.skipUnless(os.getenv('RUN_REAL_PEBBLE_TESTS'), 'RUN_REAL_PEBBLE_TESTS not set')
 class TestPebbleStorageAPIsUsingRealPebble(unittest.TestCase, PebbleStorageAPIsTestMixin):
     def setUp(self):
-        socket_path = os.getenv('PEBBLE_SOCKET')
-        pebble_dir = os.getenv('PEBBLE')
-        if not socket_path and pebble_dir:
-            socket_path = os.path.join(pebble_dir, '.pebble.socket')
-        assert socket_path and pebble_dir, 'PEBBLE must be set if RUN_REAL_PEBBLE_TESTS set'
-
-        self.prefix = tempfile.mkdtemp(dir=pebble_dir)
-        self.client = pebble.Client(socket_path=socket_path)
+        pebble_path = os.getenv('PEBBLE')
+        assert pebble_path is not None
+        self.prefix = tempfile.mkdtemp(dir=pebble_path)
+        self.client = pebble.Client(socket_path=get_socket_path())
 
     def tearDown(self):
         shutil.rmtree(self.prefix)
@@ -307,4 +309,8 @@ class TestPebbleStorageAPIsUsingRealPebble(unittest.TestCase, PebbleStorageAPIsT
     def test_make_dir_with_permission_mask(self):
         pass
 
-# TODO(benhoyt): add some real Pebble tests for Notices here
+
+@unittest.skipUnless(os.getenv('RUN_REAL_PEBBLE_TESTS'), 'RUN_REAL_PEBBLE_TESTS not set')
+class TestNoticesUsingRealPebble(unittest.TestCase, PebbleNoticesMixin):
+    def setUp(self):
+        self.client = pebble.Client(socket_path=get_socket_path())

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -5506,9 +5506,9 @@ class TestNotify(unittest.TestCase):
         harness.charm.observe_container_events('bar')
 
         id1a = harness.pebble_notify('foo', 'example.com/n1')
-        id1b = harness.pebble_notify('foo', 'example.com/n1')
         id2 = harness.pebble_notify('foo', 'foo.com/n2')
         id3 = harness.pebble_notify('bar', 'example.com/n1')
+        id1b = harness.pebble_notify('foo', 'example.com/n1')
 
         self.assertIsInstance(id1a, str)
         self.assertNotEqual(id1a, '')
@@ -5531,12 +5531,6 @@ class TestNotify(unittest.TestCase):
         }, {
             'name': 'pebble-custom-notice',
             'container': 'foo',
-            'notice_id': id1a,
-            'notice_type': 'custom',
-            'notice_key': 'example.com/n1',
-        }, {
-            'name': 'pebble-custom-notice',
-            'container': 'foo',
             'notice_id': id2,
             'notice_type': 'custom',
             'notice_key': 'foo.com/n2',
@@ -5544,6 +5538,12 @@ class TestNotify(unittest.TestCase):
             'name': 'pebble-custom-notice',
             'container': 'bar',
             'notice_id': id3,
+            'notice_type': 'custom',
+            'notice_key': 'example.com/n1',
+        }, {
+            'name': 'pebble-custom-notice',
+            'container': 'foo',
+            'notice_id': id1a,
             'notice_type': 'custom',
             'notice_key': 'example.com/n1',
         }]

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -27,6 +27,7 @@ import shutil
 import sys
 import tempfile
 import textwrap
+import time
 import typing
 import unittest
 import uuid
@@ -34,7 +35,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
-from typing_extensions import Required
 
 import ops
 import ops.testing
@@ -2647,7 +2647,7 @@ class TestHarness(unittest.TestCase):
                                          expected_relation_created[0]]
         self.assertEqual(changes[:2], expected_relation_created)
         changes = changes[2:]
-        expected_middle: typing.List[RecordedChange] = [
+        expected_middle: typing.List[typing.Dict[str, typing.Any]] = [
             {'name': 'leader-elected'},
             {'name': 'config-changed', 'data': {}},
             {'name': 'start'},
@@ -3030,7 +3030,7 @@ class RelationChangedViewer(ops.Object):
 
     def __init__(self, charm: ops.CharmBase, relation_name: str):
         super().__init__(charm, relation_name)
-        self.changes: typing.List[typing.Dict[str, str]] = []
+        self.changes: typing.List[typing.Dict[str, typing.Any]] = []
         charm.framework.observe(charm.on[relation_name].relation_changed, self.on_relation_changed)
 
     def on_relation_changed(self, event: ops.RelationEvent):
@@ -3043,19 +3043,12 @@ class RelationChangedViewer(ops.Object):
         self.changes.append(dict(data))
 
 
-class RecordedChange(typing.TypedDict, total=False):
-    name: Required[str]
-    data: typing.Dict[str, typing.Any]
-    relation: str
-    container: typing.Optional[str]
-
-
 class RecordingCharm(ops.CharmBase):
     """Record the events that we see, and any associated data."""
 
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
-        self.changes: typing.List[RecordedChange] = []
+        self.changes: typing.List[typing.Dict[str, typing.Any]] = []
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.leader_elected, self._on_leader_elected)
         self.framework.observe(self.on.leader_settings_changed, self._on_leader_settings_changed)
@@ -3149,10 +3142,11 @@ class RelationEventCharm(RecordingCharm):
             assert event.departing_unit is not None
             data['departing_unit'] = event.departing_unit.name
 
-        recording: RecordedChange = {
+        recording: typing.Dict[str, typing.Any] = {
             'name': event_name,
             'relation': event.relation.name,
-            'data': data}
+            'data': data,
+        }
 
         if self.record_relation_data_on_events:
             recording["data"].update({'relation_data': {
@@ -3176,16 +3170,25 @@ class ContainerEventCharm(RecordingCharm):
 
     def observe_container_events(self, container_name: str):
         self.framework.observe(self.on[container_name].pebble_ready, self._on_pebble_ready)
+        self.framework.observe(self.on[container_name].pebble_custom_notice,
+                               self._on_pebble_custom_notice)
 
     def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
-        self._observe_container_event('pebble-ready', event)
+        self.changes.append({
+            'name': 'pebble-ready',
+            'container': event.workload.name,
+        })
 
-    def _observe_container_event(self, event_name: str, event: ops.PebbleReadyEvent):
-        container_name = None
-        if event.workload is not None:
-            container_name = event.workload.name
-        self.changes.append(
-            {'name': event_name, 'container': container_name})
+    def _on_pebble_custom_notice(self, event: ops.PebbleCustomNoticeEvent):
+        type_str = (event.notice.type.value if isinstance(event.notice.type, pebble.NoticeType)
+                    else event.notice.type)
+        self.changes.append({
+            'name': 'pebble-custom-notice',
+            'container': event.workload.name,
+            'notice_id': event.notice.id,
+            'notice_type': type_str,
+            'notice_key': event.notice.key,
+        })
 
 
 def get_public_methods(obj: object):
@@ -5485,3 +5488,228 @@ class TestActions(unittest.TestCase):
         self._action_results["A"] = "foo"
         with self.assertRaises(ValueError):
             self.harness.run_action("results")
+
+
+class TestNotices(unittest.TestCase):
+    def test_notify_basics(self):
+        harness = ops.testing.Harness(ContainerEventCharm, meta="""
+            name: notifier
+            containers:
+              foo:
+                resource: foo-image
+              bar:
+                resource: foo-image
+        """)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        harness.charm.observe_container_events('foo')
+        harness.charm.observe_container_events('bar')
+
+        id1a = harness.pebble_notify('foo', 'example.com/n1')
+        id1b = harness.pebble_notify('foo', 'example.com/n1')
+        id2 = harness.pebble_notify('foo', 'foo.com/n2')
+        id3 = harness.pebble_notify('bar', 'example.com/n1')
+
+        self.assertIsInstance(id1a, str)
+        self.assertNotEqual(id1a, '')
+        self.assertEqual(id1a, id1b)
+
+        self.assertIsInstance(id2, str)
+        self.assertNotEqual(id2, '')
+        self.assertNotEqual(id2, id1a)
+
+        self.assertIsInstance(id3, str)
+        self.assertNotEqual(id3, '')
+
+        expected_changes = [{
+            'name': 'pebble-custom-notice',
+            'container': 'foo',
+            'notice_id': id1a,
+            'notice_type': 'custom',
+            'notice_key': 'example.com/n1',
+        }, {
+            'name': 'pebble-custom-notice',
+            'container': 'foo',
+            'notice_id': id1a,
+            'notice_type': 'custom',
+            'notice_key': 'example.com/n1',
+        }, {
+            'name': 'pebble-custom-notice',
+            'container': 'foo',
+            'notice_id': id2,
+            'notice_type': 'custom',
+            'notice_key': 'foo.com/n2',
+        }, {
+            'name': 'pebble-custom-notice',
+            'container': 'bar',
+            'notice_id': id3,
+            'notice_type': 'custom',
+            'notice_key': 'example.com/n1',
+        }]
+        self.assertEqual(harness.charm.changes, expected_changes)
+
+    def test_notify_no_repeat(self):
+        # Ensure event doesn't get triggered when notice occurs but doesn't repeat.
+
+        harness = ops.testing.Harness(ContainerEventCharm, meta="""
+            name: notifier
+            containers:
+              foo:
+                resource: foo-image
+        """)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        harness.charm.observe_container_events('foo')
+
+        id1a = harness.pebble_notify('foo', 'example.com/n1',
+                                     repeat_after=datetime.timedelta(days=1))
+        id1b = harness.pebble_notify('foo', 'example.com/n1',
+                                     repeat_after=datetime.timedelta(days=1))
+
+        self.assertEqual(id1a, id1b)
+
+        expected_changes = [{
+            'name': 'pebble-custom-notice',
+            'container': 'foo',
+            'notice_id': id1a,
+            'notice_type': 'custom',
+            'notice_key': 'example.com/n1',
+        }]
+        self.assertEqual(harness.charm.changes, expected_changes)
+
+    def test_notify_unknown_type(self):
+        harness = ops.testing.Harness(ContainerEventCharm, meta="""
+            name: notifier
+            containers:
+              foo:
+                resource: foo-image
+        """)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        harness.charm.observe_container_events('foo')
+
+        with self.assertRaises(pebble.APIError) as cm:
+            harness.pebble_notify('foo', 'example.com/n1', type='unknown')
+        self.assertEqual(cm.exception.code, 400)
+
+    def test_notify_no_begin(self):
+        num_notices = 0
+
+        class TestCharm(ops.CharmBase):
+            def __init__(self, framework: ops.Framework):
+                super().__init__(framework)
+                self.framework.observe(self.on['c1'].pebble_custom_notice,
+                                       self._on_pebble_custom_notice)
+
+            def _on_pebble_custom_notice(self, event: ops.PebbleCustomNoticeEvent):
+                nonlocal num_notices
+                num_notices += 1
+
+        harness = ops.testing.Harness(TestCharm, meta="""
+            name: notifier
+            containers:
+              c1:
+                resource: c1-image
+        """)
+        self.addCleanup(harness.cleanup)
+
+        id = harness.pebble_notify('c1', 'example.com/n1')
+
+        self.assertIsInstance(id, str)
+        self.assertNotEqual(id, '')
+        self.assertEqual(num_notices, 0)
+
+    def test_get_notice(self):
+        harness = ops.testing.Harness(ContainerEventCharm, meta="""
+            name: notifier
+            containers:
+              foo:
+                resource: foo-image
+        """)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        harness.charm.observe_container_events('foo')
+
+        id1 = harness.pebble_notify('foo', 'example.com/n1')
+        id2 = harness.pebble_notify('foo', 'example.com/n2', data={'x': 'y'})
+        time.sleep(0.01)
+        harness.pebble_notify('foo', 'example.com/n2', data={'k': 'v', 'foo': 'bar'})
+
+        container = harness.model.unit.containers['foo']
+        notice = container.get_notice(id1)
+        self.assertEqual(notice.id, id1)
+        self.assertEqual(notice.user_id, 0)
+        self.assertEqual(notice.type, pebble.NoticeType.CUSTOM)
+        self.assertEqual(notice.key, 'example.com/n1')
+        self.assertEqual(notice.first_occurred, notice.last_occurred)
+        self.assertEqual(notice.first_occurred, notice.last_repeated)
+        self.assertEqual(notice.occurrences, 1)
+        self.assertEqual(notice.last_data, {})
+        self.assertIsNone(notice.repeat_after)
+        self.assertEqual(notice.expire_after, datetime.timedelta(days=7))
+
+        notice = container.get_notice(id2)
+        self.assertEqual(notice.id, id2)
+        self.assertEqual(notice.user_id, 0)
+        self.assertEqual(notice.type, pebble.NoticeType.CUSTOM)
+        self.assertEqual(notice.key, 'example.com/n2')
+        self.assertLess(notice.first_occurred, notice.last_occurred)
+        self.assertLess(notice.first_occurred, notice.last_repeated)
+        self.assertEqual(notice.last_occurred, notice.last_repeated)
+        self.assertEqual(notice.occurrences, 2)
+        self.assertEqual(notice.last_data, {'k': 'v', 'foo': 'bar'})
+        self.assertIsNone(notice.repeat_after)
+        self.assertEqual(notice.expire_after, datetime.timedelta(days=7))
+
+        with self.assertRaises(ops.ModelError):
+            container.get_notice(id1 + 'notfound')
+
+    def test_get_notices(self):
+        harness = ops.testing.Harness(ContainerEventCharm, meta="""
+            name: notifier
+            containers:
+              foo:
+                resource: foo-image
+        """)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        harness.charm.observe_container_events('foo')
+
+        id1 = harness.pebble_notify('foo', 'example.com/n1')
+
+        container = harness.model.unit.containers['foo']
+        notice = container.get_notice(id1)
+        after = notice.last_repeated
+
+        time.sleep(0.01)
+        harness.pebble_notify('foo', 'example.com/n2')
+        time.sleep(0.01)
+        harness.pebble_notify('foo', 'example.com/n3')
+
+        notices = container.get_notices()
+        self.assertEqual(len(notices), 3)
+        self.assertEqual(notices[0].key, 'example.com/n1')
+        self.assertEqual(notices[1].key, 'example.com/n2')
+        self.assertEqual(notices[2].key, 'example.com/n3')
+        self.assertLess(notices[0].last_repeated, notices[1].last_repeated)
+        self.assertLess(notices[1].last_repeated, notices[2].last_repeated)
+
+        notices = container.get_notices(keys=['example.com/n2'])
+        self.assertEqual(len(notices), 1)
+        self.assertEqual(notices[0].key, 'example.com/n2')
+
+        notices = container.get_notices(keys=['example.com/n1', 'example.com/n3'])
+        self.assertEqual(len(notices), 2)
+        self.assertEqual(notices[0].key, 'example.com/n1')
+        self.assertEqual(notices[1].key, 'example.com/n3')
+        self.assertLess(notices[0].last_repeated, notices[1].last_repeated)
+
+        notices = container.get_notices(after=after)
+        self.assertEqual(len(notices), 2)
+        self.assertEqual(notices[0].key, 'example.com/n2')
+        self.assertEqual(notices[1].key, 'example.com/n3')
+        self.assertLess(notices[0].last_repeated, notices[1].last_repeated)
+
+        notices = container.get_notices(keys=['example.com/n3'], after=after)
+        self.assertEqual(len(notices), 1)
+        self.assertEqual(notices[0].key, 'example.com/n3')

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -5520,6 +5520,7 @@ class TestNotify(unittest.TestCase):
 
         self.assertIsInstance(id3, str)
         self.assertNotEqual(id3, '')
+        self.assertNotEqual(id3, id2)
 
         expected_changes = [{
             'name': 'pebble-custom-notice',
@@ -5549,8 +5550,7 @@ class TestNotify(unittest.TestCase):
         self.assertEqual(harness.charm.changes, expected_changes)
 
     def test_notify_no_repeat(self):
-        # Ensure event doesn't get triggered when notice occurs but doesn't repeat.
-
+        """Ensure event doesn't get triggered when notice occurs but doesn't repeat."""
         harness = ops.testing.Harness(ContainerEventCharm, meta="""
             name: notifier
             containers:
@@ -5620,7 +5620,7 @@ class PebbleNoticesMixin:
         key2 = 'example.com/' + os.urandom(16).hex()
         id1 = client.notify(pebble.NoticeType.CUSTOM, key1)
         id2 = client.notify(pebble.NoticeType.CUSTOM, key2, data={'x': 'y'})
-        time.sleep(0.01)
+        time.sleep(0.000_001)  # Ensure times are different.
         client.notify(pebble.NoticeType.CUSTOM, key2, data={'k': 'v', 'foo': 'bar'})
 
         notice = client.get_notice(id1)
@@ -5654,9 +5654,9 @@ class PebbleNoticesMixin:
         key3 = 'example.com/' + os.urandom(16).hex()
 
         client.notify(pebble.NoticeType.CUSTOM, key1)
-        time.sleep(0.01)
+        time.sleep(0.000_001)  # Ensure times are different.
         client.notify(pebble.NoticeType.CUSTOM, key2)
-        time.sleep(0.01)
+        time.sleep(0.000_001)  # Ensure times are different.
         client.notify(pebble.NoticeType.CUSTOM, key3)
 
         notices = client.get_notices()


### PR DESCRIPTION
This PR adds Harness support for Pebble Notices, specifically a new `Harness.pebble_notify` method which you call as follows -- this will add a custom notice with key "example.com/key" and some data:

```python
harness.pebble_notify('mycontainer', 'example.com/key', data={'optional': 'data'})
```

This will record a notice (which will be visible in the `Container.get_notice` and `Container.get_notices` return values) and, if the notice is new or repeated, trigger a `pebble-custom-notice` event like Juju would.

Note that I've based the fake Harness implementation on the Pebble Go code (for example, [`State.AddNotice`](https://github.com/canonical/pebble/blob/ecac3d4a3a6111e0ae1face2f9062f5210405826/internals/overlord/state/notices.go#L223) and [`v1GetNotices`](https://github.com/canonical/pebble/blob/ecac3d4a3a6111e0ae1face2f9062f5210405826/internals/daemon/api_notices.go#L45)). There are some tests of `pebble.Client.notify` and `get_notice` and `get_notices` that are run against a real Pebble server, like we do with some of the other Pebble-related functionality.

I've also removed the `get_notices` "after" param for now, as it's likely not needed in this context and is hard to implement with the Python microseconds vs Go nanoseconds discrepancy. We'll probably have to do this via a string parameter in future (or something other than `datetime.datetime`, as that only stores microseconds). But I don't think it'll be used here, as Juju does the long-polling where "after" is required.