### PR TITLE
fix(pebble): catch socket.timeout exception in pebble.Client.exec()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 * Updated Pebble Notices `get_notices` parameter name to `users=all` (previously `select=all`).
 * Added `Model.get_cloud_spec` which uses the `credential-get` hook tool to get details of the cloud where the model is deployed.
+* Fixed an issue where `pebble.Client.exec` might leak a `socket.timeout` (`builtins.TimeoutError`) exception.
 * Updated code examples in the docstring of `ops.testing` from unittest to pytest style.
 * Refactored main.py, creating a new `_Manager` class.
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -2713,6 +2713,7 @@ class Container:
 
         Raises:
             ExecError: if the command exits with a non-zero exit code.
+            TimeoutError: if the maximum timeout is reached.
         """
         if service_context is not None:
             version = JujuVersion.from_environ()

--- a/ops/model.py
+++ b/ops/model.py
@@ -2713,7 +2713,6 @@ class Container:
 
         Raises:
             ExecError: if the command exits with a non-zero exit code.
-            TimeoutError: if the maximum timeout is reached.
         """
         if service_context is not None:
             version = JujuVersion.from_environ()

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -2592,7 +2592,6 @@ class Client:
             APIError: if an error occurred communicating with pebble, or if the command is not
                 found.
             ExecError: if the command exits with a non-zero exit code.
-            TimeoutError: if the maximum timeout is reached.
         """
         if not isinstance(command, list) or not all(isinstance(s, str) for s in command):
             raise TypeError(f'command must be a list of str, not {type(command).__name__}')

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -18,6 +18,7 @@ For a command-line interface for local testing, see test/pebble_cli.py.
 """
 
 import binascii
+import builtins
 import copy
 import dataclasses
 import datetime
@@ -1722,6 +1723,11 @@ class Client:
     connecting to or transferring data with Pebble will raise a :class:`ConnectionError`. When an
     error occurs executing the request, such as trying to add an invalid layer or execute a command
     that does not exist, an :class:`APIError` is raised.
+
+    The ``timeout`` parameter specifies a timeout in seconds for blocking operations like the
+    connection attempt to Pebble; used by ``urllib.request.OpenerDirector.open``. It's not for
+    methods like :meth:`start_services` and :meth:`replan_services` mentioned above, and it's not
+    for the command execution timeout defined in method :meth:`Client.exec`.
     """
 
     _chunk_size = 8192
@@ -2029,8 +2035,10 @@ class Client:
 
             try:
                 return self._wait_change(change_id, this_timeout)
-            except TimeoutError:
-                # Catch timeout from wait endpoint and loop to check deadline
+            except (socket.timeout, builtins.TimeoutError):
+                # NOTE: in Python 3.10 socket.timeout is an alias of TimeoutError,
+                # but we still need to support Python 3.8, so catch both.
+                # Catch timeout from wait endpoint and loop to check deadline.
                 pass
 
         raise TimeoutError(f'timed out waiting for change {change_id} ({timeout} seconds)')
@@ -2584,6 +2592,7 @@ class Client:
             APIError: if an error occurred communicating with pebble, or if the command is not
                 found.
             ExecError: if the command exits with a non-zero exit code.
+            TimeoutError: if the maximum timeout is reached.
         """
         if not isinstance(command, list) or not all(isinstance(s, str) for s in command):
             raise TypeError(f'command must be a list of str, not {type(command).__name__}')


### PR DESCRIPTION
Tried to run some `container.exec` in a test charm with sleep, with some other long-running commands like apt-update, with or without timeout, but could not reproduce the issue.

Changed according to John's opinion: catch `socket.timeout` exception and continue polling till the end of the deadline.

Also updated docstring for `model.Container.exec()` and `pebble.Client.exec()`.

Closes https://github.com/canonical/operator/issues/826.

