### PR TITLE
feat: only have a `defer()` method on events that can be deferred

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2.11.0
+
+* `StopEvent`, `RemoveEvent`, and all `LifeCycleEvent`s are no longer deferrable, and will raise a `RuntimeError` if `defer()` is called on the event object.
+
 # 2.10.0
 
 * Added support for Pebble Notices (`PebbleCustomNoticeEvent`, `get_notices`, and so on)

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -243,12 +243,34 @@ class StopEvent(HookEvent):
     and that it will not start again on reboot.
     """
 
+    def defer(self) -> NoReturn:
+        """Stop events are not deferrable like other events.
+
+        This is because the unit is in the process of tearing down, and there
+        will not be an opportunity for the deferred event to run.
+
+        Raises:
+            RuntimeError: always.
+        """
+        raise RuntimeError('cannot defer stop events')
+
 
 class RemoveEvent(HookEvent):
     """Event triggered when a unit is about to be terminated.
 
     This event fires prior to Juju removing the charm and terminating its unit.
     """
+
+    def defer(self) -> NoReturn:
+        """Remove events are not deferrable like other events.
+
+        This is because the unit is about to be torn down, and there
+        will not be an opportunity for the deferred event to run.
+
+        Raises:
+            RuntimeError: always.
+        """
+        raise RuntimeError('cannot defer remove events')
 
 
 class ConfigChangedEvent(HookEvent):

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -527,7 +527,7 @@ class LifecycleEvent(EventBase):
     def defer(self) -> NoReturn:
         """Lifecycle events are not deferrable like other events.
 
-        This is because these events are run alongside each event invokation,
+        This is because these events are run alongside each event invocation,
         so deferring would always end up simply doubling the work.
 
         Raises:

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -38,6 +38,7 @@ from typing import (
     Iterable,
     List,
     Literal,
+    NoReturn,
     Optional,
     Protocol,
     Set,
@@ -172,7 +173,7 @@ class Handle:
 
 
 class EventBase:
-    """The base class for all events that may be deferred.
+    """The base class for all events.
 
     Inherit this and override the ``snapshot`` and ``restore`` methods to
     create a custom event.
@@ -522,6 +523,17 @@ class PrefixedEvents:
 
 class LifecycleEvent(EventBase):
     """Events tied to the lifecycle of the Framework object."""
+
+    def defer(self) -> NoReturn:
+        """Lifecycle events are not deferrable like other events.
+
+        This is because these events are run alongside each event invokation,
+        so deferring would always end up simply doubling the work.
+
+        Raises:
+            RuntimeError: always.
+        """
+        raise RuntimeError('cannot defer lifecycle events')
 
 
 class PreCommitEvent(LifecycleEvent):

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -522,7 +522,7 @@ start:
                 framework.observe(self.on.start_action, self._on_start_action)
 
             def _on_start_action(self, event: ops.ActionEvent):
-                event.defer()
+                event.defer()  # type: ignore
 
         fake_script(self, f"{cmd_type}-get", """echo '{"foo-name": "name", "silent": true}'""")
         self.meta = self._get_action_test_meta()
@@ -531,7 +531,7 @@ start:
         framework = self.create_framework()
         charm = MyCharm(framework)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AttributeError):
             charm.on.start_action.emit()
 
     def test_action_event_defer_fails(self):

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -522,7 +522,7 @@ start:
                 framework.observe(self.on.start_action, self._on_start_action)
 
             def _on_start_action(self, event: ops.ActionEvent):
-                event.defer()  # type: ignore
+                event.defer()
 
         fake_script(self, f"{cmd_type}-get", """echo '{"foo-name": "name", "silent": true}'""")
         self.meta = self._get_action_test_meta()
@@ -531,7 +531,7 @@ start:
         framework = self.create_framework()
         charm = MyCharm(framework)
 
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(RuntimeError):
             charm.on.start_action.emit()
 
     def test_action_event_defer_fails(self):


### PR DESCRIPTION
There are two goals for this PR:

* Prevent charms from calling `defer()` on events where that makes no sense
* Alert charmers as early as possible when they are using `defer()` where it doesn't make sense

The original version of the PR adjusted the various event classes so that the events that shouldn't have `defer()` called didn't have the method at all. This achieves both goals (most IDEs and checkers will detect that a method is being called that isn't defined). However, that was too significant a change, as we could not maintain the pattern for creating custom events and also checks like `isinstance(action_event, ops.EventBase)`.

Instead, we continue with the same practice as we already use for `ActionEvent`, `SecretExpiredEvent`, and `SecretRotateEvent`:
* Set the return type to `typing.NoReturn` - this shows any code after the `defer()` call as unreachable (at least in VS Code) - hopefully there is at least a `return` after the `defer()` call.
* Raises a `RuntimeError` if `defer()` is actually called, which prevents inappropriate `defer()` use in production and will hopefully be caught in tests.

The additional events that get this behaviour are:
* `StopEvent` (I feel that this is the most borderline)
* `RemoveEvent`
* `LifecycleEvent`s

Other options considered (as well as setting the return type):
* Change the signature of `defer()` in the classes that shouldn't use it, e.g. to have a "does_not_support_defer" argument. This will raise a `TypeError` instead of `RuntimeError` or `AttributeError`, with a hint (the name of the argument) as to why it's happened, and this will usually show in IDEs and linters. This provides an earlier warning, which is good, but I feel it's too much a nice hack.
* Call `warnings.warn("x events should not be deferred", RuntimeWarning)` or `warnings.warn("x events should not be deferred", DeprecationWarning)` in the `defer()` in the classes that shouldn't use it. This is safer, but I'm not convinced that it will be noticed. I had thought that unittest/pytest defaulted to something like `-Werror` but that isn't the case. That means that unless someone is running their tests with a similar sort of warnings filter, or is paying close attention to the test output, this is likely to be missed.

I've run the current state of the branch over ~135 Canonical charms' `tox -e unit` and there are no new failures (and the existing failures don't seem to be masking any new issues), so it seems reasonably safe to make this change.