### PR TITLE
feat(harness): add snapshot data validation in cleanup

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -731,7 +731,6 @@ class Framework(Object):
                 f'cannot save {type(value).__name__} values before registering that type')
 
         data = value.snapshot()
-
         # Use marshal as a validator, enforcing the use of simple types, as we later the
         # information is really pickled, which is too error-prone for future evolution of the
         # stored data (e.g. if the developer stores a custom object and later changes its

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -723,9 +723,13 @@ class Framework(Object):
 
     def save_snapshot(self, value: Union["StoredStateData", "EventBase"]):
         """Save a persistent snapshot of the provided value."""
+        self._storage.save_snapshot(value.handle.path, self._get_snapshot_data_and_validate(value))
+
+    def _get_snapshot_data_and_validate(self, value: Union["StoredStateData", "EventBase"]):
         if type(value) not in self._type_known:
             raise RuntimeError(
                 f'cannot save {type(value).__name__} values before registering that type')
+
         data = value.snapshot()
 
         # Use marshal as a validator, enforcing the use of simple types, as we later the
@@ -739,7 +743,7 @@ class Framework(Object):
             msg = "unable to save the data for {}, it must contain only simple types: {!r}"
             raise ValueError(msg.format(value.__class__.__name__, data)) from None
 
-        self._storage.save_snapshot(value.handle.path, data)
+        return data
 
     def load_snapshot(self, handle: Handle) -> Serializable:
         """Load a persistent snapshot."""

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -475,6 +475,7 @@ class Harness(Generic[CharmType]):
 
         Always call ``self.addCleanup(harness.cleanup)`` after creating a :class:`Harness`.
         """
+        self._framework._get_snapshot_data_and_validate(self._framework._stored)
         self._backend._cleanup()
 
     def _create_meta(self, charm_metadata_yaml: Optional[YAMLStringOrFile],

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2915,7 +2915,11 @@ class TestHarness(unittest.TestCase):
 
             def __init__(self, *args: typing.Any):
                 super().__init__(*args)
-                self._stored.set_default(status={'retention_size': ops.ActiveStatus(''), 'k8s_patch': ops.ActiveStatus(''), 'config': ops.ActiveStatus('')})
+                self._stored.set_default(
+                    status={
+                        'retention_size': ops.ActiveStatus(''),
+                        'k8s_patch': ops.ActiveStatus(''),
+                        'config': ops.ActiveStatus('')})
                 self.framework.observe(self.on.foo_pebble_ready, self._on_pebble_ready)
 
             def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
@@ -2931,6 +2935,7 @@ class TestHarness(unittest.TestCase):
         harness.begin_with_initial_hooks()
         harness.cleanup()
         self.assertRaises(ValueError)
+
 
 class TestNetwork(unittest.TestCase):
     def setUp(self):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2909,13 +2909,13 @@ class TestHarness(unittest.TestCase):
             harness.model.unit.status = ops.ErrorStatus()
         harness.model.unit.status = ops.ActiveStatus()
 
-    def test_get_snapshot_data_and_validate_works(self):
+    def test_cleanup_raises_value_error(self):
         class MyCharm(ops.CharmBase):
             _stored = ops.framework.StoredState()
 
             def __init__(self, *args: typing.Any):
                 super().__init__(*args)
-                self._stored.set_default(status={'foo': 1, 'bar': 2, 'baz': 3})
+                self._stored.set_default(status={'retention_size': ops.ActiveStatus(''), 'k8s_patch': ops.ActiveStatus(''), 'config': ops.ActiveStatus('')})
                 self.framework.observe(self.on.foo_pebble_ready, self._on_pebble_ready)
 
             def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
@@ -2929,37 +2929,8 @@ class TestHarness(unittest.TestCase):
             ''')
         self.addCleanup(harness.cleanup)
         harness.begin_with_initial_hooks()
-
+        harness.cleanup()
         self.assertRaises(ValueError)
-
-    def test_get_snapshot_data_and_validate_not_working(self):
-        class MyCharm(ops.CharmBase):
-            _stored = ops.framework.StoredState()
-
-            def __init__(self, *args: typing.Any):
-                super().__init__(*args)
-                self._stored.set_default(status={'foo': 1, 'bar': 2, 'baz': 3})
-                self.framework.observe(self.on.foo_pebble_ready, self._on_pebble_ready)
-
-            def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
-                pass
-
-        harness = ops.testing.Harness(MyCharm, meta='''
-            name: test-app
-            containers:
-              foo:
-                resource: foo-image
-            ''')
-        self.addCleanup(harness.cleanup)
-        harness.begin_with_initial_hooks()
-
-        with self.assertRaises(ValueError) as cm:
-            pass
-        self.assertIn(
-            "unable to save the data for StoredStateData, it must contain only simple types",
-            str(cm.exception)
-        )
-
 
 class TestNetwork(unittest.TestCase):
     def setUp(self):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2915,7 +2915,7 @@ class TestHarness(unittest.TestCase):
 
             def __init__(self, *args: typing.Any):
                 super().__init__(*args)
-                
+
                 # invalid data since StoredStateData can contain only simple types
                 self._stored.set_default(
                     status={

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2915,7 +2915,8 @@ class TestHarness(unittest.TestCase):
 
             def __init__(self, *args: typing.Any):
                 super().__init__(*args)
-
+                
+                # invalid data since StoredStateData can contain only simple types
                 self._stored.set_default(
                     status={
                         'status': {


### PR DESCRIPTION
- Refactor `save_snapshot` by extracting a new function `_get_snapshot_data_and_validate` so that it can be called directly and tested alone.
- Call `_get_snapshot_data_and_validate` in `cleanup`.
- Add a unit test case for cleanup.

Closes https://github.com/canonical/operator/issues/1115.