### PR TITLE
test: refactor test_main and test_storage

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -103,6 +103,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
         - {python-version: "3.8", os: "macos-latest"}  # macos-14 is arm64, and there's no Python 3.8 build for arm64
+        - {python-version: "3.9", os: "macos-latest"}  # macos-14 is arm64, and there's no Python 3.9 build for arm64
 
     steps:
       - uses: actions/checkout@v3

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -201,38 +201,3 @@ class FakeScriptTest(unittest.TestCase):
         assert fake_script_calls(self, clear=True) == [['bar', 'd e', 'f']]
 
         assert fake_script_calls(self, clear=True) == []
-
-
-class BaseTestCase(unittest.TestCase):
-
-    def create_framework(self,
-                         *,
-                         model: typing.Optional[ops.Model] = None,
-                         tmpdir: typing.Optional[pathlib.Path] = None):
-        """Create a Framework object.
-
-        By default operate in-memory; pass a temporary directory via the 'tmpdir'
-        parameter if you wish to instantiate several frameworks sharing the
-        same dir (e.g. for storing state).
-        """
-        if tmpdir is None:
-            data_fpath = ":memory:"
-            charm_dir = 'non-existant'
-        else:
-            data_fpath = tmpdir / "framework.data"
-            charm_dir = tmpdir
-
-        framework = ops.Framework(
-            SQLiteStorage(data_fpath),
-            charm_dir,
-            meta=model._cache._meta if model else ops.CharmMeta(),
-            model=model)  # type: ignore
-        self.addCleanup(framework.close)
-        return framework
-
-    def create_model(self):
-        """Create a Model object."""
-        backend = _ModelBackend(unit_name='myapp/0')
-        meta = ops.CharmMeta()
-        model = ops.Model(meta, backend)
-        return model

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -737,8 +737,9 @@ class _TestMain(abc.ABC):
             EventSpec(
                 ops.UpdateStatusEvent,
                 'update-status',
-                set_in_env={
-                    'EMIT_CUSTOM_EVENT': "1"}))
+                set_in_env={'EMIT_CUSTOM_EVENT': "1"}
+            )
+        )
 
         calls = fake_script.calls()
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import abc
+import functools
 import importlib.util
 import io
 import logging
@@ -23,7 +24,6 @@ import subprocess
 import sys
 import tempfile
 import typing
-import unittest
 import warnings
 from pathlib import Path
 from unittest.mock import patch
@@ -35,7 +35,7 @@ from ops.main import _should_use_controller_storage
 from ops.storage import SQLiteStorage
 
 from .charms.test_main.src.charm import MyCharmEvents
-from .test_helpers import fake_script, fake_script_calls
+from .test_helpers import FakeScript
 
 # This relies on the expected repository structure to find a path to
 # source of the charm under test.
@@ -93,7 +93,7 @@ class EventSpec:
 @patch('ops.main.setup_root_logging', new=lambda *a, **kw: None)  # type: ignore
 @patch('ops.main._emit_charm_event', new=lambda *a, **kw: None)  # type: ignore
 @patch('ops.charm._evaluate_status', new=lambda *a, **kw: None)  # type: ignore
-class CharmInitTestCase(unittest.TestCase):
+class TestCharmInit:
 
     @patch('sys.stderr', new_callable=io.StringIO)
     def test_breakpoint(self, fake_stderr: io.StringIO):
@@ -118,11 +118,11 @@ class CharmInitTestCase(unittest.TestCase):
         assert mock.call_count == 0
 
     def _check(
-            self,
-            charm_class: typing.Type[ops.CharmBase],
-            *,
-            extra_environ: typing.Optional[typing.Dict[str, str]] = None,
-            **kwargs: typing.Any
+        self,
+        charm_class: typing.Type[ops.CharmBase],
+        *,
+        extra_environ: typing.Optional[typing.Dict[str, str]] = None,
+        **kwargs: typing.Any
     ):
         """Helper for below tests."""
         fake_environ = {
@@ -192,7 +192,7 @@ class CharmInitTestCase(unittest.TestCase):
     def test_controller_storage_deprecated(self):
         with patch('ops.storage.juju_backend_available') as juju_backend_available:
             juju_backend_available.return_value = True
-            with self.assertWarnsRegex(DeprecationWarning, 'Controller storage'):
+            with pytest.warns(DeprecationWarning, match='Controller storage'):
                 with pytest.raises(FileNotFoundError, match='state-get'):
                     self._check(ops.CharmBase, use_juju_for_storage=True)
 
@@ -200,7 +200,7 @@ class CharmInitTestCase(unittest.TestCase):
 @patch('sys.argv', new=("hooks/config-changed",))
 @patch('ops.main._Manager._setup_root_logging', new=lambda *a, **kw: None)  # type: ignore
 @patch('ops.charm._evaluate_status', new=lambda *a, **kw: None)  # type: ignore
-class TestDispatch(unittest.TestCase):
+class TestDispatch:
     def _check(self, *, with_dispatch: bool = False, dispatch_path: str = ''):
         """Helper for below tests."""
         class MyCharm(ops.CharmBase):
@@ -257,6 +257,11 @@ _event_test = typing.List[typing.Tuple[
     typing.Dict[str, typing.Union[str, int, None]]]]
 
 
+@pytest.fixture
+def fake_script(request: pytest.FixtureRequest):
+    return FakeScript(request)
+
+
 class _TestMain(abc.ABC):
 
     @abc.abstractmethod
@@ -270,7 +275,8 @@ class _TestMain(abc.ABC):
         return NotImplemented
 
     @abc.abstractmethod
-    def _call_event(self, rel_path: Path, env: typing.Dict[str, str]):
+    def _call_event(self, fake_script: FakeScript,
+                    rel_path: Path, env: typing.Dict[str, str]):
         """Set up the environment and call (i.e. run) the given event."""
         return NotImplemented
 
@@ -283,19 +289,9 @@ class _TestMain(abc.ABC):
         """
         return NotImplemented
 
-    addCleanup = unittest.TestCase.addCleanup  # noqa
-    assertEqual = unittest.TestCase.assertEqual  # noqa
-    assertFalse = unittest.TestCase.assertFalse  # noqa
-    assertIn = unittest.TestCase.assertIn  # noqa
-    assertIsNotNone = unittest.TestCase.assertIsNotNone  # noqa
-    assertRaises = unittest.TestCase.assertRaises  # noqa
-    assertRegex = unittest.TestCase.assertRegex  # noqa
-    assertNotIn = unittest.TestCase.assertNotIn  # noqa
-    fail = unittest.TestCase.fail
-    subTest = unittest.TestCase.subTest  # noqa
-
-    def setUp(self):
-        self._setup_charm_dir()
+    @pytest.fixture(autouse=True)
+    def setup_charm(self, request: pytest.FixtureRequest, fake_script: FakeScript):
+        self._setup_charm_dir(request)
 
         # Relations events are defined dynamically and modify the class attributes.
         # We use a subclass temporarily to prevent these side effects from leaking.
@@ -305,18 +301,18 @@ class _TestMain(abc.ABC):
 
         def cleanup():
             ops.CharmBase.on = ops.CharmEvents()  # type: ignore
-        self.addCleanup(cleanup)
+        request.addfinalizer(cleanup)
 
-        fake_script(typing.cast(unittest.TestCase, self), 'is-leader', 'echo true')
-        fake_script(typing.cast(unittest.TestCase, self), 'juju-log', 'exit 0')
+        fake_script.write('is-leader', 'echo true')
+        fake_script.write('juju-log', 'exit 0')
 
         # set to something other than None for tests that care
         self.stdout = None
         self.stderr = None
 
-    def _setup_charm_dir(self):
+    def _setup_charm_dir(self, request: pytest.FixtureRequest):
         self._tmpdir = Path(tempfile.mkdtemp(prefix='tmp-ops-test-')).resolve()
-        self.addCleanup(shutil.rmtree, str(self._tmpdir))
+        request.addfinalizer(functools.partial(shutil.rmtree, str(self._tmpdir)))
         self.JUJU_CHARM_DIR = self._tmpdir / 'test_main'
         self._charm_state_file = self.JUJU_CHARM_DIR / '.unit-state.db'
         self.hooks_dir = self.JUJU_CHARM_DIR / 'hooks'
@@ -347,9 +343,10 @@ class _TestMain(abc.ABC):
         for action_name in ('start', 'foo-bar', 'get-model-name', 'get-status', 'keyerror'):
             self._setup_entry_point(actions_dir, action_name)
 
-    def _read_and_clear_state(self,
-                              event_name: str) -> typing.Union[ops.BoundStoredState,
-                                                               ops.StoredStateData]:
+    def _read_and_clear_state(
+        self,
+        event_name: str,
+    ) -> typing.Union[ops.BoundStoredState, ops.StoredStateData]:
         if self._charm_state_file.stat().st_size:
             storage = SQLiteStorage(self._charm_state_file)
             with (self.JUJU_CHARM_DIR / 'metadata.yaml').open() as m:
@@ -381,7 +378,7 @@ class _TestMain(abc.ABC):
             stored = ops.StoredStateData(None, None)  # type: ignore
         return stored
 
-    def _simulate_event(self, event_spec: EventSpec):
+    def _simulate_event(self, fake_script: FakeScript, event_spec: EventSpec):
         ppath = Path(__file__).parent
         pypath = str(ppath.parent)
         if 'PYTHONPATH' in os.environ:
@@ -460,47 +457,55 @@ class _TestMain(abc.ABC):
         if event_spec.model_name is not None:
             env['JUJU_MODEL_NAME'] = event_spec.model_name
 
-        self._call_event(Path(event_dir, event_filename), env)
+        self._call_event(fake_script, Path(event_dir, event_filename), env)
         return self._read_and_clear_state(event_spec.event_name)
 
-    def test_event_reemitted(self):
+    def test_event_reemitted(self, fake_script: FakeScript):
         # First run "install" to make sure all hooks are set up.
-        state = self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
+        state = self._simulate_event(fake_script, EventSpec(ops.InstallEvent, 'install'))
         assert isinstance(state, ops.BoundStoredState)
         assert list(state.observed_event_types) == ['InstallEvent']
 
-        state = self._simulate_event(EventSpec(ops.ConfigChangedEvent, 'config-changed'))
+        state = self._simulate_event(
+            fake_script, EventSpec(
+                ops.ConfigChangedEvent, 'config-changed'))
         assert isinstance(state, ops.BoundStoredState)
         assert list(state.observed_event_types) == ['ConfigChangedEvent']
 
         # Re-emit should pick the deferred config-changed.
-        state = self._simulate_event(EventSpec(ops.UpdateStatusEvent, 'update-status'))
+        state = self._simulate_event(
+            fake_script, EventSpec(
+                ops.UpdateStatusEvent, 'update-status'))
         assert isinstance(state, ops.BoundStoredState)
         assert list(state.observed_event_types) == \
             ['ConfigChangedEvent', 'UpdateStatusEvent']
 
-    def test_no_reemission_on_collect_metrics(self):
-        fake_script(typing.cast(unittest.TestCase, self), 'add-metric', 'exit 0')
+    def test_no_reemission_on_collect_metrics(self, fake_script: FakeScript):
+        fake_script.write('add-metric', 'exit 0')
 
         # First run "install" to make sure all hooks are set up.
-        state = self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
+        state = self._simulate_event(fake_script, EventSpec(ops.InstallEvent, 'install'))
         assert isinstance(state, ops.BoundStoredState)
         assert list(state.observed_event_types) == ['InstallEvent']
 
-        state = self._simulate_event(EventSpec(ops.ConfigChangedEvent, 'config-changed'))
+        state = self._simulate_event(
+            fake_script, EventSpec(
+                ops.ConfigChangedEvent, 'config-changed'))
         assert isinstance(state, ops.BoundStoredState)
         assert list(state.observed_event_types) == ['ConfigChangedEvent']
 
         # Re-emit should not pick the deferred config-changed because
         # collect-metrics runs in a restricted context.
-        state = self._simulate_event(EventSpec(ops.CollectMetricsEvent, 'collect-metrics'))
+        state = self._simulate_event(
+            fake_script, EventSpec(
+                ops.CollectMetricsEvent, 'collect-metrics'))
         assert isinstance(state, ops.BoundStoredState)
         assert list(state.observed_event_types) == ['CollectMetricsEvent']
 
-    def test_multiple_events_handled(self):
+    def test_multiple_events_handled(self, fake_script: FakeScript):
         self._prepare_actions()
 
-        fake_script(typing.cast(unittest.TestCase, self), 'action-get', "echo '{}'")
+        fake_script.write('action-get', "echo '{}'")
 
         # Sample events with a different amount of dashes used
         # and with endpoints from different sections of metadata.yaml
@@ -643,11 +648,11 @@ class _TestMain(abc.ABC):
         logger.debug('Expected events %s', events_under_test)
 
         # First run "install" to make sure all hooks are set up.
-        self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
+        self._simulate_event(fake_script, EventSpec(ops.InstallEvent, 'install'))
 
         # Simulate hook executions for every event.
         for event_spec, expected_event_data in events_under_test:
-            state = self._simulate_event(event_spec)
+            state = self._simulate_event(fake_script, event_spec)
             assert isinstance(state, ops.BoundStoredState)
 
             state_key = f"on_{event_spec.event_name}"
@@ -665,7 +670,7 @@ class _TestMain(abc.ABC):
                 assert getattr(state, f"{event_spec.event_name}_data") == \
                     expected_event_data
 
-    def test_event_not_implemented(self):
+    def test_event_not_implemented(self, fake_script: FakeScript):
         """Make sure events without implementation do not cause non-zero exit."""
         # Simulate a scenario where there is a symlink for an event that
         # a charm does not know how to handle.
@@ -674,25 +679,31 @@ class _TestMain(abc.ABC):
         hook_path.symlink_to('install')
 
         try:
-            self._simulate_event(EventSpec(ops.HookEvent, 'not-implemented-event'))
+            self._simulate_event(
+                fake_script, EventSpec(
+                    ops.HookEvent, 'not-implemented-event'))
         except subprocess.CalledProcessError:
-            self.fail('Event simulation for an unsupported event'
-                      ' results in a non-zero exit code returned')
+            pytest.fail('Event simulation for an unsupported event'
+                        ' results in a non-zero exit code returned')
 
-    def test_no_actions(self):
+    def test_no_actions(self, fake_script: FakeScript):
         (self.JUJU_CHARM_DIR / 'actions.yaml').unlink()
-        self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
+        self._simulate_event(fake_script, EventSpec(ops.InstallEvent, 'install'))
 
-    def test_empty_actions(self):
+    def test_empty_actions(self, fake_script: FakeScript):
         (self.JUJU_CHARM_DIR / 'actions.yaml').write_text('')
-        self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
+        self._simulate_event(fake_script, EventSpec(ops.InstallEvent, 'install'))
 
-    def test_collect_metrics(self):
-        fake_script(typing.cast(unittest.TestCase, self), 'add-metric', 'exit 0')
-        self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
+    def test_collect_metrics(self, fake_script: FakeScript):
+        fake_script.write('add-metric', 'exit 0')
+        self._simulate_event(fake_script, EventSpec(ops.InstallEvent, 'install'))
         # Clear the calls during 'install'
-        fake_script_calls(typing.cast(unittest.TestCase, self), clear=True)
-        self._simulate_event(EventSpec(ops.CollectMetricsEvent, 'collect_metrics'))
+        fake_script.calls(clear=True)
+        self._simulate_event(
+            fake_script,
+            EventSpec(
+                ops.CollectMetricsEvent,
+                'collect_metrics'))
 
         expected = [
             VERSION_LOGLINE,
@@ -700,18 +711,18 @@ class _TestMain(abc.ABC):
             ['add-metric', '--labels', 'bar=4.2', 'foo=42'],
             ['is-leader', '--format=json'],
         ]
-        calls = fake_script_calls(typing.cast(unittest.TestCase, self))
+        calls = fake_script.calls()
 
         assert calls == expected
 
-    def test_custom_event(self):
-        self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
+    def test_custom_event(self, fake_script: FakeScript):
+        self._simulate_event(fake_script, EventSpec(ops.InstallEvent, 'install'))
         # Clear the calls during 'install'
-        fake_script_calls(typing.cast(unittest.TestCase, self), clear=True)
-        self._simulate_event(EventSpec(ops.UpdateStatusEvent, 'update-status',
-                                       set_in_env={'EMIT_CUSTOM_EVENT': "1"}))
+        fake_script.calls(clear=True)
+        self._simulate_event(fake_script, EventSpec(ops.UpdateStatusEvent, 'update-status',
+                                                    set_in_env={'EMIT_CUSTOM_EVENT': "1"}))
 
-        calls = fake_script_calls(typing.cast(unittest.TestCase, self))
+        calls = fake_script.calls()
 
         custom_event_prefix = 'Emitting custom event <CustomEvent via Charm/on/custom'
         expected = [
@@ -725,8 +736,8 @@ class _TestMain(abc.ABC):
         calls[2][-1] = custom_event_prefix
         assert calls == expected
 
-    def test_logger(self):
-        fake_script(typing.cast(unittest.TestCase, self), 'action-get', "echo '{}'")
+    def test_logger(self, fake_script: FakeScript):
+        fake_script.write('action-get', "echo '{}'")
 
         test_cases = [(
             EventSpec(ops.ActionEvent, 'log_critical_action', env_var='JUJU_ACTION_NAME',
@@ -747,19 +758,21 @@ class _TestMain(abc.ABC):
         )]
 
         # Set up action symlinks.
-        self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
+        self._simulate_event(fake_script, EventSpec(ops.InstallEvent, 'install'))
 
         for event_spec, calls in test_cases:
-            self._simulate_event(event_spec)
+            self._simulate_event(fake_script, event_spec)
             assert calls in \
-                fake_script_calls(typing.cast(unittest.TestCase, self), clear=True)
+                fake_script.calls(clear=True)
 
-    def test_excepthook(self):
+    def test_excepthook(self, fake_script: FakeScript):
         with pytest.raises(subprocess.CalledProcessError):
-            self._simulate_event(EventSpec(ops.InstallEvent, 'install',
-                                           set_in_env={'TRY_EXCEPTHOOK': '1'}))
+            self._simulate_event(
+                fake_script, EventSpec(
+                    ops.InstallEvent, 'install', set_in_env={
+                        'TRY_EXCEPTHOOK': '1'}))
 
-        calls = [' '.join(i) for i in fake_script_calls(typing.cast(unittest.TestCase, self))]
+        calls = [' '.join(i) for i in fake_script.calls()]
 
         assert calls.pop(0) == ' '.join(VERSION_LOGLINE)
         assert re.search('Using local storage: not a Kubernetes podspec charm', calls.pop(0))
@@ -774,11 +787,11 @@ class _TestMain(abc.ABC):
             'RuntimeError: failing as requested', calls[0])
         assert len(calls) == 1, f"expected 1 call, but got extra: {calls[1:]}"
 
-    def test_sets_model_name(self):
+    def test_sets_model_name(self, fake_script: FakeScript):
         self._prepare_actions()
 
-        fake_script(typing.cast(unittest.TestCase, self), 'action-get', "echo '{}'")
-        state = self._simulate_event(EventSpec(
+        fake_script.write('action-get', "echo '{}'")
+        state = self._simulate_event(fake_script, EventSpec(
             ops.ActionEvent, 'get_model_name_action',
             env_var='JUJU_ACTION_NAME',
             model_name='test-model-name',
@@ -786,24 +799,23 @@ class _TestMain(abc.ABC):
         assert isinstance(state, ops.BoundStoredState)
         assert state._on_get_model_name_action == ['test-model-name']
 
-    def test_has_valid_status(self):
+    def test_has_valid_status(self, fake_script: FakeScript):
         self._prepare_actions()
 
-        fake_script(typing.cast(unittest.TestCase, self), 'action-get', "echo '{}'")
-        fake_script(typing.cast(unittest.TestCase, self), 'status-get',
-                    """echo '{"status": "unknown", "message": ""}'""")
-        state = self._simulate_event(EventSpec(
+        fake_script.write('action-get', "echo '{}'")
+        fake_script.write('status-get',
+                          """echo '{"status": "unknown", "message": ""}'""")
+        state = self._simulate_event(fake_script, EventSpec(
             ops.ActionEvent, 'get_status_action',
             env_var='JUJU_ACTION_NAME',
             set_in_env={'JUJU_ACTION_UUID': '1'}))
         assert isinstance(state, ops.BoundStoredState)
         assert state.status_name == 'unknown'
         assert state.status_message == ''
-        fake_script(
-            typing.cast(unittest.TestCase, self),
+        fake_script.write(
             'status-get',
             """echo '{"status": "blocked", "message": "help meeee"}'""")
-        state = self._simulate_event(EventSpec(
+        state = self._simulate_event(fake_script, EventSpec(
             ops.ActionEvent, 'get_status_action',
             env_var='JUJU_ACTION_NAME',
             set_in_env={'JUJU_ACTION_UUID': '1'}))
@@ -812,7 +824,7 @@ class _TestMain(abc.ABC):
         assert state.status_message == 'help meeee'
 
 
-class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
+class TestMainWithNoDispatch(_TestMain):
     has_dispatch = False
     hooks_are_symlinks = True
 
@@ -820,13 +832,17 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
         path = directory / entry_point
         path.symlink_to(self.charm_exec_path)
 
-    def _call_event(self, rel_path: Path, env: typing.Dict[str, str]):
+    def _call_event(
+        self,
+        fake_script: FakeScript,
+        rel_path: Path,
+        env: typing.Dict[str, str],
+    ):
         env['JUJU_VERSION'] = '2.7.0'
         event_file = self.JUJU_CHARM_DIR / rel_path
         # Note that sys.executable is used to make sure we are using the same
         # interpreter for the child process to support virtual environments.
-        fake_script(
-            self,
+        fake_script.write(
             "storage-get",
             """
             if [ "$1" = "-s" ]; then
@@ -858,8 +874,7 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
             fi
             """,
         )
-        fake_script(
-            self,
+        fake_script.write(
             "storage-list",
             """
             echo '["disks/0"]'
@@ -869,7 +884,11 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
             [sys.executable, str(event_file)],
             check=True, env=env, cwd=str(self.JUJU_CHARM_DIR))
 
-    def test_setup_event_links(self):
+    def test_setup_event_links(
+        self,
+        request: pytest.FixtureRequest,
+        fake_script: FakeScript,
+    ):
         """Test auto-creation of symlinks caused by initial events."""
         all_event_hooks = [
             f"hooks/{name.replace('_', '-')}"
@@ -902,32 +921,42 @@ class TestMainWithNoDispatch(_TestMain, unittest.TestCase):
                     assert os.readlink(str(hook_path)) == event_spec.event_name
 
         for initial_event in initial_events:
-            self._setup_charm_dir()
+            self._setup_charm_dir(request)
 
-            self._simulate_event(initial_event)
+            self._simulate_event(fake_script, initial_event)
             _assess_event_links(initial_event)
             # Make sure it is idempotent.
-            self._simulate_event(initial_event)
+            self._simulate_event(fake_script, initial_event)
             _assess_event_links(initial_event)
 
-    def test_setup_action_links(self):
-        self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
+    def test_setup_action_links(self, fake_script: FakeScript):
+        self._simulate_event(fake_script, EventSpec(ops.InstallEvent, 'install'))
         # foo-bar is one of the actions defined in actions.yaml
         action_hook = self.JUJU_CHARM_DIR / 'actions' / 'foo-bar'
         assert action_hook.exists()
 
 
 class TestMainWithNoDispatchButJujuIsDispatchAware(TestMainWithNoDispatch):
-    def _call_event(self, rel_path: Path, env: typing.Dict[str, str]):
+    def _call_event(
+        self,
+        fake_script: FakeScript,
+        rel_path: Path,
+        env: typing.Dict[str, str],
+    ):
         env['JUJU_DISPATCH_PATH'] = str(rel_path)
         env['JUJU_VERSION'] = '2.8.0'
-        super()._call_event(rel_path, env)
+        super()._call_event(fake_script, rel_path, env)
 
 
 class TestMainWithNoDispatchButDispatchPathIsSet(TestMainWithNoDispatch):
-    def _call_event(self, rel_path: Path, env: typing.Dict[str, str]):
+    def _call_event(
+        self,
+        fake_script: FakeScript,
+        rel_path: Path,
+        env: typing.Dict[str, str]
+    ):
         env['JUJU_DISPATCH_PATH'] = str(rel_path)
-        super()._call_event(rel_path, env)
+        super()._call_event(fake_script, rel_path, env)
 
 
 class TestMainWithNoDispatchButScriptsAreCopies(TestMainWithNoDispatch):
@@ -942,7 +971,11 @@ class TestMainWithNoDispatchButScriptsAreCopies(TestMainWithNoDispatch):
 class _TestMainWithDispatch(_TestMain):
     has_dispatch = True
 
-    def test_setup_event_links(self):
+    def test_setup_event_links(
+        self,
+        request: pytest.FixtureRequest,
+        fake_script: FakeScript
+    ):
         """Test auto-creation of symlinks.
 
         Symlink creation caused by initial events should _not_ happen when using dispatch.
@@ -963,24 +996,25 @@ class _TestMainWithDispatch(_TestMain):
                     f"Spurious hook: {event_hook}"
 
         for initial_event in initial_events:
-            self._setup_charm_dir()
+            self._setup_charm_dir(request)
 
-            self._simulate_event(initial_event)
+            self._simulate_event(fake_script, initial_event)
             _assess_event_links(initial_event)
 
-    def test_hook_and_dispatch(self):
-        old_path = self.fake_script_path
-        self.fake_script_path = self.hooks_dir
-        fake_script(typing.cast(unittest.TestCase, self), 'install', 'exit 0')
-        state = self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
+    def test_hook_and_dispatch(
+        self,
+        request: pytest.FixtureRequest,
+        fake_script: FakeScript,
+    ):
+        fs = FakeScript(request, self.hooks_dir)
+        fs.write('install', 'exit 0')
+        state = self._simulate_event(fake_script, EventSpec(ops.InstallEvent, 'install'))
         assert isinstance(state, ops.BoundStoredState)
 
         # the script was called, *and*, the .on. was called
-        assert fake_script_calls(typing.cast(
-            unittest.TestCase, self)) == [['install', '']]
+        assert fs.calls() == [['install', '']]
         assert list(state.observed_event_types) == ['InstallEvent']
 
-        self.fake_script_path = old_path
         hook = Path('hooks/install')
         expected = [
             VERSION_LOGLINE,
@@ -994,13 +1028,13 @@ class _TestMainWithDispatch(_TestMain):
              'Emitting Juju event install.'],
             ['is-leader', '--format=json'],
         ]
-        calls = fake_script_calls(typing.cast(unittest.TestCase, self))
+        calls = fake_script.calls()
         assert re.search('Initializing SQLite local storage: ', ' '.join(calls.pop(-3)))
         assert calls == expected
 
-    def test_non_executable_hook_and_dispatch(self):
+    def test_non_executable_hook_and_dispatch(self, fake_script: FakeScript):
         (self.hooks_dir / "install").write_text("")
-        state = self._simulate_event(EventSpec(ops.InstallEvent, 'install'))
+        state = self._simulate_event(fake_script, EventSpec(ops.InstallEvent, 'install'))
         assert isinstance(state, ops.BoundStoredState)
 
         assert list(state.observed_event_types) == ['InstallEvent']
@@ -1015,27 +1049,29 @@ class _TestMainWithDispatch(_TestMain):
              'Emitting Juju event install.'],
             ['is-leader', '--format=json'],
         ]
-        calls = fake_script_calls(typing.cast(unittest.TestCase, self))
+        calls = fake_script.calls()
         assert re.search('Initializing SQLite local storage: ', ' '.join(calls.pop(-3)))
         assert calls == expected
 
-    def test_hook_and_dispatch_with_failing_hook(self):
+    def test_hook_and_dispatch_with_failing_hook(
+        self,
+        request: pytest.FixtureRequest,
+        fake_script: FakeScript,
+    ):
         self.stdout = self.stderr = tempfile.TemporaryFile()
-        self.addCleanup(self.stdout.close)
+        request.addfinalizer(self.stdout.close)
 
-        old_path = self.fake_script_path
-        self.fake_script_path = self.hooks_dir
-        fake_script(typing.cast(unittest.TestCase, self), 'install', 'exit 42')
+        fs = FakeScript(request, self.hooks_dir)
+        fs.write('install', 'exit 42')
         event = EventSpec(ops.InstallEvent, 'install')
         with pytest.raises(subprocess.CalledProcessError):
-            self._simulate_event(event)
-        self.fake_script_path = old_path
+            self._simulate_event(fake_script, event)
 
         self.stdout.seek(0)
         assert self.stdout.read() == b''
         self.stderr.seek(0)
         assert self.stderr.read() == b''
-        calls = fake_script_calls(typing.cast(unittest.TestCase, self))
+        calls = fake_script.calls()
         hook = Path('hooks/install')
         expected = [
             VERSION_LOGLINE,
@@ -1045,42 +1081,54 @@ class _TestMainWithDispatch(_TestMain):
         ]
         assert calls == expected
 
-    def test_hook_and_dispatch_but_hook_is_dispatch(self):
+    @pytest.mark.parametrize("rel,ind,path_type", [
+        (True, True, "indirect"),
+        (True, False, "direct"),
+        (False, False, "absolute_direct"),
+        (False, True, "absolute_indirect")
+    ])
+    def test_hook_and_dispatch_but_hook_is_dispatch(
+        self,
+        fake_script: FakeScript,
+        rel: bool,
+        ind: bool,
+        path_type: str
+    ):
         event = EventSpec(ops.InstallEvent, 'install')
         hook_path = self.hooks_dir / 'install'
-        for ((rel, ind), path) in {
-                # relative and indirect
-                (True, True): Path('../dispatch'),
-                # relative and direct
-                (True, False): Path(self.charm_exec_path),
-                # absolute and direct
-                (False, False): (self.hooks_dir / self.charm_exec_path).resolve(),
-                # absolute and indirect
-                (False, True): self.JUJU_CHARM_DIR / 'dispatch',
-        }.items():
-            with self.subTest(path=path, rel=rel, ind=ind):
-                # sanity check
-                assert path.is_absolute() == (not rel)
-                assert (path.with_suffix('').name == 'dispatch') == ind
-                try:
-                    hook_path.symlink_to(path)
 
-                    state = self._simulate_event(event)
-                    assert isinstance(state, ops.BoundStoredState)
+        path_type_dict = {
+            "indirect": Path('../dispatch'),
+            "direct": Path(self.charm_exec_path),
+            "absolute_direct": (self.hooks_dir / self.charm_exec_path).resolve(),
+            "absolute_indirect": self.JUJU_CHARM_DIR / 'dispatch'
+        }
 
-                    # the .on. was only called once
-                    assert list(state.observed_event_types) == ['InstallEvent']
-                    assert list(state.on_install) == ['InstallEvent']
-                finally:
-                    hook_path.unlink()
+        path = path_type_dict[path_type]
 
-    def test_hook_and_dispatch_but_hook_is_dispatch_copy(self):
+        # Sanity check
+        assert path.is_absolute() == (not rel)
+        assert (path.with_suffix('').name == 'dispatch') == ind
+
+        try:
+            hook_path.symlink_to(path)
+
+            state = self._simulate_event(fake_script, event)
+            assert isinstance(state, ops.BoundStoredState)
+
+            # The `.on.` method was only called once
+            assert list(state.observed_event_types) == ['InstallEvent']
+            assert list(state.on_install) == ['InstallEvent']
+        finally:
+            hook_path.unlink()
+
+    def test_hook_and_dispatch_but_hook_is_dispatch_copy(self, fake_script: FakeScript):
         hook_path = self.hooks_dir / 'install'
         path = (self.hooks_dir / self.charm_exec_path).resolve()
         shutil.copy(str(path), str(hook_path))
 
         event = EventSpec(ops.InstallEvent, 'install')
-        state = self._simulate_event(event)
+        state = self._simulate_event(fake_script, event)
         assert isinstance(state, ops.BoundStoredState)
 
         # the .on. was only called once
@@ -1102,24 +1150,28 @@ class _TestMainWithDispatch(_TestMain):
              'Emitting Juju event install.'],
             ['is-leader', '--format=json'],
         ]
-        calls = fake_script_calls(typing.cast(unittest.TestCase, self))
+        calls = fake_script.calls()
         assert re.search('Initializing SQLite local storage: ', ' '.join(calls.pop(-3)))
 
         assert calls == expected
 
 
-class TestMainWithDispatch(_TestMainWithDispatch, unittest.TestCase):
+class TestMainWithDispatch(_TestMainWithDispatch):
     def _setup_entry_point(self, directory: Path, entry_point: str):
         path = self.JUJU_CHARM_DIR / 'dispatch'
         if not path.exists():
             path.symlink_to(os.path.join('src', 'charm.py'))
 
-    def _call_event(self, rel_path: Path, env: typing.Dict[str, str]):
+    def _call_event(
+        self,
+        fake_script: FakeScript,
+        rel_path: Path,
+        env: typing.Dict[str, str],
+    ):
         env['JUJU_DISPATCH_PATH'] = str(rel_path)
         env['JUJU_VERSION'] = '2.8.0'
         dispatch = self.JUJU_CHARM_DIR / 'dispatch'
-        fake_script(
-            self,
+        fake_script.write(
             "storage-get",
             """
             if [ "$1" = "-s" ]; then
@@ -1151,8 +1203,7 @@ class TestMainWithDispatch(_TestMainWithDispatch, unittest.TestCase):
             fi
             """,
         )
-        fake_script(
-            self,
+        fake_script.write(
             "storage-list",
             """
             echo '["disks/0"]'
@@ -1164,13 +1215,13 @@ class TestMainWithDispatch(_TestMainWithDispatch, unittest.TestCase):
             stderr=self.stderr,
             check=True, env=env, cwd=str(self.JUJU_CHARM_DIR))
 
-    def test_crash_action(self):
+    def test_crash_action(self, request: pytest.FixtureRequest, fake_script: FakeScript):
         self._prepare_actions()
         self.stderr = tempfile.TemporaryFile('w+t')
-        self.addCleanup(self.stderr.close)
-        fake_script(typing.cast(unittest.TestCase, self), 'action-get', "echo '{}'")
+        request.addfinalizer(self.stderr.close)
+        fake_script.write('action-get', "echo '{}'")
         with pytest.raises(subprocess.CalledProcessError):
-            self._simulate_event(EventSpec(
+            self._simulate_event(fake_script, EventSpec(
                 ops.ActionEvent, 'keyerror_action',
                 env_var='JUJU_ACTION_NAME',
                 set_in_env={'JUJU_ACTION_UUID': '1'}))
@@ -1180,7 +1231,7 @@ class TestMainWithDispatch(_TestMainWithDispatch, unittest.TestCase):
         assert "'foo' not found in 'bar'" in stderr
 
 
-class TestMainWithDispatchAsScript(_TestMainWithDispatch, unittest.TestCase):
+class TestMainWithDispatchAsScript(_TestMainWithDispatch):
     """Here dispatch is a script that execs the charm.py instead of a symlink."""
 
     has_dispatch = True
@@ -1193,11 +1244,15 @@ class TestMainWithDispatchAsScript(_TestMainWithDispatch, unittest.TestCase):
                 self.JUJU_CHARM_DIR / 'src/charm.py'))
             path.chmod(0o755)
 
-    def _call_event(self, rel_path: Path, env: typing.Dict[str, str]):
+    def _call_event(
+        self,
+        fake_script: FakeScript,
+        rel_path: Path,
+        env: typing.Dict[str, str],
+    ):
         env['JUJU_DISPATCH_PATH'] = str(rel_path)
         env['JUJU_VERSION'] = '2.8.0'
-        fake_script(
-            self,
+        fake_script.write(
             "storage-get",
             """
             if [ "$1" = "-s" ]; then
@@ -1229,8 +1284,7 @@ class TestMainWithDispatchAsScript(_TestMainWithDispatch, unittest.TestCase):
             fi
             """,
         )
-        fake_script(
-            self,
+        fake_script.write(
             "storage-list",
             """
             echo '["disks/0"]'
@@ -1240,7 +1294,7 @@ class TestMainWithDispatchAsScript(_TestMainWithDispatch, unittest.TestCase):
         subprocess.check_call([str(dispatch)], env=env, cwd=str(self.JUJU_CHARM_DIR))
 
 
-class TestStorageHeuristics(unittest.TestCase):
+class TestStorageHeuristics:
     def test_fallback_to_current_juju_version__too_old(self):
         meta = ops.CharmMeta.from_yaml("series: [kubernetes]")
         with patch.dict(os.environ, {"JUJU_VERSION": "1.0"}):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -316,8 +316,12 @@ class _TestMain(abc.ABC):
 
     def _setup_charm_dir(self, request: pytest.FixtureRequest):
         self._tmpdir = Path(tempfile.mkdtemp(prefix='tmp-ops-test-')).resolve()
-        request.addfinalizer(lambda: shutil.rmtree(self._tmpdir)
-                             if self._tmpdir.exists() else None)
+
+        def cleanup():
+            shutil.rmtree(self._tmpdir) if self._tmpdir.exists() else None
+
+        request.addfinalizer(cleanup)
+
         self.JUJU_CHARM_DIR = self._tmpdir / 'test_main'
         self._charm_state_file = self.JUJU_CHARM_DIR / '.unit-state.db'
         self.hooks_dir = self.JUJU_CHARM_DIR / 'hooks'

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -76,8 +76,12 @@ class StoragePermutations(abc.ABC):
 
         class Sample(ops.StoredStateData):
 
-            def __init__(self, parent: ops.Object, key: str,
-                         content: typing.Dict[str, typing.Any]):
+            def __init__(
+                self,
+                parent: ops.Object,
+                key: str,
+                content: typing.Dict[str, typing.Any],
+            ):
                 super().__init__(parent, key)
                 self.content = content
 
@@ -213,8 +217,7 @@ class StoragePermutations(abc.ABC):
     def test_save_notice(self, request: pytest.FixtureRequest, fake_script: FakeScript):
         store = self.create_storage(request, fake_script)
         store.save_notice('event', 'observer', 'method')
-        assert list(store.notices('event')) == \
-            [('event', 'observer', 'method')]
+        assert list(store.notices('event')) == [('event', 'observer', 'method')]
 
     def test_all_notices(self, request: pytest.FixtureRequest, fake_script: FakeScript):
         notices = [('e1', 'o1', 'm1'), ('e1', 'o2', 'm2'), ('e2', 'o3', 'm3')]
@@ -256,10 +259,10 @@ class StoragePermutations(abc.ABC):
         store = self.create_storage(request, fake_script)
         store.save_notice('event', 'observer', 'method')
         store.save_notice('event', 'observer', 'method2')
-        assert list(store.notices('event')) == \
-            [('event', 'observer', 'method'),
-             ('event', 'observer', 'method2'),
-             ]
+        assert list(store.notices('event')) == [
+            ('event', 'observer', 'method'),
+            ('event', 'observer', 'method2')
+        ]
 
 
 class TestSQLiteStorage(StoragePermutations):

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -49,14 +49,8 @@ class StoragePermutations(abc.ABC):
         fake_script: FakeScript,
     ) -> ops.Framework:
         """Create a Framework that we can use to test the backend storage."""
-        return ops.Framework(
-            self.create_storage(
-                request,
-                fake_script
-            ),
-            None,  # type: ignore
-            None,  # type: ignore
-            None)  # type: ignore
+        storage = self.create_storage(request, fake_script)
+        return ops.Framework(storage, None, None, None)  # type: ignore
 
     @abc.abstractmethod
     def create_storage(

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -23,7 +23,7 @@ import tempfile
 import typing
 import unittest
 import unittest.mock
-from test.test_helpers import BaseTestCase, fake_script, fake_script_calls
+from test.test_helpers import FakeScript
 from textwrap import dedent
 
 import pytest
@@ -33,22 +33,46 @@ import ops
 import ops.storage
 
 
+@pytest.fixture
+def fake_script(request: pytest.FixtureRequest):
+    return FakeScript(request)
+
+
 class StoragePermutations(abc.ABC):
 
     assertEqual = unittest.TestCase.assertEqual  # noqa
     assertRaises = unittest.TestCase.assertRaises  # noqa
 
-    def create_framework(self) -> ops.Framework:
+    def create_framework(
+        self,
+        request: pytest.FixtureRequest,
+        fake_script: FakeScript,
+    ) -> ops.Framework:
         """Create a Framework that we can use to test the backend storage."""
-        return ops.Framework(self.create_storage(), None, None, None)  # type: ignore
+        return ops.Framework(
+            self.create_storage(
+                request,
+                fake_script
+            ),
+            None,  # type: ignore
+            None,  # type: ignore
+            None)  # type: ignore
 
     @abc.abstractmethod
-    def create_storage(self) -> ops.storage.SQLiteStorage:
+    def create_storage(
+        self,
+        request: pytest.FixtureRequest,
+        fake_script: FakeScript,
+    ) -> ops.storage.SQLiteStorage:
         """Create a Storage backend that we can interact with."""
         return NotImplemented
 
-    def test_save_and_load_snapshot(self):
-        f = self.create_framework()
+    def test_save_and_load_snapshot(
+        self,
+        request: pytest.FixtureRequest,
+        fake_script: FakeScript,
+    ):
+        f = self.create_framework(request, fake_script)
 
         class Sample(ops.StoredStateData):
 
@@ -81,8 +105,8 @@ class StoragePermutations(abc.ABC):
         res = f.load_snapshot(handle)
         assert data == res.content  # type: ignore
 
-    def test_emit_event(self):
-        f = self.create_framework()
+    def test_emit_event(self, request: pytest.FixtureRequest, fake_script: FakeScript):
+        f = self.create_framework(request, fake_script)
 
         class Evt(ops.EventBase):
             def __init__(self, handle: ops.Handle, content: typing.Any):
@@ -125,23 +149,31 @@ class StoragePermutations(abc.ABC):
         s.on.event.emit(None)
         assert s.observed_content is None
 
-    def test_save_and_overwrite_snapshot(self):
-        store = self.create_storage()
+    def test_save_and_overwrite_snapshot(
+        self,
+        request: pytest.FixtureRequest,
+        fake_script: FakeScript,
+    ):
+        store = self.create_storage(request, fake_script)
         store.save_snapshot('foo', {1: 2})
         assert store.load_snapshot('foo') == {1: 2}
         store.save_snapshot('foo', {'three': 4})
         assert store.load_snapshot('foo') == {'three': 4}
 
-    def test_drop_snapshot(self):
-        store = self.create_storage()
+    def test_drop_snapshot(self, request: pytest.FixtureRequest, fake_script: FakeScript):
+        store = self.create_storage(request, fake_script)
         store.save_snapshot('foo', {1: 2})
         assert store.load_snapshot('foo') == {1: 2}
         store.drop_snapshot('foo')
         with pytest.raises(ops.storage.NoSnapshotError):
             store.load_snapshot('foo')
 
-    def test_save_snapshot_empty_string(self):
-        store = self.create_storage()
+    def test_save_snapshot_empty_string(
+        self,
+        request: pytest.FixtureRequest,
+        fake_script: FakeScript,
+    ):
+        store = self.create_storage(request, fake_script)
         with pytest.raises(ops.storage.NoSnapshotError):
             store.load_snapshot('foo')
         store.save_snapshot('foo', '')
@@ -150,8 +182,12 @@ class StoragePermutations(abc.ABC):
         with pytest.raises(ops.storage.NoSnapshotError):
             store.load_snapshot('foo')
 
-    def test_save_snapshot_none(self):
-        store = self.create_storage()
+    def test_save_snapshot_none(
+        self,
+        request: pytest.FixtureRequest,
+        fake_script: FakeScript,
+    ):
+        store = self.create_storage(request, fake_script)
         with pytest.raises(ops.storage.NoSnapshotError):
             store.load_snapshot('bar')
         store.save_snapshot('bar', None)
@@ -160,8 +196,12 @@ class StoragePermutations(abc.ABC):
         with pytest.raises(ops.storage.NoSnapshotError):
             store.load_snapshot('bar')
 
-    def test_save_snapshot_zero(self):
-        store = self.create_storage()
+    def test_save_snapshot_zero(
+        self,
+        request: pytest.FixtureRequest,
+        fake_script: FakeScript,
+    ):
+        store = self.create_storage(request, fake_script)
         with pytest.raises(ops.storage.NoSnapshotError):
             store.load_snapshot('zero')
         store.save_snapshot('zero', 0)
@@ -170,15 +210,15 @@ class StoragePermutations(abc.ABC):
         with pytest.raises(ops.storage.NoSnapshotError):
             store.load_snapshot('zero')
 
-    def test_save_notice(self):
-        store = self.create_storage()
+    def test_save_notice(self, request: pytest.FixtureRequest, fake_script: FakeScript):
+        store = self.create_storage(request, fake_script)
         store.save_notice('event', 'observer', 'method')
         assert list(store.notices('event')) == \
             [('event', 'observer', 'method')]
 
-    def test_all_notices(self):
+    def test_all_notices(self, request: pytest.FixtureRequest, fake_script: FakeScript):
         notices = [('e1', 'o1', 'm1'), ('e1', 'o2', 'm2'), ('e2', 'o3', 'm3')]
-        store = self.create_storage()
+        store = self.create_storage(request, fake_script)
         for notice in notices:
             store.save_notice(*notice)
 
@@ -195,17 +235,25 @@ class StoragePermutations(abc.ABC):
         assert list(store.notices(None)) == notices
         assert list(store.notices('')) == notices
 
-    def test_load_notices(self):
-        store = self.create_storage()
+    def test_load_notices(self, request: pytest.FixtureRequest, fake_script: FakeScript):
+        store = self.create_storage(request, fake_script)
         assert list(store.notices('path')) == []
 
-    def test_save_one_load_another_notice(self):
-        store = self.create_storage()
+    def test_save_one_load_another_notice(
+        self,
+        request: pytest.FixtureRequest,
+        fake_script: FakeScript,
+    ):
+        store = self.create_storage(request, fake_script)
         store.save_notice('event', 'observer', 'method')
         assert list(store.notices('other')) == []
 
-    def test_save_load_drop_load_notices(self):
-        store = self.create_storage()
+    def test_save_load_drop_load_notices(
+        self,
+        request: pytest.FixtureRequest,
+        fake_script: FakeScript,
+    ):
+        store = self.create_storage(request, fake_script)
         store.save_notice('event', 'observer', 'method')
         store.save_notice('event', 'observer', 'method2')
         assert list(store.notices('event')) == \
@@ -214,9 +262,9 @@ class StoragePermutations(abc.ABC):
              ]
 
 
-class TestSQLiteStorage(StoragePermutations, BaseTestCase):
+class TestSQLiteStorage(StoragePermutations):
 
-    def create_storage(self):
+    def create_storage(self, request: pytest.FixtureRequest, fake_script: FakeScript):
         return ops.storage.SQLiteStorage(':memory:')
 
     def test_permissions_new(self):
@@ -255,7 +303,7 @@ class TestSQLiteStorage(StoragePermutations, BaseTestCase):
             pytest.raises(RuntimeError, ops.storage.SQLiteStorage, filename)
 
 
-def setup_juju_backend(test_case: unittest.TestCase, state_file: pathlib.Path):
+def setup_juju_backend(fake_script: FakeScript, state_file: pathlib.Path):
     """Create fake scripts for pretending to be state-set and state-get."""
     template_args = {
         'executable': str(pathlib.Path(sys.executable).as_posix()),
@@ -263,7 +311,7 @@ def setup_juju_backend(test_case: unittest.TestCase, state_file: pathlib.Path):
         'state_file': str(state_file.as_posix()),
     }
 
-    fake_script(test_case, 'state-set', dedent('''\
+    fake_script.write('state-set', dedent('''\
         {executable} -c '
         import sys
         if "{pthpth}" not in sys.path:
@@ -284,7 +332,7 @@ def setup_juju_backend(test_case: unittest.TestCase, state_file: pathlib.Path):
         ' "$@"
         ''').format(**template_args))
 
-    fake_script(test_case, 'state-get', dedent('''\
+    fake_script.write('state-get', dedent('''\
         {executable} -Sc '
         import sys
         if "{pthpth}" not in sys.path:
@@ -302,7 +350,7 @@ def setup_juju_backend(test_case: unittest.TestCase, state_file: pathlib.Path):
         ' "$@"
         ''').format(**template_args))
 
-    fake_script(test_case, 'state-delete', dedent('''\
+    fake_script.write('state-delete', dedent('''\
         {executable} -Sc '
         import sys
         if "{pthpth}" not in sys.path:
@@ -322,18 +370,18 @@ def setup_juju_backend(test_case: unittest.TestCase, state_file: pathlib.Path):
         ''').format(**template_args))
 
 
-class TestJujuStorage(StoragePermutations, BaseTestCase):
+class TestJujuStorage(StoragePermutations):
 
-    def create_storage(self):
+    def create_storage(self, request: pytest.FixtureRequest, fake_script: FakeScript):
         fd, fn = tempfile.mkstemp(prefix='tmp-ops-test-state-')
         os.close(fd)
         state_file = pathlib.Path(fn)
-        self.addCleanup(state_file.unlink)
-        setup_juju_backend(self, state_file)
+        request.addfinalizer(state_file.unlink)
+        setup_juju_backend(fake_script, state_file)
         return ops.storage.JujuStorage()
 
 
-class TestSimpleLoader(BaseTestCase):
+class TestSimpleLoader:
 
     def test_is_c_loader(self):
         loader = ops.storage._SimpleLoader(io.StringIO(''))
@@ -376,25 +424,25 @@ class TestSimpleLoader(BaseTestCase):
         self.assertRefused(f)
 
 
-class TestJujuStateBackend(BaseTestCase):
+class TestJujuStateBackend:
 
     def test_is_not_available(self):
         assert not ops.storage.juju_backend_available()
 
-    def test_is_available(self):
-        fake_script(self, 'state-get', 'echo ""')
+    def test_is_available(self, fake_script: FakeScript):
+        fake_script.write('state-get', 'echo ""')
         assert ops.storage.juju_backend_available()
-        assert fake_script_calls(self, clear=True) == []
+        assert fake_script.calls(clear=True) == []
 
-    def test_set_encodes_args(self):
+    def test_set_encodes_args(self, fake_script: FakeScript):
         t = tempfile.NamedTemporaryFile()
         try:
-            fake_script(self, 'state-set', dedent("""
+            fake_script.write('state-set', dedent("""
                 cat >> {}
                 """).format(pathlib.Path(t.name).as_posix()))
             backend = ops.storage._JujuStorageBackend()
             backend.set('key', {'foo': 2})
-            assert fake_script_calls(self, clear=True) == [
+            assert fake_script.calls(clear=True) == [
                 ['state-set', '--file', '-'],
             ]
             t.seek(0)
@@ -406,21 +454,21 @@ class TestJujuStateBackend(BaseTestCase):
               {foo: 2}
             """)
 
-    def test_get(self):
-        fake_script(self, 'state-get', dedent("""
+    def test_get(self, fake_script: FakeScript):
+        fake_script.write('state-get', dedent("""
             echo 'foo: "bar"'
             """))
         backend = ops.storage._JujuStorageBackend()
         value = backend.get('key')
         assert value == {'foo': 'bar'}
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['state-get', 'key'],
         ]
 
-    def test_set_and_get_complex_value(self):
+    def test_set_and_get_complex_value(self, fake_script: FakeScript):
         t = tempfile.NamedTemporaryFile()
         try:
-            fake_script(self, 'state-set', dedent("""
+            fake_script.write('state-set', dedent("""
                 cat >> {}
                 """).format(pathlib.Path(t.name).as_posix()))
             backend = ops.storage._JujuStorageBackend()
@@ -433,7 +481,7 @@ class TestJujuStateBackend(BaseTestCase):
                 'seven': b'1234',
             }
             backend.set('Class[foo]/_stored', complex_val)
-            assert fake_script_calls(self, clear=True) == [
+            assert fake_script.calls(clear=True) == [
                 ['state-set', '--file', '-'],
             ]
             t.seek(0)
@@ -457,7 +505,7 @@ class TestJujuStateBackend(BaseTestCase):
             """)
         # Note that the content is yaml in a string, embedded inside YAML to declare the Key:
         # Value of where to store the entry.
-        fake_script(self, 'state-get', dedent("""
+        fake_script.write('state-get', dedent("""
             echo "foo: 2
             3: [1, 2, '3']
             four: !!set {2: null, 3: null}


### PR DESCRIPTION
Refactor test_storage and test_main to pytest style.

## Before Refactor

`test_main.py`:

```bash
$ python -m tox -e unit -- test/test_main.py
unit: commands[0]> coverage run --source=ops/ -m pytest --ignore=test/smoke -v --tb native test/test_main.py
===================================================================== test session starts ======================================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0 -- /Users/tiexin/work/operator3/.tox/unit/bin/python
cachedir: .tox/unit/.pytest_cache
rootdir: /Users/tiexin/work/operator3
collected 108 items
======================================================================= warnings summary =======================================================================
test/test_main.py::CharmInitTestCase::test_storage_with_storage
  /Users/tiexin/work/operator3/ops/main.py:456: DeprecationWarning: Controller storage is deprecated; it's intended for podspec charms and will be removed in a future release.
    warnings.warn("Controller storage is deprecated; it's intended for "

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 108 passed, 1 warning in 168.68s (0:02:48) ==========================================================
unit: commands[1]> coverage report
Name                       Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------------
ops/__init__.py               10      0      0      0   100%
ops/_private/__init__.py       0      0      0      0   100%
ops/_private/timeconv.py      61     51     28      0    11%   42-62, 74-114, 122-129
ops/_private/yaml.py           9      1      0      0    89%   33
ops/charm.py                 643    196    177     20    65%   50-80, 135-136, 147, 154-157, 164, 211, 219, 227, 270, 288, 421, 451-464, 471-479, 486-505, 580-582, 589-592, 603-605, 612-613, 647-648, 655-660, 667-686, 735-737, 744-747, 754-758, 782-783, 790-795, 802-806, 817-819, 824-825, 832, 839-840, 870, 888-889, 894, 901-903, 910-911, 923-924, 929, 936-938, 945-946, 954, 1021-1031, 1167-1168, 1198, 1203, 1208, 1218, 1226-1235, 1345, 1347, 1393-1394, 1401, 1404, 1407, 1410, 1413, 1416, 1418->1420, 1465, 1514, 1518, 1563->1572, 1566, 1568, 1594-1597, 1610-1611, 1659-1663, 1703, 1738-1740, 1743, 1763, 1772-1782, 1799-1800, 1804, 1809, 1819-1821
ops/framework.py             685    236    270     43    60%   62->exit, 64->exit, 65->exit, 66->exit, 123, 126, 129, 147, 157-172, 194, 244-245, 252, 259, 280, 288, 318, 363, 391-392, 415, 465, 467, 470, 495, 498-500, 515-516, 519, 534, 559, 562, 597-598, 609-610, 614->616, 633-635, 671->675, 687, 693, 713, 722, 733-735, 746, 758, 780, 783, 795, 808-809, 837-847, 849, 876-889, 895-954, 957, 961->exit, 982-987, 1001, 1012-1021, 1053-1055, 1062-1066, 1074-1075, 1085, 1089, 1094, 1096, 1100-1110, 1116, 1153, 1160, 1169, 1174, 1181, 1192, 1210, 1220, 1225-1227, 1231-1235, 1246, 1249-1250, 1253-1254, 1257, 1260, 1264, 1268, 1284-1285, 1288-1289, 1296-1297, 1301-1302, 1306, 1310, 1313-1318, 1321-1326, 1329-1334, 1337-1342, 1351-1352, 1359-1360, 1367-1368, 1371, 1374, 1377, 1388, 1391-1396, 1399-1404, 1407-1412
ops/jujuversion.py            80     40     48      4    42%   42, 53, 57, 61-67, 75-95, 102, 107, 124, 130, 135-142
ops/lib/__init__.py          176    176     77      0     0%   15-282
ops/log.py                    27     17      4      0    32%   29-30, 38, 55-75
ops/main.py                  262    117     92      9    49%   56-62, 75-100, 118-122, 132-143, 147, 152-220, 264, 281-301, 307, 331-332, 375-376, 408->410, 455->460, 465-469, 484, 504->509, 546
ops/model.py                1532    957    628     10    33%   100->exit, 101->exit, 146, 158, 163, 172, 177, 189, 197, 205, 225, 245, 259, 279-285, 300, 305, 317->exit, 319->exit, 326, 357, 384-395, 399-413, 432-436, 439, 465-473, 478-485, 515->exit, 520, 544-552, 556-566, 569, 579-584, 594-597, 606-608, 616-619, 633-641, 668, 696, 700, 724-735, 757-759, 796, 800-803, 806, 809, 812, 815, 818, 821, 843-844, 852, 855, 858, 861-871, 880, 883-905, 924-938, 942, 945, 948, 958-961, 964, 969-978, 985-989, 1026-1042, 1052-1055, 1066-1069, 1091-1112, 1138-1143, 1148-1154, 1164, 1191-1198, 1201-1206, 1211-1214, 1219-1242, 1262, 1281-1289, 1325, 1338-1341, 1349, 1356, 1369-1373, 1392-1397, 1414-1416, 1432-1434, 1451-1453, 1461-1463, 1508-1536, 1539, 1558-1568, 1573, 1576, 1579, 1582, 1585, 1595-1598, 1605, 1609-1613, 1618-1657, 1667-1697, 1703-1705, 1708, 1713-1719, 1722-1723, 1727, 1730-1733, 1736-1740, 1753, 1769-1771, 1774-1776, 1779, 1795-1799, 1805, 1825, 1842, 1845, 1870, 1921-1925, 1951-1953, 1965, 1968, 1971, 1974-1984, 1995-1998, 2005, 2015-2018, 2023, 2028-2029, 2034, 2039-2042, 2051, 2072-2073, 2076, 2079, 2107-2112, 2130-2145, 2149, 2153, 2157-2160, 2164-2177, 2181-2184, 2201, 2210, 2218-2220, 2228-2233, 2247-2248, 2256-2261, 2265, 2269, 2289, 2326, 2347, 2399-2432, 2484-2506, 2511-2534, 2556-2570, 2590-2596, 2600-2606, 2610-2616, 2642, 2661, 2683, 2705, 2737-2742, 2771-2774, 2782-2787, 2802, 2813, 2827, 2830, 2833, 2836, 2847, 2850, 2853, 2856, 2859, 2870, 2873, 2876, 2879, 2882, 2894-2899, 2969-2995, 3018, 3033-3060, 3064, 3067-3069, 3072-3079, 3083-3104, 3108-3127, 3130-3150, 3153-3154, 3161-3175, 3178-3179, 3183-3196, 3205-3230, 3241-3243, 3246-3248, 3251-3261, 3264-3269, 3272-3274, 3277-3278, 3283-3284, 3287, 3290, 3293, 3303-3308, 3312-3313, 3322-3331, 3335-3350, 3354, 3366-3373, 3377, 3384-3402, 3406-3411, 3416-3424, 3432-3445, 3453-3469, 3472-3475, 3478-3481, 3484-3487, 3490-3491, 3494-3495, 3502-3511, 3515-3525, 3528-3535, 3542-3543, 3553-3554, 3559-3560, 3567-3574, 3580-3585, 3610-3618, 3621-3622, 3626-3627, 3630-3634, 3661, 3705
ops/pebble.py               1282    891    431     12    26%   172->exit, 184->exit, 186->exit, 190->exit, 192->exit, 194->exit, 204-268, 284->exit, 286->exit, 288->exit, 290->exit, 292->exit, 310-315, 319-324, 331-332, 336, 346, 351-353, 360, 386-387, 390, 393, 413-417, 420, 434-435, 438-450, 453, 492-495, 498-507, 529, 534, 537, 552-557, 562, 573, 592-594, 599, 606, 617, 635-643, 648, 662, 679, 698-707, 712, 727, 749-760, 770, 778, 786, 790-796, 800, 805-809, 831-843, 848, 852-860, 863, 867-872, 881-903, 907-931, 939-947, 950, 954-959, 986-988, 992, 997-1005, 1012, 1023-1048, 1052-1064, 1067, 1071-1076, 1098-1107, 1111-1119, 1122, 1125-1130, 1191-1200, 1205-1209, 1223, 1288-1293, 1298-1306, 1316, 1389-1393, 1464-1478, 1481-1483, 1495-1497, 1500-1532, 1546-1573, 1582-1589, 1594-1600, 1609-1623, 1629-1649, 1656, 1660, 1664-1667, 1671, 1678-1680, 1684, 1688-1717, 1721, 1751-1758, 1763-1768, 1784-1793, 1802-1807, 1816-1844, 1848-1849, 1853-1855, 1859-1861, 1867-1871, 1875-1876, 1880-1882, 1899, 1917, 1938, 1959, 1980, 1986-2002, 2027-2031, 2035-2056, 2060-2075, 2080-2089, 2101-2121, 2125-2126, 2134-2138, 2142, 2146, 2168-2206, 2210-2216, 2249-2268, 2276-2287, 2293-2329, 2350-2360, 2387-2396, 2412-2420, 2442, 2464, 2608-2721, 2724-2729, 2732-2734, 2748-2761, 2779-2785, 2802-2812, 2820-2821, 2854-2864, 2871-2894, 2897-2916, 2919-2937, 2941-2943, 2947, 2950-2952, 2955, 2959, 2963, 2967-2974, 3002-3023, 3027-3069, 3079-3104
ops/storage.py               159     52     30      4    63%   47, 63->65, 76-77, 82-83, 153, 157-164, 168, 173, 191, 207-208, 243, 257-258, 265, 269-271, 275-277, 289-293, 301-307, 315, 355-356, 376-382, 394-396, 406, 416
ops/testing.py              1589   1589    768      0     0%   15-3568
ops/version.py                 2      0      0      0   100%
----------------------------------------------------------------------
TOTAL                       6517   4323   2553    102    29%
```

`test_storage.py`:

```bash
$ python -m tox -e unit -- test/test_storage.py
unit: commands[0]> coverage run --source=ops/ -m pytest --ignore=test/smoke -v --tb native test/test_storage.py
=================================================================== test session starts ====================================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0 -- /Users/tiexin/work/operator3/.tox/unit/bin/python
cachedir: .tox/unit/.pytest_cache
rootdir: /Users/tiexin/work/operator3
collected 37 items
=================================================================== 37 passed in 27.82s ====================================================================
unit: commands[1]> coverage report
Name                       Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------------
ops/__init__.py               10      0      0      0   100%
ops/_private/__init__.py       0      0      0      0   100%
ops/_private/timeconv.py      61     51     28      0    11%   42-62, 74-114, 122-129
ops/_private/yaml.py           9      2      0      0    78%   28, 33
ops/charm.py                 643    315    177      2    45%   50-80, 135-136, 147, 154-157, 164, 211, 219, 227, 270, 288, 421, 451-464, 471-479, 486-505, 580-582, 589-592, 603-605, 612-613, 647-648, 655-660, 667-686, 735-737, 744-747, 754-758, 782-783, 790-795, 802-806, 817-819, 824-825, 832, 839-840, 870, 888-889, 894, 901-903, 910-911, 923-924, 929, 936-938, 945-946, 954, 1021-1031, 1167-1168, 1171-1193, 1198, 1203, 1208, 1213, 1218, 1226-1235, 1324-1377, 1383-1396, 1399-1420, 1438-1444, 1465, 1505-1521, 1555-1572, 1594-1597, 1610-1611, 1657-1665, 1672-1678, 1703, 1731-1743, 1763, 1772-1782, 1799-1800, 1804, 1809, 1819-1821
ops/framework.py             685    279    270     42    53%   62->exit, 64->exit, 65->exit, 66->exit, 123, 126, 129, 147, 164->169, 166->169, 170, 194, 244-245, 252, 259, 280, 288, 304, 309->311, 318, 363, 391-392, 415, 431, 463-477, 480-488, 492, 495, 498-500, 508, 515-516, 519, 534, 559, 562, 597-598, 612, 615, 633-635, 654, 670-675, 679, 687, 698-704, 713, 722, 733-735, 746, 758, 780, 783, 795, 808-809, 838, 840, 841->847, 848->exit, 859, 881-889, 897->903, 899, 905-907, 915, 918, 924, 927->948, 935-936, 942, 949, 956->exit, 961-963, 981-1001, 1012-1021, 1040, 1044, 1048-1049, 1053-1055, 1062-1066, 1069-1081, 1085, 1089, 1093-1097, 1100-1110, 1114-1116, 1145-1146, 1153, 1160, 1166-1210, 1215-1221, 1225-1227, 1231-1235, 1242-1243, 1246, 1249-1250, 1253-1254, 1257, 1260, 1263-1268, 1277-1278, 1281, 1284-1285, 1288-1289, 1292, 1296-1297, 1301-1302, 1305-1310, 1313-1318, 1321-1326, 1329-1334, 1337-1342, 1351-1352, 1359-1360, 1367-1368, 1371, 1374, 1377, 1388, 1391-1396, 1399-1404, 1407-1412
ops/jujuversion.py            80     57     48      0    26%   40-49, 52-58, 61-67, 75-95, 100-103, 107, 111, 115, 124, 130, 135-142
ops/lib/__init__.py          176    176     77      0     0%   15-282
ops/log.py                    27     17      4      0    32%   29-30, 38, 55-75
ops/main.py                  262    213     92      0    14%   49-52, 56-62, 75-100, 118-122, 132-143, 147, 152-220, 240-247, 251-264, 272-301, 305-308, 316-317, 328-336, 345, 351-368, 375-376, 406-424, 427-429, 432-439, 442-475, 483-494, 504-511, 515, 519-523, 539-546, 555
ops/model.py                1532   1022    628      6    30%   100->exit, 101->exit, 118-130, 138, 146, 158, 163, 172, 177, 189, 197, 205, 215, 225, 245, 259, 279-285, 300, 305, 312-314, 317->exit, 319->exit, 323-330, 349-354, 357, 384-395, 399-413, 432-436, 439, 465-473, 478-485, 504-517, 520, 544-552, 556-566, 569, 579-584, 594-597, 606-608, 616-619, 633-641, 668, 696, 700, 724-735, 757-759, 796, 800-803, 806, 809, 812, 815, 818, 821, 841-849, 852, 855, 858, 861-871, 880, 883-905, 916-917, 924-938, 942, 945, 948, 958-961, 964, 969-978, 985-989, 1026-1042, 1052-1055, 1066-1069, 1091-1112, 1138-1143, 1148-1154, 1164, 1191-1198, 1201-1206, 1211-1214, 1219-1242, 1262, 1281-1289, 1325, 1338-1341, 1349, 1356, 1369-1373, 1392-1397, 1414-1416, 1432-1434, 1451-1453, 1461-1463, 1508-1536, 1539, 1558-1568, 1573, 1576, 1579, 1582, 1585, 1595-1598, 1605, 1609-1613, 1618-1657, 1667-1697, 1703-1705, 1708, 1713-1719, 1722-1723, 1727, 1730-1733, 1736-1740, 1750, 1753, 1769-1771, 1774-1776, 1779, 1795-1799, 1805, 1825, 1842, 1845, 1870, 1909-1910, 1921-1925, 1940, 1951-1953, 1960-1961, 1965, 1968, 1971, 1974-1984, 1995-1998, 2005, 2015-2018, 2023, 2028-2029, 2034, 2039-2042, 2051, 2072-2073, 2076, 2079, 2107-2112, 2130-2145, 2149, 2153, 2157-2160, 2164-2177, 2181-2184, 2201, 2210, 2218-2220, 2228-2233, 2247-2248, 2256-2261, 2265, 2269, 2289, 2326, 2347, 2399-2432, 2484-2506, 2511-2534, 2556-2570, 2590-2596, 2600-2606, 2610-2616, 2642, 2661, 2683, 2705, 2737-2742, 2771-2774, 2782-2787, 2802, 2813, 2824, 2827, 2830, 2833, 2836, 2847, 2850, 2853, 2856, 2859, 2870, 2873, 2876, 2879, 2882, 2894-2899, 2969-2995, 3016-3028, 3033-3060, 3064, 3067-3069, 3072-3079, 3083-3104, 3108-3127, 3130-3150, 3153-3154, 3161-3175, 3178-3179, 3183-3196, 3205-3230, 3241-3243, 3246-3248, 3251-3261, 3264-3269, 3272-3274, 3277-3278, 3283-3284, 3287, 3290, 3293, 3303-3308, 3312-3313, 3322-3331, 3335-3350, 3354, 3366-3373, 3377, 3384-3402, 3406-3411, 3416-3424, 3432-3445, 3453-3469, 3472-3475, 3478-3481, 3484-3487, 3490-3491, 3494-3495, 3502-3511, 3515-3525, 3528-3535, 3542-3543, 3553-3554, 3559-3560, 3567-3574, 3580-3585, 3610-3618, 3621-3622, 3626-3627, 3630-3634, 3661, 3705
ops/pebble.py               1282    891    431     12    26%   172->exit, 184->exit, 186->exit, 190->exit, 192->exit, 194->exit, 204-268, 284->exit, 286->exit, 288->exit, 290->exit, 292->exit, 310-315, 319-324, 331-332, 336, 346, 351-353, 360, 386-387, 390, 393, 413-417, 420, 434-435, 438-450, 453, 492-495, 498-507, 529, 534, 537, 552-557, 562, 573, 592-594, 599, 606, 617, 635-643, 648, 662, 679, 698-707, 712, 727, 749-760, 770, 778, 786, 790-796, 800, 805-809, 831-843, 848, 852-860, 863, 867-872, 881-903, 907-931, 939-947, 950, 954-959, 986-988, 992, 997-1005, 1012, 1023-1048, 1052-1064, 1067, 1071-1076, 1098-1107, 1111-1119, 1122, 1125-1130, 1191-1200, 1205-1209, 1223, 1288-1293, 1298-1306, 1316, 1389-1393, 1464-1478, 1481-1483, 1495-1497, 1500-1532, 1546-1573, 1582-1589, 1594-1600, 1609-1623, 1629-1649, 1656, 1660, 1664-1667, 1671, 1678-1680, 1684, 1688-1717, 1721, 1751-1758, 1763-1768, 1784-1793, 1802-1807, 1816-1844, 1848-1849, 1853-1855, 1859-1861, 1867-1871, 1875-1876, 1880-1882, 1899, 1917, 1938, 1959, 1980, 1986-2002, 2027-2031, 2035-2056, 2060-2075, 2080-2089, 2101-2121, 2125-2126, 2134-2138, 2142, 2146, 2168-2206, 2210-2216, 2249-2268, 2276-2287, 2293-2329, 2350-2360, 2387-2396, 2412-2420, 2442, 2464, 2608-2721, 2724-2729, 2732-2734, 2748-2761, 2779-2785, 2802-2812, 2820-2821, 2854-2864, 2871-2894, 2897-2916, 2919-2937, 2941-2943, 2947, 2950-2952, 2955, 2959, 2963, 2967-2974, 3002-3023, 3027-3069, 3079-3104
ops/storage.py               159     12     30      2    90%   46, 112, 157-164, 306, 416
ops/testing.py              1589   1589    768      0     0%   15-3568
ops/version.py                 2      0      0      0   100%
----------------------------------------------------------------------
TOTAL                       6517   4624   2553     64    25%
```

## After Refactor

`test_main.py`:

```bash
$ python -m tox -e unit -- test/test_main.py
unit: commands[0]> coverage run --source=ops/ -m pytest --ignore=test/smoke -v --tb native test/test_main.py
=================================================================================================================================================== test session starts ====================================================================================================================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0 -- /Users/tiexin/work/operator3/.tox/unit/bin/python
cachedir: .tox/unit/.pytest_cache
rootdir: /Users/tiexin/work/operator3
collected 114 items
======================================================================================================================================== 114 passed, 1 warning in 178.77s (0:02:58) ========================================================================================================================================
unit: commands[1]> coverage report
Name                       Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------------
ops/__init__.py               10      0      0      0   100%
ops/_private/__init__.py       0      0      0      0   100%
ops/_private/timeconv.py      61     51     28      0    11%   42-62, 74-114, 122-129
ops/_private/yaml.py           9      1      0      0    89%   33
ops/charm.py                 643    196    177     20    65%   50-80, 135-136, 147, 154-157, 164, 211, 219, 227, 270, 288, 421, 451-464, 471-479, 486-505, 580-582, 589-592, 603-605, 612-613, 647-648, 655-660, 667-686, 735-737, 744-747, 754-758, 782-783, 790-795, 802-806, 817-819, 824-825, 832, 839-840, 870, 888-889, 894, 901-903, 910-911, 923-924, 929, 936-938, 945-946, 954, 1021-1031, 1167-1168, 1198, 1203, 1208, 1218, 1226-1235, 1345, 1347, 1393-1394, 1401, 1404, 1407, 1410, 1413, 1416, 1418->1420, 1465, 1514, 1518, 1563->1572, 1566, 1568, 1594-1597, 1610-1611, 1659-1663, 1703, 1738-1740, 1743, 1763, 1772-1782, 1799-1800, 1804, 1809, 1819-1821
ops/framework.py             685    236    270     43    60%   62->exit, 64->exit, 65->exit, 66->exit, 123, 126, 129, 147, 157-172, 194, 244-245, 252, 259, 280, 288, 318, 363, 391-392, 415, 465, 467, 470, 495, 498-500, 515-516, 519, 534, 559, 562, 597-598, 609-610, 614->616, 633-635, 671->675, 687, 693, 713, 722, 733-735, 746, 758, 780, 783, 795, 808-809, 837-847, 849, 876-889, 895-954, 957, 961->exit, 982-987, 1001, 1012-1021, 1053-1055, 1062-1066, 1074-1075, 1085, 1089, 1094, 1096, 1100-1110, 1116, 1153, 1160, 1169, 1174, 1181, 1192, 1210, 1220, 1225-1227, 1231-1235, 1246, 1249-1250, 1253-1254, 1257, 1260, 1264, 1268, 1284-1285, 1288-1289, 1296-1297, 1301-1302, 1306, 1310, 1313-1318, 1321-1326, 1329-1334, 1337-1342, 1351-1352, 1359-1360, 1367-1368, 1371, 1374, 1377, 1388, 1391-1396, 1399-1404, 1407-1412
ops/jujuversion.py            80     40     48      4    42%   42, 53, 57, 61-67, 75-95, 102, 107, 124, 130, 135-142
ops/lib/__init__.py          176    176     77      0     0%   15-282
ops/log.py                    27     17      4      0    32%   29-30, 38, 55-75
ops/main.py                  262    117     92      9    49%   56-62, 75-100, 118-122, 132-143, 147, 152-220, 264, 281-301, 307, 331-332, 375-376, 408->410, 455->460, 465-469, 484, 504->509, 546
ops/model.py                1532    957    628     10    33%   100->exit, 101->exit, 146, 158, 163, 172, 177, 189, 197, 205, 225, 245, 259, 279-285, 300, 305, 317->exit, 319->exit, 326, 357, 384-395, 399-413, 432-436, 439, 465-473, 478-485, 515->exit, 520, 544-552, 556-566, 569, 579-584, 594-597, 606-608, 616-619, 633-641, 668, 696, 700, 724-735, 757-759, 796, 800-803, 806, 809, 812, 815, 818, 821, 843-844, 852, 855, 858, 861-871, 880, 883-905, 924-938, 942, 945, 948, 958-961, 964, 969-978, 985-989, 1026-1042, 1052-1055, 1066-1069, 1091-1112, 1138-1143, 1148-1154, 1164, 1191-1198, 1201-1206, 1211-1214, 1219-1242, 1262, 1281-1289, 1325, 1338-1341, 1349, 1356, 1369-1373, 1392-1397, 1414-1416, 1432-1434, 1451-1453, 1461-1463, 1508-1536, 1539, 1558-1568, 1573, 1576, 1579, 1582, 1585, 1595-1598, 1605, 1609-1613, 1618-1657, 1667-1697, 1703-1705, 1708, 1713-1719, 1722-1723, 1727, 1730-1733, 1736-1740, 1753, 1769-1771, 1774-1776, 1779, 1795-1799, 1805, 1825, 1842, 1845, 1870, 1921-1925, 1951-1953, 1965, 1968, 1971, 1974-1984, 1995-1998, 2005, 2015-2018, 2023, 2028-2029, 2034, 2039-2042, 2051, 2072-2073, 2076, 2079, 2107-2112, 2130-2145, 2149, 2153, 2157-2160, 2164-2177, 2181-2184, 2201, 2210, 2218-2220, 2228-2233, 2247-2248, 2256-2261, 2265, 2269, 2289, 2326, 2347, 2399-2432, 2484-2506, 2511-2534, 2556-2570, 2590-2596, 2600-2606, 2610-2616, 2642, 2661, 2683, 2705, 2737-2742, 2771-2774, 2782-2787, 2802, 2813, 2827, 2830, 2833, 2836, 2847, 2850, 2853, 2856, 2859, 2870, 2873, 2876, 2879, 2882, 2894-2899, 2969-2995, 3018, 3033-3060, 3064, 3067-3069, 3072-3079, 3083-3104, 3108-3127, 3130-3150, 3153-3154, 3161-3175, 3178-3179, 3183-3196, 3205-3230, 3241-3243, 3246-3248, 3251-3261, 3264-3269, 3272-3274, 3277-3278, 3283-3284, 3287, 3290, 3293, 3303-3308, 3312-3313, 3322-3331, 3335-3350, 3354, 3366-3373, 3377, 3384-3402, 3406-3411, 3416-3424, 3432-3445, 3453-3469, 3472-3475, 3478-3481, 3484-3487, 3490-3491, 3494-3495, 3502-3511, 3515-3525, 3528-3535, 3542-3543, 3553-3554, 3559-3560, 3567-3574, 3580-3585, 3610-3618, 3621-3622, 3626-3627, 3630-3634, 3661, 3705
ops/pebble.py               1282    891    431     12    26%   172->exit, 184->exit, 186->exit, 190->exit, 192->exit, 194->exit, 204-268, 284->exit, 286->exit, 288->exit, 290->exit, 292->exit, 310-315, 319-324, 331-332, 336, 346, 351-353, 360, 386-387, 390, 393, 413-417, 420, 434-435, 438-450, 453, 492-495, 498-507, 529, 534, 537, 552-557, 562, 573, 592-594, 599, 606, 617, 635-643, 648, 662, 679, 698-707, 712, 727, 749-760, 770, 778, 786, 790-796, 800, 805-809, 831-843, 848, 852-860, 863, 867-872, 881-903, 907-931, 939-947, 950, 954-959, 986-988, 992, 997-1005, 1012, 1023-1048, 1052-1064, 1067, 1071-1076, 1098-1107, 1111-1119, 1122, 1125-1130, 1191-1200, 1205-1209, 1223, 1288-1293, 1298-1306, 1316, 1389-1393, 1464-1478, 1481-1483, 1495-1497, 1500-1532, 1546-1573, 1582-1589, 1594-1600, 1609-1623, 1629-1649, 1656, 1660, 1664-1667, 1671, 1678-1680, 1684, 1688-1717, 1721, 1751-1758, 1763-1768, 1784-1793, 1802-1807, 1816-1844, 1848-1849, 1853-1855, 1859-1861, 1867-1871, 1875-1876, 1880-1882, 1899, 1917, 1938, 1959, 1980, 1986-2002, 2027-2031, 2035-2056, 2060-2075, 2080-2089, 2101-2121, 2125-2126, 2134-2138, 2142, 2146, 2168-2206, 2210-2216, 2249-2268, 2276-2287, 2293-2329, 2350-2360, 2387-2396, 2412-2420, 2442, 2464, 2608-2721, 2724-2729, 2732-2734, 2748-2761, 2779-2785, 2802-2812, 2820-2821, 2854-2864, 2871-2894, 2897-2916, 2919-2937, 2941-2943, 2947, 2950-2952, 2955, 2959, 2963, 2967-2974, 3002-3023, 3027-3069, 3079-3104
ops/storage.py               159     52     30      4    63%   47, 63->65, 76-77, 82-83, 153, 157-164, 168, 173, 191, 207-208, 243, 257-258, 265, 269-271, 275-277, 289-293, 301-307, 315, 355-356, 376-382, 394-396, 406, 416
ops/testing.py              1589   1589    768      0     0%   15-3568
ops/version.py                 2      0      0      0   100%
----------------------------------------------------------------------
TOTAL                       6517   4323   2553    102    29%
```

Test cases number increased because of parametrize.

`test_storage.py`:

```bash
$ python -m tox -e unit -- test/test_storage.py
unit: commands[0]> coverage run --source=ops/ -m pytest --ignore=test/smoke -v --tb native test/test_storage.py
=================================================================================================================================================== test session starts ====================================================================================================================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0 -- /Users/tiexin/work/operator3/.tox/unit/bin/python
cachedir: .tox/unit/.pytest_cache
rootdir: /Users/tiexin/work/operator3
collected 37 items
=================================================================================================================================================== 37 passed in 25.12s ====================================================================================================================================================
unit: commands[1]> coverage report
Name                       Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------------
ops/__init__.py               10      0      0      0   100%
ops/_private/__init__.py       0      0      0      0   100%
ops/_private/timeconv.py      61     51     28      0    11%   42-62, 74-114, 122-129
ops/_private/yaml.py           9      2      0      0    78%   28, 33
ops/charm.py                 643    315    177      2    45%   50-80, 135-136, 147, 154-157, 164, 211, 219, 227, 270, 288, 421, 451-464, 471-479, 486-505, 580-582, 589-592, 603-605, 612-613, 647-648, 655-660, 667-686, 735-737, 744-747, 754-758, 782-783, 790-795, 802-806, 817-819, 824-825, 832, 839-840, 870, 888-889, 894, 901-903, 910-911, 923-924, 929, 936-938, 945-946, 954, 1021-1031, 1167-1168, 1171-1193, 1198, 1203, 1208, 1213, 1218, 1226-1235, 1324-1377, 1383-1396, 1399-1420, 1438-1444, 1465, 1505-1521, 1555-1572, 1594-1597, 1610-1611, 1657-1665, 1672-1678, 1703, 1731-1743, 1763, 1772-1782, 1799-1800, 1804, 1809, 1819-1821
ops/framework.py             685    279    270     42    53%   62->exit, 64->exit, 65->exit, 66->exit, 123, 126, 129, 147, 164->169, 166->169, 170, 194, 244-245, 252, 259, 280, 288, 304, 309->311, 318, 363, 391-392, 415, 431, 463-477, 480-488, 492, 495, 498-500, 508, 515-516, 519, 534, 559, 562, 597-598, 612, 615, 633-635, 654, 670-675, 679, 687, 698-704, 713, 722, 733-735, 746, 758, 780, 783, 795, 808-809, 838, 840, 841->847, 848->exit, 859, 881-889, 897->903, 899, 905-907, 915, 918, 924, 927->948, 935-936, 942, 949, 956->exit, 961-963, 981-1001, 1012-1021, 1040, 1044, 1048-1049, 1053-1055, 1062-1066, 1069-1081, 1085, 1089, 1093-1097, 1100-1110, 1114-1116, 1145-1146, 1153, 1160, 1166-1210, 1215-1221, 1225-1227, 1231-1235, 1242-1243, 1246, 1249-1250, 1253-1254, 1257, 1260, 1263-1268, 1277-1278, 1281, 1284-1285, 1288-1289, 1292, 1296-1297, 1301-1302, 1305-1310, 1313-1318, 1321-1326, 1329-1334, 1337-1342, 1351-1352, 1359-1360, 1367-1368, 1371, 1374, 1377, 1388, 1391-1396, 1399-1404, 1407-1412
ops/jujuversion.py            80     57     48      0    26%   40-49, 52-58, 61-67, 75-95, 100-103, 107, 111, 115, 124, 130, 135-142
ops/lib/__init__.py          176    176     77      0     0%   15-282
ops/log.py                    27     17      4      0    32%   29-30, 38, 55-75
ops/main.py                  262    213     92      0    14%   49-52, 56-62, 75-100, 118-122, 132-143, 147, 152-220, 240-247, 251-264, 272-301, 305-308, 316-317, 328-336, 345, 351-368, 375-376, 406-424, 427-429, 432-439, 442-475, 483-494, 504-511, 515, 519-523, 539-546, 555
ops/model.py                1532   1022    628      6    30%   100->exit, 101->exit, 118-130, 138, 146, 158, 163, 172, 177, 189, 197, 205, 215, 225, 245, 259, 279-285, 300, 305, 312-314, 317->exit, 319->exit, 323-330, 349-354, 357, 384-395, 399-413, 432-436, 439, 465-473, 478-485, 504-517, 520, 544-552, 556-566, 569, 579-584, 594-597, 606-608, 616-619, 633-641, 668, 696, 700, 724-735, 757-759, 796, 800-803, 806, 809, 812, 815, 818, 821, 841-849, 852, 855, 858, 861-871, 880, 883-905, 916-917, 924-938, 942, 945, 948, 958-961, 964, 969-978, 985-989, 1026-1042, 1052-1055, 1066-1069, 1091-1112, 1138-1143, 1148-1154, 1164, 1191-1198, 1201-1206, 1211-1214, 1219-1242, 1262, 1281-1289, 1325, 1338-1341, 1349, 1356, 1369-1373, 1392-1397, 1414-1416, 1432-1434, 1451-1453, 1461-1463, 1508-1536, 1539, 1558-1568, 1573, 1576, 1579, 1582, 1585, 1595-1598, 1605, 1609-1613, 1618-1657, 1667-1697, 1703-1705, 1708, 1713-1719, 1722-1723, 1727, 1730-1733, 1736-1740, 1750, 1753, 1769-1771, 1774-1776, 1779, 1795-1799, 1805, 1825, 1842, 1845, 1870, 1909-1910, 1921-1925, 1940, 1951-1953, 1960-1961, 1965, 1968, 1971, 1974-1984, 1995-1998, 2005, 2015-2018, 2023, 2028-2029, 2034, 2039-2042, 2051, 2072-2073, 2076, 2079, 2107-2112, 2130-2145, 2149, 2153, 2157-2160, 2164-2177, 2181-2184, 2201, 2210, 2218-2220, 2228-2233, 2247-2248, 2256-2261, 2265, 2269, 2289, 2326, 2347, 2399-2432, 2484-2506, 2511-2534, 2556-2570, 2590-2596, 2600-2606, 2610-2616, 2642, 2661, 2683, 2705, 2737-2742, 2771-2774, 2782-2787, 2802, 2813, 2824, 2827, 2830, 2833, 2836, 2847, 2850, 2853, 2856, 2859, 2870, 2873, 2876, 2879, 2882, 2894-2899, 2969-2995, 3016-3028, 3033-3060, 3064, 3067-3069, 3072-3079, 3083-3104, 3108-3127, 3130-3150, 3153-3154, 3161-3175, 3178-3179, 3183-3196, 3205-3230, 3241-3243, 3246-3248, 3251-3261, 3264-3269, 3272-3274, 3277-3278, 3283-3284, 3287, 3290, 3293, 3303-3308, 3312-3313, 3322-3331, 3335-3350, 3354, 3366-3373, 3377, 3384-3402, 3406-3411, 3416-3424, 3432-3445, 3453-3469, 3472-3475, 3478-3481, 3484-3487, 3490-3491, 3494-3495, 3502-3511, 3515-3525, 3528-3535, 3542-3543, 3553-3554, 3559-3560, 3567-3574, 3580-3585, 3610-3618, 3621-3622, 3626-3627, 3630-3634, 3661, 3705
ops/pebble.py               1282    891    431     12    26%   172->exit, 184->exit, 186->exit, 190->exit, 192->exit, 194->exit, 204-268, 284->exit, 286->exit, 288->exit, 290->exit, 292->exit, 310-315, 319-324, 331-332, 336, 346, 351-353, 360, 386-387, 390, 393, 413-417, 420, 434-435, 438-450, 453, 492-495, 498-507, 529, 534, 537, 552-557, 562, 573, 592-594, 599, 606, 617, 635-643, 648, 662, 679, 698-707, 712, 727, 749-760, 770, 778, 786, 790-796, 800, 805-809, 831-843, 848, 852-860, 863, 867-872, 881-903, 907-931, 939-947, 950, 954-959, 986-988, 992, 997-1005, 1012, 1023-1048, 1052-1064, 1067, 1071-1076, 1098-1107, 1111-1119, 1122, 1125-1130, 1191-1200, 1205-1209, 1223, 1288-1293, 1298-1306, 1316, 1389-1393, 1464-1478, 1481-1483, 1495-1497, 1500-1532, 1546-1573, 1582-1589, 1594-1600, 1609-1623, 1629-1649, 1656, 1660, 1664-1667, 1671, 1678-1680, 1684, 1688-1717, 1721, 1751-1758, 1763-1768, 1784-1793, 1802-1807, 1816-1844, 1848-1849, 1853-1855, 1859-1861, 1867-1871, 1875-1876, 1880-1882, 1899, 1917, 1938, 1959, 1980, 1986-2002, 2027-2031, 2035-2056, 2060-2075, 2080-2089, 2101-2121, 2125-2126, 2134-2138, 2142, 2146, 2168-2206, 2210-2216, 2249-2268, 2276-2287, 2293-2329, 2350-2360, 2387-2396, 2412-2420, 2442, 2464, 2608-2721, 2724-2729, 2732-2734, 2748-2761, 2779-2785, 2802-2812, 2820-2821, 2854-2864, 2871-2894, 2897-2916, 2919-2937, 2941-2943, 2947, 2950-2952, 2955, 2959, 2963, 2967-2974, 3002-3023, 3027-3069, 3079-3104
ops/storage.py               159     12     30      2    90%   46, 112, 157-164, 306, 416
ops/testing.py              1589   1589    768      0     0%   15-3568
ops/version.py                 2      0      0      0   100%
----------------------------------------------------------------------
TOTAL                       6517   4624   2553     64    25%
```

Unchanged.