### PR TITLE
ci: standardize quotes in source code on ' and """

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -607,9 +607,9 @@ class StorageEvent(HookEvent):
         """
         snapshot: Dict[str, Any] = {}
         if isinstance(self.storage, model.Storage):
-            snapshot["storage_name"] = self.storage.name
-            snapshot["storage_index"] = self.storage.index
-            snapshot["storage_location"] = str(self.storage.location)
+            snapshot['storage_name'] = self.storage.name
+            snapshot['storage_index'] = self.storage.index
+            snapshot['storage_location'] = str(self.storage.location)
         return snapshot
 
     def restore(self, snapshot: Dict[str, Any]):
@@ -617,15 +617,15 @@ class StorageEvent(HookEvent):
 
         Not meant to be called by charm code.
         """
-        storage_name = snapshot.get("storage_name")
-        storage_index = snapshot.get("storage_index")
-        storage_location = snapshot.get("storage_location")
+        storage_name = snapshot.get('storage_name')
+        storage_index = snapshot.get('storage_index')
+        storage_location = snapshot.get('storage_location')
 
         if storage_name and storage_index is not None:
             storages = self.framework.model.storages[storage_name]
             self.storage = next((s for s in storages if s.index == storage_index), None)  # type: ignore # noqa
             if self.storage is None:
-                msg = 'failed loading storage (name={!r}, index={!r}) from snapshot' \
+                msg = 'failed loading storage (name={!r}, index={!r}) from snapshot'\
                     .format(storage_name, storage_index)
                 raise RuntimeError(msg)
             if storage_location is None:
@@ -1547,8 +1547,8 @@ class ContainerMeta:
         under each key.
         """
         for mount in mounts:
-            storage = mount.get("storage", "")
-            mount = mount.get("location", "")
+            storage = mount.get('storage', '')
+            mount = mount.get('location', '')
 
             if not mount:
                 continue
@@ -1590,13 +1590,13 @@ class ContainerStorageMeta:
 
     def __getattr__(self, name: str):
         # TODO(benhoyt): this should just be a property "location"
-        if name == "location":
+        if name == 'location':
             if len(self._locations) == 1:
                 return self._locations[0]
             else:
                 raise RuntimeError(
-                    "container has more than one mount point with the same backing storage. "
-                    "Request .locations to see a list"
+                    'container has more than one mount point with the same backing storage. '
+                    'Request .locations to see a list'
                 )
         else:
             raise AttributeError(

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -78,9 +78,9 @@ _ObjectPath = Tuple[Optional[_Path], _Kind]
 _PathToObjectMapping = Dict[_Path, 'Object']
 _PathToSerializableMapping = Dict[_Path, Serializable]
 
-_T = TypeVar("_T")
+_T = TypeVar('_T')
 _EventType = TypeVar('_EventType', bound='EventBase')
-_ObjectType = TypeVar("_ObjectType", bound="Object")
+_ObjectType = TypeVar('_ObjectType', bound='Object')
 
 logger = logging.getLogger(__name__)
 
@@ -154,8 +154,8 @@ class Handle:
     def from_path(cls, path: str) -> 'Handle':
         """Build a handle from the indicated path."""
         handle = None
-        for pair in path.split("/"):
-            pair = pair.split("[")
+        for pair in path.split('/'):
+            pair = pair.split('[')
             good = False
             if len(pair) == 1:
                 kind, key = pair[0], None
@@ -240,7 +240,7 @@ class EventBase:
         3. At some future time, event C happens, which also checks if A can
            proceed.
         """
-        logger.debug("Deferring %s.", self)
+        logger.debug('Deferring %s.', self)
         self.deferred = True
 
     def snapshot(self) -> Dict[str, Any]:
@@ -359,7 +359,7 @@ class HandleKind:
     """
 
     def __get__(self, obj: 'Object', obj_type: 'Type[Object]') -> str:
-        kind = typing.cast(str, obj_type.__dict__.get("handle_kind"))
+        kind = typing.cast(str, obj_type.__dict__.get('handle_kind'))
         if kind:
             return kind
         return obj_type.__name__
@@ -419,12 +419,12 @@ class Object:
 class ObjectEvents(Object):
     """Convenience type to allow defining ``.on`` attributes at class level."""
 
-    handle_kind = "on"
+    handle_kind = 'on'
 
     def __init__(self, parent: Optional[Object] = None, key: Optional[str] = None):
         if parent is not None:
             super().__init__(parent, key)
-        self._cache: weakref.WeakKeyDictionary[Object, 'ObjectEvents'] = \
+        self._cache: weakref.WeakKeyDictionary[Object, 'ObjectEvents'] =\
             weakref.WeakKeyDictionary()
 
     def __get__(self, emitter: Object, emitter_type: 'Type[Object]'):
@@ -621,7 +621,7 @@ class Framework(Object):
 
         if isinstance(storage, (str, pathlib.Path)):
             logger.warning(
-                "deprecated: Framework now takes a Storage not a path")
+                'deprecated: Framework now takes a Storage not a path')
             storage = SQLiteStorage(storage)
         # TODO(benhoyt): should probably have a Storage protocol
         self._storage: 'SQLiteStorage' = storage  # type: ignore
@@ -709,7 +709,7 @@ class Framework(Object):
         self._type_registry[(parent_path, kind_)] = cls
         self._type_known.add(cls)
 
-    def save_snapshot(self, value: Union["StoredStateData", "EventBase"]):
+    def save_snapshot(self, value: Union['StoredStateData', 'EventBase']):
         """Save a persistent snapshot of the provided value."""
         if type(value) not in self._type_known:
             raise RuntimeError(
@@ -724,7 +724,7 @@ class Framework(Object):
         try:
             marshal.dumps(data)
         except ValueError:
-            msg = "unable to save the data for {}, it must contain only simple types: {!r}"
+            msg = 'unable to save the data for {}, it must contain only simple types: {!r}'
             raise ValueError(msg.format(value.__class__.__name__, data)) from None
 
         self._storage.save_snapshot(value.handle.path, data)
@@ -789,7 +789,7 @@ class Framework(Object):
 
         self.register_type(event_type, emitter, event_kind)  # type: ignore
 
-        if hasattr(emitter, "handle"):
+        if hasattr(emitter, 'handle'):
             emitter_path = emitter.handle.path
         else:
             raise RuntimeError(
@@ -802,7 +802,7 @@ class Framework(Object):
 
         method_name = observer.__name__
 
-        assert isinstance(observer.__self__, Object), "can't register observers " \
+        assert isinstance(observer.__self__, Object), "can't register observers "\
                                                       "that aren't `Object`s"
         observer_obj = observer.__self__
         if not sig.parameters:
@@ -833,7 +833,7 @@ class Framework(Object):
         event_path = event.handle.path
         event_kind = event.handle.kind
         parent = event.handle.parent
-        assert isinstance(parent, Handle), "event handle must have a parent"
+        assert isinstance(parent, Handle), 'event handle must have a parent'
         parent_path = parent.path
         # TODO Track observers by (parent_path, event_kind) rather than as a list of
         #  all observers. Avoiding linear search through all observers for every event
@@ -916,7 +916,7 @@ class Framework(Object):
 
             if observer:
                 if single_event_path is None:
-                    logger.debug("Re-emitting deferred event %s.", event)
+                    logger.debug('Re-emitting deferred event %s.', event)
                 elif isinstance(event, LifecycleEvent):
                     # Ignore Lifecycle events: they are "private" and not interesting.
                     pass
@@ -924,7 +924,7 @@ class Framework(Object):
                     # if the event we are emitting now is not the event being
                     # dispatched, and it also is not an event we have deferred,
                     # it must be a custom event
-                    logger.debug("Emitting custom event %s.", event)
+                    logger.debug('Emitting custom event %s.', event)
 
                 custom_handler = getattr(observer, method_name, None)
                 if custom_handler:
@@ -995,7 +995,7 @@ class Framework(Object):
             pdb.Pdb().set_trace(code_frame)
         else:
             logger.warning(
-                "Breakpoint %r skipped (not found in the requested breakpoints: %s)",
+                'Breakpoint %r skipped (not found in the requested breakpoints: %s)',
                 name, indicated_breakpoints)
 
     def remove_unreferenced_events(self) -> None:
@@ -1071,8 +1071,8 @@ class BoundStoredState:
             data = StoredStateData(parent, attr_name)
 
         # __dict__ is used to avoid infinite recursion.
-        self.__dict__["_data"] = data
-        self.__dict__["_attr_name"] = attr_name
+        self.__dict__['_data'] = data
+        self.__dict__['_attr_name'] = attr_name
 
         parent.framework.observe(parent.framework.on.commit, self._data.on_commit)  # type: ignore
 
@@ -1086,14 +1086,14 @@ class BoundStoredState:
 
     def __getattr__(self, key: str) -> Any:
         # "on" is the only reserved key that can't be used in the data map.
-        if key == "on":
+        if key == 'on':
             return self._data.on
         if key not in self._data:
             raise AttributeError(f"attribute '{key}' is not stored")
         return _wrap_stored(self._data, self._data[key])
 
     def __setattr__(self, key: str, value: Any):
-        if key == "on":
+        if key == 'on':
             raise AttributeError("attribute 'on' is reserved and cannot be set")
 
         unwrapped = _unwrap_stored(self._data, value)
@@ -1185,7 +1185,7 @@ class StoredState:
                 if bound is not None:
                     # the StoredState instance is being stored in two different
                     # attributes -> unclear what is expected of us -> bail out
-                    raise RuntimeError("StoredState shared by {0}.{1} and {0}.{2}".format(
+                    raise RuntimeError('StoredState shared by {0}.{1} and {0}.{2}'.format(
                         cls.__name__, self.attr_name, attr_name))
                 # we've found ourselves for the first time; save where, and bind the object
                 self.attr_name = attr_name

--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -30,11 +30,11 @@ class JujuVersion:
     operators.
     """
 
-    _pattern_re = re.compile(r'''^
+    _pattern_re = re.compile(r"""^
     (?P<major>\d{1,9})\.(?P<minor>\d{1,9})       # <major> and <minor> numbers are always there
     ((?:\.|-(?P<tag>[a-z]+))(?P<patch>\d{1,9}))? # sometimes with .<patch> or -<tag><patch>
     (\.(?P<build>\d{1,9}))?$                     # and sometimes with a <build> number.
-    ''', re.VERBOSE)
+    """, re.VERBOSE)
 
     def __init__(self, version: str):
         m = self._pattern_re.match(version)

--- a/ops/lib/__init__.py
+++ b/ops/lib/__init__.py
@@ -38,11 +38,11 @@ logger = logging.getLogger(__name__)
 
 _libraries = None
 
-_libline_re = re.compile(r'''^LIB([A-Z]+)\s*=\s*([0-9]+|['"][a-zA-Z0-9_.\-@]+['"])''')
-_libname_re = re.compile(r'''^[a-z][a-z0-9]+$''')
+_libline_re = re.compile(r"""^LIB([A-Z]+)\s*=\s*([0-9]+|['"][a-zA-Z0-9_.\-@]+['"])""")
+_libname_re = re.compile(r"""^[a-z][a-z0-9]+$""")
 
 # Not perfect, but should do for now.
-_libauthor_re = re.compile(r'''^[A-Za-z0-9_+.-]+@[a-z0-9_-]+(?:\.[a-z0-9_-]+)*\.[a-z]{2,3}$''')
+_libauthor_re = re.compile(r"""^[A-Za-z0-9_+.-]+@[a-z0-9_-]+(?:\.[a-z0-9_-]+)*\.[a-z]{2,3}$""")
 
 
 def use(name: str, api: int, author: str) -> ModuleType:
@@ -62,7 +62,7 @@ def use(name: str, api: int, author: str) -> ModuleType:
         TypeError: if the name, api, or author are the wrong type.
         ValueError: if the name, api, or author are invalid.
     """
-    warnings.warn("ops.lib is deprecated, prefer charm libraries instead",
+    warnings.warn('ops.lib is deprecated, prefer charm libraries instead',
                   category=DeprecationWarning)
     if not isinstance(name, str):
         raise TypeError(f"invalid library name: {name!r} (must be a str)")
@@ -104,7 +104,7 @@ def autoimport():
     DEPRECATED: This function is deprecated. Prefer charm libraries instead
     (https://juju.is/docs/sdk/library).
     """
-    warnings.warn("ops.lib is deprecated, prefer charm libraries instead",
+    warnings.warn('ops.lib is deprecated, prefer charm libraries instead',
                   category=DeprecationWarning)
     global _libraries
     _libraries = {}
@@ -120,8 +120,8 @@ def autoimport():
 
 def _find_all_specs(path: typing.Iterable[str]) -> typing.Iterator[ModuleSpec]:
     for sys_dir in path:
-        if sys_dir == "":
-            sys_dir = "."
+        if sys_dir == '':
+            sys_dir = '.'
         try:
             top_dirs = os.listdir(sys_dir)
         except (FileNotFoundError, NotADirectoryError):
@@ -152,14 +152,14 @@ def _find_all_specs(path: typing.Iterable[str]) -> typing.Iterator[ModuleSpec]:
                 spec_name = f"{top_dir}.opslib.{lib_dir}"
                 spec = finder.find_spec(spec_name)
                 if spec is None:
-                    logger.debug("    No spec for %r", spec_name)
+                    logger.debug('    No spec for %r', spec_name)
                     continue
                 if spec.loader is None:
                     # a namespace package; not supported
-                    logger.debug("    No loader for %r (probably a namespace package)", spec_name)
+                    logger.debug('    No loader for %r (probably a namespace package)', spec_name)
                     continue
 
-                logger.debug("    Found %r", spec_name)
+                logger.debug('    Found %r', spec_name)
                 yield spec
 
 
@@ -171,7 +171,7 @@ _NEEDED_KEYS = {'NAME': str, 'AUTHOR': str, 'API': int, 'PATCH': int}
 
 def _join_and(keys: List[str]) -> str:
     if len(keys) == 0:
-        return ""
+        return ''
     if len(keys) == 1:
         return keys[0]
     all_except_last = ', '.join(keys[:-1])
@@ -193,13 +193,13 @@ class _Missing:
         return f"got {_join_and(sorted(got))}, but missing {_join_and(sorted(exp - got))}"
 
 
-def _parse_lib(spec: ModuleSpec) -> typing.Optional["_Lib"]:
+def _parse_lib(spec: ModuleSpec) -> typing.Optional['_Lib']:
     if spec.origin is None:
         # "can't happen"
-        logger.warning("No origin for %r (no idea why; please report)", spec.name)
+        logger.warning('No origin for %r (no idea why; please report)', spec.name)
         return None
 
-    logger.debug("    Parsing %r", spec.name)
+    logger.debug('    Parsing %r', spec.name)
 
     try:
         with open(spec.origin, 'rt', encoding='utf-8') as f:
@@ -209,7 +209,7 @@ def _parse_lib(spec: ModuleSpec) -> typing.Optional["_Lib"]:
                     break
                 if n > _MAX_LIB_LINES:
                     logger.debug(
-                        "      Missing opslib metadata after reading to line %d: %s",
+                        '      Missing opslib metadata after reading to line %d: %s',
                         _MAX_LIB_LINES, _Missing(libinfo))
                     return None
                 m = _libline_re.match(line)
@@ -220,22 +220,22 @@ def _parse_lib(spec: ModuleSpec) -> typing.Optional["_Lib"]:
                     value = literal_eval(value)
                     if not isinstance(value, _NEEDED_KEYS[key]):
                         logger.debug(
-                            "      Bad type for %s: expected %s, got %s",
+                            '      Bad type for %s: expected %s, got %s',
                             key, _NEEDED_KEYS[key].__name__, type(value).__name__)
                         return None
                     libinfo[key] = value
             else:
                 if len(libinfo) != len(_NEEDED_KEYS):
                     logger.debug(
-                        "      Missing opslib metadata after reading to end of file: %s",
+                        '      Missing opslib metadata after reading to end of file: %s',
                         _Missing(libinfo))
                     return None
     except Exception as e:
-        logger.debug("      Failed: %s", e)
+        logger.debug('      Failed: %s', e)
         return None
 
     lib = _Lib(spec, libinfo['NAME'], libinfo['AUTHOR'], libinfo['API'], libinfo['PATCH'])
-    logger.debug("    Success: found library %s", lib)
+    logger.debug('    Success: found library %s', lib)
 
     return lib
 
@@ -255,7 +255,7 @@ class _Lib:
         return f"<_Lib {self}>"
 
     def __str__(self):
-        return "{0.name} by {0.author}, API {0.api}, patch {0.patch}".format(self)
+        return '{0.name} by {0.author}, API {0.api}, patch {0.patch}'.format(self)
 
     def import_module(self) -> ModuleType:
         if self._module is None:

--- a/ops/log.py
+++ b/ops/log.py
@@ -65,11 +65,11 @@ def setup_root_logging(model_backend: _ModelBackend, debug: bool = False,
                     value: BaseException,
                     tb: types.TracebackType):
         logger.error(
-            "Uncaught exception while in charm code:",
+            'Uncaught exception while in charm code:',
             exc_info=(etype, value, tb))
         if exc_stderr:
             print(f"Uncaught {etype.__name__} in charm code: {value}",
                   file=sys.stderr)
-            print("Use `juju debug-log` to see the full traceback.", file=sys.stderr)
+            print('Use `juju debug-log` to see the full traceback.', file=sys.stderr)
 
     sys.excepthook = except_hook

--- a/ops/main.py
+++ b/ops/main.py
@@ -54,7 +54,7 @@ def _exe_path(path: Path) -> Optional[Path]:
 
 
 def _get_charm_dir():
-    charm_dir = os.environ.get("JUJU_CHARM_DIR")
+    charm_dir = os.environ.get('JUJU_CHARM_DIR')
     if charm_dir is None:
         # Assume $JUJU_CHARM_DIR/lib/op/main.py structure.
         charm_dir = Path(f'{__file__}/../../..').resolve()
@@ -79,7 +79,7 @@ def _create_event_link(charm: 'ops.charm.CharmBase', bound_event: 'ops.framework
         event_dir = charm.framework.charm_dir / 'hooks'
         event_path = event_dir / bound_event.event_kind.replace('_', '-')
     elif issubclass(bound_event.event_type, ops.charm.ActionEvent):
-        if not bound_event.event_kind.endswith("_action"):
+        if not bound_event.event_kind.endswith('_action'):
             raise RuntimeError(
                 f'action event name {bound_event.event_kind} needs _action suffix')
         event_dir = charm.framework.charm_dir / 'actions'
@@ -116,7 +116,7 @@ def _setup_event_links(charm_dir: Path, charm: 'ops.charm.CharmBase'):
         charm: An instance of the Charm class.
 
     """
-    link_to = os.path.realpath(os.environ.get("JUJU_DISPATCH_PATH", sys.argv[0]))
+    link_to = os.path.realpath(os.environ.get('JUJU_DISPATCH_PATH', sys.argv[0]))
     for bound_event in charm.on.events().values():
         # Only events that originate from Juju need symlinks.
         if issubclass(bound_event.event_type, (ops.charm.HookEvent, ops.charm.ActionEvent)):
@@ -134,7 +134,7 @@ def _emit_charm_event(charm: 'ops.charm.CharmBase', event_name: str):
     try:
         event_to_emit = getattr(charm.on, event_name)
     except AttributeError:
-        logger.debug("Event %s not defined for %s.", event_name, charm)
+        logger.debug('Event %s not defined for %s.', event_name, charm)
 
     # If the event is not supported by the charm implementation, do
     # not error out or try to emit it. This is to support rollbacks.
@@ -169,13 +169,13 @@ def _get_event_args(charm: 'ops.charm.CharmBase',
             args.append(int(os.environ['JUJU_SECRET_REVISION']))
         return args, {}
     elif issubclass(event_type, ops.charm.StorageEvent):
-        storage_id = os.environ.get("JUJU_STORAGE_ID", "")
+        storage_id = os.environ.get('JUJU_STORAGE_ID', '')
         if storage_id:
-            storage_name = storage_id.split("/")[0]
+            storage_name = storage_id.split('/')[0]
         else:
             # Before JUJU_STORAGE_ID exists, take the event name as
             # <storage_name>_storage_<attached|detached> and replace it with <storage_name>
-            storage_name = "-".join(bound_event.event_kind.split("_")[:-2])
+            storage_name = '-'.join(bound_event.event_kind.split('_')[:-2])
 
         storages = model.storages[storage_name]
         index, storage_location = model._backend._storage_event_details()
@@ -273,26 +273,26 @@ class _Dispatcher:
 
         # super strange that there isn't an is_executable
         if not os.access(str(dispatch_path), os.X_OK):
-            logger.warning("Legacy %s exists but is not executable.", self._dispatch_path)
+            logger.warning('Legacy %s exists but is not executable.', self._dispatch_path)
             return
 
         if dispatch_path.resolve() == Path(sys.argv[0]).resolve():
-            logger.debug("Legacy %s is just a link to ourselves.", self._dispatch_path)
+            logger.debug('Legacy %s is just a link to ourselves.', self._dispatch_path)
             return
 
         argv = sys.argv.copy()
         argv[0] = str(dispatch_path)
-        logger.info("Running legacy %s.", self._dispatch_path)
+        logger.info('Running legacy %s.', self._dispatch_path)
         try:
             subprocess.run(argv, check=True)
         except subprocess.CalledProcessError as e:
-            logger.warning("Legacy %s exited with status %d.", self._dispatch_path, e.returncode)
+            logger.warning('Legacy %s exited with status %d.', self._dispatch_path, e.returncode)
             sys.exit(e.returncode)
         except OSError as e:
-            logger.warning("Unable to run legacy %s: %s", self._dispatch_path, e)
+            logger.warning('Unable to run legacy %s: %s', self._dispatch_path, e)
             sys.exit(1)
         else:
-            logger.debug("Legacy %s exited with status 0.", self._dispatch_path)
+            logger.debug('Legacy %s exited with status 0.', self._dispatch_path)
 
     def _set_name_from_path(self, path: Path):
         """Sets the name attribute to that which can be inferred from the given path."""
@@ -322,7 +322,7 @@ class _Dispatcher:
         self._dispatch_path = Path(os.environ['JUJU_DISPATCH_PATH'])
 
         if 'OPERATOR_DISPATCH' in os.environ:
-            logger.debug("Charm called itself via %s.", self._dispatch_path)
+            logger.debug('Charm called itself via %s.', self._dispatch_path)
             sys.exit(0)
         os.environ['OPERATOR_DISPATCH'] = '1'
 
@@ -348,17 +348,17 @@ def _should_use_controller_storage(db_path: Path, meta: CharmMeta) -> bool:
     # only use controller storage for Kubernetes podspec charms
     is_podspec = 'kubernetes' in meta.series
     if not is_podspec:
-        logger.debug("Using local storage: not a Kubernetes podspec charm")
+        logger.debug('Using local storage: not a Kubernetes podspec charm')
         return False
 
     # are we in a new enough Juju?
     cur_version = JujuVersion.from_environ()
 
     if cur_version.has_controller_storage():
-        logger.debug("Using controller storage: JUJU_VERSION=%s", cur_version)
+        logger.debug('Using controller storage: JUJU_VERSION=%s', cur_version)
         return True
     else:
-        logger.debug("Using local storage: JUJU_VERSION=%s", cur_version)
+        logger.debug('Using local storage: JUJU_VERSION=%s', cur_version)
         return False
 
 
@@ -384,7 +384,7 @@ def main(charm_class: Type[ops.charm.CharmBase],
     # only to juju-log as normal.
     handling_action = ('JUJU_ACTION_NAME' in os.environ)
     setup_root_logging(model_backend, debug=debug, exc_stderr=handling_action)
-    logger.debug("ops %s up and running.", ops.__version__)  # type:ignore
+    logger.debug('ops %s up and running.', ops.__version__)  # type:ignore
 
     dispatcher = _Dispatcher(charm_dir)
     dispatcher.run_any_legacy_hook()
@@ -410,7 +410,7 @@ def main(charm_class: Type[ops.charm.CharmBase],
         use_juju_for_storage = _should_use_controller_storage(charm_state_path, meta)
     elif use_juju_for_storage:
         warnings.warn("Controller storage is deprecated; it's intended for "
-                      "podspec charms and will be removed in a future release.",
+                      'podspec charms and will be removed in a future release.',
                       category=DeprecationWarning)
 
     if use_juju_for_storage:

--- a/ops/model.py
+++ b/ops/model.py
@@ -488,7 +488,7 @@ class Unit:
         self._status = None
         self._collected_statuses: 'List[StatusBase]' = []
 
-        if self._is_our_unit and hasattr(meta, "containers"):
+        if self._is_our_unit and hasattr(meta, 'containers'):
             containers: _ContainerMeta_Raw = meta.containers
             self._containers = ContainerMapping(iter(containers), backend)
 
@@ -568,7 +568,7 @@ class Unit:
         shown in the output of 'juju status'.
         """
         if not isinstance(version, str):
-            raise TypeError("workload version must be a str, not {}: {!r}".format(
+            raise TypeError('workload version must be a str, not {}: {!r}'.format(
                 type(version).__name__, version))
         self._backend.application_version_set(version)
 
@@ -1609,7 +1609,7 @@ class RelationDataContent(LazyMapping, MutableMapping[str, str]):
         if self._backend.app_name == self._entity.name:
             # minions can't read local app databags
             raise RelationDataAccessError(
-                "{} is not leader and cannot read its own application databag".format(
+                '{} is not leader and cannot read its own application databag'.format(
                     self._backend.unit_name
                 )
             )
@@ -1640,7 +1640,7 @@ class RelationDataContent(LazyMapping, MutableMapping[str, str]):
             is_our_app: bool = self._backend.app_name == self._entity.name
             if not is_our_app:
                 raise RelationDataAccessError(
-                    "{} cannot write the data of remote application {}".format(
+                    '{} cannot write the data of remote application {}'.format(
                         self._backend.app_name, self._entity.name
                     ))
             # Whether the application data bag is mutable or not depends on
@@ -1656,7 +1656,7 @@ class RelationDataContent(LazyMapping, MutableMapping[str, str]):
             # is it OUR UNIT's?
             if self._backend.unit_name != self._entity.name:
                 raise RelationDataAccessError(
-                    "{} cannot write databag of {}: not the same unit.".format(
+                    '{} cannot write databag of {}: not the same unit.'.format(
                         self._backend.unit_name, self._entity.name
                     )
                 )
@@ -1725,7 +1725,7 @@ class StatusBase:
 
     def __init__(self, message: str = ''):
         if self.__class__ is StatusBase:
-            raise TypeError("cannot instantiate a base class")
+            raise TypeError('cannot instantiate a base class')
         self.message = message
 
     def __eq__(self, other: 'StatusBase') -> bool:
@@ -1761,7 +1761,7 @@ class StatusBase:
         """Register a Status for the child's name."""
         if not isinstance(getattr(child, 'name'), str):
             raise TypeError(f"Can't register StatusBase subclass {child}: ",
-                            "missing required `name: str` class attribute")
+                            'missing required `name: str` class attribute')
         cls._statuses[child.name] = child
         return child
 
@@ -1798,7 +1798,7 @@ class UnknownStatus(StatusBase):
         super().__init__('')
 
     def __repr__(self):
-        return "UnknownStatus()"
+        return 'UnknownStatus()'
 
 
 @StatusBase.register
@@ -1976,7 +1976,7 @@ class Storage:
     @property
     def id(self) -> int:
         """DEPRECATED. Use :attr:`Storage.index` instead."""
-        logger.warning("model.Storage.id is being replaced - please use model.Storage.index")
+        logger.warning('model.Storage.id is being replaced - please use model.Storage.index')
         return self.index
 
     @property
@@ -1988,7 +1988,7 @@ class Storage:
     def location(self) -> Path:
         """Location of the storage."""
         if self._location is None:
-            raw = self._backend.storage_get(self.full_id, "location")
+            raw = self._backend.storage_get(self.full_id, 'location')
             self._location = Path(raw)
         return self._location
 
@@ -2081,17 +2081,17 @@ class Container:
         try:
             self._pebble.get_system_info()
         except pebble.ConnectionError as e:
-            logger.debug("Pebble API is not ready; ConnectionError: %s", e)
+            logger.debug('Pebble API is not ready; ConnectionError: %s', e)
             return False
         except FileNotFoundError as e:
             # In some cases, charm authors can attempt to hit the Pebble API before it has had the
             # chance to create the UNIX socket in the shared volume.
-            logger.debug("Pebble API is not ready; UNIX socket not found: %s", e)
+            logger.debug('Pebble API is not ready; UNIX socket not found: %s', e)
             return False
         except pebble.APIError as e:
             # An API error is only raised when the Pebble API returns invalid JSON, or the response
             # cannot be read. Both of these are a likely indicator that something is wrong.
-            logger.warning("Pebble API is not ready; APIError: %s", e)
+            logger.warning('Pebble API is not ready; APIError: %s', e)
             return False
         return True
 
@@ -2475,12 +2475,12 @@ class Container:
         try:
             pw_name = pwd.getpwuid(info.st_uid).pw_name
         except KeyError:
-            logger.warning("Could not get name for user %s", info.st_uid)
+            logger.warning('Could not get name for user %s', info.st_uid)
             pw_name = None
         try:
             gr_name = grp.getgrgid(info.st_gid).gr_name
         except KeyError:
-            logger.warning("Could not get name for group %s", info.st_gid)
+            logger.warning('Could not get name for group %s', info.st_gid)
             gr_name = None
         return pebble.FileInfo(
             path=str(path),
@@ -2982,7 +2982,7 @@ class _ModelBackend:
              ) -> Union[str, Any, None]:
         kwargs = dict(stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, encoding='utf-8')
         if input_stream:
-            kwargs.update({"input": input_stream})
+            kwargs.update({'input': input_stream})
         which_cmd = shutil.which(args[0])
         if which_cmd is None:
             raise RuntimeError(f'command not found: {args[0]}')
@@ -3093,7 +3093,7 @@ class _ModelBackend:
         args = ['relation-set', '-r', str(relation_id)]
         if is_app:
             args.append('--app')
-        args.extend(["--file", "-"])
+        args.extend(['--file', '-'])
 
         try:
             content = yaml.safe_dump({key: value})
@@ -3137,12 +3137,12 @@ class _ModelBackend:
         tmpdir = Path(tempfile.mkdtemp('-pod-spec-set'))
         try:
             spec_path = tmpdir / 'spec.yaml'
-            with spec_path.open("wt", encoding="utf8") as f:
+            with spec_path.open('wt', encoding='utf8') as f:
                 yaml.safe_dump(spec, stream=f)
             args = ['--file', str(spec_path)]
             if k8s_resources:
                 k8s_res_path = tmpdir / 'k8s-resources.yaml'
-                with k8s_res_path.open("wt", encoding="utf8") as f:
+                with k8s_res_path.open('wt', encoding='utf8') as f:
                     yaml.safe_dump(k8s_resources, stream=f)
                 args.extend(['--k8s-resources', str(k8s_res_path)])
             self._run('pod-spec-set', *args)
@@ -3208,10 +3208,10 @@ class _ModelBackend:
         match = self._STORAGE_KEY_RE.match(output)
         if match is None:
             raise RuntimeError(f'unable to find storage key in {output!r}')
-        key = match.groupdict()["storage_key"]
+        key = match.groupdict()['storage_key']
 
-        index = int(key.split("/")[1])
-        location = self.storage_get(key, "location")
+        index = int(key.split('/')[1])
+        location = self.storage_get(key, 'location')
         return index, location
 
     def storage_get(self, storage_name_id: str, attribute: str) -> str:
@@ -3264,7 +3264,7 @@ class _ModelBackend:
     def juju_log(self, level: str, message: str) -> None:
         """Pass a log message on to the juju logger."""
         for line in self.log_split(message):
-            self._run('juju-log', '--log-level', level, "--", line)
+            self._run('juju-log', '--log-level', level, '--', line)
 
     def network_get(self, binding_name: str, relation_id: Optional[int] = None) -> '_NetworkDict':
         """Return network info provided by network-get for a given binding.
@@ -3480,13 +3480,13 @@ class _ModelBackend:
 
     def reboot(self, now: bool = False):
         if now:
-            self._run("juju-reboot", "--now")
+            self._run('juju-reboot', '--now')
             # Juju will kill the Charm process, and in testing no code after
             # this point would execute. However, we want to guarantee that for
             # Charmers, so we force that to be the case.
             sys.exit()
         else:
-            self._run("juju-reboot")
+            self._run('juju-reboot')
 
 
 class _ModelBackendValidator:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -199,22 +199,22 @@ if TYPE_CHECKING:
     from typing_extensions import NotRequired
 
     _CheckInfoDict = TypedDict('_CheckInfoDict',
-                               {"name": str,
-                                "level": NotRequired[Optional[Union['CheckLevel', str]]],
-                                "status": Union['CheckStatus', str],
-                                "failures": NotRequired[int],
-                                "threshold": int})
+                               {'name': str,
+                                'level': NotRequired[Optional[Union['CheckLevel', str]]],
+                                'status': Union['CheckStatus', str],
+                                'failures': NotRequired[int],
+                                'threshold': int})
     _FileInfoDict = TypedDict('_FileInfoDict',
-                              {"path": str,
-                               "name": str,
-                               "size": NotRequired[Optional[int]],
-                               "permissions": str,
-                               "last-modified": str,
-                               "user-id": NotRequired[Optional[int]],
-                               "user": NotRequired[Optional[str]],
-                               "group-id": NotRequired[Optional[int]],
-                               "group": NotRequired[Optional[str]],
-                               "type": Union['FileType', str]})
+                              {'path': str,
+                               'name': str,
+                               'size': NotRequired[Optional[int]],
+                               'permissions': str,
+                               'last-modified': str,
+                               'user-id': NotRequired[Optional[int]],
+                               'user': NotRequired[Optional[str]],
+                               'group-id': NotRequired[Optional[int]],
+                               'group': NotRequired[Optional[str]],
+                               'type': Union['FileType', str]})
 
     _ProgressDict = TypedDict('_ProgressDict',
                               {'label': str,
@@ -365,7 +365,7 @@ class ProtocolError(Error):
 class PathError(Error):
     """Raised when there's an error with a specific path."""
 
-    kind: typing.Literal["not-found", "permission-denied", "generic-file-error"]
+    kind: typing.Literal['not-found', 'permission-denied', 'generic-file-error']
     """Short string representing the kind of error."""
 
     message: str
@@ -1515,7 +1515,7 @@ class ExecProcess(Generic[AnyStr]):
         if self.stdout is None:
             raise TypeError(
                 "can't use wait_output() when exec was called with the stdout argument; "
-                "use wait() instead"
+                'use wait() instead'
             )
 
         if self._encoding is not None:
@@ -1802,7 +1802,7 @@ class Client:
             if e.args and isinstance(e.args[0], FileNotFoundError):
                 raise ConnectionError(
                     f"Could not connect to Pebble: socket not found at {self.socket_path!r} "
-                    "(container restarted?)") from None
+                    '(container restarted?)') from None
             raise ConnectionError(e.reason) from e
 
         return response
@@ -2801,7 +2801,7 @@ class _FilesParser:
 
     def __init__(self, boundary: Union[bytes, str]):
         self._response: Optional[_FilesResponse] = None  # externally managed
-        self._part_type: Optional[Literal["response", "files"]] = None  # externally managed
+        self._part_type: Optional[Literal['response', 'files']] = None  # externally managed
         self._headers: Optional[email.message.Message] = None  # externally managed
         self._files: Dict[str, _Tempfile] = {}
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -82,7 +82,7 @@ _RawStatus = TypedDict('_RawStatus', {
     'status': _StatusName,
     'message': str,
 })
-_RawConfig = TypedDict("_RawConfig", {'options': Dict[str, _ConfigOption]})
+_RawConfig = TypedDict('_RawConfig', {'options': Dict[str, _ConfigOption]})
 
 
 # YAMLStringOrFile is something like metadata.yaml or actions.yaml. You can
@@ -427,7 +427,7 @@ class Harness(Generic[CharmType]):
                 rel_ids = self._backend._relation_ids_map.get(relname, [])
                 random.shuffle(rel_ids)
                 for rel_id in rel_ids:
-                    app_name = self._backend._relation_app_and_units[rel_id]["app"]
+                    app_name = self._backend._relation_app_and_units[rel_id]['app']
                     self._emit_relation_created(relname, rel_id, app_name)
         if self._backend._is_leader:
             charm.on.leader_elected.emit()
@@ -445,13 +445,13 @@ class Harness(Generic[CharmType]):
         # If the initial hooks do not set a unit status, the Juju controller will switch
         # the unit status from "Maintenance" to "Unknown". See gh#726
         post_setup_sts = self._backend.status_get()
-        if post_setup_sts.get("status") == "maintenance" and not post_setup_sts.get("message"):
-            self._backend.status_set("unknown", "", is_app=False)
+        if post_setup_sts.get('status') == 'maintenance' and not post_setup_sts.get('message'):
+            self._backend.status_set('unknown', '', is_app=False)
         all_ids = list(self._backend._relation_names.items())
         random.shuffle(all_ids)
         for rel_id, rel_name in all_ids:
             rel_app_and_units = self._backend._relation_app_and_units[rel_id]
-            app_name = rel_app_and_units["app"]
+            app_name = rel_app_and_units['app']
             # Note: Juju *does* fire relation events for a given relation in the sorted order of
             # the unit names. It also always fires relation-changed immediately after
             # relation-joined for the same unit.
@@ -460,7 +460,7 @@ class Harness(Generic[CharmType]):
             if self._backend._relation_data_raw[rel_id].get(app_name):
                 app = self._model.get_app(app_name)
                 charm.on[rel_name].relation_changed.emit(relation, app, None)
-            for unit_name in sorted(rel_app_and_units["units"]):
+            for unit_name in sorted(rel_app_and_units['units']):
                 remote_unit = self._model.get_unit(unit_name)
                 charm.on[rel_name].relation_joined.emit(
                     relation, remote_unit.app, remote_unit)
@@ -489,7 +489,7 @@ class Harness(Generic[CharmType]):
         charm_metadata: Optional[Dict[str, Any]] = None
         charmcraft_metadata: Optional[Dict[str, Any]] = None
         # Check charmcraft.yaml and load it if it exists
-        charmcraft_meta = charm_dir / "charmcraft.yaml"
+        charmcraft_meta = charm_dir / 'charmcraft.yaml'
         if charmcraft_meta.is_file():
             self._charm_dir = charm_dir
             charmcraft_metadata = yaml.safe_load(charmcraft_meta.read_text())
@@ -502,7 +502,7 @@ class Harness(Generic[CharmType]):
         else:
             # Check charmcraft.yaml for metadata if no metadata is provided
             if charmcraft_metadata is not None:
-                meta_keys = ["name", "summary", "description"]
+                meta_keys = ['name', 'summary', 'description']
                 if any(key in charmcraft_metadata for key in meta_keys):
                     # Unrelated keys in the charmcraft.yaml file will be ignored.
                     charm_metadata = charmcraft_metadata
@@ -516,7 +516,7 @@ class Harness(Generic[CharmType]):
 
         # Use default metadata if metadata is not found
         if charm_metadata is None:
-            charm_metadata = {"name": "test-charm"}
+            charm_metadata = {'name': 'test-charm'}
 
         action_metadata: Optional[Dict[str, Any]] = None
         # Load actions from parameters if provided
@@ -526,8 +526,8 @@ class Harness(Generic[CharmType]):
             action_metadata = yaml.safe_load(action_metadata_yaml)
         else:
             # Check charmcraft.yaml for actions if no actions are provided
-            if charmcraft_metadata is not None and "actions" in charmcraft_metadata:
-                action_metadata = charmcraft_metadata["actions"]
+            if charmcraft_metadata is not None and 'actions' in charmcraft_metadata:
+                action_metadata = charmcraft_metadata['actions']
 
             # Still no actions, check actions.yaml
             if action_metadata is None:
@@ -555,10 +555,10 @@ class Harness(Generic[CharmType]):
             config = yaml.safe_load(charm_config_yaml)
         else:
             # Check charmcraft.yaml for config if no config is provided
-            charmcraft_meta = charm_dir / "charmcraft.yaml"
+            charmcraft_meta = charm_dir / 'charmcraft.yaml'
             if charmcraft_meta.is_file():
                 charmcraft_metadata: Dict[str, Any] = yaml.safe_load(charmcraft_meta.read_text())
-                config = charmcraft_metadata.get("config")
+                config = charmcraft_metadata.get('config')
 
             # Still no config, check config.yaml
             if config is None:
@@ -594,7 +594,7 @@ class Harness(Generic[CharmType]):
                         }
         if resource_name not in self._meta.resources.keys():
             raise RuntimeError(f'Resource {resource_name} is not a defined resources')
-        if self._meta.resources[resource_name].type != "oci-image":
+        if self._meta.resources[resource_name].type != 'oci-image':
             raise RuntimeError(f'Resource {resource_name} is not an OCI Image')
 
         as_yaml = yaml.safe_dump(contents)
@@ -614,7 +614,7 @@ class Harness(Generic[CharmType]):
         if resource_name not in self._meta.resources.keys():
             raise RuntimeError(f'Resource {resource_name} is not a defined resource')
         record = self._meta.resources[resource_name]
-        if record.type != "file":
+        if record.type != 'file':
             raise RuntimeError(
                 f'Resource {resource_name} is not a file, but actually {record.type}')
         filename = record.filename
@@ -626,7 +626,7 @@ class Harness(Generic[CharmType]):
     def populate_oci_resources(self) -> None:
         """Populate all OCI resources."""
         for name, data in self._meta.resources.items():
-            if data.type == "oci-image":
+            if data.type == 'oci-image':
                 self.add_oci_resource(name)
 
     def disable_hooks(self) -> None:
@@ -840,8 +840,8 @@ class Harness(Generic[CharmType]):
             self._backend.app_name: {}}
 
         self._backend._relation_app_and_units[relation_id] = {
-            "app": remote_app,
-            "units": [],
+            'app': remote_app,
+            'units': [],
         }
         # Reload the relation_ids list
         if self._model is not None:
@@ -952,7 +952,7 @@ class Harness(Generic[CharmType]):
                 'the remote unit name should be {}/<some-number>, not {!r}.'
                 ''.format(relation_name, app.name, app.name, remote_unit_name))
         app_and_units = self._backend._relation_app_and_units
-        app_and_units[relation_id]["units"].append(remote_unit_name)
+        app_and_units[relation_id]['units'].append(remote_unit_name)
         # Make sure that the Model reloads the relation_list for this relation_id, as well as
         # reloading the relation data for this unit.
         remote_unit = self._model.get_unit(remote_unit_name)
@@ -1008,7 +1008,7 @@ class Harness(Generic[CharmType]):
         self._emit_relation_departed(relation_id, remote_unit_name)
         # remove the relation data for the departed unit now that the event has happened
         self._backend._relation_list_map[relation_id].remove(remote_unit_name)
-        self._backend._relation_app_and_units[relation_id]["units"].remove(remote_unit_name)
+        self._backend._relation_app_and_units[relation_id]['units'].remove(remote_unit_name)
         self._backend._relation_data_raw[relation_id].pop(remote_unit_name)
         self.model._relations._invalidate(relation_name=relation.name)
 
@@ -1324,7 +1324,7 @@ class Harness(Generic[CharmType]):
         event.
         """
         if num_units < 0:
-            raise TypeError("num_units must be 0 or a positive integer.")
+            raise TypeError('num_units must be 0 or a positive integer.')
         self._backend._planned_units = num_units
 
     def reset_planned_units(self) -> None:
@@ -1765,7 +1765,7 @@ class Harness(Generic[CharmType]):
             harness.handle_exec('database', ['foo'], handler=handle_timeout)
         """
         if (handler is None and result is None) or (handler is not None and result is not None):
-            raise TypeError("Either handler or result must be provided, but not both.")
+            raise TypeError('Either handler or result must be provided, but not both.')
         container_name = container if isinstance(container, str) else container.name
         if result is not None:
             if isinstance(result, int) and not isinstance(result, bool):
@@ -2020,8 +2020,8 @@ class _TestingModelBackend:
         self.model_uuid = str(uuid.uuid4())
 
         self._harness_tmp_dir = tempfile.TemporaryDirectory(prefix='ops-harness-')
-        self._harness_storage_path = pathlib.Path(self._harness_tmp_dir.name) / "storages"
-        self._harness_container_path = pathlib.Path(self._harness_tmp_dir.name) / "containers"
+        self._harness_storage_path = pathlib.Path(self._harness_tmp_dir.name) / 'storages'
+        self._harness_container_path = pathlib.Path(self._harness_tmp_dir.name) / 'containers'
         self._harness_storage_path.mkdir()
         self._harness_container_path.mkdir()
         # this is used by the _record_calls decorator
@@ -2196,8 +2196,8 @@ class _TestingModelBackend:
     def resource_get(self, resource_name: str):
         if resource_name not in self._resources_map:
             raise model.ModelError(
-                "ERROR could not download resource: HTTP request failed: "
-                "Get https://.../units/unit-{}/resources/{}: resource#{}/{} not found".format(
+                'ERROR could not download resource: HTTP request failed: '
+                'Get https://.../units/unit-{}/resources/{}: resource#{}/{} not found'.format(
                     self.unit_name.replace('/', '-'), resource_name, self.app_name, resource_name
                 ))
         filename, contents = self._resources_map[resource_name]
@@ -2239,7 +2239,7 @@ class _TestingModelBackend:
                     if include_detached or self._storage_is_attached(name, index))
 
     def storage_get(self, storage_name_id: str, attribute: str) -> Any:
-        name, index = storage_name_id.split("/", 1)
+        name, index = storage_name_id.split('/', 1)
         index = int(index)
         try:
             if index not in self._storage_attached[name]:
@@ -2297,7 +2297,7 @@ class _TestingModelBackend:
                     root = client._root
                     mounting_dir = root / mount.location[1:]
                     mounting_dir.parent.mkdir(parents=True, exist_ok=True)
-                    target_dir = pathlib.Path(store["location"])
+                    target_dir = pathlib.Path(store['location'])
                     target_dir.mkdir(parents=True, exist_ok=True)
                     mounting_dir.symlink_to(target_dir)
 
@@ -2324,14 +2324,14 @@ class _TestingModelBackend:
         assert self._running_action is not None
         action_meta = self._meta.actions[self._running_action.name]
         for name, action_meta in action_meta.parameters.items():
-            if "default" in action_meta:
-                params[name] = action_meta["default"]
+            if 'default' in action_meta:
+                params[name] = action_meta['default']
         params.update(self._running_action.parameters)
         return params
 
     def action_set(self, results: Dict[str, Any]):
         assert self._running_action is not None
-        for key in ("stdout", "stderr", "stdout-encoding", "stderr-encoding"):
+        for key in ('stdout', 'stderr', 'stdout-encoding', 'stderr-encoding'):
             if key in results:
                 # Match Juju's error message.
                 raise model.ModelError(f'ERROR cannot set reserved action key "{key}"')
@@ -2673,7 +2673,7 @@ class _TestingExecProcess:
         self._timeout = timeout
         self._is_timeout = is_timeout
         if exit_code is None and not is_timeout:
-            raise ValueError("when is_timeout is False, exit_code must not be None")
+            raise ValueError('when is_timeout is False, exit_code must not be None')
         self._exit_code = exit_code
         self.stdin = stdin
         self.stdout = stdout
@@ -2703,7 +2703,7 @@ class _TestingExecProcess:
 
     def send_signal(self, sig: Union[int, str]):
         # the process is always terminated when ExecProcess is return in the simulation.
-        raise BrokenPipeError("[Errno 32] Broken pipe")
+        raise BrokenPipeError('[Errno 32] Broken pipe')
 
 
 @_copy_docstrings(pebble.Client)
@@ -2931,7 +2931,7 @@ class _TestingPebbleClient:
 
     @staticmethod
     def _check_absolute_path(path: str):
-        if not path.startswith("/"):
+        if not path.startswith('/'):
             raise pebble.PathError(
                 'generic-file-error',
                 f'paths must be absolute, got {path!r}'
@@ -2945,7 +2945,7 @@ class _TestingPebbleClient:
         try:
             return cast(
                 Union[BinaryIO, TextIO],
-                file_path.open("rb" if encoding is None else "r", encoding=encoding))
+                file_path.open('rb' if encoding is None else 'r', encoding=encoding))
         except FileNotFoundError:
             raise pebble.PathError('not-found', f'stat {path}: no such file or directory')
         except IsADirectoryError:
@@ -3023,8 +3023,8 @@ class _TestingPebbleClient:
             rel_path = os.path.relpath(file_info.path, start=self._root)
             rel_path = '/' if rel_path == '.' else '/' + rel_path
             file_info.path = rel_path
-            if rel_path == "/":
-                file_info.name = "/"
+            if rel_path == '/':
+                file_info.name = '/'
         return file_infos
 
     def make_dir(
@@ -3132,7 +3132,7 @@ class _TestingPebbleClient:
         self._check_connection()
         handler = self._find_exec_handler(command)
         if handler is None:
-            message = "execution handler not found, please register one using Harness.handle_exec"
+            message = 'execution handler not found, please register one using Harness.handle_exec'
             raise pebble.APIError(
                 body={}, code=500, status='Internal Server Error', message=message
             )
@@ -3154,7 +3154,7 @@ class _TestingPebbleClient:
             group = service.group if group is None else group
             group_id = service.group_id if group_id is None else group_id
 
-        if hasattr(stdin, "read"):
+        if hasattr(stdin, 'read'):
             stdin = stdin.read()  # type: ignore
 
         exec_args = ExecArgs(
@@ -3189,8 +3189,8 @@ class _TestingPebbleClient:
                 return cast(pebble.ExecProcess[Any], exec_process)
             else:
                 raise RuntimeError(
-                    "a TimeoutError occurred in the execution handler, "
-                    "but no timeout value was provided in the execution arguments."
+                    'a TimeoutError occurred in the execution handler, '
+                    'but no timeout value was provided in the execution arguments.'
                 ) from None
         if result is None:
             exit_code = 0
@@ -3203,8 +3203,8 @@ class _TestingPebbleClient:
         else:
             raise TypeError(f"execution handler returned an unexpected type: {type(result)!r}.")
         if combine_stderr and proc_stderr.getvalue():
-            raise ValueError("execution handler returned a non-empty stderr "
-                             "even though combine_stderr is enabled.")
+            raise ValueError('execution handler returned a non-empty stderr '
+                             'even though combine_stderr is enabled.')
         if stdout is not None:
             shutil.copyfileobj(cast(io.IOBase, proc_stdout), cast(io.IOBase, stdout))
             proc_stdout = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,14 @@ profile = "black"
 max-line-length = 99
 max-doc-length = 99
 exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
+select = ["E", "W", "F", "C", "N", "R", "D", "H", "Q0"]
 ignore = ["D105", "D107", "W503"]
 # D100, D101, D102, D103, D104: Ignore missing docstrings in tests
 per-file-ignores = ["test/*:D100,D101,D102,D103,D104"]
 docstring-convention = "google"
+inline-quotes = "single"
+multiline-quotes = "double"
+docstring-quotes = "double"
 
 [tool.pyright]
 include = ["ops/*.py", "ops/_private/*.py", "test/*.py", "test/charms/*/src/*.py"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ autopep8~=1.6
 flake8~=6.1
 flake8-docstrings~=1.7
 flake8-builtins~=2.1
+flake8-quotes~=3.3
 pyproject-flake8~=6.1
 pep8-naming~=0.13
 pytest~=7.2

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -115,7 +115,7 @@ class Charm(ops.CharmBase):
         self.framework.observe(self.on.custom, self._on_custom)
 
         if os.getenv('TRY_EXCEPTHOOK', False):
-            raise RuntimeError("failing as requested")
+            raise RuntimeError('failing as requested')
 
     def _on_install(self, event: ops.InstallEvent):
         self._stored.on_install.append(type(event).__name__)

--- a/test/fake_pebble.py
+++ b/test/fake_pebble.py
@@ -28,12 +28,12 @@ import urllib.parse
 from typing_extensions import NotRequired
 
 _Response = typing.TypedDict(
-    "_Response", {
-        "result": typing.Optional[typing.Dict[str, str]],
-        "status": str,
-        "status-code": int,
-        "type": str,
-        "change": NotRequired[str]})
+    '_Response', {
+        'result': typing.Optional[typing.Dict[str, str]],
+        'status': str,
+        'status-code': int,
+        'type': str,
+        'change': NotRequired[str]})
 
 
 class Handler(http.server.BaseHTTPRequestHandler):
@@ -67,45 +67,45 @@ class Handler(http.server.BaseHTTPRequestHandler):
 
     def bad_request(self, message: str):
         d: _Response = {
-            "result": {
-                "message": message,
+            'result': {
+                'message': message,
             },
-            "status": "Bad Request",
-            "status-code": 400,
-            "type": "error"
+            'status': 'Bad Request',
+            'status-code': 400,
+            'type': 'error'
         }
         self.respond(d, 400)
 
     def not_found(self):
         d: _Response = {
-            "result": {
-                "message": "invalid API endpoint requested"
+            'result': {
+                'message': 'invalid API endpoint requested'
             },
-            "status": "Not Found",
-            "status-code": 404,
-            "type": "error"
+            'status': 'Not Found',
+            'status-code': 404,
+            'type': 'error'
         }
         self.respond(d, 404)
 
     def method_not_allowed(self):
         d: _Response = {
-            "result": {
-                "message": 'method "PUT" not allowed'
+            'result': {
+                'message': 'method "PUT" not allowed'
             },
-            "status": "Method Not Allowed",
-            "status-code": 405,
-            "type": "error"
+            'status': 'Method Not Allowed',
+            'status-code': 405,
+            'type': 'error'
         }
         self.respond(d, 405)
 
     def internal_server_error(self, msg: Exception):
         d: _Response = {
-            "result": {
-                "message": f"internal server error: {msg}",
+            'result': {
+                'message': f"internal server error: {msg}",
             },
-            "status": "Internal Server Error",
-            "status-code": 500,
-            "type": "error"
+            'status': 'Internal Server Error',
+            'status-code': 500,
+            'type': 'error'
         }
         self.respond(d, 500)
 
@@ -162,12 +162,12 @@ class Handler(http.server.BaseHTTPRequestHandler):
                         query: typing.Dict[str, str],
                         data: typing.Dict[str, str]):
         self.respond({
-            "result": {
-                "version": "3.14.159"
+            'result': {
+                'version': '3.14.159'
             },
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
 
     def services_action(self,
@@ -182,11 +182,11 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     self.bad_request(f'service "{service}" does not exist')
                     return
             self.respond({
-                "change": "1234",
-                "result": None,
-                "status": "Accepted",
-                "status-code": 202,
-                "type": "async"
+                'change': '1234',
+                'result': None,
+                'status': 'Accepted',
+                'status-code': 202,
+                'type': 'async'
             })
         else:
             self.bad_request(f'action "{action}" not implemented')

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -26,11 +26,11 @@ async def test_smoke(ops_test: OpsTest):
 
     # Build the charm. (We just build it for focal -- it *should* work to deploy it on
     # older versions of Juju.)
-    charm = await ops_test.build_charm("./test/charms/test_smoke/")
+    charm = await ops_test.build_charm('./test/charms/test_smoke/')
 
     for series in ['focal', 'bionic', 'xenial']:
         app = await ops_test.model.deploy(
             charm, series=series, application_name=f"{series}-smoke")
         await ops_test.model.wait_for_idle(timeout=600)
 
-        assert app.status == "active", f"Series {series} failed with '{app.status}' status"
+        assert app.status == 'active', f"Series {series} failed with '{app.status}' status"

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -89,7 +89,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(charm.started, True)
 
-        with self.assertRaisesRegex(TypeError, "observer methods must now be explicitly provided"):
+        with self.assertRaisesRegex(TypeError, 'observer methods must now be explicitly provided'):
             framework.observe(charm.on.start, charm)  # type: ignore
 
     def test_observe_decorated_method(self):
@@ -166,7 +166,7 @@ class TestCharm(unittest.TestCase):
                 self.seen.append(type(event).__name__)
 
         # language=YAML
-        self.meta = ops.CharmMeta.from_yaml(metadata='''
+        self.meta = ops.CharmMeta.from_yaml(metadata="""
 name: my-charm
 requires:
  req1:
@@ -183,7 +183,7 @@ peers:
    interface: peer1
  peer-2:
    interface: peer2
-''')
+""")
 
         charm = MyCharm(self.create_framework())
 
@@ -226,7 +226,7 @@ peers:
 
             def _on_stor1_attach(self, event: ops.StorageAttachedEvent):
                 self.seen.append(type(event).__name__)
-                this.assertEqual(event.storage.location, Path("/var/srv/stor1/0"))
+                this.assertEqual(event.storage.location, Path('/var/srv/stor1/0'))
 
             def _on_stor2_detach(self, event: ops.StorageDetachingEvent):
                 self.seen.append(type(event).__name__)
@@ -238,7 +238,7 @@ peers:
                 self.seen.append(type(event).__name__)
 
         # language=YAML
-        self.meta = ops.CharmMeta.from_yaml('''
+        self.meta = ops.CharmMeta.from_yaml("""
 name: my-charm
 storage:
   stor-4:
@@ -259,11 +259,11 @@ storage:
     multiple:
       range: 2-
     type: filesystem
-''')
+""")
 
         fake_script(
             self,
-            "storage-get",
+            'storage-get',
             """
             if [ "$1" = "-s" ]; then
                 id=${2#*/}
@@ -296,7 +296,7 @@ storage:
         )
         fake_script(
             self,
-            "storage-list",
+            'storage-list',
             """
             echo '["disks/0"]'
             """,
@@ -309,12 +309,12 @@ storage:
 
         charm = MyCharm(self.create_framework())
 
-        charm.on['stor1'].storage_attached.emit(ops.Storage("stor1", 0, charm.model._backend))
-        charm.on['stor2'].storage_detaching.emit(ops.Storage("stor2", 0, charm.model._backend))
-        charm.on['stor3'].storage_attached.emit(ops.Storage("stor3", 0, charm.model._backend))
-        charm.on['stor-4'].storage_attached.emit(ops.Storage("stor-4", 0, charm.model._backend))
+        charm.on['stor1'].storage_attached.emit(ops.Storage('stor1', 0, charm.model._backend))
+        charm.on['stor2'].storage_detaching.emit(ops.Storage('stor2', 0, charm.model._backend))
+        charm.on['stor3'].storage_attached.emit(ops.Storage('stor3', 0, charm.model._backend))
+        charm.on['stor-4'].storage_attached.emit(ops.Storage('stor-4', 0, charm.model._backend))
         charm.on['stor-multiple-dashes'].storage_attached.emit(
-            ops.Storage("stor-multiple-dashes", 0, charm.model._backend))
+            ops.Storage('stor-multiple-dashes', 0, charm.model._backend))
 
         self.assertEqual(charm.seen, [
             'StorageAttachedEvent',
@@ -346,12 +346,12 @@ storage:
                 self.seen.append(type(event).__name__)
 
         # language=YAML
-        self.meta = ops.CharmMeta.from_yaml(metadata='''
+        self.meta = ops.CharmMeta.from_yaml(metadata="""
 name: my-charm
 containers:
   container-a:
   containerb:
-''')
+""")
 
         charm = MyCharm(self.create_framework())
 
@@ -377,7 +377,7 @@ containers:
 
     def test_relations_meta(self):
         # language=YAML
-        self.meta = ops.CharmMeta.from_yaml('''
+        self.meta = ops.CharmMeta.from_yaml("""
 name: my-charm
 requires:
   database:
@@ -387,7 +387,7 @@ requires:
   metrics:
     interface: prometheus-scraping
     optional: true
-''')
+""")
 
         self.assertEqual(self.meta.requires['database'].interface_name, 'mongodb')
         self.assertEqual(self.meta.requires['database'].limit, 1)
@@ -402,32 +402,32 @@ requires:
     def test_relations_meta_limit_type_validation(self):
         with self.assertRaisesRegex(TypeError, "limit should be an int, not <class 'str'>"):
             # language=YAML
-            self.meta = ops.CharmMeta.from_yaml('''
+            self.meta = ops.CharmMeta.from_yaml("""
 name: my-charm
 requires:
   database:
     interface: mongodb
     limit: foobar
-''')
+""")
 
     def test_relations_meta_scope_type_validation(self):
         with self.assertRaisesRegex(TypeError,
                                     "scope should be one of 'global', 'container'; not 'foobar'"):
             # language=YAML
-            self.meta = ops.CharmMeta.from_yaml('''
+            self.meta = ops.CharmMeta.from_yaml("""
 name: my-charm
 requires:
   database:
     interface: mongodb
     scope: foobar
-''')
+""")
 
     @classmethod
     def _get_action_test_meta(cls):
         # language=YAML
-        return ops.CharmMeta.from_yaml(metadata='''
+        return ops.CharmMeta.from_yaml(metadata="""
 name: my-charm
-''', actions='''
+""", actions="""
 foo-bar:
   description: "Foos the bar."
   params:
@@ -443,13 +443,13 @@ foo-bar:
 start:
   description: "Start the unit."
   additionalProperties: false
-''')
+""")
 
     def _setup_test_action(self):
         fake_script(self, 'action-get', """echo '{"foo-name": "name", "silent": true}'""")
-        fake_script(self, 'action-set', "")
-        fake_script(self, 'action-log', "")
-        fake_script(self, 'action-fail', "")
+        fake_script(self, 'action-set', '')
+        fake_script(self, 'action-log', '')
+        fake_script(self, 'action-fail', '')
         self.meta = self._get_action_test_meta()
 
     def test_action_events(self):
@@ -479,12 +479,12 @@ start:
         self.assertIn('start_action', events)
 
         charm.on.foo_bar_action.emit()
-        self.assertEqual(charm.seen_action_params, {"foo-name": "name", "silent": True})
+        self.assertEqual(charm.seen_action_params, {'foo-name': 'name', 'silent': True})
         self.assertEqual(fake_script_calls(self), [
             ['action-get', '--format=json'],
-            ['action-log', "test-log"],
-            ['action-set', "res=val with spaces"],
-            ['action-fail', "test-fail"],
+            ['action-log', 'test-log'],
+            ['action-set', 'res=val with spaces'],
+            ['action-fail', 'test-fail'],
         ])
 
     def test_invalid_action_results(self):
@@ -571,9 +571,9 @@ containers:
         location: /test/otherdata
 """)
         self.assertIsInstance(meta.containers['test1'], ops.ContainerMeta)
-        self.assertIsInstance(meta.containers['test1'].mounts["data"], ops.ContainerStorageMeta)
-        self.assertEqual(meta.containers['test1'].mounts["data"].location, '/test/storagemount')
-        self.assertEqual(meta.containers['test1'].mounts["other"].location, '/test/otherdata')
+        self.assertIsInstance(meta.containers['test1'].mounts['data'], ops.ContainerStorageMeta)
+        self.assertEqual(meta.containers['test1'].mounts['data'].location, '/test/storagemount')
+        self.assertEqual(meta.containers['test1'].mounts['other'].location, '/test/otherdata')
 
     def test_containers_storage_multiple_mounts(self):
         meta = ops.CharmMeta.from_yaml("""
@@ -591,14 +591,14 @@ containers:
         location: /test/otherdata
 """)
         self.assertIsInstance(meta.containers['test1'], ops.ContainerMeta)
-        self.assertIsInstance(meta.containers['test1'].mounts["data"], ops.ContainerStorageMeta)
+        self.assertIsInstance(meta.containers['test1'].mounts['data'], ops.ContainerStorageMeta)
         self.assertEqual(
-            meta.containers['test1'].mounts["data"].locations[0],
+            meta.containers['test1'].mounts['data'].locations[0],
             '/test/storagemount')
-        self.assertEqual(meta.containers['test1'].mounts["data"].locations[1], '/test/otherdata')
+        self.assertEqual(meta.containers['test1'].mounts['data'].locations[1], '/test/otherdata')
 
         with self.assertRaises(RuntimeError):
-            meta.containers["test1"].mounts["data"].location
+            meta.containers['test1'].mounts['data'].location
 
     def test_secret_events(self):
         class MyCharm(ops.CharmBase):

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -43,19 +43,19 @@ class TestFramework(BaseTestCase):
 
     def test_deprecated_init(self):
         # For 0.7, this still works, but it is deprecated.
-        with self.assertLogs(level="WARNING") as cm:
+        with self.assertLogs(level='WARNING') as cm:
             framework = ops.Framework(':memory:', None, None, None)  # type: ignore
         self.assertIn(
-            "WARNING:ops.framework:deprecated: Framework now takes a Storage not a path",
+            'WARNING:ops.framework:deprecated: Framework now takes a Storage not a path',
             cm.output)
         self.assertIsInstance(framework._storage, SQLiteStorage)
 
     def test_handle_path(self):
         cases = [
-            (ops.Handle(None, "root", None), "root"),
-            (ops.Handle(None, "root", "1"), "root[1]"),
-            (ops.Handle(ops.Handle(None, "root", None), "child", None), "root/child"),
-            (ops.Handle(ops.Handle(None, "root", "1"), "child", "2"), "root[1]/child[2]"),
+            (ops.Handle(None, 'root', None), 'root'),
+            (ops.Handle(None, 'root', '1'), 'root[1]'),
+            (ops.Handle(ops.Handle(None, 'root', None), 'child', None), 'root/child'),
+            (ops.Handle(ops.Handle(None, 'root', '1'), 'child', '2'), 'root[1]/child[2]'),
         ]
         for handle, path in cases:
             self.assertEqual(str(handle), path)
@@ -78,7 +78,7 @@ class TestFramework(BaseTestCase):
         class Foo(ops.Object):
             pass
 
-        handle = ops.Handle(None, "a_foo", "some_key")
+        handle = ops.Handle(None, 'a_foo', 'some_key')
 
         framework.register_type(Foo, None, handle.kind)  # type: ignore
 
@@ -86,9 +86,9 @@ class TestFramework(BaseTestCase):
             framework.load_snapshot(handle)
         except NoSnapshotError as e:
             self.assertEqual(e.handle_path, str(handle))
-            self.assertEqual(str(e), "no snapshot data found for a_foo[some_key] object")
+            self.assertEqual(str(e), 'no snapshot data found for a_foo[some_key] object')
         else:
-            self.fail("exception NoSnapshotError not raised")
+            self.fail('exception NoSnapshotError not raised')
 
     def test_snapshot_roundtrip(self):
         class Foo:
@@ -99,12 +99,12 @@ class TestFramework(BaseTestCase):
                 self.my_n = n
 
             def snapshot(self) -> typing.Dict[str, int]:
-                return {"My N!": self.my_n}
+                return {'My N!': self.my_n}
 
             def restore(self, snapshot: typing.Dict[str, int]):
-                self.my_n = snapshot["My N!"] + 1
+                self.my_n = snapshot['My N!'] + 1
 
-        handle = ops.Handle(None, "a_foo", "some_key")
+        handle = ops.Handle(None, 'a_foo', 'some_key')
         event = Foo(handle, 1)
 
         framework1 = self.create_framework(tmpdir=self.tmpdir)
@@ -160,22 +160,22 @@ class TestFramework(BaseTestCase):
                 self.seen.append(f"on_foo:{event.handle.kind}")
                 self.reprs.append(repr(event))
 
-        pub = MyNotifier(framework, "1")
-        obs = MyObserver(framework, "1")
+        pub = MyNotifier(framework, '1')
+        obs = MyObserver(framework, '1')
 
         framework.observe(pub.foo, obs.on_any)
         framework.observe(pub.bar, obs.on_any)
 
-        with self.assertRaisesRegex(RuntimeError, "^Framework.observe requires a method"):
+        with self.assertRaisesRegex(RuntimeError, '^Framework.observe requires a method'):
             framework.observe(pub.baz, obs)  # type: ignore
 
         pub.foo.emit()
         pub.bar.emit()
 
-        self.assertEqual(obs.seen, ["on_any:foo", "on_any:bar"])
+        self.assertEqual(obs.seen, ['on_any:foo', 'on_any:bar'])
         self.assertEqual(obs.reprs, [
-            "<MyEvent via MyNotifier[1]/foo[1]>",
-            "<MyEvent via MyNotifier[1]/bar[2]>",
+            '<MyEvent via MyNotifier[1]/foo[1]>',
+            '<MyEvent via MyNotifier[1]/bar[2]>',
         ])
 
     def test_bad_sig_observer(self):
@@ -207,14 +207,14 @@ class TestFramework(BaseTestCase):
                 assert False, 'should not be reached'
 
         framework = self.create_framework()
-        pub = MyNotifier(framework, "pub")
-        obs = MyObserver(framework, "obs")
+        pub = MyNotifier(framework, 'pub')
+        obs = MyObserver(framework, 'obs')
 
-        with self.assertRaisesRegex(TypeError, "must accept event parameter"):
+        with self.assertRaisesRegex(TypeError, 'must accept event parameter'):
             framework.observe(pub.foo, obs._on_foo)  # type: ignore
-        with self.assertRaisesRegex(TypeError, "has extra required parameter"):
+        with self.assertRaisesRegex(TypeError, 'has extra required parameter'):
             framework.observe(pub.bar, obs._on_bar)  # type: ignore
-        with self.assertRaisesRegex(TypeError, "has extra required parameter"):
+        with self.assertRaisesRegex(TypeError, 'has extra required parameter'):
             framework.observe(pub.baz, obs._on_baz)  # type: ignore
         framework.observe(pub.qux, obs._on_qux)
 
@@ -287,10 +287,10 @@ class TestFramework(BaseTestCase):
                 if not self.done.get(event.handle.kind):
                     event.defer()
 
-        pub1 = MyNotifier1(framework, "1")
-        pub2 = MyNotifier2(framework, "1")
-        obs1 = MyObserver(framework, "1")
-        obs2 = MyObserver(framework, "2")
+        pub1 = MyNotifier1(framework, '1')
+        pub2 = MyNotifier2(framework, '1')
+        obs1 = MyObserver(framework, '1')
+        obs2 = MyObserver(framework, '2')
 
         framework.observe(pub1.a, obs1.on_any)
         framework.observe(pub1.b, obs1.on_any)
@@ -303,30 +303,30 @@ class TestFramework(BaseTestCase):
         pub2.c.emit()
 
         # Events remain stored because they were deferred.
-        ev_a_handle = ops.Handle(pub1, "a", "1")
+        ev_a_handle = ops.Handle(pub1, 'a', '1')
         framework.load_snapshot(ev_a_handle)
-        ev_b_handle = ops.Handle(pub1, "b", "2")
+        ev_b_handle = ops.Handle(pub1, 'b', '2')
         framework.load_snapshot(ev_b_handle)
-        ev_c_handle = ops.Handle(pub2, "c", "3")
+        ev_c_handle = ops.Handle(pub2, 'c', '3')
         framework.load_snapshot(ev_c_handle)
         # make sure the objects are gone before we reemit them
         gc.collect()
 
         framework.reemit()
-        obs1.done["a"] = True
-        obs2.done["b"] = True
+        obs1.done['a'] = True
+        obs2.done['b'] = True
         framework.reemit()
         framework.reemit()
-        obs1.done["b"] = True
-        obs2.done["a"] = True
+        obs1.done['b'] = True
+        obs2.done['a'] = True
         framework.reemit()
-        obs2.done["c"] = True
+        obs2.done['c'] = True
         framework.reemit()
         framework.reemit()
         framework.reemit()
 
-        self.assertEqual(" ".join(obs1.seen), "a b a b a b b b")
-        self.assertEqual(" ".join(obs2.seen), "a b c a b c a b c a c a c c")
+        self.assertEqual(' '.join(obs1.seen), 'a b a b a b b b')
+        self.assertEqual(' '.join(obs2.seen), 'a b c a b c a b c a c a c c')
 
         # Now the event objects must all be gone from storage.
         self.assertRaises(NoSnapshotError, framework.load_snapshot, ev_a_handle)
@@ -342,11 +342,11 @@ class TestFramework(BaseTestCase):
                 self.my_n = n
 
             def snapshot(self):
-                return {"My N!": self.my_n}
+                return {'My N!': self.my_n}
 
             def restore(self, snapshot: typing.Dict[str, typing.Any]):
                 super().restore(snapshot)
-                self.my_n = snapshot["My N!"] + 1
+                self.my_n = snapshot['My N!'] + 1
 
         class MyNotifier(ops.Object):
             foo = ops.EventSource(MyEvent)
@@ -360,8 +360,8 @@ class TestFramework(BaseTestCase):
                 self.seen.append(f"on_foo:{event.handle.kind}={event.my_n}")
                 event.defer()
 
-        pub = MyNotifier(framework, "1")
-        obs = MyObserver(framework, "1")
+        pub = MyNotifier(framework, '1')
+        obs = MyObserver(framework, '1')
 
         framework.observe(pub.foo, obs._on_foo)
         pub.foo.emit(1)
@@ -377,7 +377,7 @@ class TestFramework(BaseTestCase):
         #    from the one modified during the first restore (otherwise
         #    we'd get a foo=3).
         #
-        self.assertEqual(obs.seen, ["on_foo:foo=2", "on_foo:foo=2"])
+        self.assertEqual(obs.seen, ['on_foo:foo=2', 'on_foo:foo=2'])
 
     def test_weak_observer(self):
         framework = self.create_framework()
@@ -395,20 +395,20 @@ class TestFramework(BaseTestCase):
 
         class MyObserver(ops.Object):
             def _on_foo(self, event: ops.EventBase):
-                observed_events.append("foo")
+                observed_events.append('foo')
 
-        pub = MyNotifier(framework, "1")
-        obs = MyObserver(framework, "2")
+        pub = MyNotifier(framework, '1')
+        obs = MyObserver(framework, '2')
 
         framework.observe(pub.on.foo, obs._on_foo)
         pub.on.foo.emit()
-        self.assertEqual(observed_events, ["foo"])
+        self.assertEqual(observed_events, ['foo'])
         # Now delete the observer, and note that when we emit the event, it
         # doesn't update the local slice again
         del obs
         gc.collect()
         pub.on.foo.emit()
-        self.assertEqual(observed_events, ["foo"])
+        self.assertEqual(observed_events, ['foo'])
 
     def test_forget_and_multiple_objects(self):
         framework = self.create_framework()
@@ -420,23 +420,23 @@ class TestFramework(BaseTestCase):
             def restore(self, snapshot: typing.Dict[str, typing.Any]) -> None:
                 raise NotImplementedError()
 
-        o1 = MyObject(framework, "path")
+        o1 = MyObject(framework, 'path')
         # Creating a second object at the same path should fail with RuntimeError
         with self.assertRaises(RuntimeError):
-            o2 = MyObject(framework, "path")
+            o2 = MyObject(framework, 'path')
         # Unless we _forget the object first
         framework._forget(o1)
-        o2 = MyObject(framework, "path")
+        o2 = MyObject(framework, 'path')
         self.assertEqual(o1.handle.path, o2.handle.path)
         # Deleting the tracked object should also work
         del o2
         gc.collect()
-        o3 = MyObject(framework, "path")
+        o3 = MyObject(framework, 'path')
         self.assertEqual(o1.handle.path, o3.handle.path)
         framework.close()
         # Or using a second framework
         framework_copy = self.create_framework()
-        o_copy = MyObject(framework_copy, "path")
+        o_copy = MyObject(framework_copy, 'path')
         self.assertEqual(o1.handle.path, o_copy.handle.path)
 
     def test_forget_and_multiple_objects_with_load_snapshot(self):
@@ -448,13 +448,13 @@ class TestFramework(BaseTestCase):
                 self.value = name
 
             def snapshot(self):
-                return {"value": self.value}
+                return {'value': self.value}
 
             def restore(self, snapshot: typing.Dict[str, typing.Any]):
-                self.value = snapshot["value"]
+                self.value = snapshot['value']
 
         framework.register_type(MyObject, None, MyObject.handle_kind)
-        o1 = MyObject(framework, "path")
+        o1 = MyObject(framework, 'path')
         framework.save_snapshot(o1)  # type: ignore
         framework.commit()
         o_handle = o1.handle
@@ -472,18 +472,18 @@ class TestFramework(BaseTestCase):
         self.assertEqual(o2.value, o3.value)
         # A loaded object also prevents direct creation of an object
         with self.assertRaises(RuntimeError):
-            MyObject(framework, "path")
+            MyObject(framework, 'path')
         framework.close()
         # But we can create an object, or load a snapshot in a copy of the framework
         framework_copy1 = self.create_framework(tmpdir=self.tmpdir)
-        o_copy1 = MyObject(framework_copy1, "path")
-        self.assertEqual(o_copy1.value, "path")
+        o_copy1 = MyObject(framework_copy1, 'path')
+        self.assertEqual(o_copy1.value, 'path')
         framework_copy1.close()
         framework_copy2 = self.create_framework(tmpdir=self.tmpdir)
         framework_copy2.register_type(MyObject, None, MyObject.handle_kind)
         o_copy2 = framework_copy2.load_snapshot(o_handle)
         o_copy2 = typing.cast(MyObject, o_copy2)
-        self.assertEqual(o_copy2.value, "path")
+        self.assertEqual(o_copy2.value, 'path')
 
     def test_events_base(self):
         framework = self.create_framework()
@@ -510,8 +510,8 @@ class TestFramework(BaseTestCase):
             def _on_bar(self, event: ops.EventBase):
                 self.seen.append(f"on_bar:{event.handle.kind}")
 
-        pub = MyNotifier(framework, "1")
-        obs = MyObserver(framework, "1")
+        pub = MyNotifier(framework, '1')
+        obs = MyObserver(framework, '1')
 
         # Confirm that temporary persistence of BoundEvents doesn't cause errors,
         # and that events can be observed.
@@ -521,7 +521,7 @@ class TestFramework(BaseTestCase):
         # Confirm that events can be emitted and seen.
         pub.on.foo.emit()
 
-        self.assertEqual(obs.seen, ["on_foo:foo"])
+        self.assertEqual(obs.seen, ['on_foo:foo'])
         fqn = f"{pub.on.__class__.__module__}.{pub.on.__class__.__qualname__}"
         self.assertEqual(repr(pub.on), f"<{fqn}: bar, foo>")
 
@@ -539,25 +539,25 @@ class TestFramework(BaseTestCase):
                 foo = event
         # Python 3.12+ raises the original exception with a note, but earlier
         # Python chains the exceptions.
-        if hasattr(cm.exception, "__notes__"):
+        if hasattr(cm.exception, '__notes__'):
             cause = str(cm.exception)
         else:
             cause = str(cm.exception.__cause__)
         self.assertEqual(
             cause,
-            "EventSource(MyEvent) reused as MyEvents.foo and OtherEvents.foo")
+            'EventSource(MyEvent) reused as MyEvents.foo and OtherEvents.foo')
 
         with self.assertRaises(RuntimeError) as cm:
             class MyNotifier(ops.Object):  # type: ignore
                 on = MyEvents()  # type: ignore
                 bar = event
-        if hasattr(cm.exception, "__notes__"):
+        if hasattr(cm.exception, '__notes__'):
             cause = str(cm.exception)
         else:
             cause = str(cm.exception.__cause__)
         self.assertEqual(
             cause,
-            "EventSource(MyEvent) reused as MyEvents.foo and MyNotifier.bar")
+            'EventSource(MyEvent) reused as MyEvents.foo and MyNotifier.bar')
 
     def test_reemit_ignores_unknown_event_type(self):
         # The event type may have been gone for good, and nobody cares,
@@ -566,7 +566,7 @@ class TestFramework(BaseTestCase):
         framework = self.create_framework()
 
         class MyEvent(ops.EventBase):
-            handle_kind = "test"
+            handle_kind = 'test'
 
         class MyNotifier(ops.Object):
             foo = ops.EventSource(MyEvent)
@@ -580,14 +580,14 @@ class TestFramework(BaseTestCase):
                 self.seen.append(event.handle)
                 event.defer()
 
-        pub = MyNotifier(framework, "1")
-        obs = MyObserver(framework, "1")
+        pub = MyNotifier(framework, '1')
+        obs = MyObserver(framework, '1')
 
         framework.observe(pub.foo, obs._on_foo)
         pub.foo.emit()
 
         event_handle = obs.seen[0]
-        self.assertEqual(event_handle.kind, "foo")
+        self.assertEqual(event_handle.kind, 'foo')
 
         framework.commit()
         framework.close()
@@ -630,8 +630,8 @@ class TestFramework(BaseTestCase):
                 self.seen.append(f"on_bar:{type(event).__name__}:{event.handle.kind}")
                 event.defer()
 
-        pub = MyNotifier(framework, "1")
-        obs = MyObserver(framework, "1")
+        pub = MyNotifier(framework, '1')
+        obs = MyObserver(framework, '1')
 
         pub.on.foo.emit()
         pub.bar.emit()
@@ -642,7 +642,7 @@ class TestFramework(BaseTestCase):
         pub.on.foo.emit()
         pub.bar.emit()
 
-        self.assertEqual(obs.seen, ["on_foo:MyFoo:foo", "on_bar:MyBar:bar"])
+        self.assertEqual(obs.seen, ['on_foo:MyFoo:foo', 'on_bar:MyBar:bar'])
 
     def test_dynamic_event_types(self):
         framework = self.create_framework()
@@ -670,8 +670,8 @@ class TestFramework(BaseTestCase):
                 self.seen.append(f"on_bar:{type(event).__name__}:{event.handle.kind}")
                 event.defer()
 
-        pub = MyNotifier(framework, "1")
-        obs = MyObserver(framework, "1")
+        pub = MyNotifier(framework, '1')
+        obs = MyObserver(framework, '1')
 
         class MyFoo(ops.EventBase):
             pass
@@ -685,8 +685,8 @@ class TestFramework(BaseTestCase):
         class NoneEvent(ops.EventBase):
             pass
 
-        pub.on_a.define_event("foo", MyFoo)
-        pub.on_b.define_event("bar", MyBar)
+        pub.on_a.define_event('foo', MyFoo)
+        pub.on_b.define_event('bar', MyBar)
 
         framework.observe(pub.on_a.foo, obs._on_foo)
         framework.observe(pub.on_b.bar, obs._on_bar)
@@ -694,7 +694,7 @@ class TestFramework(BaseTestCase):
         pub.on_a.foo.emit()
         pub.on_b.bar.emit()
 
-        self.assertEqual(obs.seen, ["on_foo:MyFoo:foo", "on_bar:MyBar:bar"])
+        self.assertEqual(obs.seen, ['on_foo:MyFoo:foo', 'on_bar:MyBar:bar'])
 
         # Definitions remained local to the specific type.
         self.assertRaises(AttributeError, lambda: pub.on_a.bar)
@@ -702,15 +702,15 @@ class TestFramework(BaseTestCase):
 
         # Try to use an event name which is not a valid python identifier.
         with self.assertRaises(RuntimeError):
-            pub.on_a.define_event("dead-beef", DeadBeefEvent)
+            pub.on_a.define_event('dead-beef', DeadBeefEvent)
 
         # Try to use a python keyword for an event name.
         with self.assertRaises(RuntimeError):
-            pub.on_a.define_event("None", NoneEvent)
+            pub.on_a.define_event('None', NoneEvent)
 
         # Try to override an existing attribute.
         with self.assertRaises(RuntimeError):
-            pub.on_a.define_event("foo", MyFoo)
+            pub.on_a.define_event('foo', MyFoo)
 
     def test_event_key_roundtrip(self):
         class MyEvent(ops.EventBase):
@@ -742,8 +742,8 @@ class TestFramework(BaseTestCase):
                     MyObserver.has_deferred = True
 
         framework1 = self.create_framework(tmpdir=self.tmpdir)
-        pub1 = MyNotifier(framework1, "pub")
-        obs1 = MyObserver(framework1, "obs")
+        pub1 = MyNotifier(framework1, 'pub')
+        obs1 = MyObserver(framework1, 'obs')
         framework1.observe(pub1.foo, obs1._on_foo)
         pub1.foo.emit('first')
         self.assertEqual(obs1.seen, [('1', 'first')])
@@ -753,8 +753,8 @@ class TestFramework(BaseTestCase):
         del framework1
 
         framework2 = self.create_framework(tmpdir=self.tmpdir)
-        pub2 = MyNotifier(framework2, "pub")
-        obs2 = MyObserver(framework2, "obs")
+        pub2 = MyNotifier(framework2, 'pub')
+        obs2 = MyObserver(framework2, 'obs')
         framework2.observe(pub2.foo, obs2._on_foo)
         pub2.foo.emit('second')
         framework2.reemit()
@@ -782,15 +782,15 @@ class TestFramework(BaseTestCase):
 
     def test_snapshot_saving_restricted_to_simple_types(self):
         # this can not be saved, as it has not simple types!
-        to_be_saved = {"bar": TestFramework}
+        to_be_saved = {'bar': TestFramework}
 
         class FooEvent(ops.EventBase):
-            handle_kind = "test"
+            handle_kind = 'test'
 
             def snapshot(self):
                 return to_be_saved
 
-        handle = ops.Handle(None, "a_foo", "some_key")
+        handle = ops.Handle(None, 'a_foo', 'some_key')
         event = FooEvent(handle)
 
         framework = self.create_framework()
@@ -798,7 +798,7 @@ class TestFramework(BaseTestCase):
         with self.assertRaises(ValueError) as cm:
             framework.save_snapshot(event)
         expected = (
-            "unable to save the data for FooEvent, it must contain only simple types: "
+            'unable to save the data for FooEvent, it must contain only simple types: '
             "{'bar': <class 'test.test_framework.TestFramework'>}")
         self.assertEqual(str(cm.exception), expected)
 
@@ -816,7 +816,7 @@ class TestFramework(BaseTestCase):
         framework = self.create_framework()
         e = Emitter(framework, 'key')
         e.on.foo.emit()
-        ev_1_handle = ops.Handle(e.on, "foo", "1")
+        ev_1_handle = ops.Handle(e.on, 'foo', '1')
         with self.assertRaises(NoSnapshotError):
             framework.load_snapshot(ev_1_handle)
         # Committing will save the framework's state, but no other snapshots should be saved
@@ -895,13 +895,13 @@ class TestStoredState(BaseTestCase):
 
     def test_stored_dict_repr(self):
         self.assertEqual(repr(ops.StoredDict(None, {})),  # type: ignore
-                         "ops.framework.StoredDict()")
-        self.assertEqual(repr(ops.StoredDict(None, {"a": 1})),  # type: ignore
+                         'ops.framework.StoredDict()')
+        self.assertEqual(repr(ops.StoredDict(None, {'a': 1})),  # type: ignore
                          "ops.framework.StoredDict({'a': 1})")
 
     def test_stored_list_repr(self):
         self.assertEqual(repr(ops.StoredList(None, [])),  # type: ignore
-                         "ops.framework.StoredList()")
+                         'ops.framework.StoredList()')
         self.assertEqual(repr(ops.StoredList(None, [1, 2, 3])),  # type: ignore
                          'ops.framework.StoredList([1, 2, 3])')
 
@@ -972,7 +972,7 @@ class TestStoredState(BaseTestCase):
             _stored: ops.StoredState
 
         framework = self.create_framework(tmpdir=self.tmpdir)
-        obj = cls(framework, "1")
+        obj = cls(framework, '1')
         assert isinstance(obj, _StoredProtocol)
 
         try:
@@ -980,18 +980,18 @@ class TestStoredState(BaseTestCase):
         except AttributeError as e:
             self.assertEqual(str(e), "attribute 'foo' is not stored")
         else:
-            self.fail("AttributeError not raised")
+            self.fail('AttributeError not raised')
 
         try:
-            obj._stored.on = "nonono"  # type: ignore
+            obj._stored.on = 'nonono'  # type: ignore
         except AttributeError as e:
             self.assertEqual(str(e), "attribute 'on' is reserved and cannot be set")
         else:
-            self.fail("AttributeError not raised")
+            self.fail('AttributeError not raised')
 
         obj._stored.foo = 41
         obj._stored.foo = 42
-        obj._stored.bar = "s"
+        obj._stored.bar = 's'
         obj._stored.baz = 4.2
         obj._stored.bing = True
 
@@ -1006,10 +1006,10 @@ class TestStoredState(BaseTestCase):
 
         # Since this has the same absolute object handle, it will get its state back.
         framework_copy = self.create_framework(tmpdir=self.tmpdir)
-        obj_copy = cls(framework_copy, "1")
+        obj_copy = cls(framework_copy, '1')
         assert isinstance(obj_copy, _StoredProtocol)
         self.assertEqual(obj_copy._stored.foo, 42)
-        self.assertEqual(obj_copy._stored.bar, "s")
+        self.assertEqual(obj_copy._stored.bar, 's')
         self.assertEqual(obj_copy._stored.baz, 4.2)
         self.assertEqual(obj_copy._stored.bing, True)
 
@@ -1031,7 +1031,7 @@ class TestStoredState(BaseTestCase):
         z = Base(framework, None)
 
         a._stored.foo = 42
-        b._stored.foo = "hello"
+        b._stored.foo = 'hello'
         z._stored.foo = {1}
 
         framework.commit()
@@ -1043,7 +1043,7 @@ class TestStoredState(BaseTestCase):
         z2 = Base(framework2, None)
 
         self.assertEqual(a2._stored.foo, 42)
-        self.assertEqual(b2._stored.foo, "hello")
+        self.assertEqual(b2._stored.foo, 'hello')
         self.assertEqual(z2._stored.foo, {1})
 
     def test_two_names_one_state(self):
@@ -1063,8 +1063,8 @@ class TestStoredState(BaseTestCase):
         framework.close()
 
         # make sure we're not changing the object on failure
-        self.assertNotIn("_stored", obj.__dict__)
-        self.assertNotIn("_stored2", obj.__dict__)
+        self.assertNotIn('_stored', obj.__dict__)
+        self.assertNotIn('_stored2', obj.__dict__)
 
     def test_same_name_two_classes(self):
         class Base(ops.Object):
@@ -1085,12 +1085,12 @@ class TestStoredState(BaseTestCase):
         a._stored.foo = 42
 
         with self.assertRaises(RuntimeError):
-            b._stored.foo = "xyzzy"
+            b._stored.foo = 'xyzzy'
 
         framework.close()
 
         # make sure we're not changing the object on failure
-        self.assertNotIn("_stored", b.__dict__)
+        self.assertNotIn('_stored', b.__dict__)
 
     def test_mutable_types_invalid(self):
         framework = self.create_framework()
@@ -1294,8 +1294,8 @@ class TestStoredState(BaseTestCase):
 
         # Validate correctness of modification operations.
         for get_a, b, expected_res, op, validate_op in test_operations:
-            storage = SQLiteStorage(self.tmpdir / "framework.data")
-            framework = WrappedFramework(storage, self.tmpdir, None, None, "foo")  # type: ignore
+            storage = SQLiteStorage(self.tmpdir / 'framework.data')
+            framework = WrappedFramework(storage, self.tmpdir, None, None, 'foo')  # type: ignore
             obj = SomeObject(framework, '1')
 
             obj._stored.a = get_a()
@@ -1320,9 +1320,9 @@ class TestStoredState(BaseTestCase):
             framework.commit()
             framework.close()
 
-            storage_copy = SQLiteStorage(self.tmpdir / "framework.data")
+            storage_copy = SQLiteStorage(self.tmpdir / 'framework.data')
             framework_copy = WrappedFramework(
-                storage_copy, self.tmpdir, None, None, "foo")  # type: ignore
+                storage_copy, self.tmpdir, None, None, 'foo')  # type: ignore
 
             obj_copy2 = SomeObject(framework_copy, '1')
 
@@ -1344,14 +1344,14 @@ class TestStoredState(BaseTestCase):
             bool,                                             # Result of op(B, A).
         ]
         test_operations: typing.List[test_case] = [(
-            {"1"},
-            {"1", "2"},
+            {'1'},
+            {'1', '2'},
             lambda a, b: a < b,
             True,
             False,
         ), (
-            {"1"},
-            {"1", "2"},
+            {'1'},
+            {'1', '2'},
             lambda a, b: a > b,
             False,
             True
@@ -1363,8 +1363,8 @@ class TestStoredState(BaseTestCase):
             True,
             True
         ), (
-            {"a", "c"},
-            {"c", "a"},
+            {'a', 'c'},
+            {'c', 'a'},
             lambda a, b: a == b,
             True,
             True
@@ -1375,14 +1375,14 @@ class TestStoredState(BaseTestCase):
             True,
             True
         ), (
-            {"1": "2"},
-            {"1": "2"},
+            {'1': '2'},
+            {'1': '2'},
             lambda a, b: a == b,
             True,
             True
         ), (
-            {"1": "2"},
-            {"1": "3"},
+            {'1': '2'},
+            {'1': '3'},
             lambda a, b: a == b,
             False,
             False
@@ -1444,29 +1444,29 @@ class TestStoredState(BaseTestCase):
             typing.Set[str],  # The expected result of operation(other_set, obj._stored.set).
         ]
         test_operations: typing.List[test_case] = [(
-            {"1"},
+            {'1'},
             lambda a, b: a | b,
-            {"1", "a", "b"},
-            {"1", "a", "b"}
+            {'1', 'a', 'b'},
+            {'1', 'a', 'b'}
         ), (
-            {"a", "c"},
+            {'a', 'c'},
             lambda a, b: a - b,
-            {"b"},
-            {"c"}
+            {'b'},
+            {'c'}
         ), (
-            {"a", "c"},
+            {'a', 'c'},
             lambda a, b: a & b,
-            {"a"},
-            {"a"}
+            {'a'},
+            {'a'}
         ), (
-            {"a", "c", "d"},
+            {'a', 'c', 'd'},
             lambda a, b: a ^ b,
-            {"b", "c", "d"},
-            {"b", "c", "d"}
+            {'b', 'c', 'd'},
+            {'b', 'c', 'd'}
         ), (
             set(),
             lambda a, b: set(a),
-            {"a", "b"},
+            {'a', 'b'},
             set()
         )]
 
@@ -1481,7 +1481,7 @@ class TestStoredState(BaseTestCase):
         # original sets are not changed or used as a result.
         for i, (variable_operand, operation, ab_res, ba_res) in enumerate(test_operations):
             obj = SomeObject(framework, str(i))
-            obj._stored.set = {"a", "b"}
+            obj._stored.set = {'a', 'b'}
             assert isinstance(obj._stored.set, ops.StoredSet)
 
             for a, b, expected in [
@@ -1550,14 +1550,14 @@ class BreakpointTests(BaseTestCase):
             # We want to verify that there are *no* logs at warning level.
             # However, assertNoLogs is Python 3.10+.
             try:
-                with self.assertLogs(level="WARNING"):
+                with self.assertLogs(level='WARNING'):
                     framework.breakpoint()
             except AssertionError:
                 pass
             else:
-                self.fail("No warning logs should be generated")
+                self.fail('No warning logs should be generated')
         self.assertEqual(mock.call_count, 0)
-        self.assertEqual(fake_stderr.getvalue(), "")
+        self.assertEqual(fake_stderr.getvalue(), '')
 
     def test_pdb_properly_called(self, fake_stderr: io.StringIO):
         # The debugger needs to leave the user in the frame where the breakpoint is executed,
@@ -1718,16 +1718,16 @@ class BreakpointTests(BaseTestCase):
 
     def test_named_indicated_unnamed(self, fake_stderr: io.StringIO):
         # Some breakpoint was indicated, but the framework call was unnamed
-        with self.assertLogs(level="WARNING") as cm:
+        with self.assertLogs(level='WARNING') as cm:
             self.check_trace_set('some-breakpoint', None, 0)
         self.assertEqual(cm.output, [
-            "WARNING:ops.framework:Breakpoint None skipped "
+            'WARNING:ops.framework:Breakpoint None skipped '
             "(not found in the requested breakpoints: {'some-breakpoint'})"
         ])
 
     def test_named_indicated_somethingelse(self, fake_stderr: io.StringIO):
         # Some breakpoint was indicated, but the framework call was with a different name
-        with self.assertLogs(level="WARNING") as cm:
+        with self.assertLogs(level='WARNING') as cm:
             self.check_trace_set('some-breakpoint', 'other-name', 0)
         self.assertEqual(cm.output, [
             "WARNING:ops.framework:Breakpoint 'other-name' skipped "
@@ -1773,8 +1773,8 @@ class DebugHookTests(BaseTestCase):
         framework = self.create_framework()
         framework._juju_debug_at = {'hook'}
 
-        publisher = ops.CharmEvents(framework, "1")
-        observer = GenericObserver(framework, "1")
+        publisher = ops.CharmEvents(framework, '1')
+        observer = GenericObserver(framework, '1')
         framework.observe(publisher.install, observer.callback_method)
 
         with patch('sys.stderr', new_callable=io.StringIO) as fake_stderr:
@@ -1802,10 +1802,10 @@ class DebugHookTests(BaseTestCase):
         class CustomEvents(ops.ObjectEvents):
             foobar_action = ops.EventSource(ops.ActionEvent)
 
-        publisher = CustomEvents(framework, "1")
-        observer = GenericObserver(framework, "1")
+        publisher = CustomEvents(framework, '1')
+        observer = GenericObserver(framework, '1')
         framework.observe(publisher.foobar_action, observer.callback_method)
-        fake_script(self, 'action-get', "echo {}")
+        fake_script(self, 'action-get', 'echo {}')
 
         with patch('sys.stderr', new_callable=io.StringIO):
             with patch('pdb.runcall') as mock:
@@ -1822,10 +1822,10 @@ class DebugHookTests(BaseTestCase):
         class CustomEvents(ops.ObjectEvents):
             foobar_action = ops.EventSource(ops.ActionEvent)
 
-        publisher = CustomEvents(framework, "1")
-        observer = GenericObserver(framework, "1")
+        publisher = CustomEvents(framework, '1')
+        observer = GenericObserver(framework, '1')
         framework.observe(publisher.foobar_action, observer.callback_method)
-        fake_script(self, 'action-get', "echo {}")
+        fake_script(self, 'action-get', 'echo {}')
 
         with patch('sys.stderr', new_callable=io.StringIO):
             with patch('pdb.runcall') as mock:
@@ -1842,8 +1842,8 @@ class DebugHookTests(BaseTestCase):
         framework = self.create_framework()
         framework._juju_debug_at = {'hook'}
 
-        publisher = MyNotifier(framework, "1")
-        observer = GenericObserver(framework, "1")
+        publisher = MyNotifier(framework, '1')
+        observer = GenericObserver(framework, '1')
         framework.observe(publisher.bar, observer.callback_method)
 
         with patch('pdb.runcall') as mock:
@@ -1856,8 +1856,8 @@ class DebugHookTests(BaseTestCase):
         framework = self.create_framework()
         framework._juju_debug_at = {'foo', 'hook', 'all', 'whatever'}
 
-        publisher = ops.CharmEvents(framework, "1")
-        observer = GenericObserver(framework, "1")
+        publisher = ops.CharmEvents(framework, '1')
+        observer = GenericObserver(framework, '1')
         framework.observe(publisher.install, observer.callback_method)
 
         with patch('sys.stderr', new_callable=io.StringIO):
@@ -1871,8 +1871,8 @@ class DebugHookTests(BaseTestCase):
         framework = self.create_framework()
         framework._juju_debug_at = {'hook'}
 
-        publisher = ops.CharmEvents(framework, "1")
-        observer = GenericObserver(framework, "1")
+        publisher = ops.CharmEvents(framework, '1')
+        observer = GenericObserver(framework, '1')
 
         with patch('pdb.runcall') as mock:
             publisher.install.emit()
@@ -1884,8 +1884,8 @@ class DebugHookTests(BaseTestCase):
         framework = self.create_framework()
         framework._juju_debug_at = {'something-else'}
 
-        publisher = ops.CharmEvents(framework, "1")
-        observer = GenericObserver(framework, "1")
+        publisher = ops.CharmEvents(framework, '1')
+        observer = GenericObserver(framework, '1')
         framework.observe(publisher.install, observer.callback_method)
 
         with patch.dict(os.environ, {'JUJU_DEBUG_AT': 'something-else'}):
@@ -1899,8 +1899,8 @@ class DebugHookTests(BaseTestCase):
         framework = self.create_framework()
         framework._juju_debug_at = set()
 
-        publisher = ops.CharmEvents(framework, "1")
-        observer = GenericObserver(framework, "1")
+        publisher = ops.CharmEvents(framework, '1')
+        observer = GenericObserver(framework, '1')
         framework.observe(publisher.install, observer.callback_method)
 
         with patch('pdb.runcall') as mock:
@@ -1913,8 +1913,8 @@ class DebugHookTests(BaseTestCase):
         framework = self.create_framework()
         framework._juju_debug_at = {'hook'}
 
-        publisher = ops.CharmEvents(framework, "1")
-        observer = GenericObserver(framework, "1")
+        publisher = ops.CharmEvents(framework, '1')
+        observer = GenericObserver(framework, '1')
         framework.observe(publisher.install, observer.callback_method)
 
         with patch('sys.stderr', new_callable=io.StringIO) as fake_stderr:

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -28,8 +28,8 @@ from ops.storage import SQLiteStorage
 def fake_script(test_case: unittest.TestCase, name: str, content: str):
     if not hasattr(test_case, 'fake_script_path'):
         fake_script_path = tempfile.mkdtemp('-fake_script')
-        old_path = os.environ["PATH"]
-        os.environ['PATH'] = os.pathsep.join([fake_script_path, os.environ["PATH"]])
+        old_path = os.environ['PATH']
+        os.environ['PATH'] = os.pathsep.join([fake_script_path, os.environ['PATH']])
 
         def cleanup():
             shutil.rmtree(fake_script_path)
@@ -49,13 +49,13 @@ def fake_script(test_case: unittest.TestCase, name: str, content: str):
         # Before executing the provided script, dump the provided arguments in calls.txt.
         # ASCII 1E is RS 'record separator', and 1C is FS 'file separator', which seem appropriate.
         f.write(  # type: ignore
-            '''#!/bin/sh
+            """#!/bin/sh
 {{ printf {name}; printf "\\036%s" "$@"; printf "\\034"; }} >> {path}/calls.txt
-{content}'''.format_map(template_args))
+{content}""".format_map(template_args))
     os.chmod(str(path), 0o755)  # type: ignore
     # TODO: this hardcodes the path to bash.exe, which works for now but might
     #       need to be set via environ or something like that.
-    path.with_suffix(".bat").write_text(  # type: ignore
+    path.with_suffix('.bat').write_text(  # type: ignore
         f'@"C:\\Program Files\\git\\bin\\bash.exe" {path} %*\n')
 
 
@@ -119,10 +119,10 @@ class BaseTestCase(unittest.TestCase):
         same dir (e.g. for storing state).
         """
         if tmpdir is None:
-            data_fpath = ":memory:"
+            data_fpath = ':memory:'
             charm_dir = 'non-existant'
         else:
-            data_fpath = tmpdir / "framework.data"
+            data_fpath = tmpdir / 'framework.data'
             charm_dir = tmpdir
 
         framework = ops.Framework(

--- a/test/test_infra.py
+++ b/test/test_infra.py
@@ -34,7 +34,7 @@ def get_python_filepaths(include_tests: bool = True):
     for root in roots:
         for dirpath, _, filenames in os.walk(root):
             for filename in filenames:
-                if filename.endswith(".py"):
+                if filename.endswith('.py'):
                     python_paths.append(os.path.join(dirpath, filename))
     return python_paths
 
@@ -45,13 +45,13 @@ class InfrastructureTests(unittest.TestCase):
         # ensure we're not using unneeded backslash to escape strings
         issues: typing.List[typing.Tuple[str, int, str]] = []
         for filepath in get_python_filepaths():
-            with open(filepath, "rt", encoding="utf8") as fh:
+            with open(filepath, 'rt', encoding='utf8') as fh:
                 for idx, line in enumerate(fh, 1):
-                    if (r'\"' in line or r"\'" in line) and "NOQA" not in line:
+                    if (r'\"' in line or r"\'" in line) and 'NOQA' not in line:
                         issues.append((filepath, idx, line.rstrip()))
         if issues:
-            msgs = ["{}:{:d}:{}".format(*issue) for issue in issues]
-            self.fail("Spurious backslashes found, please fix these quotings:\n" + "\n".join(msgs))
+            msgs = ['{}:{:d}:{}'.format(*issue) for issue in issues]
+            self.fail('Spurious backslashes found, please fix these quotings:\n' + '\n'.join(msgs))
 
     def test_ensure_copyright(self):
         # all non-empty Python files must have a proper copyright somewhere in the first 5 lines
@@ -61,14 +61,14 @@ class InfrastructureTests(unittest.TestCase):
             if os.stat(filepath).st_size == 0:
                 continue
 
-            with open(filepath, "rt", encoding="utf8") as fh:
+            with open(filepath, 'rt', encoding='utf8') as fh:
                 for line in itertools.islice(fh, 5):
                     if regex.match(line):
                         break
                 else:
                     issues.append(filepath)
         if issues:
-            self.fail("Please add copyright headers to the following files:\n" + "\n".join(issues))
+            self.fail('Please add copyright headers to the following files:\n' + '\n'.join(issues))
 
     def _run_setup(self, *args: str) -> str:
         proc = subprocess.run(
@@ -84,7 +84,7 @@ class InfrastructureTests(unittest.TestCase):
         self.assertEqual(setup_version, ops.__version__)
 
     def test_setup_description(self):
-        with open("README.md", "rt", encoding="utf8") as fh:
+        with open('README.md', 'rt', encoding='utf8') as fh:
             disk_readme = fh.read().strip()
 
         setup_readme = self._run_setup('--long-description')
@@ -117,7 +117,7 @@ class InfrastructureTests(unittest.TestCase):
 
 class ImportersTestCase(unittest.TestCase):
 
-    template = "from ops import {module_name}"
+    template = 'from ops import {module_name}'
 
     def test_imports(self):
         mod_names = [

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -22,15 +22,15 @@ class TestJujuVersion(unittest.TestCase):
 
     def test_parsing(self):
         test_cases = [
-            ("0.0.0", 0, 0, '', 0, 0),
-            ("0.0.2", 0, 0, '', 2, 0),
-            ("0.1.0", 0, 1, '', 0, 0),
-            ("0.2.3", 0, 2, '', 3, 0),
-            ("10.234.3456", 10, 234, '', 3456, 0),
-            ("10.234.3456.1", 10, 234, '', 3456, 1),
-            ("1.21-alpha12", 1, 21, 'alpha', 12, 0),
-            ("1.21-alpha1.34", 1, 21, 'alpha', 1, 34),
-            ("2.7", 2, 7, '', 0, 0)
+            ('0.0.0', 0, 0, '', 0, 0),
+            ('0.0.2', 0, 0, '', 2, 0),
+            ('0.1.0', 0, 1, '', 0, 0),
+            ('0.2.3', 0, 2, '', 3, 0),
+            ('10.234.3456', 10, 234, '', 3456, 0),
+            ('10.234.3456.1', 10, 234, '', 3456, 1),
+            ('1.21-alpha12', 1, 21, 'alpha', 12, 0),
+            ('1.21-alpha1.34', 1, 21, 'alpha', 1, 34),
+            ('2.7', 2, 7, '', 0, 0)
         ]
 
         for vs, major, minor, tag, patch, build in test_cases:
@@ -93,18 +93,18 @@ class TestJujuVersion(unittest.TestCase):
 
     def test_parsing_errors(self):
         invalid_versions = [
-            "xyz",
-            "foo.bar",
-            "foo.bar.baz",
-            "dead.beef.ca.fe",
-            "1234567890.2.1",     # The major version is too long.
-            "0.2..1",             # Two periods next to each other.
-            "1.21.alpha1",        # Tag comes after period.
-            "1.21-alpha",         # No patch number but a tag is present.
-            "1.21-alpha1beta",    # Non-numeric string after the patch number.
-            "1.21-alpha-dev",     # Tag duplication.
-            "1.21-alpha_dev3",    # Underscore in a tag.
-            "1.21-alpha123dev3",  # Non-numeric string after the patch number.
+            'xyz',
+            'foo.bar',
+            'foo.bar.baz',
+            'dead.beef.ca.fe',
+            '1234567890.2.1',     # The major version is too long.
+            '0.2..1',             # Two periods next to each other.
+            '1.21.alpha1',        # Tag comes after period.
+            '1.21-alpha',         # No patch number but a tag is present.
+            '1.21-alpha1beta',    # Non-numeric string after the patch number.
+            '1.21-alpha-dev',     # Tag duplication.
+            '1.21-alpha_dev3',    # Underscore in a tag.
+            '1.21-alpha123dev3',  # Non-numeric string after the patch number.
         ]
         for v in invalid_versions:
             with self.assertRaises(RuntimeError):
@@ -112,27 +112,27 @@ class TestJujuVersion(unittest.TestCase):
 
     def test_equality(self):
         test_cases = [
-            ("1.0.0", "1.0.0", True),
-            ("01.0.0", "1.0.0", True),
-            ("10.0.0", "9.0.0", False),
-            ("1.0.0", "1.0.1", False),
-            ("1.0.1", "1.0.0", False),
-            ("1.0.0", "1.1.0", False),
-            ("1.1.0", "1.0.0", False),
-            ("1.0.0", "2.0.0", False),
-            ("1.2-alpha1", "1.2.0", False),
-            ("1.2-alpha2", "1.2-alpha1", False),
-            ("1.2-alpha2.1", "1.2-alpha2", False),
-            ("1.2-alpha2.2", "1.2-alpha2.1", False),
-            ("1.2-beta1", "1.2-alpha1", False),
-            ("1.2-beta1", "1.2-alpha2.1", False),
-            ("1.2-beta1", "1.2.0", False),
-            ("1.2.1", "1.2.0", False),
-            ("2.0.0", "1.0.0", False),
-            ("2.0.0.0", "2.0.0", True),
-            ("2.0.0.0", "2.0.0.0", True),
-            ("2.0.0.1", "2.0.0.0", False),
-            ("2.0.1.10", "2.0.0.0", False),
+            ('1.0.0', '1.0.0', True),
+            ('01.0.0', '1.0.0', True),
+            ('10.0.0', '9.0.0', False),
+            ('1.0.0', '1.0.1', False),
+            ('1.0.1', '1.0.0', False),
+            ('1.0.0', '1.1.0', False),
+            ('1.1.0', '1.0.0', False),
+            ('1.0.0', '2.0.0', False),
+            ('1.2-alpha1', '1.2.0', False),
+            ('1.2-alpha2', '1.2-alpha1', False),
+            ('1.2-alpha2.1', '1.2-alpha2', False),
+            ('1.2-alpha2.2', '1.2-alpha2.1', False),
+            ('1.2-beta1', '1.2-alpha1', False),
+            ('1.2-beta1', '1.2-alpha2.1', False),
+            ('1.2-beta1', '1.2.0', False),
+            ('1.2.1', '1.2.0', False),
+            ('2.0.0', '1.0.0', False),
+            ('2.0.0.0', '2.0.0', True),
+            ('2.0.0.0', '2.0.0.0', True),
+            ('2.0.0.1', '2.0.0.0', False),
+            ('2.0.1.10', '2.0.0.0', False),
         ]
 
         for a, b, expected in test_cases:
@@ -141,28 +141,28 @@ class TestJujuVersion(unittest.TestCase):
 
     def test_comparison(self):
         test_cases = [
-            ("1.0.0", "1.0.0", False, True),
-            ("01.0.0", "1.0.0", False, True),
-            ("10.0.0", "9.0.0", False, False),
-            ("1.0.0", "1.0.1", True, True),
-            ("1.0.1", "1.0.0", False, False),
-            ("1.0.0", "1.1.0", True, True),
-            ("1.1.0", "1.0.0", False, False),
-            ("1.0.0", "2.0.0", True, True),
-            ("1.2-alpha1", "1.2.0", True, True),
-            ("1.2-alpha2", "1.2-alpha1", False, False),
-            ("1.2-alpha2.1", "1.2-alpha2", False, False),
-            ("1.2-alpha2.2", "1.2-alpha2.1", False, False),
-            ("1.2-beta1", "1.2-alpha1", False, False),
-            ("1.2-beta1", "1.2-alpha2.1", False, False),
-            ("1.2-beta1", "1.2.0", True, True),
-            ("1.2.1", "1.2.0", False, False),
-            ("2.0.0", "1.0.0", False, False),
-            ("2.0.0.0", "2.0.0", False, True),
-            ("2.0.0.0", "2.0.0.0", False, True),
-            ("2.0.0.1", "2.0.0.0", False, False),
-            ("2.0.1.10", "2.0.0.0", False, False),
-            ("2.10.0", "2.8.0", False, False),
+            ('1.0.0', '1.0.0', False, True),
+            ('01.0.0', '1.0.0', False, True),
+            ('10.0.0', '9.0.0', False, False),
+            ('1.0.0', '1.0.1', True, True),
+            ('1.0.1', '1.0.0', False, False),
+            ('1.0.0', '1.1.0', True, True),
+            ('1.1.0', '1.0.0', False, False),
+            ('1.0.0', '2.0.0', True, True),
+            ('1.2-alpha1', '1.2.0', True, True),
+            ('1.2-alpha2', '1.2-alpha1', False, False),
+            ('1.2-alpha2.1', '1.2-alpha2', False, False),
+            ('1.2-alpha2.2', '1.2-alpha2.1', False, False),
+            ('1.2-beta1', '1.2-alpha1', False, False),
+            ('1.2-beta1', '1.2-alpha2.1', False, False),
+            ('1.2-beta1', '1.2.0', True, True),
+            ('1.2.1', '1.2.0', False, False),
+            ('2.0.0', '1.0.0', False, False),
+            ('2.0.0.0', '2.0.0', False, True),
+            ('2.0.0.0', '2.0.0.0', False, True),
+            ('2.0.0.1', '2.0.0.0', False, False),
+            ('2.0.1.10', '2.0.0.0', False, False),
+            ('2.10.0', '2.8.0', False, False),
         ]
 
         for a, b, expected_strict, expected_weak in test_cases:

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -34,7 +34,7 @@ pytestmark: pytest.MarkDecorator = pytest.mark.filterwarnings('ignore::Deprecati
 
 # ModuleSpec to pass when we know it will not be used but we want the
 # type to match.
-_dummy_spec = ModuleSpec("", loader=None)
+_dummy_spec = ModuleSpec('', loader=None)
 
 
 def _mklib(topdir: str, pkgname: str, libname: str) -> Path:
@@ -66,7 +66,7 @@ def _mklib(topdir: str, pkgname: str, libname: str) -> Path:
 
 
 def _flatten(specgen: typing.Iterable[ModuleSpec]) -> typing.List[str]:
-    return sorted([os.path.dirname(spec.origin if spec.origin is not None else "")
+    return sorted([os.path.dirname(spec.origin if spec.origin is not None else '')
                   for spec in specgen])
 
 
@@ -81,7 +81,7 @@ class TestLibFinder(TestCase):
 
         self.assertEqual(list(ops.lib._find_all_specs([tmpdir])), [])
 
-        _mklib(tmpdir, "foo", "bar").write_text("")
+        _mklib(tmpdir, 'foo', 'bar').write_text('')
 
         self.assertEqual(
             _flatten(ops.lib._find_all_specs([tmpdir])),
@@ -98,19 +98,19 @@ class TestLibFinder(TestCase):
         dirs = [tmp_dir_a, tmp_dir_b]
 
         for top in [tmp_dir_a, tmp_dir_b]:
-            for pkg in ["bar", "baz"]:
-                for lib in ["meep", "quux"]:
-                    _mklib(top, pkg, lib).write_text("")
+            for pkg in ['bar', 'baz']:
+                for lib in ['meep', 'quux']:
+                    _mklib(top, pkg, lib).write_text('')
 
         expected = [
-            os.path.join(tmp_dir_a, "bar", "opslib", "meep"),
-            os.path.join(tmp_dir_a, "bar", "opslib", "quux"),
-            os.path.join(tmp_dir_a, "baz", "opslib", "meep"),
-            os.path.join(tmp_dir_a, "baz", "opslib", "quux"),
-            os.path.join(tmp_dir_b, "bar", "opslib", "meep"),
-            os.path.join(tmp_dir_b, "bar", "opslib", "quux"),
-            os.path.join(tmp_dir_b, "baz", "opslib", "meep"),
-            os.path.join(tmp_dir_b, "baz", "opslib", "quux"),
+            os.path.join(tmp_dir_a, 'bar', 'opslib', 'meep'),
+            os.path.join(tmp_dir_a, 'bar', 'opslib', 'quux'),
+            os.path.join(tmp_dir_a, 'baz', 'opslib', 'meep'),
+            os.path.join(tmp_dir_a, 'baz', 'opslib', 'quux'),
+            os.path.join(tmp_dir_b, 'bar', 'opslib', 'meep'),
+            os.path.join(tmp_dir_b, 'bar', 'opslib', 'quux'),
+            os.path.join(tmp_dir_b, 'baz', 'opslib', 'meep'),
+            os.path.join(tmp_dir_b, 'baz', 'opslib', 'quux'),
         ]
 
         self.assertEqual(_flatten(ops.lib._find_all_specs(dirs)), expected)
@@ -121,11 +121,11 @@ class TestLibFinder(TestCase):
         os.chdir(tmpcwd)
         self.addCleanup(os.chdir, cwd)
 
-        dirs = [""]
+        dirs = ['']
 
         self.assertEqual(list(ops.lib._find_all_specs(dirs)), [])
 
-        _mklib(tmpcwd, "foo", "bar").write_text("")
+        _mklib(tmpcwd, 'foo', 'bar').write_text('')
 
         paths = _flatten(ops.lib._find_all_specs(dirs))
         self.assertEqual(
@@ -136,11 +136,11 @@ class TestLibFinder(TestCase):
         """Check that having one bogus dir in sys.path doesn't cause the finder to abort."""
         tmpdir = self._mkdtemp()
 
-        dirs = [tmpdir, "/bogus"]
+        dirs = [tmpdir, '/bogus']
 
         self.assertEqual(list(ops.lib._find_all_specs(dirs)), [])
 
-        _mklib(tmpdir, "foo", "bar").write_text("")
+        _mklib(tmpdir, 'foo', 'bar').write_text('')
 
         self.assertEqual(
             _flatten(ops.lib._find_all_specs(dirs)),
@@ -152,7 +152,7 @@ class TestLibFinder(TestCase):
 
         self.assertEqual(list(ops.lib._find_all_specs([tmpdir])), [])
 
-        _mklib(tmpdir, "foo", "bar").write_text('')
+        _mklib(tmpdir, 'foo', 'bar').write_text('')
 
         path = Path(tmpdir) / 'baz'
         path.mkdir()
@@ -168,7 +168,7 @@ class TestLibFinder(TestCase):
 
         self.assertEqual(list(ops.lib._find_all_specs([tmpdir])), [])
 
-        _mklib(tmpdir, "foo", "bar")  # no __init__.py  =>  a namespace package
+        _mklib(tmpdir, 'foo', 'bar')  # no __init__.py  =>  a namespace package
 
         self.assertEqual(list(ops.lib._find_all_specs([tmpdir])), [])
 
@@ -185,75 +185,75 @@ class TestLibParser(TestCase):
 
     def test_simple(self):
         """Check that we can load a reasonably straightforward lib."""
-        m = self._mkmod('foo', '''
+        m = self._mkmod('foo', """
         LIBNAME = "foo"
         LIBEACH = float('-inf')
         LIBAPI = 2
         LIBPATCH = 42
         LIBAUTHOR = "alice@example.com"
         LIBANANA = True
-        ''')
+        """)
         lib = ops.lib._parse_lib(m)
-        self.assertEqual(lib, ops.lib._Lib(_dummy_spec, "foo", "alice@example.com", 2, 42))
+        self.assertEqual(lib, ops.lib._Lib(_dummy_spec, 'foo', 'alice@example.com', 2, 42))
         # also check the repr while we're at it
         self.assertEqual(repr(lib), '<_Lib foo by alice@example.com, API 2, patch 42>')
 
     def test_libauthor_has_dashes(self):
-        m = self._mkmod('foo', '''
+        m = self._mkmod('foo', """
         LIBNAME = "foo"
         LIBAPI = 2
         LIBPATCH = 42
         LIBAUTHOR = "alice-someone@example.com"
         LIBANANA = True
-        ''')
+        """)
         lib = ops.lib._parse_lib(m)
-        self.assertEqual(lib, ops.lib._Lib(_dummy_spec, "foo", "alice-someone@example.com", 2, 42))
+        self.assertEqual(lib, ops.lib._Lib(_dummy_spec, 'foo', 'alice-someone@example.com', 2, 42))
         # also check the repr while we're at it
         self.assertEqual(repr(lib), '<_Lib foo by alice-someone@example.com, API 2, patch 42>')
 
     def test_lib_definitions_without_spaces(self):
-        m = self._mkmod('foo', '''
+        m = self._mkmod('foo', """
         LIBNAME="foo"
         LIBAPI=2
         LIBPATCH=42
         LIBAUTHOR="alice@example.com"
         LIBANANA=True
-        ''')
+        """)
         lib = ops.lib._parse_lib(m)
-        self.assertEqual(lib, ops.lib._Lib(_dummy_spec, "foo", "alice@example.com", 2, 42))
+        self.assertEqual(lib, ops.lib._Lib(_dummy_spec, 'foo', 'alice@example.com', 2, 42))
         # also check the repr while we're at it
         self.assertEqual(repr(lib), '<_Lib foo by alice@example.com, API 2, patch 42>')
 
     def test_lib_definitions_trailing_comments(self):
-        m = self._mkmod('foo', '''
+        m = self._mkmod('foo', """
         LIBNAME = "foo" # comment style 1
         LIBAPI = 2 = comment style 2
         LIBPATCH = 42
         LIBAUTHOR = "alice@example.com"anything after the quote is a comment
         LIBANANA = True
-        ''')
+        """)
         lib = ops.lib._parse_lib(m)
-        self.assertEqual(lib, ops.lib._Lib(_dummy_spec, "foo", "alice@example.com", 2, 42))
+        self.assertEqual(lib, ops.lib._Lib(_dummy_spec, 'foo', 'alice@example.com', 2, 42))
         # also check the repr while we're at it
         self.assertEqual(repr(lib), '<_Lib foo by alice@example.com, API 2, patch 42>')
 
     def test_incomplete(self):
         """Check that if anything is missing, nothing is returned."""
-        m = self._mkmod('foo', '''
+        m = self._mkmod('foo', """
         LIBNAME = "foo"
         LIBAPI = 2
         LIBPATCH = 42
-        ''')
+        """)
         self.assertIsNone(ops.lib._parse_lib(m))
 
     def test_too_long(self):
         """Check that if the file is too long, nothing is returned."""
-        m = self._mkmod('foo', '\n' * ops.lib._MAX_LIB_LINES + '''
+        m = self._mkmod('foo', '\n' * ops.lib._MAX_LIB_LINES + """
         LIBNAME = "foo"
         LIBAPI = 2
         LIBPATCH = 42
         LIBAUTHOR = "alice@example.com"
-        ''')
+        """)
         self.assertIsNone(ops.lib._parse_lib(m))
 
     def test_no_origin(self):
@@ -271,52 +271,52 @@ class TestLibParser(TestCase):
     def test_bogus_lib(self):
         """Check our behaviour when the lib is messed up."""
         # note the syntax error (that is carefully chosen to pass the initial regexp)
-        m = self._mkmod('foo', '''
+        m = self._mkmod('foo', """
         LIBNAME = "1'
         LIBAPI = 2
         LIBPATCH = 42
         LIBAUTHOR = "alice@example.com"
-        ''')
+        """)
         self.assertIsNone(ops.lib._parse_lib(m))
 
     def test_name_is_number(self):
         """Check our behaviour when the name in the lib is a number."""
-        m = self._mkmod('foo', '''
+        m = self._mkmod('foo', """
         LIBNAME = 1
         LIBAPI = 2
         LIBPATCH = 42
         LIBAUTHOR = "alice@example.com"
-        ''')
+        """)
         self.assertIsNone(ops.lib._parse_lib(m))
 
     def test_api_is_string(self):
         """Check our behaviour when the api in the lib is a string."""
-        m = self._mkmod('foo', '''
+        m = self._mkmod('foo', """
         LIBNAME = 'foo'
         LIBAPI = '2'
         LIBPATCH = 42
         LIBAUTHOR = "alice@example.com"
-        ''')
+        """)
         self.assertIsNone(ops.lib._parse_lib(m))
 
     def test_patch_is_string(self):
         """Check our behaviour when the patch in the lib is a string."""
-        m = self._mkmod('foo', '''
+        m = self._mkmod('foo', """
         LIBNAME = 'foo'
         LIBAPI = 2
         LIBPATCH = '42'
         LIBAUTHOR = "alice@example.com"
-        ''')
+        """)
         self.assertIsNone(ops.lib._parse_lib(m))
 
     def test_author_is_number(self):
         """Check our behaviour when the author in the lib is a number."""
-        m = self._mkmod('foo', '''
+        m = self._mkmod('foo', """
         LIBNAME = 'foo'
         LIBAPI = 2
         LIBPATCH = 42
         LIBAUTHOR = 43
-        ''')
+        """)
         self.assertIsNone(ops.lib._parse_lib(m))
 
     def test_other_encoding(self):
@@ -328,13 +328,13 @@ class TestLibParser(TestCase):
             self.assertIsNotNone(m.origin)
             return
         with open(m.origin, 'wt', encoding='latin-1') as f:
-            f.write(dedent('''
+            f.write(dedent("""
             LIBNAME = "foo"
             LIBAPI = 2
             LIBPATCH = 42
             LIBAUTHOR = "alice@example.com"
             LIBANANA = "Ñoño"
-            '''))
+            """))
         self.assertIsNone(ops.lib._parse_lib(m))
 
 
@@ -342,42 +342,42 @@ class TestLib(TestCase):
 
     def test_lib_comparison(self):
         self.assertNotEqual(
-            ops.lib._Lib(_dummy_spec, "foo", "alice@example.com", 1, 0),
-            ops.lib._Lib(_dummy_spec, "bar", "bob@example.com", 0, 1))
+            ops.lib._Lib(_dummy_spec, 'foo', 'alice@example.com', 1, 0),
+            ops.lib._Lib(_dummy_spec, 'bar', 'bob@example.com', 0, 1))
         self.assertEqual(
-            ops.lib._Lib(_dummy_spec, "foo", "alice@example.com", 1, 1),
-            ops.lib._Lib(_dummy_spec, "foo", "alice@example.com", 1, 1))
+            ops.lib._Lib(_dummy_spec, 'foo', 'alice@example.com', 1, 1),
+            ops.lib._Lib(_dummy_spec, 'foo', 'alice@example.com', 1, 1))
 
         self.assertLess(
-            ops.lib._Lib(_dummy_spec, "foo", "alice@example.com", 1, 0),
-            ops.lib._Lib(_dummy_spec, "foo", "alice@example.com", 1, 1))
+            ops.lib._Lib(_dummy_spec, 'foo', 'alice@example.com', 1, 0),
+            ops.lib._Lib(_dummy_spec, 'foo', 'alice@example.com', 1, 1))
         self.assertLess(
-            ops.lib._Lib(_dummy_spec, "foo", "alice@example.com", 0, 1),
-            ops.lib._Lib(_dummy_spec, "foo", "alice@example.com", 1, 1))
+            ops.lib._Lib(_dummy_spec, 'foo', 'alice@example.com', 0, 1),
+            ops.lib._Lib(_dummy_spec, 'foo', 'alice@example.com', 1, 1))
         self.assertLess(
-            ops.lib._Lib(_dummy_spec, "foo", "alice@example.com", 1, 1),
-            ops.lib._Lib(_dummy_spec, "foo", "bob@example.com", 1, 1))
+            ops.lib._Lib(_dummy_spec, 'foo', 'alice@example.com', 1, 1),
+            ops.lib._Lib(_dummy_spec, 'foo', 'bob@example.com', 1, 1))
         self.assertLess(
-            ops.lib._Lib(_dummy_spec, "bar", "alice@example.com", 1, 1),
-            ops.lib._Lib(_dummy_spec, "foo", "alice@example.com", 1, 1))
+            ops.lib._Lib(_dummy_spec, 'bar', 'alice@example.com', 1, 1),
+            ops.lib._Lib(_dummy_spec, 'foo', 'alice@example.com', 1, 1))
 
         with self.assertRaises(TypeError):
-            42 < ops.lib._Lib(_dummy_spec, "bar", "alice@example.com", 1, 1)  # type:ignore
+            42 < ops.lib._Lib(_dummy_spec, 'bar', 'alice@example.com', 1, 1)  # type:ignore
         with self.assertRaises(TypeError):
-            ops.lib._Lib(_dummy_spec, "bar", "alice@example.com", 1, 1) < 42  # type: ignore
+            ops.lib._Lib(_dummy_spec, 'bar', 'alice@example.com', 1, 1) < 42  # type: ignore
 
         # these two might be surprising in that they don't raise an exception,
         # but they are correct: our __eq__ bailing means Python falls back to
         # its default of checking object identity.
-        self.assertNotEqual(ops.lib._Lib(_dummy_spec, "bar", "alice@example.com", 1, 1), 42)
-        self.assertNotEqual(42, ops.lib._Lib(_dummy_spec, "bar", "alice@example.com", 1, 1))
+        self.assertNotEqual(ops.lib._Lib(_dummy_spec, 'bar', 'alice@example.com', 1, 1), 42)
+        self.assertNotEqual(42, ops.lib._Lib(_dummy_spec, 'bar', 'alice@example.com', 1, 1))
 
     def test_lib_order(self):
-        a = ops.lib._Lib(_dummy_spec, "bar", "alice@example.com", 1, 0)
-        b = ops.lib._Lib(_dummy_spec, "bar", "alice@example.com", 1, 1)
-        c = ops.lib._Lib(_dummy_spec, "foo", "alice@example.com", 1, 0)
-        d = ops.lib._Lib(_dummy_spec, "foo", "alice@example.com", 1, 1)
-        e = ops.lib._Lib(_dummy_spec, "foo", "bob@example.com", 1, 1)
+        a = ops.lib._Lib(_dummy_spec, 'bar', 'alice@example.com', 1, 0)
+        b = ops.lib._Lib(_dummy_spec, 'bar', 'alice@example.com', 1, 1)
+        c = ops.lib._Lib(_dummy_spec, 'foo', 'alice@example.com', 1, 0)
+        d = ops.lib._Lib(_dummy_spec, 'foo', 'alice@example.com', 1, 1)
+        e = ops.lib._Lib(_dummy_spec, 'foo', 'bob@example.com', 1, 1)
 
         for i in range(20):
             with self.subTest(i):
@@ -415,7 +415,7 @@ class TestLibFunctional(TestCase):
         tmpdir = self._mkdtemp()
         sys.path = [tmpdir]
 
-        _mklib(tmpdir, "foo", "bar").write_text(dedent("""
+        _mklib(tmpdir, 'foo', 'bar').write_text(dedent("""
         LIBNAME = "baz"
         LIBAPI = 2
         LIBPATCH = 42
@@ -434,11 +434,11 @@ class TestLibFunctional(TestCase):
 
     def test_use_finds_best_same_toplevel(self):
         """Test that ops.lib.use("baz") works when there are two baz in the same toplevel."""
-        pkg_b = "foo"
-        lib_b = "bar"
+        pkg_b = 'foo'
+        lib_b = 'bar'
         patch_b = 40
-        for pkg_a in ["foo", "fooA"]:
-            for lib_a in ["bar", "barA"]:
+        for pkg_a in ['foo', 'fooA']:
+            for lib_a in ['bar', 'barA']:
                 if (pkg_a, lib_a) == (pkg_b, lib_b):
                     # everything-is-the-same :-)
                     continue
@@ -474,11 +474,11 @@ class TestLibFunctional(TestCase):
 
     def test_use_finds_best_diff_toplevel(self):
         """Test that ops.lib.use("baz") works when there are two baz in the different toplevels."""
-        pkg_b = "foo"
-        lib_b = "bar"
+        pkg_b = 'foo'
+        lib_b = 'bar'
         patch_b = 40
-        for pkg_a in ["foo", "fooA"]:
-            for lib_a in ["bar", "barA"]:
+        for pkg_a in ['foo', 'fooA']:
+            for lib_a in ['bar', 'barA']:
                 for patch_a in [38, 42]:
                     desc = f"A: {pkg_a}/{lib_a}/{patch_a}; B: {pkg_b}/{lib_b}/{patch_b}"
                     with self.subTest(desc):
@@ -518,7 +518,7 @@ class TestLibFunctional(TestCase):
         tmpdir = self._mkdtemp()
         sys.path = [tmpdir]
 
-        _mklib(tmpdir, "foo", "bar").write_text(dedent("""
+        _mklib(tmpdir, 'foo', 'bar').write_text(dedent("""
         LIBNAME = "baz"
         LIBAPI = 2
         LIBPATCH = 42
@@ -536,7 +536,7 @@ class TestLibFunctional(TestCase):
         tmpdir = self._mkdtemp()
         sys.path = [tmpdir]
 
-        path = _mklib(tmpdir, "foo", "bar")
+        path = _mklib(tmpdir, 'foo', 'bar')
         path.write_text(dedent("""
         LIBNAME = "baz"
         LIBAPI = 2
@@ -544,7 +544,7 @@ class TestLibFunctional(TestCase):
         LIBAUTHOR = "alice@example.com"
 
         from {} import quux
-        """).format("." if relative else "foo.opslib.bar"))
+        """).format('.' if relative else 'foo.opslib.bar'))
         (path.parent / 'quux.py').write_text(dedent("""
         this = 42
         """))
@@ -567,7 +567,7 @@ class TestLibFunctional(TestCase):
         tmpdir = self._mkdtemp()
         sys.path = [tmpdir]
 
-        _mklib(tmpdir, "foo", "bar").write_text(dedent("""
+        _mklib(tmpdir, 'foo', 'bar').write_text(dedent("""
         LIBNAME = "baz"
         LIBAPI = 2
         LIBPATCH = 42

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -92,7 +92,7 @@ class TestLogging(unittest.TestCase):
                 ('WARNING', 'warning message'),
                 ('CRITICAL', 'critical message'),
              ])
-        self.assertEqual(buffer.getvalue(), "")
+        self.assertEqual(buffer.getvalue(), '')
 
     def test_debug_logging(self):
         buffer = io.StringIO()
@@ -145,7 +145,7 @@ class TestLogging(unittest.TestCase):
         calls = self.backend.calls()
         self.assertEqual(len(calls), 3)
         # Verify that we note that we are splitting the log message.
-        self.assertTrue("Splitting into multiple chunks" in calls[0][1])
+        self.assertTrue('Splitting into multiple chunks' in calls[0][1])
 
         # Verify that it got split into the expected chunks.
         self.assertTrue(len(calls[1][1]) == MAX_LOG_LINE_LEN)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -195,7 +195,7 @@ class CharmInitTestCase(unittest.TestCase):
                     self._check(ops.CharmBase, use_juju_for_storage=True)
 
 
-@patch('sys.argv', new=("hooks/config-changed",))
+@patch('sys.argv', new=('hooks/config-changed',))
 @patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)  # type: ignore
 @patch('ops.charm._evaluate_status', new=lambda *a, **kw: None)  # type: ignore
 class TestDispatch(unittest.TestCase):
@@ -322,7 +322,7 @@ class _TestMain(abc.ABC):
         self.charm_exec_path = os.path.relpath(charm_path, str(self.hooks_dir))
         shutil.copytree(str(TEST_CHARM_DIR), str(self.JUJU_CHARM_DIR))
 
-        charm_spec = importlib.util.spec_from_file_location("charm", charm_path)
+        charm_spec = importlib.util.spec_from_file_location('charm', charm_path)
         assert charm_spec is not None
         self.charm_module = importlib.util.module_from_spec(charm_spec)
         assert charm_spec.loader is not None
@@ -706,7 +706,7 @@ class _TestMain(abc.ABC):
         # Clear the calls during 'install'
         fake_script_calls(typing.cast(unittest.TestCase, self), clear=True)
         self._simulate_event(EventSpec(ops.UpdateStatusEvent, 'update-status',
-                                       set_in_env={'EMIT_CUSTOM_EVENT': "1"}))
+                                       set_in_env={'EMIT_CUSTOM_EVENT': '1'}))
 
         calls = fake_script_calls(typing.cast(unittest.TestCase, self))
 
@@ -767,7 +767,7 @@ class _TestMain(abc.ABC):
             '(?ms)juju-log --log-level ERROR -- Uncaught exception while in charm code:\n'
             'Traceback .most recent call last.:\n'
             '  .*'
-            '    raise RuntimeError."failing as requested".\n'
+            '    raise RuntimeError..failing as requested..\n'
             'RuntimeError: failing as requested'
         )
         self.assertEqual(len(calls), 1, f"expected 1 call, but got extra: {calls[1:]}")
@@ -822,7 +822,7 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
         # interpreter for the child process to support virtual environments.
         fake_script(
             self,
-            "storage-get",
+            'storage-get',
             """
             if [ "$1" = "-s" ]; then
                 id=${2#*/}
@@ -855,7 +855,7 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
         )
         fake_script(
             self,
-            "storage-list",
+            'storage-list',
             """
             echo '["disks/0"]'
             """,
@@ -993,7 +993,7 @@ class _TestMainWithDispatch(_TestMain):
         self.assertEqual(calls, expected)
 
     def test_non_executable_hook_and_dispatch(self):
-        (self.hooks_dir / "install").write_text("")
+        (self.hooks_dir / 'install').write_text('')
         state = self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
         assert isinstance(state, ops.BoundStoredState)
 
@@ -1115,7 +1115,7 @@ class TestMainWithDispatch(_TestMainWithDispatch, unittest.TestCase):
         dispatch = self.JUJU_CHARM_DIR / 'dispatch'
         fake_script(
             self,
-            "storage-get",
+            'storage-get',
             """
             if [ "$1" = "-s" ]; then
                 id=${2#*/}
@@ -1148,7 +1148,7 @@ class TestMainWithDispatch(_TestMainWithDispatch, unittest.TestCase):
         )
         fake_script(
             self,
-            "storage-list",
+            'storage-list',
             """
             echo '["disks/0"]'
             """,
@@ -1192,7 +1192,7 @@ class TestMainWithDispatchAsScript(_TestMainWithDispatch, unittest.TestCase):
         env['JUJU_VERSION'] = '2.8.0'
         fake_script(
             self,
-            "storage-get",
+            'storage-get',
             """
             if [ "$1" = "-s" ]; then
                 id=${2#*/}
@@ -1225,7 +1225,7 @@ class TestMainWithDispatchAsScript(_TestMainWithDispatch, unittest.TestCase):
         )
         fake_script(
             self,
-            "storage-list",
+            'storage-list',
             """
             echo '["disks/0"]'
             """,
@@ -1236,21 +1236,21 @@ class TestMainWithDispatchAsScript(_TestMainWithDispatch, unittest.TestCase):
 
 class TestStorageHeuristics(unittest.TestCase):
     def test_fallback_to_current_juju_version__too_old(self):
-        meta = ops.CharmMeta.from_yaml("series: [kubernetes]")
-        with patch.dict(os.environ, {"JUJU_VERSION": "1.0"}):
-            self.assertFalse(_should_use_controller_storage(Path("/xyzzy"), meta))
+        meta = ops.CharmMeta.from_yaml('series: [kubernetes]')
+        with patch.dict(os.environ, {'JUJU_VERSION': '1.0'}):
+            self.assertFalse(_should_use_controller_storage(Path('/xyzzy'), meta))
 
     def test_fallback_to_current_juju_version__new_enough(self):
-        meta = ops.CharmMeta.from_yaml("series: [kubernetes]")
-        with patch.dict(os.environ, {"JUJU_VERSION": "2.8"}):
-            self.assertTrue(_should_use_controller_storage(Path("/xyzzy"), meta))
+        meta = ops.CharmMeta.from_yaml('series: [kubernetes]')
+        with patch.dict(os.environ, {'JUJU_VERSION': '2.8'}):
+            self.assertTrue(_should_use_controller_storage(Path('/xyzzy'), meta))
 
     def test_not_if_not_in_k8s(self):
-        meta = ops.CharmMeta.from_yaml("series: [ecs]")
-        with patch.dict(os.environ, {"JUJU_VERSION": "2.8"}):
-            self.assertFalse(_should_use_controller_storage(Path("/xyzzy"), meta))
+        meta = ops.CharmMeta.from_yaml('series: [ecs]')
+        with patch.dict(os.environ, {'JUJU_VERSION': '2.8'}):
+            self.assertFalse(_should_use_controller_storage(Path('/xyzzy'), meta))
 
     def test_not_if_already_local(self):
-        meta = ops.CharmMeta.from_yaml("series: [kubernetes]")
-        with patch.dict(os.environ, {"JUJU_VERSION": "2.8"}), tempfile.NamedTemporaryFile() as fd:
+        meta = ops.CharmMeta.from_yaml('series: [kubernetes]')
+        with patch.dict(os.environ, {'JUJU_VERSION': '2.8'}), tempfile.NamedTemporaryFile() as fd:
             self.assertFalse(_should_use_controller_storage(Path(fd.name), meta))

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -37,7 +37,7 @@ from ops.model import _ModelBackend
 
 class TestModel(unittest.TestCase):
     def setUp(self):
-        self.harness = ops.testing.Harness(ops.CharmBase, meta='''
+        self.harness = ops.testing.Harness(ops.CharmBase, meta="""
             name: myapp
             provides:
               db0:
@@ -51,7 +51,7 @@ class TestModel(unittest.TestCase):
             resources:
               foo: {type: file, filename: foo.txt}
               bar: {type: file, filename: bar.txt}
-        ''', config='''
+        """, config="""
         options:
             foo:
                 type: string
@@ -59,7 +59,7 @@ class TestModel(unittest.TestCase):
                 type: int
             qux:
                 type: boolean
-        ''')
+        """)
         self.addCleanup(self.harness.cleanup)
         self.relation_id_db0 = self.harness.add_relation('db0', 'db')
         self.harness._get_backend_calls(reset=True)
@@ -92,7 +92,7 @@ class TestModel(unittest.TestCase):
         m = ops.Model(ops.CharmMeta(), self.harness._backend)
         self.assertEqual(m.name, 'default')
         with self.assertRaises(AttributeError):
-            m.name = "changes-disallowed"  # type: ignore
+            m.name = 'changes-disallowed'  # type: ignore
 
     def test_relations_keys(self):
         rel_app1 = self.harness.add_relation('db1', 'remoteapp1')
@@ -672,7 +672,7 @@ class TestModel(unittest.TestCase):
     def test_workload_version_invalid(self):
         with self.assertRaises(TypeError) as cm:
             self.model.unit.set_workload_version(5)  # type: ignore
-        self.assertEqual(str(cm.exception), "workload version must be a str, not int: 5")
+        self.assertEqual(str(cm.exception), 'workload version must be a str, not int: 5')
         self.assertBackendCalls([])
 
     def test_resources(self):
@@ -890,14 +890,14 @@ class TestModel(unittest.TestCase):
         }
         model = ops.Model(meta, _ModelBackend('myapp/0'))
 
-        fake_script(self, 'storage-list', '''
+        fake_script(self, 'storage-list', """
             if [ "$1" = disks ]; then
                 echo '["disks/0", "disks/1"]'
             else
                 echo '[]'
             fi
-        ''')
-        fake_script(self, 'storage-get', '''
+        """)
+        fake_script(self, 'storage-get', """
             if [ "$2" = disks/0 ]; then
                 echo '"/var/srv/disks/0"'
             elif [ "$2" = disks/1 ]; then
@@ -905,7 +905,7 @@ class TestModel(unittest.TestCase):
             else
                 exit 2
             fi
-        ''')
+        """)
         fake_script(self, 'storage-add', '')
 
         self.assertEqual(len(model.storages), 2)
@@ -969,17 +969,17 @@ class TestModel(unittest.TestCase):
         self.assertEqual(str(cm.exception), 'ERROR cannot get status\n')
         self.assertEqual(cm.exception.args[0], 'ERROR cannot get status\n')
 
-    @patch("grp.getgrgid")
-    @patch("pwd.getpwuid")
+    @patch('grp.getgrgid')
+    @patch('pwd.getpwuid')
     def test_push_path_unnamed(self, getpwuid: MagicMock, getgrgid: MagicMock):
         getpwuid.side_effect = KeyError
         getgrgid.side_effect = KeyError
-        harness = ops.testing.Harness(ops.CharmBase, meta='''
+        harness = ops.testing.Harness(ops.CharmBase, meta="""
             name: test-app
             containers:
               foo:
                 resource: foo-image
-            ''')
+            """)
         harness.begin()
         harness.set_can_connect('foo', True)
         container = harness.model.unit.containers['foo']
@@ -987,8 +987,8 @@ class TestModel(unittest.TestCase):
         with tempfile.TemporaryDirectory() as push_src:
             push_path = pathlib.Path(push_src) / 'src.txt'
             push_path.write_text('hello')
-            container.push_path(push_path, "/")
-        assert container.exists("/src.txt"), 'push_path failed: file "src.txt" missing'
+            container.push_path(push_path, '/')
+        assert container.exists('/src.txt'), 'push_path failed: file "src.txt" missing'
 
 
 class PushPullCase:
@@ -1194,12 +1194,12 @@ recursive_push_pull_cases = [
 @pytest.mark.parametrize('case', recursive_push_pull_cases)
 def test_recursive_push_and_pull(case: PushPullCase):
     # full "integration" test of push+pull
-    harness = ops.testing.Harness(ops.CharmBase, meta='''
+    harness = ops.testing.Harness(ops.CharmBase, meta="""
         name: test-app
         containers:
           foo:
             resource: foo-image
-        ''')
+        """)
     harness.begin()
     harness.set_can_connect('foo', True)
     c = harness.model.unit.containers['foo']
@@ -1292,12 +1292,12 @@ def test_recursive_push_and_pull(case: PushPullCase):
     ),
 ])
 def test_push_path_relative(case: PushPullCase):
-    harness = ops.testing.Harness(ops.CharmBase, meta='''
+    harness = ops.testing.Harness(ops.CharmBase, meta="""
         name: test-app
         containers:
           foo:
             resource: foo-image
-        ''')
+        """)
     harness.begin()
     harness.set_can_connect('foo', True)
     container = harness.model.unit.containers['foo']
@@ -1313,7 +1313,7 @@ def test_push_path_relative(case: PushPullCase):
                 testfile_path = pathlib.Path(tmp / testfile)
                 testfile_path.parent.mkdir(parents=True, exist_ok=True)
                 testfile_path.touch(exist_ok=True)
-                testfile_path.write_text("test", encoding="utf-8")
+                testfile_path.write_text('test', encoding='utf-8')
 
             # push path under test to container
             assert case.dst is not None
@@ -1330,7 +1330,7 @@ def test_push_path_relative(case: PushPullCase):
 class TestApplication(unittest.TestCase):
 
     def setUp(self):
-        self.harness = ops.testing.Harness(ops.CharmBase, meta='''
+        self.harness = ops.testing.Harness(ops.CharmBase, meta="""
             name: myapp
             provides:
               db0:
@@ -1347,7 +1347,7 @@ class TestApplication(unittest.TestCase):
             containers:
               bar:
                 k: v
-        ''')
+        """)
         self.peer_rel_id = self.harness.add_relation('db2', 'db2')
         self.app = self.harness.model.app
         self.addCleanup(self.harness.cleanup)
@@ -1359,7 +1359,7 @@ class TestApplication(unittest.TestCase):
         c = self.harness.charm.unit.get_container('bar')
         c.add_layer('layer1', {
             'summary': 'layer',
-            'services': {"baz": {'override': 'replace', 'summary': 'echo', 'command': 'echo 1'}},
+            'services': {'baz': {'override': 'replace', 'summary': 'echo', 'command': 'echo 1'}},
         })
 
         s = c.get_service('baz')  # So far, so good
@@ -1407,7 +1407,7 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(self.app.planned_units(), 1)
 
         with self.assertRaises(TypeError):
-            self.harness.set_planned_units("foo")  # type: ignore
+            self.harness.set_planned_units('foo')  # type: ignore
 
         with self.assertRaises(TypeError):
             self.harness.set_planned_units(-3423000102312321090)
@@ -1545,7 +1545,7 @@ containers:
     def test_restart_fallback(self):
         def restart_services(service_names: str):
             self.pebble.requests.append(('restart', service_names))
-            raise pebble.APIError({}, 400, "", "")
+            raise pebble.APIError({}, 400, '', '')
 
         self.pebble.restart_services = restart_services
         # Setup the Pebble client to respond to a call to get_services()
@@ -1569,7 +1569,7 @@ containers:
 
     def test_restart_fallback_non_400_error(self):
         def restart_services(service_names: str):
-            raise pebble.APIError({}, 500, "", "")
+            raise pebble.APIError({}, 500, '', '')
 
         self.pebble.restart_services = restart_services
         with self.assertRaises(pebble.APIError) as cm:
@@ -1890,7 +1890,7 @@ containers:
             stdin='STDIN',
             stdout=stdout,
             stderr=stderr,
-            encoding="encoding",
+            encoding='encoding',
             combine_stderr=True,
         )
         self.assertEqual(self.pebble.requests, [
@@ -1906,7 +1906,7 @@ containers:
                 stdin='STDIN',
                 stdout=stdout,
                 stderr=stderr,
-                encoding="encoding",
+                encoding='encoding',
                 combine_stderr=True,
             ))
         ])
@@ -2122,7 +2122,7 @@ class TestModelBindings(unittest.TestCase):
         fake_script(self, 'relation-ids',
                     """([ "$1" = db0 ] && echo '["db0:4"]') || echo '[]'""")
         fake_script(self, 'relation-list', """[ "$2" = 4 ] && echo '["remoteapp1/0"]' || exit 2""")
-        self.network_get_out = '''{
+        self.network_get_out = """{
   "bind-addresses": [
     {
       "mac-address": "de:ad:be:ef:ca:fe",
@@ -2174,7 +2174,7 @@ class TestModelBindings(unittest.TestCase):
     "dead:beef::1",
     "2001:db8::3"
   ]
-}'''
+}"""
 
     def ensure_relation(self, name: str = 'db1', relation_id: typing.Optional[int] = None):
         """Wrapper around self.model.get_relation that enforces that None is not returned."""
@@ -2411,9 +2411,9 @@ class TestModelBackend(unittest.TestCase):
                 self.backend.relation_get(1, 'fooentity', is_app=is_app_v)  # type: ignore
 
     def test_is_leader_refresh(self):
-        meta = ops.CharmMeta.from_yaml('''
+        meta = ops.CharmMeta.from_yaml("""
             name: myapp
-        ''')
+        """)
         model = ops.Model(meta, self.backend)
         fake_script(self, 'is-leader', 'echo false')
         self.assertFalse(model.unit.is_leader())
@@ -2488,14 +2488,14 @@ class TestModelBackend(unittest.TestCase):
     def test_relation_get_juju_version_quirks(self):
         self.addCleanup(os.environ.pop, 'JUJU_VERSION', None)
 
-        fake_script(self, 'relation-get', '''echo '{"foo": "bar"}' ''')
+        fake_script(self, 'relation-get', """echo '{"foo": "bar"}' """)
 
         # on 2.7.0+, things proceed as expected
         for v in ['2.8.0', '2.7.0']:
             with self.subTest(v):
                 os.environ['JUJU_VERSION'] = v
                 rel_data = self.backend.relation_get(1, 'foo/0', is_app=True)
-                self.assertEqual(rel_data, {"foo": "bar"})
+                self.assertEqual(rel_data, {'foo': 'bar'})
                 calls = [' '.join(i) for i in fake_script_calls(self, clear=True)]
                 self.assertEqual(calls, ['relation-get -r 1 - foo/0 --app --format=json'])
 
@@ -2538,8 +2538,8 @@ class TestModelBackend(unittest.TestCase):
         content = '{"message": "", "status": "unknown", "status-data": {}}'
         fake_script(self, 'status-get', f"echo '{content}'")
         s = self.backend.status_get(is_app=False)
-        self.assertEqual(s['status'], "unknown")
-        self.assertEqual(s['message'], "")
+        self.assertEqual(s['status'], 'unknown')
+        self.assertEqual(s['message'], '')
         # taken from actual Juju output
         content = dedent("""
             {
@@ -2559,8 +2559,8 @@ class TestModelBackend(unittest.TestCase):
             """)
         fake_script(self, 'status-get', f"echo '{content}'")
         s = self.backend.status_get(is_app=True)
-        self.assertEqual(s['status'], "maintenance")
-        self.assertEqual(s['message'], "installing")
+        self.assertEqual(s['status'], 'maintenance')
+        self.assertEqual(s['message'], 'installing')
         self.assertEqual(fake_script_calls(self, clear=True), [
             ['status-get', '--include-data', '--application=False', '--format=json'],
             ['status-get', '--include-data', '--application=True', '--format=json'],
@@ -2583,9 +2583,9 @@ class TestModelBackend(unittest.TestCase):
 
     def test_local_set_invalid_status(self):
         # juju returns exit code 1 if you ask to set status to 'unknown' or 'error'
-        meta = ops.CharmMeta.from_yaml('''
+        meta = ops.CharmMeta.from_yaml("""
             name: myapp
-        ''')
+        """)
         model = ops.Model(meta, self.backend)
         fake_script(self, 'status-set', 'exit 1')
         fake_script(self, 'is-leader', 'echo true')
@@ -2614,34 +2614,34 @@ class TestModelBackend(unittest.TestCase):
 
     def test_local_get_status(self):
         for name, expected_cls in (
-            ("active", ops.ActiveStatus),
-            ("waiting", ops.WaitingStatus),
-            ("blocked", ops.BlockedStatus),
-            ("maintenance", ops.MaintenanceStatus),
-            ("error", ops.ErrorStatus),
+            ('active', ops.ActiveStatus),
+            ('waiting', ops.WaitingStatus),
+            ('blocked', ops.BlockedStatus),
+            ('maintenance', ops.MaintenanceStatus),
+            ('error', ops.ErrorStatus),
         ):
-            meta = ops.CharmMeta.from_yaml('''
+            meta = ops.CharmMeta.from_yaml("""
                 name: myapp
-            ''')
+            """)
             model = ops.Model(meta, self.backend)
 
             with self.subTest(name):
                 content = json.dumps({
-                    "message": "foo",
-                    "status": name,
-                    "status-data": {},
+                    'message': 'foo',
+                    'status': name,
+                    'status-data': {},
                 })
                 fake_script(self, 'status-get', f"echo '{content}'")
 
                 self.assertIsInstance(model.unit.status, expected_cls)
                 self.assertEqual(model.unit.status.name, name)
-                self.assertEqual(model.unit.status.message, "foo")
+                self.assertEqual(model.unit.status.message, 'foo')
 
                 content = json.dumps({
-                    "application-status": {
-                        "message": "bar",
-                        "status": name,
-                        "status-data": {},
+                    'application-status': {
+                        'message': 'bar',
+                        'status': name,
+                        'status-data': {},
                     }
                 })
                 fake_script(self, 'status-get', f"echo '{content}'")
@@ -2649,7 +2649,7 @@ class TestModelBackend(unittest.TestCase):
 
                 self.assertIsInstance(model.app.status, expected_cls)
                 self.assertEqual(model.app.status.name, name)
-                self.assertEqual(model.app.status.message, "bar")
+                self.assertEqual(model.app.status.message, 'bar')
 
     def test_status_set_is_app_not_bool_raises(self):
         for is_app_v in [None, 1, 2.0, 'a', b'beef', object]:
@@ -2682,7 +2682,7 @@ class TestModelBackend(unittest.TestCase):
         self.assertEqual(fake_script_calls(self, clear=True), [])
 
     def test_network_get(self):
-        network_get_out = '''{
+        network_get_out = """{
   "bind-addresses": [
     {
       "mac-address": "",
@@ -2702,7 +2702,7 @@ class TestModelBackend(unittest.TestCase):
   "ingress-addresses": [
     "192.0.2.2"
   ]
-}'''
+}"""
         fake_script(self, 'network-get',
                     f'''[ "$1" = deadbeef ] && echo '{network_get_out}' || exit 1''')
         network_info = self.backend.network_get('deadbeef')
@@ -2722,12 +2722,12 @@ class TestModelBackend(unittest.TestCase):
         test_cases = [(
             lambda: fake_script(self, 'network-get',
                                 f'echo {err_no_endpoint} >&2 ; exit 1'),
-            lambda: self.backend.network_get("deadbeef"),
+            lambda: self.backend.network_get('deadbeef'),
             ops.ModelError,
             [['network-get', 'deadbeef', '--format=json']],
         ), (
             lambda: fake_script(self, 'network-get', f'echo {err_no_rel} >&2 ; exit 2'),
-            lambda: self.backend.network_get("deadbeef", 3),
+            lambda: self.backend.network_get('deadbeef', 3),
             ops.RelationNotFoundError,
             [['network-get', 'deadbeef', '-r', '3', '--format=json']],
         )]
@@ -2751,14 +2751,14 @@ class TestModelBackend(unittest.TestCase):
         with self.assertRaises(ops.ModelError):
             self.backend.action_set(OrderedDict([('foo', 'bar'), ('dead', 'beef cafe')]))
         self.assertCountEqual(
-            ["action-set", "dead=beef cafe", "foo=bar"], fake_script_calls(self, clear=True)[0])
+            ['action-set', 'dead=beef cafe', 'foo=bar'], fake_script_calls(self, clear=True)[0])
 
     def test_action_log_error(self):
         fake_script(self, 'action-get', '')
         fake_script(self, 'action-log', 'echo fooerror >&2 ; exit 1')
         with self.assertRaises(ops.ModelError):
             self.backend.action_log('log-message')
-        calls = [["action-log", "log-message"]]
+        calls = [['action-log', 'log-message']]
         self.assertEqual(fake_script_calls(self, clear=True), calls)
 
     def test_action_get(self):
@@ -3762,5 +3762,5 @@ class TestLazyNotice(unittest.TestCase):
         )
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -77,14 +77,14 @@ class TestTypes(unittest.TestCase):
 
     def test_api_error(self):
         body = {
-            "result": {
-                "message": "no services to start provided"
+            'result': {
+                'message': 'no services to start provided'
             },
-            "status": "Bad Request",
-            "status-code": 400,
-            "type": "error"
+            'status': 'Bad Request',
+            'status-code': 400,
+            'type': 'error'
         }
-        error = pebble.APIError(body, 400, "Bad Request", "no services")
+        error = pebble.APIError(body, 400, 'Bad Request', 'no services')
         self.assertIsInstance(error, pebble.Error)
         self.assertEqual(error.body, body)
         self.assertEqual(error.code, 400)
@@ -286,18 +286,18 @@ single log
 
     def test_task_from_dict(self):
         d: pebble._TaskDict = {
-            "id": "78",
-            "kind": "start",
-            "progress": {
-                "done": 1,
-                "label": "",
-                "total": 1,
+            'id': '78',
+            'kind': 'start',
+            'progress': {
+                'done': 1,
+                'label': '',
+                'total': 1,
             },
-            "ready-time": "2021-01-28T14:37:03.270218778+13:00",
-            "spawn-time": "2021-01-28T14:37:02.247158162+13:00",
-            "status": "Done",
-            "summary": 'Start service "svc"',
-            "data": {"exit-code": 42},
+            'ready-time': '2021-01-28T14:37:03.270218778+13:00',
+            'spawn-time': '2021-01-28T14:37:02.247158162+13:00',
+            'status': 'Done',
+            'summary': 'Start service "svc"',
+            'data': {'exit-code': 42},
         }
         task = pebble.Task.from_dict(d)
         self.assertEqual(task.id, '78')
@@ -347,16 +347,16 @@ single log
 
     def test_change_from_dict(self):
         d: 'pebble._ChangeDict' = {
-            "id": "70",
-            "kind": "autostart",
-            "err": "SILLY",
-            "ready": True,
-            "ready-time": "2021-01-28T14:37:04.291517768+13:00",
-            "spawn-time": "2021-01-28T14:37:02.247202105+13:00",
-            "status": "Done",
-            "summary": 'Autostart service "svc"',
-            "tasks": [],
-            "data": {"exit-code": 42},
+            'id': '70',
+            'kind': 'autostart',
+            'err': 'SILLY',
+            'ready': True,
+            'ready-time': '2021-01-28T14:37:04.291517768+13:00',
+            'spawn-time': '2021-01-28T14:37:02.247202105+13:00',
+            'status': 'Done',
+            'summary': 'Autostart service "svc"',
+            'tasks': [],
+            'data': {'exit-code': 42},
         }
         change = pebble.Change.from_dict(d)
         self.assertEqual(change.id, '70')
@@ -541,7 +541,7 @@ checks:
         plan = pebble.Plan('')
         self.assertEqual(plan.log_targets, {})
 
-        location = "https://example.com:3100/loki/api/v1/push"
+        location = 'https://example.com:3100/loki/api/v1/push'
         plan = pebble.Plan(f"""
 log-targets:
   baz:
@@ -553,7 +553,7 @@ log-targets:
         self.assertEqual(len(plan.log_targets), 1)
         self.assertEqual(plan.log_targets['baz'].name, 'baz')
         self.assertEqual(plan.log_targets['baz'].override, 'replace')
-        self.assertEqual(plan.log_targets['baz'].type, "loki")
+        self.assertEqual(plan.log_targets['baz'].type, 'loki')
         self.assertEqual(plan.log_targets['baz'].location, location)
 
         # Should be read-only ("can't set attribute")
@@ -567,7 +567,7 @@ log-targets:
         self.assertEqual(str(plan), '{}\n')
 
         # With a service, we return validated yaml content.
-        raw = '''\
+        raw = """\
 services:
  foo:
   override: replace
@@ -583,7 +583,7 @@ log-targets:
   override: replace
   type: loki
   location: https://example.com:3100/loki/api/v1/push
-'''
+"""
         plan = pebble.Plan(raw)
         reformed = yaml.safe_dump(yaml.safe_load(raw))
         self.assertEqual(plan.to_yaml(), reformed)
@@ -597,16 +597,16 @@ services:
     command: echo foo
 """)
 
-        old_service = pebble.Service(name="foo",
+        old_service = pebble.Service(name='foo',
                                      raw={
-                                          "override": "replace",
-                                          "command": "echo foo"
+                                          'override': 'replace',
+                                          'command': 'echo foo'
                                      })
-        old_services = {"foo": old_service}
+        old_services = {'foo': old_service}
         self.assertEqual(plan.services, old_services)
 
         services_as_dict = {
-            "foo": {"override": "replace", "command": "echo foo"}
+            'foo': {'override': 'replace', 'command': 'echo foo'}
         }
         self.assertEqual(plan.services, services_as_dict)
 
@@ -895,8 +895,8 @@ class TestService(unittest.TestCase):
             'group': 'staff',
             'group-id': 2000,
         }
-        one = pebble.Service("Name 1", d)
-        two = pebble.Service("Name 1", d)
+        one = pebble.Service('Name 1', d)
+        two = pebble.Service('Name 1', d)
         self.assertEqual(one, two)
 
         as_dict = {
@@ -1262,31 +1262,31 @@ class MockTime:
 
 def build_mock_change_dict(change_id: str = '70') -> 'pebble._ChangeDict':
     return {
-        "id": change_id,
-        "kind": "autostart",
-        "ready": True,
-        "ready-time": "2021-01-28T14:37:04.291517768+13:00",
-        "spawn-time": "2021-01-28T14:37:02.247202105+13:00",
-        "status": "Done",
-        "summary": 'Autostart service "svc"',
-        "tasks": [
+        'id': change_id,
+        'kind': 'autostart',
+        'ready': True,
+        'ready-time': '2021-01-28T14:37:04.291517768+13:00',
+        'spawn-time': '2021-01-28T14:37:02.247202105+13:00',
+        'status': 'Done',
+        'summary': 'Autostart service "svc"',
+        'tasks': [
             {
-                "id": "78",
-                "kind": "start",
-                "progress": {
-                    "done": 1,
-                    "label": "",
-                    "total": 1,
-                    "extra-field": "foo",  # type: ignore
+                'id': '78',
+                'kind': 'start',
+                'progress': {
+                    'done': 1,
+                    'label': '',
+                    'total': 1,
+                    'extra-field': 'foo',  # type: ignore
                 },
-                "ready-time": "2021-01-28T14:37:03.270218778+13:00",
-                "spawn-time": "2021-01-28T14:37:02.247158162+13:00",
-                "status": "Done",
-                "summary": 'Start service "svc"',
-                "extra-field": "foo",
+                'ready-time': '2021-01-28T14:37:03.270218778+13:00',
+                'spawn-time': '2021-01-28T14:37:02.247158162+13:00',
+                'status': 'Done',
+                'summary': 'Start service "svc"',
+                'extra-field': 'foo',
             },
         ],
-        "extra-field": "foo",
+        'extra-field': 'foo',
     }
 
 
@@ -1459,13 +1459,13 @@ class TestClient(unittest.TestCase):
 
     def test_get_system_info(self):
         self.client.responses.append({
-            "result": {
-                "version": "1.2.3",
-                "extra-field": "foo",
+            'result': {
+                'version': '1.2.3',
+                'extra-field': 'foo',
             },
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         info = self.client.get_system_info()
         self.assertEqual(info.version, '1.2.3')
@@ -1475,10 +1475,10 @@ class TestClient(unittest.TestCase):
 
     def test_get_warnings(self):
         empty: typing.Dict[str, typing.Any] = {
-            "result": [],
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'result': [],
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         }
         self.client.responses.append(empty)
         warnings = self.client.get_warnings()
@@ -1495,10 +1495,10 @@ class TestClient(unittest.TestCase):
 
     def test_ack_warnings(self):
         self.client.responses.append({
-            "result": 0,
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'result': 0,
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         num = self.client.ack_warnings(datetime_nzdt(2021, 1, 28, 15, 11, 0))
         self.assertEqual(num, 0)
@@ -1534,10 +1534,10 @@ class TestClient(unittest.TestCase):
 
     def test_get_changes(self):
         empty: typing.Dict[str, typing.Any] = {
-            "result": [],
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'result': [],
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         }
         self.client.responses.append(empty)
         changes = self.client.get_changes()
@@ -1552,12 +1552,12 @@ class TestClient(unittest.TestCase):
         self.assertEqual(changes, [])
 
         self.client.responses.append({
-            "result": [
+            'result': [
                 build_mock_change_dict(),
             ],
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         changes = self.client.get_changes()
         self.assertEqual(len(changes), 1)
@@ -1572,10 +1572,10 @@ class TestClient(unittest.TestCase):
 
     def test_get_change(self):
         self.client.responses.append({
-            "result": build_mock_change_dict(),
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'result': build_mock_change_dict(),
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         change = self.client.get_change(pebble.ChangeID('70'))
         self.assert_mock_change(change)
@@ -1585,10 +1585,10 @@ class TestClient(unittest.TestCase):
 
     def test_get_change_str(self):
         self.client.responses.append({
-            "result": build_mock_change_dict(),
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'result': build_mock_change_dict(),
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         change = self.client.get_change('70')  # type: ignore
         self.assert_mock_change(change)
@@ -1598,10 +1598,10 @@ class TestClient(unittest.TestCase):
 
     def test_abort_change(self):
         self.client.responses.append({
-            "result": build_mock_change_dict(),
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'result': build_mock_change_dict(),
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         change = self.client.abort_change(pebble.ChangeID('70'))
         self.assert_mock_change(change)
@@ -1615,19 +1615,19 @@ class TestClient(unittest.TestCase):
             api_func: typing.Callable[[], str],
             services: typing.List[str]):
         self.client.responses.append({
-            "change": "70",
-            "result": None,
-            "status": "Accepted",
-            "status-code": 202,
-            "type": "async"
+            'change': '70',
+            'result': None,
+            'status': 'Accepted',
+            'status-code': 202,
+            'type': 'async'
         })
         change = build_mock_change_dict()
         change['ready'] = True
         self.client.responses.append({
-            "result": change,
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'result': change,
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         change_id = api_func()
         self.assertEqual(change_id, '70')
@@ -1639,11 +1639,11 @@ class TestClient(unittest.TestCase):
     def _services_action_async_helper(
             self, action: str, api_func: typing.Callable[..., str], services: typing.List[str]):
         self.client.responses.append({
-            "change": "70",
-            "result": None,
-            "status": "Accepted",
-            "status-code": 202,
-            "type": "async"
+            'change': '70',
+            'result': None,
+            'status': 'Accepted',
+            'status-code': 202,
+            'type': 'async'
         })
         change_id = api_func(timeout=0)
         self.assertEqual(change_id, '70')
@@ -1722,19 +1722,19 @@ class TestClient(unittest.TestCase):
 
     def test_change_error(self):
         self.client.responses.append({
-            "change": "70",
-            "result": None,
-            "status": "Accepted",
-            "status-code": 202,
-            "type": "async"
+            'change': '70',
+            'result': None,
+            'status': 'Accepted',
+            'status-code': 202,
+            'type': 'async'
         })
         change = build_mock_change_dict()
         change['err'] = 'Some kind of service error'
         self.client.responses.append({
-            "result": change,
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'result': change,
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         with self.assertRaises(pebble.ChangeError) as cm:
             self.client.autostart_services()
@@ -1751,10 +1751,10 @@ class TestClient(unittest.TestCase):
     def test_wait_change_success(self, timeout: typing.Optional[float] = 30.0):
         change = build_mock_change_dict()
         self.client.responses.append({
-            "result": change,
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'result': change,
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
 
         response = self.client.wait_change(pebble.ChangeID('70'), timeout=timeout)
@@ -1771,16 +1771,16 @@ class TestClient(unittest.TestCase):
     def test_wait_change_success_multiple_calls(self):
         def timeout_response(n: float):
             self.time.sleep(n)  # simulate passing of time due to wait_change call
-            raise pebble.APIError({}, 504, "Gateway Timeout", "timed out")
+            raise pebble.APIError({}, 504, 'Gateway Timeout', 'timed out')
 
         self.client.responses.append(lambda: timeout_response(4))
 
         change = build_mock_change_dict()
         self.client.responses.append({
-            "result": change,
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'result': change,
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
 
         response = self.client.wait_change(pebble.ChangeID('70'))
@@ -1796,16 +1796,16 @@ class TestClient(unittest.TestCase):
 
     def test_wait_change_success_polled(self, timeout: typing.Optional[float] = 30.0):
         # Trigger polled mode
-        self.client.responses.append(pebble.APIError({}, 404, "Not Found", "not found"))
+        self.client.responses.append(pebble.APIError({}, 404, 'Not Found', 'not found'))
 
         for i in range(3):
             change = build_mock_change_dict()
             change['ready'] = i == 2
             self.client.responses.append({
-                "result": change,
-                "status": "OK",
-                "status-code": 200,
-                "type": "sync"
+                'result': change,
+                'status': 'OK',
+                'status-code': 200,
+                'type': 'sync'
             })
 
         response = self.client.wait_change(pebble.ChangeID('70'), timeout=timeout, delay=1)
@@ -1827,7 +1827,7 @@ class TestClient(unittest.TestCase):
     def test_wait_change_timeout(self):
         def timeout_response(n: float):
             self.time.sleep(n)  # simulate passing of time due to wait_change call
-            raise pebble.APIError({}, 504, "Gateway Timeout", "timed out")
+            raise pebble.APIError({}, 504, 'Gateway Timeout', 'timed out')
 
         self.client.responses.append(lambda: timeout_response(4))
         self.client.responses.append(lambda: timeout_response(2))
@@ -1846,16 +1846,16 @@ class TestClient(unittest.TestCase):
 
     def test_wait_change_timeout_polled(self):
         # Trigger polled mode
-        self.client.responses.append(pebble.APIError({}, 404, "Not Found", "not found"))
+        self.client.responses.append(pebble.APIError({}, 404, 'Not Found', 'not found'))
 
         change = build_mock_change_dict()
         change['ready'] = False
         for _ in range(3):
             self.client.responses.append({
-                "result": change,
-                "status": "OK",
-                "status-code": 200,
-                "type": "sync"
+                'result': change,
+                'status': 'OK',
+                'status-code': 200,
+                'type': 'sync'
             })
 
         with self.assertRaises(pebble.TimeoutError) as cm:
@@ -1876,10 +1876,10 @@ class TestClient(unittest.TestCase):
         change = build_mock_change_dict()
         change['err'] = 'Some kind of service error'
         self.client.responses.append({
-            "result": change,
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'result': change,
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         # wait_change() itself shouldn't raise an error
         response = self.client.wait_change(pebble.ChangeID('70'))
@@ -1892,10 +1892,10 @@ class TestClient(unittest.TestCase):
 
     def test_add_layer(self):
         okay_response = {
-            "result": True,
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'result': True,
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         }
         self.client.responses.append(okay_response)
         self.client.responses.append(okay_response)
@@ -1949,10 +1949,10 @@ services:
     override: replace
 """[1:]
         self.client.responses.append({
-            "result": plan_yaml,
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'result': plan_yaml,
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         plan = self.client.get_plan()
         self.assertEqual(plan.to_yaml(), plan_yaml)
@@ -1966,21 +1966,21 @@ services:
 
     def test_get_services_all(self):
         self.client.responses.append({
-            "result": [
+            'result': [
                 {
-                    "current": "inactive",
-                    "name": "svc1",
-                    "startup": "disabled"
+                    'current': 'inactive',
+                    'name': 'svc1',
+                    'startup': 'disabled'
                 },
                 {
-                    "current": "active",
-                    "name": "svc2",
-                    "startup": "enabled"
+                    'current': 'active',
+                    'name': 'svc2',
+                    'startup': 'enabled'
                 }
             ],
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         services = self.client.get_services()
         self.assertEqual(len(services), 2)
@@ -1997,21 +1997,21 @@ services:
 
     def test_get_services_names(self):
         self.client.responses.append({
-            "result": [
+            'result': [
                 {
-                    "current": "inactive",
-                    "name": "svc1",
-                    "startup": "disabled"
+                    'current': 'inactive',
+                    'name': 'svc1',
+                    'startup': 'disabled'
                 },
                 {
-                    "current": "active",
-                    "name": "svc2",
-                    "startup": "enabled"
+                    'current': 'active',
+                    'name': 'svc2',
+                    'startup': 'enabled'
                 }
             ],
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         services = self.client.get_services(['svc1', 'svc2'])
         self.assertEqual(len(services), 2)
@@ -2023,16 +2023,16 @@ services:
         self.assertEqual(services[1].current, pebble.ServiceStatus.ACTIVE)
 
         self.client.responses.append({
-            "result": [
+            'result': [
                 {
-                    "current": "active",
-                    "name": "svc2",
-                    "startup": "enabled"
+                    'current': 'active',
+                    'name': 'svc2',
+                    'startup': 'enabled'
                 }
             ],
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         services = self.client.get_services(['svc2'])
         self.assertEqual(len(services), 1)
@@ -2434,7 +2434,7 @@ bad path\r
 
     def test_list_files_path(self):
         self.client.responses.append({
-            "result": [
+            'result': [
                 {
                     'path': '/etc/hosts',
                     'name': 'hosts',
@@ -2489,7 +2489,7 @@ bad path\r
 
     def test_list_files_pattern(self):
         self.client.responses.append({
-            "result": [],
+            'result': [],
             'status': 'OK',
             'status-code': 200,
             'type': 'sync',
@@ -2504,7 +2504,7 @@ bad path\r
 
     def test_list_files_itself(self):
         self.client.responses.append({
-            "result": [],
+            'result': [],
             'status': 'OK',
             'status-code': 200,
             'type': 'sync',
@@ -2519,7 +2519,7 @@ bad path\r
 
     def test_make_dir_basic(self):
         self.client.responses.append({
-            "result": [{'path': '/foo/bar'}],
+            'result': [{'path': '/foo/bar'}],
             'status': 'OK',
             'status-code': 200,
             'type': 'sync',
@@ -2534,7 +2534,7 @@ bad path\r
 
     def test_make_dir_all_options(self):
         self.client.responses.append({
-            "result": [{'path': '/foo/bar'}],
+            'result': [{'path': '/foo/bar'}],
             'status': 'OK',
             'status-code': 200,
             'type': 'sync',
@@ -2557,7 +2557,7 @@ bad path\r
 
     def test_make_dir_error(self):
         self.client.responses.append({
-            "result": [{
+            'result': [{
                 'path': '/foo/bar',
                 'error': {
                     'kind': 'permission-denied',
@@ -2576,7 +2576,7 @@ bad path\r
 
     def test_remove_path_basic(self):
         self.client.responses.append({
-            "result": [{'path': '/boo/far'}],
+            'result': [{'path': '/boo/far'}],
             'status': 'OK',
             'status-code': 200,
             'type': 'sync',
@@ -2591,7 +2591,7 @@ bad path\r
 
     def test_remove_path_recursive(self):
         self.client.responses.append({
-            "result": [{'path': '/boo/far'}],
+            'result': [{'path': '/boo/far'}],
             'status': 'OK',
             'status-code': 200,
             'type': 'sync',
@@ -2608,7 +2608,7 @@ bad path\r
 
     def test_remove_path_error(self):
         self.client.responses.append({
-            "result": [{
+            'result': [{
                 'path': '/boo/far',
                 'error': {
                     'kind': 'generic-file-error',
@@ -2663,23 +2663,23 @@ bad path\r
 
     def test_get_checks_all(self):
         self.client.responses.append({
-            "result": [
+            'result': [
                 {
-                    "name": "chk1",
-                    "status": "up",
-                    "threshold": 2,
+                    'name': 'chk1',
+                    'status': 'up',
+                    'threshold': 2,
                 },
                 {
-                    "name": "chk2",
-                    "level": "alive",
-                    "status": "down",
-                    "failures": 5,
-                    "threshold": 3,
+                    'name': 'chk2',
+                    'level': 'alive',
+                    'status': 'down',
+                    'failures': 5,
+                    'threshold': 3,
                 }
             ],
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         checks = self.client.get_checks()
         self.assertEqual(len(checks), 2)
@@ -2700,17 +2700,17 @@ bad path\r
 
     def test_get_checks_filters(self):
         self.client.responses.append({
-            "result": [
+            'result': [
                 {
-                    "name": "chk2",
-                    "level": "ready",
-                    "status": "up",
-                    "threshold": 3,
+                    'name': 'chk2',
+                    'level': 'ready',
+                    'status': 'up',
+                    'threshold': 3,
                 },
             ],
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         checks = self.client.get_checks(level=pebble.CheckLevel.READY, names=['chk2'])
         self.assertEqual(len(checks), 1)
@@ -2726,17 +2726,17 @@ bad path\r
 
     def test_checklevel_conversion(self):
         self.client.responses.append({
-            "result": [
+            'result': [
                 {
-                    "name": "chk2",
-                    "level": "foobar!",
-                    "status": "up",
-                    "threshold": 3,
+                    'name': 'chk2',
+                    'level': 'foobar!',
+                    'status': 'up',
+                    'threshold': 3,
                 },
             ],
-            "status": "OK",
-            "status-code": 200,
-            "type": "sync"
+            'status': 'OK',
+            'status-code': 200,
+            'type': 'sync'
         })
         checks = self.client.get_checks(level=pebble.CheckLevel.READY, names=['chk2'])
         self.assertEqual(len(checks), 1)
@@ -2875,7 +2875,7 @@ class TestSocketClient(unittest.TestCase):
         with self.assertRaises(pebble.ConnectionError) as cm:
             client.get_system_info()
         self.assertIsInstance(cm.exception, pebble.Error)
-        self.assertIn("Could not connect to Pebble", str(cm.exception))
+        self.assertIn('Could not connect to Pebble', str(cm.exception))
 
     def test_real_client(self):
         shutdown, socket_path = fake_pebble.start_server()
@@ -3272,7 +3272,7 @@ class TestExec(unittest.TestCase):
         stdio.receives.append('{"command":"end"}')
         stderr.receives.append('{"command":"end"}')
         stdout_buffer = io.BytesIO()
-        process = self.client.exec(["echo", "FOOBAR"], stdout=stdout_buffer, encoding=None)
+        process = self.client.exec(['echo', 'FOOBAR'], stdout=stdout_buffer, encoding=None)
         with self.assertRaises(TypeError):
             process.wait_output()
 
@@ -3288,7 +3288,7 @@ class TestExec(unittest.TestCase):
             process = self.client.exec(['python3', '--version'])
             out, err = process.wait_output()
         self.assertEqual(cm.output, [
-            "WARNING:ops.pebble:Cannot decode I/O command (invalid JSON)",
+            'WARNING:ops.pebble:Cannot decode I/O command (invalid JSON)',
             "WARNING:ops.pebble:Invalid I/O command 'foo'",
         ])
 
@@ -3376,7 +3376,7 @@ class TestExec(unittest.TestCase):
             process = self.client.exec(['echo', 'foo'], stdout=out, stderr=err)
             process.wait()
         self.assertEqual(cm.output, [
-            "WARNING:ops.pebble:Cannot decode I/O command (invalid JSON)",
+            'WARNING:ops.pebble:Cannot decode I/O command (invalid JSON)',
             "WARNING:ops.pebble:Invalid I/O command 'foo'",
         ])
 

--- a/test/test_real_pebble.py
+++ b/test/test_real_pebble.py
@@ -260,30 +260,30 @@ class TestRealPebble(unittest.TestCase):
         self.assertEqual(reads, [b'one\n', b'2\n', b'THREE\n'])
 
     def test_log_forwarding(self):
-        self.client.add_layer("log-forwarder", {
-            "services": {
-                "tired": {
-                    "override": "replace",
-                    "command": "sleep 1",
+        self.client.add_layer('log-forwarder', {
+            'services': {
+                'tired': {
+                    'override': 'replace',
+                    'command': 'sleep 1',
                 },
             },
-            "log-targets": {
-                "pretend-loki": {
-                    "type": "loki",
-                    "override": "replace",
-                    "location": "https://example.com",
-                    "services": ["all"],
-                    "labels": {"foo": "bar"},
+            'log-targets': {
+                'pretend-loki': {
+                    'type': 'loki',
+                    'override': 'replace',
+                    'location': 'https://example.com',
+                    'services': ['all'],
+                    'labels': {'foo': 'bar'},
                 },
             },
         }, combine=True)
         plan = self.client.get_plan()
         self.assertEqual(len(plan.log_targets), 1)
-        self.assertEqual(plan.log_targets["pretend-loki"].type, "loki")
-        self.assertEqual(plan.log_targets["pretend-loki"].override, "replace")
-        self.assertEqual(plan.log_targets["pretend-loki"].location, "https://example.com")
-        self.assertEqual(plan.log_targets["pretend-loki"].services, ["all"])
-        self.assertEqual(plan.log_targets["pretend-loki"].labels, {"foo": "bar"})
+        self.assertEqual(plan.log_targets['pretend-loki'].type, 'loki')
+        self.assertEqual(plan.log_targets['pretend-loki'].override, 'replace')
+        self.assertEqual(plan.log_targets['pretend-loki'].location, 'https://example.com')
+        self.assertEqual(plan.log_targets['pretend-loki'].services, ['all'])
+        self.assertEqual(plan.log_targets['pretend-loki'].labels, {'foo': 'bar'})
 
 
 @unittest.skipUnless(os.getenv('RUN_REAL_PEBBLE_TESTS'), 'RUN_REAL_PEBBLE_TESTS not set')

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -222,14 +222,14 @@ class TestSQLiteStorage(StoragePermutations, BaseTestCase):
 
     def test_permissions_new(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            filename = os.path.join(temp_dir, ".unit-state.db")
+            filename = os.path.join(temp_dir, '.unit-state.db')
             storage = ops.storage.SQLiteStorage(filename)
             self.assertEqual(stat.S_IMODE(os.stat(filename).st_mode), stat.S_IRUSR | stat.S_IWUSR)
             storage.close()
 
     def test_permissions_existing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            filename = os.path.join(temp_dir, ".unit-state.db")
+            filename = os.path.join(temp_dir, '.unit-state.db')
             ops.storage.SQLiteStorage(filename).close()
             # Set the file to access that will need fixing for user, group, and other.
             os.chmod(filename, 0o744)
@@ -237,22 +237,22 @@ class TestSQLiteStorage(StoragePermutations, BaseTestCase):
             self.assertEqual(stat.S_IMODE(os.stat(filename).st_mode), stat.S_IRUSR | stat.S_IWUSR)
             storage.close()
 
-    @unittest.mock.patch("os.path.exists")
+    @unittest.mock.patch('os.path.exists')
     def test_permissions_race(self, exists: unittest.mock.MagicMock):
         exists.return_value = False
         with tempfile.TemporaryDirectory() as temp_dir:
-            filename = os.path.join(temp_dir, ".unit-state.db")
+            filename = os.path.join(temp_dir, '.unit-state.db')
             # Create an existing file, but the mock will simulate a race condition saying that it
             # does not exist.
-            open(filename, "w").close()
+            open(filename, 'w').close()
             self.assertRaises(RuntimeError, ops.storage.SQLiteStorage, filename)
 
-    @unittest.mock.patch("os.chmod")
+    @unittest.mock.patch('os.chmod')
     def test_permissions_failure(self, chmod: unittest.mock.MagicMock):
         chmod.side_effect = OSError
         with tempfile.TemporaryDirectory() as temp_dir:
-            filename = os.path.join(temp_dir, ".unit-state.db")
-            open(filename, "w").close()
+            filename = os.path.join(temp_dir, '.unit-state.db')
+            open(filename, 'w').close()
             self.assertRaises(RuntimeError, ops.storage.SQLiteStorage, filename)
 
 
@@ -264,7 +264,7 @@ def setup_juju_backend(test_case: unittest.TestCase, state_file: pathlib.Path):
         'state_file': str(state_file.as_posix()),
     }
 
-    fake_script(test_case, 'state-set', dedent('''\
+    fake_script(test_case, 'state-set', dedent("""\
         {executable} -c '
         import sys
         if "{pthpth}" not in sys.path:
@@ -283,9 +283,9 @@ def setup_juju_backend(test_case: unittest.TestCase, state_file: pathlib.Path):
         with state_file.open("wb") as f:
             pickle.dump(state, f)
         ' "$@"
-        ''').format(**template_args))
+        """).format(**template_args))
 
-    fake_script(test_case, 'state-get', dedent('''\
+    fake_script(test_case, 'state-get', dedent("""\
         {executable} -Sc '
         import sys
         if "{pthpth}" not in sys.path:
@@ -301,9 +301,9 @@ def setup_juju_backend(test_case: unittest.TestCase, state_file: pathlib.Path):
         result = state.get(sys.argv[1], "\\n")
         sys.stdout.write(result)
         ' "$@"
-        ''').format(**template_args))
+        """).format(**template_args))
 
-    fake_script(test_case, 'state-delete', dedent('''\
+    fake_script(test_case, 'state-delete', dedent("""\
         {executable} -Sc '
         import sys
         if "{pthpth}" not in sys.path:
@@ -320,7 +320,7 @@ def setup_juju_backend(test_case: unittest.TestCase, state_file: pathlib.Path):
         with state_file.open("wb") as f:
             pickle.dump(state, f)
         ' "$@"
-        ''').format(**template_args))
+        """).format(**template_args))
 
 
 class TestJujuStorage(StoragePermutations, BaseTestCase):


### PR DESCRIPTION
DRAFT: this isn't finished yet, but I've spent too much time on it already.

I had almost finished an ad-hoc "just enough tokenizer" that did strings, and then I ran into the f-string problem. Then I discovered that the [`tokenize`](https://docs.python.org/3/library/tokenize.html) module does support round-tripping whitespace (by the use of start/end line/col markings), so I wrote the script in [this commit message](https://github.com/canonical/operator/commit/6847b8e3838053ae2f2ddebcfb093031359da574) that uses that.

That converted the non-f-string strings, and then I was trying to go through manually with search-and-replace to do the f-strings (I'm sure we could automate that part too, but it's not trivial). And then I realized my first pass hadn't done a number of the non-f-strings, e.g., in `test/test_testing.py` -- I'm not sure why.

In any case, worth pursuing at some point, but I'm going to drop it for now and get back to useful work.

Fixes #1099