### PR TITLE
chore: move to ruff for linting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,8 +33,8 @@ furo._compute_navigation_tree = _compute_navigation_tree
 
 # Pull in fix from https://github.com/sphinx-doc/sphinx/pull/11222/files to fix
 # "invalid signature for autoattribute ('ops.pebble::ServiceDict.backoff-delay')"
-import re
-import sphinx.ext.autodoc
+import re  # noqa: E402
+import sphinx.ext.autodoc  # noqa: E402
 sphinx.ext.autodoc.py_ext_sig_re = re.compile(
     r'''^ ([\w.]+::)?            # explicit module name
           ([\w.]+\.)?            # module and/or class name(s)
@@ -150,7 +150,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # Find the current builder
 builder = "dirhtml"
 if '-b' in sys.argv:
-    builder = sys.argv[sys.argv.index('-b')+1]
+    builder = sys.argv[sys.argv.index('-b') + 1]
 
 html_theme = 'furo'
 html_last_updated_fmt = ""
@@ -158,7 +158,7 @@ html_permalinks_icon = "¶"
 html_theme_options = {
     "light_css_variables": {
         "color-sidebar-background-border": "none",
-        "font-stack": "Ubuntu, -apple-system, Segoe UI, Roboto, Oxygen, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif",
+        "font-stack": "Ubuntu, -apple-system, Segoe UI, Roboto, Oxygen, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif",  # noqa: E501
         "font-stack--monospace": "Ubuntu Mono, Consolas, Monaco, Courier, monospace",
         "color-foreground-primary": "#111",
         "color-foreground-secondary": "var(--color-foreground-primary)",
@@ -168,7 +168,7 @@ html_theme_options = {
         "color-brand-primary": "#111",
         "color-brand-content": "#06C",
         # NOTE: this looks horrible -- commented out
-        #"color-api-background": "#cdcdcd",
+        # "color-api-background": "#cdcdcd",
         "color-inline-code-background": "rgba(0,0,0,.03)",
         "color-sidebar-link-text": "#111",
         "color-sidebar-item-background--current": "#ebebeb",

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -173,20 +173,20 @@ __all__ = [
 # isort:skip_file
 
 # Import pebble explicitly. It's the one module we don't import names from below.
-from . import pebble  # type: ignore # noqa: F401
+from . import pebble  # type: ignore
 
 # Also import charm explicitly. This is not strictly necessary as the
 # "from .charm" import automatically does that, but be explicit since this
 # import was here previously
-from . import charm  # type: ignore # noqa: F401
+from . import charm  # type: ignore # noqa: F401 `.charm` imported but unused
 
 # Import the main module, which we've overriden in main.py to be callable.
 # This allows "import ops; ops.main(Charm)" to work as expected.
-from . import main  # type: ignore # noqa: F401
+from . import main  # type: ignore
 
 # Explicitly import names from submodules so users can just "import ops" and
 # then use them as "ops.X".
-from .charm import (  # noqa: F401
+from .charm import (
     ActionEvent,
     ActionMeta,
     CharmBase,
@@ -237,7 +237,7 @@ from .charm import (  # noqa: F401
     WorkloadEvent,
 )
 
-from .framework import (  # noqa: F401
+from .framework import (
     BoundEvent,
     BoundStoredState,
     CommitEvent,
@@ -261,9 +261,9 @@ from .framework import (  # noqa: F401
     StoredStateData,
 )
 
-from .jujuversion import JujuVersion  # noqa: F401
+from .jujuversion import JujuVersion
 
-from .model import (  # noqa: F401 E402
+from .model import (
     ActiveStatus,
     Application,
     Binding,
@@ -312,4 +312,4 @@ from .model import (  # noqa: F401 E402
 # NOTE: don't import testing or Harness here, as that's a test-time concern
 # rather than a runtime concern.
 
-from .version import version as __version__  # noqa: F401 E402
+from .version import version as __version__

--- a/ops/_private/__init__.py
+++ b/ops/_private/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019-2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -630,7 +630,7 @@ class StorageEvent(HookEvent):
 
         if storage_name and storage_index is not None:
             storages = self.framework.model.storages[storage_name]
-            self.storage = next((s for s in storages if s.index == storage_index), None)  # type: ignore # noqa
+            self.storage = next((s for s in storages if s.index == storage_index), None)  # type: ignore
             if self.storage is None:
                 msg = 'failed loading storage (name={!r}, index={!r}) from snapshot' \
                     .format(storage_name, storage_index)
@@ -970,8 +970,7 @@ class CollectStatusEvent(EventBase):
                     return
                 event.add_status(ops.ActiveStatus())
 
-    .. # noqa (pydocstyle barfs on the above for unknown reasons I've spent hours on)
-    """
+    """  # noqa: D405, D214, D411, D416  Final return confuses docstyle.
 
     def add_status(self, status: model.StatusBase):
         """Add a status for evaluation.

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -60,13 +60,13 @@ class Serializable(typing.Protocol):
     @property
     def handle(self) -> 'Handle': ...  # noqa
     @handle.setter
-    def handle(self, val: 'Handle'): ...  # noqa
+    def handle(self, val: 'Handle'): ...
     def snapshot(self) -> Dict[str, Any]: ...  # noqa
     def restore(self, snapshot: Dict[str, Any]) -> None: ...  # noqa
 
 
 class _StoredObject(Protocol):
-    _under: Any = None  # noqa
+    _under: Any = None
 
 
 StoredObject = Union['StoredList', 'StoredSet', 'StoredDict']

--- a/ops/model.py
+++ b/ops/model.py
@@ -296,9 +296,9 @@ class _ModelCache:
         self._weakrefs: _WeakCacheType = weakref.WeakValueDictionary()
 
     @typing.overload
-    def get(self, entity_type: Type['Unit'], name: str) -> 'Unit': ...  # noqa
+    def get(self, entity_type: Type['Unit'], name: str) -> 'Unit': ...
     @typing.overload
-    def get(self, entity_type: Type['Application'], name: str) -> 'Application': ...  # noqa
+    def get(self, entity_type: Type['Application'], name: str) -> 'Application': ...
 
     def get(self, entity_type: 'UnitOrApplicationType', name: str):
         """Fetch the cached entity of type `entity_type` with name `name`."""
@@ -2238,11 +2238,11 @@ class Container:
         return checks[check_name]
 
     @typing.overload
-    def pull(self, path: Union[str, PurePath], *, encoding: None) -> BinaryIO:  # noqa
+    def pull(self, path: Union[str, PurePath], *, encoding: None) -> BinaryIO:
         ...
 
     @typing.overload
-    def pull(self, path: Union[str, PurePath], *, encoding: str = 'utf-8') -> TextIO:  # noqa
+    def pull(self, path: Union[str, PurePath], *, encoding: str = 'utf-8') -> TextIO:
         ...
 
     def pull(self, path: Union[str, PurePath], *,
@@ -2639,7 +2639,7 @@ class Container:
 
     # Exec I/O is str if encoding is provided (the default)
     @typing.overload
-    def exec(  # noqa
+    def exec(
         self,
         command: List[str],
         *,
@@ -2661,7 +2661,7 @@ class Container:
 
     # Exec I/O is bytes if encoding is explicitly set to None
     @typing.overload
-    def exec(  # noqa
+    def exec(
         self,
         command: List[str],
         *,

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -168,7 +168,7 @@ _ServiceInfoDict = TypedDict('_ServiceInfoDict',
 
 
 class _BodyHandler(Protocol):
-    def __call__(self, data: bytes, done: bool = False) -> None: ...  # noqa
+    def __call__(self, data: bytes, done: bool = False) -> None: ...
 
 
 _HeaderHandler = Callable[[bytes], None]
@@ -179,14 +179,14 @@ _HeaderHandler = Callable[[bytes], None]
 
 class _Tempfile(Protocol):
     name = ''
-    def write(self, data: bytes): ...  # noqa
-    def close(self): ...  # noqa
+    def write(self, data: bytes): ...
+    def close(self): ...
 
 
 class _FileLikeIO(Protocol[typing.AnyStr]):  # That also covers TextIO and BytesIO
-    def read(self, __n: int = ...) -> typing.AnyStr: ...  # for BinaryIO  # noqa
-    def write(self, __s: typing.AnyStr) -> int: ...  # noqa
-    def __enter__(self) -> typing.IO[typing.AnyStr]: ...  # noqa
+    def read(self, __n: int = ...) -> typing.AnyStr: ...  # for BinaryIO
+    def write(self, __s: typing.AnyStr) -> int: ...
+    def __enter__(self) -> typing.IO[typing.AnyStr]: ...
 
 
 _AnyStrFileLikeIO = Union[_FileLikeIO[bytes], _FileLikeIO[str]]
@@ -275,11 +275,11 @@ if TYPE_CHECKING:
 
 
 class _WebSocket(Protocol):
-    def connect(self, url: str, socket: socket.socket): ...  # noqa
-    def shutdown(self): ...                                  # noqa
-    def send(self, payload: str): ...                        # noqa
-    def send_binary(self, payload: bytes): ...               # noqa
-    def recv(self) -> Union[str, bytes]: ...                 # noqa
+    def connect(self, url: str, socket: socket.socket): ...
+    def shutdown(self): ...
+    def send(self, payload: str): ...
+    def send_binary(self, payload: bytes): ...
+    def recv(self) -> Union[str, bytes]: ...
 
 
 logger = logging.getLogger(__name__)
@@ -2098,11 +2098,11 @@ class Client:
         return [ServiceInfo.from_dict(info) for info in resp['result']]
 
     @typing.overload
-    def pull(self, path: str, *, encoding: None) -> BinaryIO:  # noqa
+    def pull(self, path: str, *, encoding: None) -> BinaryIO:
         ...
 
     @typing.overload
-    def pull(self, path: str, *, encoding: str = 'utf-8') -> TextIO:  # noqa
+    def pull(self, path: str, *, encoding: str = 'utf-8') -> TextIO:
         ...
 
     def pull(self,
@@ -2381,7 +2381,7 @@ class Client:
 
     # Exec I/O is str if encoding is provided (the default)
     @typing.overload
-    def exec(  # noqa
+    def exec(
         self,
         command: List[str],
         *,
@@ -2403,7 +2403,7 @@ class Client:
 
     # Exec I/O is bytes if encoding is explicitly set to None
     @typing.overload
-    def exec(  # noqa
+    def exec(
         self,
         command: List[str],
         *,

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2687,14 +2687,14 @@ class _TestingModelBackend:
         # should be testing details of error messages).
         if protocol == 'icmp':
             if port is not None:
-                raise model.ModelError(f'ERROR protocol "{protocol}" doesn\'t support any ports; got "{port}"\n')  # NOQA: test_quote_backslashes
+                raise model.ModelError(f'ERROR protocol "{protocol}" doesn\'t support any ports; got "{port}"\n')  # noqa: E501
         elif protocol in ['tcp', 'udp']:
             if port is None:
-                raise model.ModelError(f'ERROR invalid port "{protocol}": strconv.Atoi: parsing "{protocol}": invalid syntax\n')  # NOQA: test_quote_backslashes
+                raise model.ModelError(f'ERROR invalid port "{protocol}": strconv.Atoi: parsing "{protocol}": invalid syntax\n')  # noqa: E501
             if not (1 <= port <= 65535):
-                raise model.ModelError(f'ERROR port range bounds must be between 1 and 65535, got {port}-{port}\n')  # NOQA: test_quote_backslashes
+                raise model.ModelError(f'ERROR port range bounds must be between 1 and 65535, got {port}-{port}\n')  # noqa: E501
         else:
-            raise model.ModelError(f'ERROR invalid protocol "{protocol}", expected "tcp", "udp", or "icmp"\n')  # NOQA: test_quote_backslashes
+            raise model.ModelError(f'ERROR invalid protocol "{protocol}", expected "tcp", "udp", or "icmp"\n')  # noqa: E501
 
     def reboot(self, now: bool = False):
         self._reboot_count += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,19 +62,49 @@ recursive = true
 jobs = -1
 aggressive = 3
 
-[tool.isort]
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-ignore = ["D105", "D107", "W503"]
-# D100, D101, D102, D103, D104: Ignore missing docstrings in tests
-per-file-ignores = ["test/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
+[tool.ruff]
+line-length = 99
+target-version = "py38"
+
+[tool.ruff.lint]
+select = [
+    # Pyflakes
+    "F",
+    # Pycodestyle
+    "E",
+    "W",
+    # isort
+    "I001",
+    # pep8-naming
+    "N",
+    # flake8-builtins
+    "A",
+    # flake8-copyright
+    "CPY",
+    # pyflakes-docstrings
+    "D",
+]
+ignore = [
+    # Missing docstring in magic method
+    "D105",
+    # Missing docstring in `__init__`
+    "D107",
+]
+[tool.ruff.per-file-ignores]
+"test/*" = ["D"]
+"docs/conf.py" = [
+    "CPY001",  # Missing copyright notice at top of file
+    "D100",  # Missing docstring in public module
+    "I001",  # [*] Import block is un-sorted or un-formatted
+    "A001",  # Variable `copyright` is shadowing a Python builtin
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.flake8-builtins]
+builtins-ignorelist = ["id", "min", "map", "range", "type", "TimeoutError", "ConnectionError", "Warning", "input", "format"]
 
 [tool.pyright]
 include = ["ops/*.py", "ops/_private/*.py", "test/*.py", "test/charms/*/src/*.py"]

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019-2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/charms/test_main/lib/__init__.py
+++ b/test/charms/test_main/lib/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019-2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/test_infra.py
+++ b/test/test_infra.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import itertools
 import os
-import re
 import subprocess
 import sys
 import tempfile
@@ -34,38 +32,6 @@ def get_python_filepaths(include_tests: bool = True):
                 if filename.endswith(".py"):
                     python_paths.append(os.path.join(dirpath, filename))
     return python_paths
-
-
-class InfrastructureTests(unittest.TestCase):
-
-    def test_quote_backslashes(self):
-        # ensure we're not using unneeded backslash to escape strings
-        issues: typing.List[typing.Tuple[str, int, str]] = []
-        for filepath in get_python_filepaths():
-            with open(filepath, "rt", encoding="utf8") as fh:
-                for idx, line in enumerate(fh, 1):
-                    if (r'\"' in line or r"\'" in line) and "NOQA" not in line:
-                        issues.append((filepath, idx, line.rstrip()))
-        if issues:
-            msgs = ["{}:{:d}:{}".format(*issue) for issue in issues]
-            self.fail("Spurious backslashes found, please fix these quotings:\n" + "\n".join(msgs))
-
-    def test_ensure_copyright(self):
-        # all non-empty Python files must have a proper copyright somewhere in the first 5 lines
-        issues: typing.List[str] = []
-        regex = re.compile(r"# Copyright \d\d\d\d(-\d\d\d\d)? Canonical Ltd.\n")
-        for filepath in get_python_filepaths():
-            if os.stat(filepath).st_size == 0:
-                continue
-
-            with open(filepath, "rt", encoding="utf8") as fh:
-                for line in itertools.islice(fh, 5):
-                    if regex.match(line):
-                        break
-                else:
-                    issues.append(filepath)
-        if issues:
-            self.fail("Please add copyright headers to the following files:\n" + "\n".join(issues))
 
 
 class ImportersTestCase(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -44,18 +44,9 @@ commands =
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    autopep8~=1.6
-    flake8~=6.1
-    flake8-docstrings~=1.7
-    flake8-builtins~=2.1
-    isort~=5.11
-    pep8-naming~=0.13
-    pyproject-flake8~=6.1
+    ruff~=0.1.4
 commands =
-    # pflake8 wrapper suppports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
-    autopep8 --diff {[vars]all_path}
+    ruff check --preview
 
 [testenv:static]
 description = Run static type checker


### PR DESCRIPTION
This PR replaces flake8, flake8-docstrings, flake8-builtins, isort, autopep8, pep8-naming, pyproject-flake8, and two test_infra unit tests with ruff for linting. Formatting remains unchanged (to be addressed in #1103).

Notes:

1. Ruff does not yet implement all of the pycodestyle rules, which we checked/fixed with autopep8, see: https://github.com/astral-sh/ruff/issues/2402
2. Ruff implements all Flake8 rules (the "F" rules).
3. flake8-docstrings is not listed in the Ruff re-implementation list by pydocstyle is there, which flake8-docstrings is based on
4. Ruff reimplements flake8-builtins (but picks up much more than we were previously, which is odd).
5. Ruff's isort is "profile='black'".
6. With flake8 we had "R" rules enabled, but I can't figure out what those were, or what provided them.

Where the linter picks up issues that the old tools did not, handle in one of these ways:
* Ignore with a `noqa:` directive if it's a false positive or should otherwise be permanently ignored in that specific case
* Ignore for a file or group of files (the docs and tests have several of these) where it's something we want to pick up in the core code but not everywhere
* Ignore with a note to review later when it's likely that there would be too much additional noise in this PR
* Make the recommended change, when it's small and seems reasonable

#1104 will continue on from this with a few more changes that are minimal and reasonable, and enabling additional rule sets (since they are bundled with ruff, and since ruff is so fast, they are basically free) that I agree with/like the most.

A few outdated `noqa:`  directives have been removed (ruff detects these as well).

Fixes #1102.