### PR TITLE
docs(Harness): add a paragraph on peer relations in add_relation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 
 * Use "integrate with" rather than "relate to" (#1145)
 * Updated code examples in the docstring of `ops.testing` from unittest to pytest style (#1157)
+* Add peer relation details in `Harness.add_relation` docstring (#1168)
 
 # 2.11.0 - 29 Feb 2024
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -818,9 +818,9 @@ class Harness(Generic[CharmType]):
         Alternatively, charm tests can call :meth:`add_relation_unit` and
         :meth:`update_relation_data` explicitly.
 
-        For peer relations defined in `charmcraft.yaml`, :meth:`begin_with_initial_hooks` will
-        create them automatically, so the caller doesn't need to call :meth:`add_relation`. If
-        the caller chooses to add a peer relation by themselves, make sure to call
+        For peer relations defined in the charm's metadata, :meth:`begin_with_initial_hooks`
+        will create them automatically, so the caller doesn't need to call :meth:`add_relation`.
+        If the caller chooses to add a peer relation by themselves, make sure to call
         :meth:`add_relation` before :meth:`begin_with_initial_hooks` so that Harness won't
         create it again.
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -818,6 +818,12 @@ class Harness(Generic[CharmType]):
         Alternatively, charm tests can call :meth:`add_relation_unit` and
         :meth:`update_relation_data` explicitly.
 
+        For peer relations defined in `charmcraft.yaml`, :meth:`begin_with_initial_hooks` will
+        create them automatically, so the caller doesn't need to call :meth:`add_relation`. If
+        the caller chooses to add a peer relation by themselves, make sure to call
+        :meth:`add_relation` before :meth:`begin_with_initial_hooks` so that Harness won't
+        create it again.
+
         Example usage::
 
             secret_id = harness.add_model_secret('mysql', {'password': 'SECRET'})


### PR DESCRIPTION
Add a short paragraph about Harness `begin_with_initial_hooks` behaviour on peer relations in the docstring of method `add_relation`.

Closes https://github.com/canonical/operator/issues/1161.

Hold until RTD PRs are merged so that the lint/doc build can pass.