### PR TITLE
feat: model error on testing module if invalid status set by charm

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -79,6 +79,79 @@ source .tox/unit/bin/activate
 pytest -v test/test_real_pebble.py
 ```
 
+## Using an `ops` branch in a charm
+
+When making changes to `ops`, you'll commonly want to try those changes out in
+a charm.
+
+### From a Git branch
+
+If your changes are in a Git branch, you can simply replace your `ops` version
+in `requirements.txt` (or `pyproject.toml`) with a reference to the branch, like:
+
+```
+#ops ~= 2.9
+git+https://github.com/{your-username}/operator@{your-branch-name}
+```
+
+`git` is not normally available when `charmcraft` is packing the charm, so you'll
+need to also tell `charmcraft` that it's required for the build, by adding
+something like this to your `charmcraft.yaml`:
+
+```yaml
+parts:
+  charm:
+    build-packages:
+      - git
+```
+
+### From local code
+
+If your changes are only on your local device, you can inject your local `ops`
+into the charm after it has packed, and before you deploy it, by unzipping the
+`.charm` file and replacing the `ops` folder in the virtualenv. This small
+script will handle that for you:
+
+```shell-script
+#!/usr/bin/env bash
+
+if [ "$#" -lt 2 ]
+then
+	echo "Inject local copy of Python Operator Framework source into charm"
+	echo
+    echo "usage: inject-ops.sh file.charm /path/to/ops/dir" >&2
+    exit 1
+fi
+
+if [ ! -f "$2/framework.py" ]; then
+    echo "$2/framework.py not found; arg 2 should be path to 'ops' directory"
+    exit 1
+fi
+
+set -ex
+
+mkdir inject-ops-tmp
+unzip -q $1 -d inject-ops-tmp
+rm -rf inject-ops-tmp/venv/ops
+cp -r $2 inject-ops-tmp/venv/ops
+cd inject-ops-tmp
+zip -q -r ../inject-ops-new.charm .
+cd ..
+rm -rf inject-ops-tmp
+rm $1
+mv inject-ops-new.charm $1
+```
+
+### Using a Juju branch
+
+If your `ops` change relies on a change in a Juju branch, you'll need to deploy
+your charm to a controller using that version of Juju. For example, with microk8s:
+
+1. [Build Juju and its dependencies](https://github.com/juju/juju/blob/3.4/CONTRIBUTING.md#build-juju-and-its-dependencies)
+2. Run `make microk8s-operator-update`
+3. Run `GOBIN=/path/to/your/juju/_build/linux_amd64/bin:$GOBIN /path/to/your/juju bootstrap`
+4. Add a model and deploy your charm as normal
+
 # Documentation
 
 In general, new functionality

--- a/ops/model.py
+++ b/ops/model.py
@@ -1790,6 +1790,14 @@ class UnknownStatus(StatusBase):
     A unit-agent has finished calling install, config-changed and start, but the
     charm has not called status-set yet.
 
+    This status is for READ ONLY and should not be used to set a unit status. The following
+    charm code would be an invalid charm code.
+
+        ```
+        # Raises ops.model.ModelError : ERROR invalid status "unknown", expected one of
+        # [maintenance blocked waiting active]
+        self.unit.status = UnknownStatus()
+        ```
     """
     name = 'unknown'
 
@@ -1807,6 +1815,15 @@ class ErrorStatus(StatusBase):
 
     The unit-agent has encountered an error (the application or unit requires
     human intervention in order to operate correctly).
+
+    This status is for READ ONLY and should not be used to set a unit status. The following
+    charm code would be an invalid charm code.
+
+        ```
+        # Raises ops.model.ModelError : ERROR invalid status "error", expected one of
+        # [maintenance blocked waiting active]
+        self.unit.status = ErrorStatus()
+        ```
     """
     name = 'error'
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -1790,14 +1790,8 @@ class UnknownStatus(StatusBase):
     A unit-agent has finished calling install, config-changed and start, but the
     charm has not called status-set yet.
 
-    This status is for READ ONLY and should not be used to set a unit status. The following
-    charm code would be an invalid charm code.
-
-        ```
-        # Raises ops.model.ModelError : ERROR invalid status "unknown", expected one of
-        # [maintenance blocked waiting active]
-        self.unit.status = UnknownStatus()
-        ```
+    This status is read-only; trying to set unit or application status to
+    ``UnknownStatus`` will raise :class:`ModelError`.
     """
     name = 'unknown'
 
@@ -1816,14 +1810,8 @@ class ErrorStatus(StatusBase):
     The unit-agent has encountered an error (the application or unit requires
     human intervention in order to operate correctly).
 
-    This status is for READ ONLY and should not be used to set a unit status. The following
-    charm code would be an invalid charm code.
-
-        ```
-        # Raises ops.model.ModelError : ERROR invalid status "error", expected one of
-        # [maintenance blocked waiting active]
-        self.unit.status = ErrorStatus()
-        ```
+    This status is read-only; trying to set unit or application status to
+    ``ErrorStatus`` will raise :class:`ModelError`.
     """
     name = 'error'
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -446,7 +446,7 @@ class Harness(Generic[CharmType]):
         # the unit status from "Maintenance" to "Unknown". See gh#726
         post_setup_sts = self._backend.status_get()
         if post_setup_sts.get("status") == "maintenance" and not post_setup_sts.get("message"):
-            self._backend.status_set("unknown", "", is_app=False)
+            self._backend.status_set("unknown", "", is_app=False, by_testing_backend=True)
         all_ids = list(self._backend._relation_names.items())
         random.shuffle(all_ids)
         for rel_id, rel_name in all_ids:
@@ -2222,7 +2222,17 @@ class _TestingModelBackend:
         else:
             return self._unit_status
 
-    def status_set(self, status: '_StatusName', message: str = '', *, is_app: bool = False):
+    def status_set(
+        self,
+        status: "_StatusName",
+        message: str = "",
+        *,
+        is_app: bool = False,
+        by_testing_backend: bool = False,
+    ):
+        if not by_testing_backend and status in {model.ErrorStatus.name, model.UnknownStatus.name}:
+            raise model.ModelError(f'ERROR invalid status "{status}", expected one of'
+                                   ' [maintenance blocked waiting active]')
         if is_app:
             self._app_status = {'status': status, 'message': message}
         else:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -446,7 +446,7 @@ class Harness(Generic[CharmType]):
         # the unit status from "Maintenance" to "Unknown". See gh#726
         post_setup_sts = self._backend.status_get()
         if post_setup_sts.get("status") == "maintenance" and not post_setup_sts.get("message"):
-            self._backend.status_set("unknown", "", is_app=False, by_testing_backend=True)
+            self._backend._unit_status = {'status': 'unknown', 'message': ''}
         all_ids = list(self._backend._relation_names.items())
         random.shuffle(all_ids)
         for rel_id, rel_name in all_ids:
@@ -2222,15 +2222,8 @@ class _TestingModelBackend:
         else:
             return self._unit_status
 
-    def status_set(
-        self,
-        status: "_StatusName",
-        message: str = "",
-        *,
-        is_app: bool = False,
-        by_testing_backend: bool = False,
-    ):
-        if not by_testing_backend and status in {model.ErrorStatus.name, model.UnknownStatus.name}:
+    def status_set(self, status: '_StatusName', message: str = '', *, is_app: bool = False):
+        if status in [model.ErrorStatus.name, model.UnknownStatus.name]:
             raise model.ModelError(f'ERROR invalid status "{status}", expected one of'
                                    ' [maintenance blocked waiting active]')
         if is_app:

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2851,6 +2851,29 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness.model.app.status, ops.ActiveStatus('active app'))
         self.assertEqual(harness.model.unit.status, ops.ActiveStatus('active unit'))
 
+    def test_invalid_status_set(self):
+
+        class TestCharm(ops.CharmBase):
+            def __init__(self, framework: ops.Framework):
+                super().__init__(framework)
+                self.framework.observe(self.on.collect_app_status, self._on_collect_app_status)
+                self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
+                self.app_status_to_add = ops.ErrorStatus('errored app')
+                self.unit_status_to_add = ops.ErrorStatus('errored unit')
+
+            def _on_collect_app_status(self, event: ops.CollectStatusEvent):
+                event.add_status(self.app_status_to_add)
+
+            def _on_collect_unit_status(self, event: ops.CollectStatusEvent):
+                event.add_status(self.unit_status_to_add)
+
+        harness = ops.testing.Harness(TestCharm)
+        harness.set_leader(True)
+        harness.begin()
+
+        with self.assertRaises(ops.model.ModelError):
+            harness.evaluate_status()
+
 
 class TestNetwork(unittest.TestCase):
     def setUp(self):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2852,27 +2852,21 @@ class TestHarness(unittest.TestCase):
         self.assertEqual(harness.model.unit.status, ops.ActiveStatus('active unit'))
 
     def test_invalid_status_set(self):
-
-        class TestCharm(ops.CharmBase):
-            def __init__(self, framework: ops.Framework):
-                super().__init__(framework)
-                self.framework.observe(self.on.collect_app_status, self._on_collect_app_status)
-                self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
-                self.app_status_to_add = ops.ErrorStatus('errored app')
-                self.unit_status_to_add = ops.ErrorStatus('errored unit')
-
-            def _on_collect_app_status(self, event: ops.CollectStatusEvent):
-                event.add_status(self.app_status_to_add)
-
-            def _on_collect_unit_status(self, event: ops.CollectStatusEvent):
-                event.add_status(self.unit_status_to_add)
-
-        harness = ops.testing.Harness(TestCharm)
+        harness = ops.testing.Harness(ops.CharmBase)
         harness.set_leader(True)
         harness.begin()
 
         with self.assertRaises(ops.model.ModelError):
-            harness.evaluate_status()
+            harness.model.app.status = ops.UnknownStatus()
+        with self.assertRaises(ops.model.ModelError):
+            harness.model.app.status = ops.ErrorStatus()
+        harness.model.app.status = ops.ActiveStatus()
+
+        with self.assertRaises(ops.model.ModelError):
+            harness.model.unit.status = ops.UnknownStatus()
+        with self.assertRaises(ops.model.ModelError):
+            harness.model.unit.status = ops.ErrorStatus()
+        harness.model.unit.status = ops.ActiveStatus()
 
 
 class TestNetwork(unittest.TestCase):


### PR DESCRIPTION
This small enhancement:
1. documents that `ErrorStatus` and `UnknownStatus` is for read-only.
2. raises an ops.ModelError, which is the same behavior on real juju backend.
