### PR TITLE
chore: bump version string for working on the next release

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -242,4 +242,4 @@ See [.github/workflows/publish.yml](.github/workflows/publish.yml) for details. 
 
 You can troubleshoot errors on the [Actions Tab](https://github.com/canonical/operator/actions).
 
-Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and [Mattermost](https://chat.charmhub.io/charmhub/channels/charm-dev)
+Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)

--- a/ops/version.py
+++ b/ops/version.py
@@ -17,4 +17,4 @@
 This module is NOT to be used when developing charms using ops.
 """
 
-version: str = '2.10.0.dev0'
+version: str = '2.10.0'

--- a/ops/version.py
+++ b/ops/version.py
@@ -17,4 +17,4 @@
 This module is NOT to be used when developing charms using ops.
 """
 
-version: str = '2.10.0'
+version: str = '2.11.0.dev0'


### PR DESCRIPTION
Also change the publishing instructions to post about the release on Matrix rather than Mattermost.