### PR TITLE
fix: include log-targets when adding a new layer with harness

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1117,6 +1117,23 @@ class LogTarget:
         dct = {name: value for name, value in fields if value}
         return typing.cast('LogTargetDict', dct)
 
+    def _merge(self, other: 'LogTarget'):
+        """Merges this log target object with another log target definition.
+
+        For attributes present in both objects, the passed in log target
+        attributes take precedence.
+        """
+        if other.type != '':
+            self.type = other.type
+        if other.location != '':
+            self.location = other.location
+        self.services.extend(other.services)
+        if other.labels is not None:
+            if self.labels is None:
+                self.labels = {}
+            for name, value in other.labels.items():
+                self.labels[name] = value
+
     def __repr__(self):
         return f'LogTarget({self.to_dict()!r})'
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1062,6 +1062,74 @@ class Check:
         dct = {name: value for name, value in fields if value}
         return typing.cast('CheckDict', dct)
 
+    def _merge(self, other: 'Check'):
+        """Merges this check object with another check definition.
+
+        For attributes present in both objects, the passed in check
+        attributes take precedence.
+        """
+        if other.level != '':
+            self.level = other.level
+        if other.period != '':
+            self.period = other.period
+        if other.timeout != '':
+            self.timeout = other.timeout
+        if other.threshold is not None:
+            self.threshold = other.threshold
+        if other.http is not None:
+            if other_url := other.http.get('url'):
+                if self.http is None:
+                    self.http = {}
+                self.http['url'] = other_url
+            if other_headers := other.http.get('headers'):
+                if self.http is None:
+                    self.http = {'headers': {}}
+                for header, value in other_headers.items():
+                    self.http['headers'][header] = value
+        if other.tcp is not None:
+            if other_port := other.tcp.get('port'):
+                if self.tcp is None:
+                    self.tcp = {}
+                self.tcp['port'] = other_port
+            if other_host := other.tcp.get('host'):
+                if self.tcp is None:
+                    self.tcp = {}
+                self.tcp['host'] = other_host
+        if other.exec is not None:
+            if other_command := other.exec.get('command'):
+                if self.exec is None:
+                    self.exec = {}
+                self.exec['command'] = other_command
+            if other_service_context := other.exec.get('service-context'):
+                if self.exec is None:
+                    self.exec = {}
+                self.exec['service-context'] = other_service_context
+            if other_environment := other.exec.get('environment'):
+                if self.exec is None:
+                    self.exec = {'environment': {}}
+                for environment, value in other_environment.items():
+                    self.exec['environment'][environment] = value
+            if other_user_id := other.exec.get('user-id'):
+                if self.exec is None:
+                    self.exec = {}
+                self.exec['user-id'] = other_user_id
+            if other_user := other.exec.get('user'):
+                if self.exec is None:
+                    self.exec = {}
+                self.exec['user'] = other_user
+            if other_group_id := other.exec.get('group-id'):
+                if self.exec is None:
+                    self.exec = {}
+                self.exec['group-id'] = other_group_id
+            if other_group := other.exec.get('group'):
+                if self.exec is None:
+                    self.exec = {}
+                self.exec['group'] = other_group
+            if other_working_dir := other.exec.get('working-dir'):
+                if self.exec is None:
+                    self.exec = {}
+                self.exec['working-dir'] = other_working_dir
+
     def __repr__(self) -> str:
         return f'Check({self.to_dict()!r})'
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -3067,6 +3067,21 @@ class _TestingPebbleClient:
                         s._merge(service)
                     else:
                         layer.services[name] = service
+            for name, log_target in layer_obj.log_targets.items():
+                if not log_target.override:
+                    raise RuntimeError(f'400 Bad Request: layer "{label}" must define'
+                                       f'"override" for log target "{name}"')
+                if log_target.override not in ('merge', 'replace'):
+                    raise RuntimeError(f'400 Bad Request: layer "{label}" has invalid '
+                                       f'"override" value for log target "{name}"')
+                elif log_target.override == 'replace':
+                    layer.log_targets[name] = log_target
+                elif log_target.override == 'merge':
+                    if combine and name in layer.log_targets:
+                        l_t = layer.log_targets[name]
+                        l_t._merge(log_target)
+                    else:
+                        layer.log_targets[name] = log_target
 
         else:
             self._layers[label] = layer_obj

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -3082,6 +3082,21 @@ class _TestingPebbleClient:
                         l_t._merge(log_target)
                     else:
                         layer.log_targets[name] = log_target
+            for name, check in layer_obj.checks.items():
+                if not check.override:
+                    raise RuntimeError(f'400 Bad Request: layer "{label}" must define'
+                                       f'"override" for check "{name}"')
+                if check.override not in ('merge', 'replace'):
+                    raise RuntimeError(f'400 Bad Request: layer "{label}" has invalid '
+                                       f'"override" value for check "{name}"')
+                elif check.override == 'replace':
+                    layer.checks[name] = check
+                elif check.override == 'merge':
+                    if combine and name in layer.checks:
+                        c = layer.checks[name]
+                        c._merge(check)
+                    else:
+                        layer.checks[name] = check
 
         else:
             self._layers[label] = layer_obj


### PR DESCRIPTION
When unit testing charms with Harness, if they are adding a new pebble layer with `log-targets`, these targets are ignored. This PR is fixing that faulty behavior.

The logic is extracted from the pebble code base:

- https://github.com/canonical/pebble/blob/master/internals/plan/plan.go#L620-L642
- https://github.com/canonical/pebble/blob/master/internals/plan/plan.go#L526-L540