### PR TITLE
chore: update version to 2.13.0.dev0

### DIFF
--- a/ops/version.py
+++ b/ops/version.py
@@ -17,4 +17,4 @@
 This module is NOT to be used when developing charms using ops.
 """
 
-version: str = '2.12.0'
+version: str = '2.13.0.dev0'


### PR DESCRIPTION
[2.12.0 is live in PyPI now](https://pypi.org/project/ops/), bumping the version to 2.13.0.dev0.