### PR TITLE
fix(pebble)!: change select=all to users=all for pebble get_notices

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2.12.0
+
+* Updated Pebble Notices `get_notices` parameter name to `users=all` (previously `select=all`).
+
 # 2.11.0
 
 * `StopEvent`, `RemoveEvent`, and all `LifeCycleEvent`s are no longer deferrable, and will raise a `RuntimeError` if `defer()` is called on the event object.

--- a/ops/model.py
+++ b/ops/model.py
@@ -2757,7 +2757,7 @@ class Container:
     def get_notices(
         self,
         *,
-        select: Optional[pebble.NoticesSelect] = None,
+        users: Optional[pebble.NoticesUsers] = None,
         user_id: Optional[int] = None,
         types: Optional[Iterable[Union[pebble.NoticeType, str]]] = None,
         keys: Optional[Iterable[str]] = None,
@@ -2768,7 +2768,7 @@ class Container:
         parameters.
         """
         return self._pebble.get_notices(
-            select=select,
+            users=users,
             user_id=user_id,
             types=types,
             keys=keys,

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1316,7 +1316,7 @@ class NoticeType(enum.Enum):
     CUSTOM = 'custom'
 
 
-class NoticesSelect(enum.Enum):
+class NoticesUsers(enum.Enum):
     """Enum of :meth:`Client.get_notices` ``select`` values."""
 
     ALL = 'all'
@@ -2803,7 +2803,7 @@ class Client:
     def get_notices(
         self,
         *,
-        select: Optional[NoticesSelect] = None,
+        users: Optional[NoticesUsers] = None,
         user_id: Optional[int] = None,
         types: Optional[Iterable[Union[NoticeType, str]]] = None,
         keys: Optional[Iterable[str]] = None,
@@ -2824,7 +2824,7 @@ class Client:
         type has nanosecond precision).
 
         Args:
-            select: Select which notices to return (instead of returning
+            users: Select which notices to return (instead of returning
                 notices for the current user).
             user_id: Filter for notices for the specified user, including
                 public notices (only works for Pebble admins).
@@ -2832,8 +2832,8 @@ class Client:
             keys: Filter for notices with any of the specified keys.
         """
         query: Dict[str, Union[str, List[str]]] = {}
-        if select is not None:
-            query['select'] = select.value
+        if users is not None:
+            query['users'] = users.value
         if user_id is not None:
             query['user-id'] = str(user_id)
         if types is not None:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -2824,7 +2824,7 @@ class Client:
         type has nanosecond precision).
 
         Args:
-            users: Filter which users' notices to return (instead of returning
+            users: Change which users' notices to return (instead of returning
                 notices for the current user).
             user_id: Filter for notices for the specified user, including
                 public notices (only works for Pebble admins).

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1317,10 +1317,10 @@ class NoticeType(enum.Enum):
 
 
 class NoticesUsers(enum.Enum):
-    """Enum of :meth:`Client.get_notices` ``select`` values."""
+    """Enum of :meth:`Client.get_notices` ``users`` values."""
 
     ALL = 'all'
-    """Select notices from all users (any user ID, including public notices).
+    """Return notices from all users (any user ID, including public notices).
 
     This only works for Pebble admins (for example, root).
     """
@@ -2824,7 +2824,7 @@ class Client:
         type has nanosecond precision).
 
         Args:
-            users: Select which notices to return (instead of returning
+            users: Filter which users' notices to return (instead of returning
                 notices for the current user).
             user_id: Filter for notices for the specified user, including
                 public notices (only works for Pebble admins).

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -3361,7 +3361,7 @@ class _TestingPebbleClient:
     def get_notices(
         self,
         *,
-        select: Optional[pebble.NoticesSelect] = None,
+        users: Optional[pebble.NoticesUsers] = None,
         user_id: Optional[int] = None,
         types: Optional[Iterable[Union[pebble.NoticeType, str]]] = None,
         keys: Optional[Iterable[str]] = None,
@@ -3371,9 +3371,9 @@ class _TestingPebbleClient:
         filter_user_id = 0  # default is to filter by request UID (root)
         if user_id is not None:
             filter_user_id = user_id
-        if select is not None:
+        if users is not None:
             if user_id is not None:
-                raise self._api_error(400, 'cannot use both "select" and "user_id"')
+                raise self._api_error(400, 'cannot use both "users" and "user_id"')
             filter_user_id = None
 
         if types is not None:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1977,7 +1977,7 @@ containers:
 
         notices = self.container.get_notices(
             user_id=1000,
-            select=pebble.NoticesSelect.ALL,
+            users=pebble.NoticesUsers.ALL,
             types=[pebble.NoticeType.CUSTOM],
             keys=['example.com/a', 'example.com/b'],
         )
@@ -1988,7 +1988,7 @@ containers:
 
         self.assertEqual(self.pebble.requests, [('get_notices', dict(
             user_id=1000,
-            select=pebble.NoticesSelect.ALL,
+            users=pebble.NoticesUsers.ALL,
             types=[pebble.NoticeType.CUSTOM],
             keys=['example.com/a', 'example.com/b'],
         ))])

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -3032,7 +3032,7 @@ bad path\r
 
         notices = self.client.get_notices(
             user_id=1000,
-            select=pebble.NoticesSelect.ALL,
+            users=pebble.NoticesUsers.ALL,
             types=[pebble.NoticeType.CUSTOM],
             keys=['example.com/a', 'example.com/b'],
         )
@@ -3042,7 +3042,7 @@ bad path\r
 
         query = {
             'user-id': '1000',
-            'select': 'all',
+            'users': 'all',
             'types': ['custom'],
             'keys': ['example.com/a', 'example.com/b'],
         }


### PR DESCRIPTION
## Description

Pebble added support for notices, aggregated events that are recorded with a type and key. The `/v1/notices` API had a parameter "select=all" to show notices for all users, and the parameter name is changed to "users=all" in recent [release v1.9.0](https://github.com/canonical/pebble/releases/tag/v1.9.0).

This PR is the corresponding changes to the ops framework.

Related doc: [OP042 - User ID features for Pebble Notices
](https://docs.google.com/document/d/1tQwUxz-rV-NjH-UodDbSDhGcMJGfD3OSoTnBLI9aoGU/edit#heading=h.kavgppauvkj5)

## Issue

See here: https://github.com/canonical/operator/issues/1132

## Changes

- `pebble.Client.get_notices`
- `model.Container.get_notices`
- unit tests

## Unit Test

```bash
TOTAL                       6389    472   2278    207    91%
  unit: OK (79.29=setup[0.05]+cmd[77.96,1.28] seconds)
  congratulations :) (79.37 seconds)
```

For pebble:

```bash
TOTAL                       6389   3911   2278    109    32%
  unit: OK (3.29=setup[0.05]+cmd[2.14,1.10] seconds)
  congratulations :) (3.37 seconds)
```

## Some Manual Test

Start pebble:

```bash
ubuntu@ip-172-31-42-22:~/operator$ pebble run
2024-03-12T03:29:19.467Z [pebble] Started daemon.
2024-03-12T03:29:19.475Z [pebble] POST /v1/services 7.925291ms 202
2024-03-12T03:29:19.476Z [pebble] Started default services with change 25.
2024-03-12T03:29:19.484Z [pebble] Service "srv1" starting: /home/ubuntu/go-hello-http/go-hello-http
2024-03-12T03:29:57.541Z [pebble] GET /v1/services?names=srv1 111.759µs 200
2024-03-12T03:35:08.152Z [pebble] GET /v1/notices?users=all 378.712µs 200
```

Run some CLI commands like `pebble notify example.com/hello`.

Import local code and test:

```bash
>>> from ops.pebble import Client, NoticesUsers
>>> c = Client(socket_path="/home/ubuntu/pebble/.pebble.socket")
>>> c.get_notices(select=NoticesUsers.ALL)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Client.get_notices() got an unexpected keyword argument 'select'
>>> c.get_notices(users=NoticesUsers.ALL)
[Notice(id='1', user_id=None, type='change-update', key='1', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 45, 177670, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 45, 194173, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 45, 194173, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='2', user_id=None, type='change-update', key='2', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 45, 202394, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 45, 220967, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 45, 220967, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='3', user_id=None, type='change-update', key='3', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 45, 226236, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 45, 244244, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 45, 244244, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='4', user_id=None, type='change-update', key='4', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 45, 252882, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 45, 571870, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 45, 571870, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='5', user_id=None, type='change-update', key='5', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 45, 580936, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 45, 901958, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 45, 901958, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='6', user_id=None, type='change-update', key='6', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 45, 910847, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 29637, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 46, 29637, tzinfo=datetime.timezone.utc), occurrences=4, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='7', user_id=None, type='change-update', key='7', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 43557, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 61571, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 46, 61571, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='8', user_id=None, type='change-update', key='8', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 67223, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 86111, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 46, 86111, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='9', user_id=None, type='change-update', key='9', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 95695, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 114935, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 46, 114935, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='10', user_id=None, type='change-update', key='10', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 121511, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 142470, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 46, 142470, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='11', user_id=None, type='change-update', key='11', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 149212, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 169333, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 46, 169333, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='12', user_id=None, type='change-update', key='12', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 179003, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 200757, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 46, 200757, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='13', user_id=1000, type=<NoticeType.CUSTOM: 'custom'>, key='example.com/a28644b3066f27d4f21b08a81df07398', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 564708, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 564708, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 46, 564708, tzinfo=datetime.timezone.utc), occurrences=1, last_data={}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='14', user_id=1000, type=<NoticeType.CUSTOM: 'custom'>, key='example.com/025e5d433d999642c2fc9862d1e6c5b3', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 571342, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 578330, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 46, 578330, tzinfo=datetime.timezone.utc), occurrences=2, last_data={'foo': 'bar', 'k': 'v'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='15', user_id=1000, type=<NoticeType.CUSTOM: 'custom'>, key='example.com/6896450162eb363557e52f2934f5fb6f', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 588712, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 588712, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 46, 588712, tzinfo=datetime.timezone.utc), occurrences=1, last_data={}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='16', user_id=1000, type=<NoticeType.CUSTOM: 'custom'>, key='example.com/d52f3370d7e101ded78681a4639c5690', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 595262, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 595262, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 46, 595262, tzinfo=datetime.timezone.utc), occurrences=1, last_data={}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='17', user_id=1000, type=<NoticeType.CUSTOM: 'custom'>, key='example.com/25e878f34f7bbad646f91763f2994000', first_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 601619, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 5, 46, 601619, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 5, 46, 601619, tzinfo=datetime.timezone.utc), occurrences=1, last_data={}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='18', user_id=None, type='change-update', key='13', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 47, 194340, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 47, 219760, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 47, 219760, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='19', user_id=None, type='change-update', key='14', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 47, 229983, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 47, 254717, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 47, 254717, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='20', user_id=None, type='change-update', key='15', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 47, 261549, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 47, 284729, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 47, 284729, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='21', user_id=None, type='change-update', key='16', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 47, 294920, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 47, 618948, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 47, 618948, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='22', user_id=None, type='change-update', key='17', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 47, 629580, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 47, 953210, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 47, 953210, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='23', user_id=None, type='change-update', key='18', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 47, 963030, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 86382, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 48, 86382, tzinfo=datetime.timezone.utc), occurrences=4, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='24', user_id=None, type='change-update', key='19', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 103830, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 126401, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 48, 126401, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='25', user_id=None, type='change-update', key='20', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 135552, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 159090, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 48, 159090, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='26', user_id=None, type='change-update', key='21', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 170514, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 197623, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 48, 197623, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='27', user_id=None, type='change-update', key='22', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 205621, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 230234, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 48, 230234, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='28', user_id=None, type='change-update', key='23', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 238430, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 263624, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 48, 263624, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='29', user_id=None, type='change-update', key='24', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 275047, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 300175, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 48, 300175, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'exec'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='30', user_id=1000, type=<NoticeType.CUSTOM: 'custom'>, key='example.com/5ea5a03addca7d36ce83982323d58ba1', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 659337, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 659337, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 48, 659337, tzinfo=datetime.timezone.utc), occurrences=1, last_data={}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='31', user_id=1000, type=<NoticeType.CUSTOM: 'custom'>, key='example.com/18495099e6b1a7cbea83362d168896f3', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 668411, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 675960, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 48, 675960, tzinfo=datetime.timezone.utc), occurrences=2, last_data={'foo': 'bar', 'k': 'v'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='32', user_id=1000, type=<NoticeType.CUSTOM: 'custom'>, key='example.com/fcdf8a7081a78be59811125b0099bc76', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 687990, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 687990, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 48, 687990, tzinfo=datetime.timezone.utc), occurrences=1, last_data={}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='33', user_id=1000, type=<NoticeType.CUSTOM: 'custom'>, key='example.com/1f6f7be36a3ad62bf3869d50477170c0', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 696109, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 696109, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 48, 696109, tzinfo=datetime.timezone.utc), occurrences=1, last_data={}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='34', user_id=1000, type=<NoticeType.CUSTOM: 'custom'>, key='example.com/db0e4b360cc2661e201695d230eb7d67', first_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 704684, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 11, 48, 704684, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 11, 48, 704684, tzinfo=datetime.timezone.utc), occurrences=1, last_data={}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='35', user_id=None, type='change-update', key='25', first_occurred=datetime.datetime(2024, 3, 12, 3, 29, 19, 468346, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 29, 20, 486013, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 29, 20, 486013, tzinfo=datetime.timezone.utc), occurrences=3, last_data={'kind': 'autostart'}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='36', user_id=1000, type=<NoticeType.CUSTOM: 'custom'>, key='example.com/hello', first_occurred=datetime.datetime(2024, 3, 12, 3, 30, 23, 61818, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 30, 24, 941537, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 30, 24, 941537, tzinfo=datetime.timezone.utc), occurrences=2, last_data={}, repeat_after=None, expire_after=datetime.timedelta(days=7)), Notice(id='37', user_id=1000, type=<NoticeType.CUSTOM: 'custom'>, key='other.com/bar', first_occurred=datetime.datetime(2024, 3, 12, 3, 30, 38, 292781, tzinfo=datetime.timezone.utc), last_occurred=datetime.datetime(2024, 3, 12, 3, 30, 38, 292781, tzinfo=datetime.timezone.utc), last_repeated=datetime.datetime(2024, 3, 12, 3, 30, 38, 292781, tzinfo=datetime.timezone.utc), occurrences=1, last_data={'email': 'john@smith.com', 'name': 'value'}, repeat_after=None, expire_after=datetime.timedelta(days=7))]
```