### PR TITLE
docs: tweak the wording around can_connect() usage

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -2097,7 +2097,7 @@ class Container:
 
         For example::
 
-            # Add state based on any earlier errors communicating with Pebble.
+            # Add status based on any earlier errors communicating with Pebble.
             ...
             # Check that Pebble is still reachable now.
             container = self.unit.get_container("example")

--- a/ops/model.py
+++ b/ops/model.py
@@ -2065,13 +2065,15 @@ class Container:
     For methods that make changes to the container, if the change fails or times out, then a
     :class:`ops.pebble.ChangeError` or :class:`ops.pebble.TimeoutError` will be raised.
 
-    Interactions with the container use Pebble, so all methods may raise exceptions when there are
-    problems communicating with Pebble. Problems connecting to or transferring data with Pebble
-    will raise a :class:`ops.pebble.ConnectionError` - generally you can guard against these by
-    first checking :meth:`can_connect`, but it is possible for problems to occur after
-    :meth:`can_connect` has succeeded. When an error occurs executing the request, such as trying
-    to add an invalid layer or execute a command that does not exist, an
-    :class:`ops.pebble.APIError` is raised.
+    Interactions with the container use Pebble, so all methods may raise
+    exceptions when there are problems communicating with Pebble. Problems
+    connecting to or transferring data with Pebble will raise a
+    :class:`ops.pebble.ConnectionError` - you can guard against these by first
+    checking :meth:`can_connect`, but that generally introduces a race condition 
+    where problems occur after :meth:`can_connect` has succeeded. When an error
+    occurs executing the request, such as trying to add an invalid layer or
+    execute a command that does not exist, an :class:`ops.pebble.APIError` is
+    raised.
     """
 
     name: str
@@ -2095,14 +2097,12 @@ class Container:
 
         For example::
 
+            # Add state based on any earlier errors communicating with Pebble.
+            ...
+            # Check that Pebble is still reachable now.
             container = self.unit.get_container("example")
-            if container.can_connect():
-                try:
-                    c.pull('/does/not/exist')
-                except ProtocolError, PathError:
-                    # handle it
-            else:
-                event.defer()
+            if not container.can_connect():
+                event.add_status(ops.WaitingStatus("Waiting for Pebble..."))
         """
         try:
             self._pebble.get_system_info()

--- a/ops/model.py
+++ b/ops/model.py
@@ -2069,7 +2069,7 @@ class Container:
     exceptions when there are problems communicating with Pebble. Problems
     connecting to or transferring data with Pebble will raise a
     :class:`ops.pebble.ConnectionError` - you can guard against these by first
-    checking :meth:`can_connect`, but that generally introduces a race condition 
+    checking :meth:`can_connect`, but that generally introduces a race condition
     where problems occur after :meth:`can_connect` has succeeded. When an error
     occurs executing the request, such as trying to add an invalid layer or
     execute a command that does not exist, an :class:`ops.pebble.APIError` is


### PR DESCRIPTION
`can_connect()` is a point-in-time check, and, if used as a guard for interacting with Pebble, introduces a race condition where Pebble was responding at the `can_connect()` time, but is not when the rest of the work is done.

We already encourage people to handle errors communicating with Pebble when doing the later work (catching `ConnectionError`), which means that most of the time the `can_connect` call is not providing any value (and incurs a small cost). However, the documentation, particularly the example, encourages this pattern, and this has been copied to many other places (charm sources, docs).

This PR adjusts the documentation to be less encouraging of `can_connect()` use as a guard, and changes the example to one where a point-in-time check is wanted (for collecting unit status).