### PR TITLE
fix(harness): don't error out when attempting attaching storage before begin

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1539,7 +1539,9 @@ class StorageMeta:
         self.multiple_range = None
         if 'multiple' in raw:
             range = raw['multiple']['range']
-            if '-' not in range:
+            if range[-1] == '+':
+                self.multiple_range = (int(range[:-1]), None)
+            elif '-' not in range:
                 self.multiple_range = (int(range), int(range))
             else:
                 range = range.split('-')

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -748,8 +748,7 @@ class Harness(Generic[CharmType]):
         and is presently marked as detached.
 
         The test harness uses symbolic links to imitate storage mounts, which may lead to some
-        inconsistencies compared to the actual charm. Users should be cognisant of
-        this potential discrepancy.
+        inconsistencies compared to the actual charm.
 
         Args:
             storage_id: The full storage ID of the storage unit being attached, including the

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -258,6 +258,10 @@ storage:
     multiple:
       range: 2-
     type: filesystem
+  stor-plus:
+    multiple:
+      range: 10+
+    type: filesystem
 ''')
 
         fake_script(
@@ -305,6 +309,7 @@ storage:
         self.assertEqual(self.meta.storages['stor2'].multiple_range, (2, 2))
         self.assertEqual(self.meta.storages['stor3'].multiple_range, (2, None))
         self.assertEqual(self.meta.storages['stor-4'].multiple_range, (2, 4))
+        self.assertEqual(self.meta.storages['stor-plus'].multiple_range, (10, None))
 
         charm = MyCharm(self.create_framework())
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -4496,9 +4496,9 @@ class TestPebbleStorageAPIsUsingMocks(
         self.addCleanup(harness.cleanup)
 
         store_id = harness.add_storage('store1')[0]
+        harness.attach_storage(store_id)
 
         harness.begin()
-        harness.attach_storage(store_id)
         harness.set_can_connect('c1', True)
         harness.set_can_connect('c2', True)
         harness.set_can_connect('c3', True)


### PR DESCRIPTION
One minor fix to the `storage` metadata: [charmcraft.yaml](https://juju.is/docs/sdk/charmcraft-yaml#heading--storage) and [metadata.yaml](https://juju.is/docs/sdk/metadata-yaml#heading--storage) support a `multiple.range` value in the form `<n>+` - this would previously error out when we attempted to read the metadata. We now support this (as an alias for `<n>-`, which is an open-ended range rather than "n or less", and have a test for it.

Adds a minor clarification in the API docs when `Harness.add_storage` will emit a storage-attached event.

In `begin_with_initial_hooks`, if the storage has already been attached, then don't try to attach it a second time, but *do* emit the storage-attached event, since that will not have been done previously.

Make the `_storage_attach` method safe to call multiple times. This appears to have been the intention based on comments in the code, but, in practice, attempting to symlink the mount would fail. Now, if the symlink already exists (and has the same target) then we continue.

Adds a variety of tests for Harness `add_storage` and `attach_storage` behaviour.

Fixes #1127