### PR TITLE
docs(testing): update code samples in ops.testing from unittest to pytest style

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 * Updated Pebble Notices `get_notices` parameter name to `users=all` (previously `select=all`).
 * Added `Model.get_cloud_spec` which uses the `credential-get` hook tool to get details of the cloud where the model is deployed.
+* Updated code examples in the docstring of `ops.testing` from unittest to pytest style.
 
 # 2.11.0
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -185,9 +185,9 @@ class Harness(Generic[CharmType]):
                 harness.cleanup()
 
     Below is an example test using :meth:`begin_with_initial_hooks` that ensures
-    the charm responds correctly to config changes (the parameter ``harness`` in the 
+    the charm responds correctly to config changes (the parameter ``harness`` in the
     test function is a pytest fixture that does setup/teardown, see :class:`Harness`)::
-        
+
         def test_foo(harness):
             # Instantiate the charm and trigger events that Juju would on startup
             harness.begin_with_initial_hooks()

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -380,7 +380,7 @@ class Harness(Generic[CharmType]):
         containers (in addition to triggering pebble-ready for each).
 
         Example::
-            def test_foo():
+
             harness = Harness(MyCharm)
             # Do initial setup here
             # Add storage if needed before begin_with_initial_hooks() is called
@@ -1699,7 +1699,7 @@ class Harness(Generic[CharmType]):
         Example usage::
 
             # charm.py
-            class MyCharm(ops.CharmBase):
+            class ExampleCharm(ops.CharmBase):
                 def __init__(self, *args):
                     super().__init__(*args)
                     self.framework.observe(self.on["mycontainer"].pebble_ready,
@@ -1711,7 +1711,7 @@ class Harness(Generic[CharmType]):
             # test_charm.py
             @pytest.fixture()
             def harness():
-                harness = Harness(MyCharm)
+                harness = Harness(ExampleCharm)
                 yield harness
                 harness.cleanup()
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -179,10 +179,10 @@ class Harness(Generic[CharmType]):
     Always call ``harness.cleanup()`` after creating a :class:`Harness`::
 
         @pytest.fixture()
-            def harness():
-                harness = Harness(MyCharm)
-                yield harness
-                harness.cleanup()
+        def harness():
+            harness = Harness(MyCharm)
+            yield harness
+            harness.cleanup()
 
     Below is an example test using :meth:`begin_with_initial_hooks` that ensures
     the charm responds correctly to config changes (the parameter ``harness`` in the
@@ -1930,7 +1930,7 @@ class Harness(Generic[CharmType]):
 
             # test_charm.py
             def test_start(harness):
-                cloud_spec_dict = {
+                cloud_spec = ops.model.CloudSpec.from_dict({
                     'name': 'localhost',
                     'type': 'lxd',
                     'endpoint': 'https://127.0.0.1:8443',
@@ -1942,12 +1942,11 @@ class Harness(Generic[CharmType]):
                             'server-cert': 'baz'
                         },
                     },
-                }
-                harness.set_cloud_spec(ops.model.CloudSpec.from_dict(cloud_spec_dict))
+                })
+                harness.set_cloud_spec(cloud_spec)
                 harness.begin()
                 harness.charm.on.start.emit()
-                expected = ops.model.CloudSpec.from_dict(cloud_spec_dict)
-                assert harness.charm.cloud_spec == expected
+                assert harness.charm.cloud_spec == cloud_spec
 
         """
         self._backend._cloud_spec = spec


### PR DESCRIPTION
Since we are encouraging charm tests to be written with pytest, we should use that in test code examples in ops.testing.

Only code samples from `ops/testing.py` are updated, other files/test cases are not updated.

Closes https://github.com/canonical/operator/issues/1154.