### PR TITLE
chore: adjust isort to be more compatible with ruff

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -631,7 +631,9 @@ class StorageEvent(HookEvent):
 
         if storage_name and storage_index is not None:
             storages = self.framework.model.storages[storage_name]
-            self.storage = next((s for s in storages if s.index == storage_index), None)  # type: ignore
+            self.storage = next(
+                (s for s in storages if s.index == storage_index),
+                None)  # type: ignore
             if self.storage is None:
                 msg = 'failed loading storage (name={!r}, index={!r}) from snapshot' \
                     .format(storage_name, storage_index)

--- a/tox.ini
+++ b/tox.ini
@@ -36,9 +36,9 @@ commands =
 description = Apply coding style standards to code
 deps =
     autopep8~=1.6
-    isort~=5.11
+    isort~=5.13
 commands =
-    isort {[vars]all_path}
+    isort {[vars]all_path} --multi-line=3 --line-length=99 --split-on-trailing-comma
     autopep8 --in-place {[vars]all_path}
 
 [testenv:lint]


### PR DESCRIPTION
Currently, running `tox -e fmt` leaves the code in a state that `tox -e lint` complains about, for two reasons:

* Wrapping a line in ops/charm - I'm not sure why this difference exists since autopep8 and ruff have the same max line length (or why it wasn't picked up before we used ruff), but ruff is ok with the wrapped version, so it seems like the simple fix here is to just have it wrapped.
* "from x import a,b,c" style imports and wrapping.

For the import issue, if we adjust isort to use the "vertical hanging indent" mode (weirdly called "3") that gets most of the way there, but even though the docs show a trailing comma, one isn't included. However, if we use the `--split-on-trailing-comma` mode as well that does lead to a compatible format. We're not using the "force wrapping via trailing comma" trick anywhere, but it seems harmless enough to have it enabled.

I've put the options in tox.ini rather than pyproject.toml because we're intending to move to `ruff` for formatting soon (#1103) and this ensures that these options go away, rather than getting missed in pyproject.toml. I can change that if we'd rather keep all the options in one place.

Also bumped the isort version, which isn't required but I did while investigating, and since I've tested it and it's ok, seems reasonable. Also passed the line length to isort, which isn't needed at the moment but is more consistent.