### PR TITLE
feat: add the ability to compare two Plan objects with == and create a Plan from a dict

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2.11.0
+
+* Added support for creating `pebble.Plan` objects by passing in a `pebble.PlanDict`, and the
+  ability to compare two `Plan` objects with `==`.
+
 # 2.10.0
 
 * Added support for Pebble Notices (`PebbleCustomNoticeEvent`, `get_notices`, and so on)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@
 
 * `StopEvent`, `RemoveEvent`, and all `LifeCycleEvent`s are no longer deferrable, and will raise a `RuntimeError` if `defer()` is called on the event object.
 * Added `ActionEvent.id`, exposing the JUJU_ACTION_UUID environment variable.
-* Added support for creating `pebble.Plan` objects by passing in a `pebble.PlanDict`, and the
-  ability to compare two `Plan` objects with `==`.
+* Added support for creating `pebble.Plan` objects by passing in a `pebble.PlanDict`, the
+  ability to compare two `Plan` objects with `==`, and the ability to create an empty Plan with `Plan()`.
 
 # 2.10.0
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,11 +22,13 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
 
 _old_compute_navigation_tree = furo._compute_navigation_tree
 
+
 def _compute_navigation_tree(context):
     tree_html = _old_compute_navigation_tree(context)
     if not tree_html and context.get("toc"):
         tree_html = furo.navigation.get_navigation_tree(context["toc"])
     return tree_html
+
 
 furo._compute_navigation_tree = _compute_navigation_tree
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -791,8 +791,10 @@ class Plan:
 
     __str__ = to_yaml
 
-    def __eq__(self, __value: object) -> bool:
-        if isinstance(__value, Plan):
+    def __eq__(self, __value: Union['PlanDict', 'Plan']) -> bool:
+        if isinstance(__value, dict):
+            return self.to_dict() == __value
+        elif isinstance(__value, Plan):
             return self.to_dict() == __value.to_dict()
         return super().__eq__(__value)
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -735,8 +735,11 @@ class Plan:
     documented at https://github.com/canonical/pebble/#layer-specification.
     """
 
-    def __init__(self, raw: str):
-        d = yaml.safe_load(raw) or {}  # type: ignore
+    def __init__(self, raw: Optional[Union[str, 'PlanDict']]):
+        if isinstance(raw, str):
+            d = yaml.safe_load(raw) or {}  # type: ignore
+        else:
+            d = raw or {}
         d = typing.cast('PlanDict', d)
 
         self._raw = raw
@@ -787,6 +790,11 @@ class Plan:
         return yaml.safe_dump(self.to_dict())
 
     __str__ = to_yaml
+
+    def __eq__(self, __value: object) -> bool:
+        if isinstance(__value, Plan):
+            return self.to_dict() == __value.to_dict()
+        return super().__eq__(__value)
 
 
 class Layer:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -743,7 +743,7 @@ class Plan:
     documented at https://github.com/canonical/pebble/#layer-specification.
     """
 
-    def __init__(self, raw: Optional[Union[str, 'PlanDict']]):
+    def __init__(self, raw: Optional[Union[str, 'PlanDict']] = None):
         if isinstance(raw, str):  # noqa: SIM108
             d = yaml.safe_load(raw) or {}  # type: ignore
         else:
@@ -799,12 +799,12 @@ class Plan:
 
     __str__ = to_yaml
 
-    def __eq__(self, __value: Union['PlanDict', 'Plan']) -> bool:
-        if isinstance(__value, dict):
-            return self.to_dict() == __value
-        elif isinstance(__value, Plan):
-            return self.to_dict() == __value.to_dict()
-        return super().__eq__(__value)
+    def __eq__(self, other: Union['PlanDict', 'Plan']) -> bool:
+        if isinstance(other, dict):
+            return self.to_dict() == other
+        elif isinstance(other, Plan):
+            return self.to_dict() == other.to_dict()
+        return NotImplemented
 
 
 class Layer:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -179,13 +179,17 @@ _HeaderHandler = Callable[[bytes], None]
 
 class _Tempfile(Protocol):
     name = ''
+
     def write(self, data: bytes): ...
+
     def close(self): ...
 
 
 class _FileLikeIO(Protocol[typing.AnyStr]):  # That also covers TextIO and BytesIO
     def read(self, __n: int = ...) -> typing.AnyStr: ...  # for BinaryIO
+
     def write(self, __s: typing.AnyStr) -> int: ...
+
     def __enter__(self) -> typing.IO[typing.AnyStr]: ...
 
 
@@ -276,9 +280,13 @@ if TYPE_CHECKING:
 
 class _WebSocket(Protocol):
     def connect(self, url: str, socket: socket.socket): ...
+
     def shutdown(self): ...
+
     def send(self, payload: str): ...
+
     def send_binary(self, payload: bytes): ...
+
     def recv(self) -> Union[str, bytes]: ...
 
 
@@ -736,7 +744,7 @@ class Plan:
     """
 
     def __init__(self, raw: Optional[Union[str, 'PlanDict']]):
-        if isinstance(raw, str):
+        if isinstance(raw, str):  # noqa: SIM108
             d = yaml.safe_load(raw) or {}  # type: ignore
         else:
             d = raw or {}

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -654,6 +654,15 @@ services:
     override: replace
 ''')
         self.assertTrue(plan1 == plan2)
+        plan1_as_dict = pebble.PlanDict({
+            "services": {
+                "foo": pebble.ServiceDict({
+                    "command": "echo foo",
+                    "override": "replace",
+                })
+            },
+        })
+        self.assertTrue(plan1, plan1_as_dict)
         plan3 = pebble.Plan('''
 services:
   foo:

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands =
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    ruff~=0.2.1
+    ruff~=0.2.2
 commands =
     ruff check --preview
 


### PR DESCRIPTION
This PR adds two minor features to `pebble.Plan` objects to simplify testing (particularly with Scenario):

* The ability to compare two `pebble.Plan` objects, or a `Plan` with a `dict`, with `==` - comparison to any other type of object  will still return False.
* The ability to instantiate a `pebble.Plan` object from a `pebble.PlanDict` (or equivalent dict).

This aligns the `Plan` functionality with `Layer` objects.