### PR TITLE
fix: inspect the correct signature when validating observe arguments

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -813,11 +813,17 @@ class Framework(Object):
         if not sig.parameters:
             raise TypeError(
                 f'{type(observer_obj).__name__}.{method_name} must accept event parameter')
-        elif any(param.default is inspect.Parameter.empty for param in extra_params):
+        else:
             # Allow for additional optional params, since there's no reason to exclude them, but
             # required params will break.
-            raise TypeError(
-                f'{type(observer_obj).__name__}.{method_name} has extra required parameter')
+            required_params = [
+                param.name for param in extra_params
+                if param.default is inspect.Parameter.empty
+            ]
+            if required_params:
+                raise TypeError(
+                    f'{type(observer_obj).__name__}.{method_name} has extra required '
+                    f'parameter: {", ".join(required_params)}')
 
         # TODO Prevent the exact same parameters from being registered more than once.
 

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -782,18 +782,12 @@ class Framework(Object):
             RuntimeError: if bound_event or observer are the wrong type.
         """
         if not isinstance(bound_event, BoundEvent):
-            raise RuntimeError(
+            raise TypeError(
                 f'Framework.observe requires a BoundEvent as second parameter, got {bound_event}')
         # Help users of older versions of the framework.
-        if isinstance(observer, charm.CharmBase):
+        if not isinstance(observer, types.MethodType):
             raise TypeError(
-                'observer methods must now be explicitly provided;'
-                ' please replace observe(self.on.{0}, self)'
-                ' with e.g. observe(self.on.{0}, self._on_{0})'.format(
-                    bound_event.event_kind))
-        if not callable(observer):
-            raise RuntimeError(
-                f'Framework.observe requires a callable as third parameter, got {observer}')
+                f"Framework.observe requires a method as the 'observer' parameter, got {observer}")
 
         event_type = bound_event.event_type
         event_kind = bound_event.event_kind
@@ -804,7 +798,7 @@ class Framework(Object):
         if hasattr(emitter, "handle"):
             emitter_path = emitter.handle.path
         else:
-            raise RuntimeError(
+            raise TypeError(
                 f'event emitter {type(emitter).__name__} must have a "handle" attribute')
 
         # Validate that the method has an acceptable call signature.

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -808,7 +808,6 @@ class Framework(Object):
 
         # Validate that the method has an acceptable call signature.
         sig = inspect.signature(observer, follow_wrapped=False)
-        # Self isn't included in the params list, so the first arg will be the event.
         try:
             sig.bind(EventBase(None))  # type: ignore
         except TypeError as e:

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -784,16 +784,16 @@ class Framework(Object):
         if not isinstance(bound_event, BoundEvent):
             raise RuntimeError(
                 f'Framework.observe requires a BoundEvent as second parameter, got {bound_event}')
-        if not isinstance(observer, types.MethodType):
-            # help users of older versions of the framework
-            if isinstance(observer, charm.CharmBase):
-                raise TypeError(
-                    'observer methods must now be explicitly provided;'
-                    ' please replace observe(self.on.{0}, self)'
-                    ' with e.g. observe(self.on.{0}, self._on_{0})'.format(
-                        bound_event.event_kind))
+        # Help users of older versions of the framework.
+        if isinstance(observer, charm.CharmBase):
+            raise TypeError(
+                'observer methods must now be explicitly provided;'
+                ' please replace observe(self.on.{0}, self)'
+                ' with e.g. observe(self.on.{0}, self._on_{0})'.format(
+                    bound_event.event_kind))
+        if not callable(observer):
             raise RuntimeError(
-                f'Framework.observe requires a method as third parameter, got {observer}')
+                f'Framework.observe requires a callable as third parameter, got {observer}')
 
         event_type = bound_event.event_type
         event_kind = bound_event.event_kind
@@ -808,7 +808,7 @@ class Framework(Object):
                 f'event emitter {type(emitter).__name__} must have a "handle" attribute')
 
         # Validate that the method has an acceptable call signature.
-        sig = inspect.signature(observer)
+        sig = inspect.signature(observer, follow_wrapped=False)
         # Self isn't included in the params list, so the first arg will be the event.
         extra_params = list(sig.parameters.values())[1:]
 

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -784,7 +784,6 @@ class Framework(Object):
         if not isinstance(bound_event, BoundEvent):
             raise TypeError(
                 f'Framework.observe requires a BoundEvent as second parameter, got {bound_event}')
-        # Help users of older versions of the framework.
         if not isinstance(observer, types.MethodType):
             raise TypeError(
                 f"Framework.observe requires a method as the 'observer' parameter, got {observer}")

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -819,6 +819,8 @@ class Framework(Object):
             required_params = [
                 param.name for param in extra_params
                 if param.default is inspect.Parameter.empty
+                and param.kind not in (inspect.Parameter.VAR_POSITIONAL,
+                                       inspect.Parameter.VAR_KEYWORD)
             ]
             if required_params:
                 raise TypeError(

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -89,9 +89,6 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(charm.started, True)
 
-        with self.assertRaisesRegex(TypeError, "observer methods must now be explicitly provided"):
-            framework.observe(charm.on.start, charm)  # type: ignore
-
     def test_observe_decorated_method(self):
         # we test that charm methods decorated with @functools.wraps(wrapper)
         # can be observed by Framework. Simpler decorators won't work because

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -89,6 +89,9 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(charm.started, True)
 
+        with self.assertRaises(TypeError):
+            framework.observe(charm.on.start, charm)  # type: ignore
+
     def test_observe_decorated_method(self):
         # we test that charm methods decorated with @functools.wraps(wrapper)
         # can be observed by Framework. Simpler decorators won't work because

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -167,7 +167,7 @@ class TestFramework(BaseTestCase):
         framework.observe(pub.foo, obs.on_any)
         framework.observe(pub.bar, obs.on_any)
 
-        with self.assertRaisesRegex(RuntimeError, "^Framework.observe requires a method"):
+        with self.assertRaisesRegex(TypeError, "^Framework.observe requires a method"):
             framework.observe(pub.baz, obs)  # type: ignore
 
         pub.foo.emit()
@@ -888,12 +888,12 @@ class TestFramework(BaseTestCase):
                 'ObjectWithStorage[obj]/on/event[1]']))
 
     def test_wrapped_handler(self):
-        def add_arg(func):  # type: ignore
-            @functools.wraps(func)  # type: ignore
+        def add_arg(func: typing.Callable[..., None]) -> typing.Callable[..., None]:
+            @functools.wraps(func)
             def wrapper(charm: ops.CharmBase, event: ops.EventBase):
-                return func(charm, event, "extra-arg")  # type: ignore
+                return func(charm, event, "extra-arg")
 
-            return wrapper  # type: ignore
+            return wrapper
 
         class MyCharm(ops.CharmBase):
             @add_arg
@@ -902,7 +902,7 @@ class TestFramework(BaseTestCase):
 
         framework = self.create_framework()
         charm = MyCharm(framework)
-        framework.observe(charm.on.start, charm._on_event)  # type: ignore
+        framework.observe(charm.on.start, charm._on_event)
         charm.on.start.emit()
 
 


### PR DESCRIPTION
When validating the `observe` arguments, inspect the signature of the method that we'll call, rather than digging down into any wrapped version, so that wrappers can adjust the signature as required, as long as the framework can still call them with the expected arguments.

This also fixes a bug where the check would fail to properly identify `*` and `**` as not required, so a signature like `def _on_x(self, event, *args, **kwargs)` would fail, even though the framework can use it to emit events.

Also remove the code that checks for `framework.observe(self.on.x, self)` style calls, which were possible in some old version of ops, and raises a specific error just for that (the general error is clear enough, and we don't believe anyone is still doing this).

When checking the type of the event handler, raise `TypeError` for errors, rather than a mixture of `RuntimeError` and `TypeError`.

Fixes #1129