### PR TITLE
chore: adjust the imports so that both ruff and isort pass

### DIFF
--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -18,9 +18,10 @@ import os
 import sys
 import typing
 
+import ops
+
 sys.path.append('lib')
 
-import ops
 
 logger = logging.getLogger()
 


### PR DESCRIPTION
`tox -e fmt`, `tox -e lint` run in a loop should result in no changes and both passing.