### PR TITLE
fix(framework): add warning on lost observer weakref

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -60,12 +60,9 @@ class Serializable(typing.Protocol):
 
     @property
     def handle(self) -> 'Handle': ...  # noqa
-
     @handle.setter
     def handle(self, val: 'Handle'): ...
-
     def snapshot(self) -> Dict[str, Any]: ...  # noqa
-
     def restore(self, snapshot: Dict[str, Any]) -> None: ...  # noqa
 
 
@@ -948,7 +945,7 @@ class Framework(Object):
                     event_is_action = isinstance(event, charm.ActionEvent)
                     with self._event_context(event_handle.kind):
                         if (
-                                event_is_from_juju or event_is_action
+                            event_is_from_juju or event_is_action
                         ) and self._juju_debug_at.intersection({'all', 'hook'}):
                             # Present the welcome message and run under PDB.
                             self._show_debug_code_message()
@@ -1182,7 +1179,7 @@ class StoredState:
     def __get__(self,
                 parent: Optional['_ObjectType'],
                 parent_type: 'Type[_ObjectType]') -> Union['StoredState',
-    BoundStoredState]:
+                                                           BoundStoredState]:
         if self.parent_type is not None and self.parent_type not in parent_type.mro():
             # the StoredState instance is being shared between two unrelated classes
             # -> unclear what is expected of us -> bail out

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -60,9 +60,12 @@ class Serializable(typing.Protocol):
 
     @property
     def handle(self) -> 'Handle': ...  # noqa
+
     @handle.setter
     def handle(self, val: 'Handle'): ...
+
     def snapshot(self) -> Dict[str, Any]: ...  # noqa
+
     def restore(self, snapshot: Dict[str, Any]) -> None: ...  # noqa
 
 
@@ -945,7 +948,7 @@ class Framework(Object):
                     event_is_action = isinstance(event, charm.ActionEvent)
                     with self._event_context(event_handle.kind):
                         if (
-                            event_is_from_juju or event_is_action
+                                event_is_from_juju or event_is_action
                         ) and self._juju_debug_at.intersection({'all', 'hook'}):
                             # Present the welcome message and run under PDB.
                             self._show_debug_code_message()
@@ -953,6 +956,14 @@ class Framework(Object):
                         else:
                             # Regular call to the registered method.
                             custom_handler(event)
+
+            else:
+                logger.warning(
+                    f"Weakref to Object at path {observer_path} has been killed somewhere "
+                    "between charm initialization and event emission. "
+                    "This can mean that you are using an Object which is not hard-referenced "
+                    "anywhere from the CharmBase tree. We won't be able to emit any events on it."
+                )
 
             if event.deferred:
                 deferred = True
@@ -1171,7 +1182,7 @@ class StoredState:
     def __get__(self,
                 parent: Optional['_ObjectType'],
                 parent_type: 'Type[_ObjectType]') -> Union['StoredState',
-                                                           BoundStoredState]:
+    BoundStoredState]:
         if self.parent_type is not None and self.parent_type not in parent_type.mro():
             # the StoredState instance is being shared between two unrelated classes
             # -> unclear what is expected of us -> bail out

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -956,10 +956,9 @@ class Framework(Object):
 
             else:
                 logger.warning(
-                    f"Weakref to Object at path {observer_path} has been killed somewhere "
-                    "between charm initialization and event emission. "
-                    "This can mean that you are using an Object which is not hard-referenced "
-                    "anywhere from the CharmBase tree. We won't be able to emit any events on it."
+                    f"Reference to ops.Object at path {observer_path} has been garbage collected "
+                    "between when the charm was initialised and when the event was emitted. "
+                    "Make sure sure you store a reference to the observer."
                 )
 
             if event.deferred:

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -128,7 +128,7 @@ class TestCharm(unittest.TestCase):
         # check that the event has been seen by the observer
         self.assertIsInstance(charm.seen, ops.StartEvent)
 
-    def test_observe_nested_object_noninstantiated(self):
+    def test_observer_not_referenced_warning(self):
         class MyObj(ops.Object):
             def __init__(self, charm: ops.CharmBase):
                 super().__init__(charm, "obj")
@@ -150,7 +150,7 @@ class TestCharm(unittest.TestCase):
         c = MyCharm(framework)
         with self.assertLogs() as logs:
             c.on.start.emit()
-        assert logs
+        assert any('Reference to ops.Object' in log for log in logs.output)
 
     def test_empty_action(self):
         meta = ops.CharmMeta.from_yaml('name: my-charm', '')

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -130,13 +130,12 @@ class TestCharm(unittest.TestCase):
 
     def test_observe_nested_object_noninstantiated(self):
         class MyObj(ops.Object):
-            def __init__(self, charm, *args: typing.Any):
+            def __init__(self, charm: ops.CharmBase):
                 super().__init__(charm, "obj")
                 framework.observe(charm.on.start, self._on_start)
 
-            def _on_start(self, _):
+            def _on_start(self, _: ops.StartEvent):
                 raise RuntimeError()  # never reached!
-
 
         class MyCharm(ops.CharmBase):
             def __init__(self, *args: typing.Any):
@@ -144,7 +143,7 @@ class TestCharm(unittest.TestCase):
                 MyObj(self)  # not assigned!
                 framework.observe(self.on.start, self._on_start)
 
-            def _on_start(self, event: ops.EventBase):
+            def _on_start(self, _: ops.StartEvent):
                 pass  # is reached
 
         framework = self.create_framework()


### PR DESCRIPTION
So this is a tricky one.

At times charmers are tempted to write:
```
        class MyObj(ops.Object):
            def __init__(self, charm, *args: typing.Any):
                super().__init__(charm, "obj")
                framework.observe(charm.on.start, self._on_start)

            def _on_start(self, _):
                raise RuntimeError()  # never reached!!! 


        class MyCharm(ops.CharmBase):
            def __init__(self, *args: typing.Any):
                super().__init__(*args)
                MyObj(self)  # not assigned!
                framework.observe(self.on.start, self._on_start)

            def _on_start(self, event: ops.EventBase):
                pass  # is reached
```

and expect that both _on_start methods will be triggered, while due to some subtle implementation details, MyObj._on_start never fires because the notice is silently dropped if the weakref stored in Framework._observer has been gc'd between charm instantiation time and Framework._emit time.

Long story short, I'm not sure why that codepath is so permissive and we don't error out altogether, that is, I don't see a legitimate reason why _observer is a weakref dict instead of a regular dict, as that predates me by a bunch. Perhaps @jameinel has some more context there?

For now, I'd propose adding a warning there so that people have something to go on with when that happens. We can also consider raising an exception, or making _observer a regular dict if those are viable alternatives.