### PR TITLE
fix: revert macaroonbakery exception now that underlying issue is fixed

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,4 @@ pytest-operator~=0.23
 coverage[toml]~=7.0
 typing_extensions~=4.2
 
-macaroonbakery != 1.3.3  # TODO: remove once this is fixed: https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
-
 -r requirements.txt


### PR DESCRIPTION
https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94 is fixed now and version 1.3.4 of that project has been released, so this should not be needed any more.