### PR TITLE
test: refactor test_model to pytest style

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -103,7 +103,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
         - {python-version: "3.8", os: "macos-latest"}  # macos-14 is arm64, and there's no Python 3.8 build for arm64
-        - {python-version: "3.9", os: "macos-latest"}  # macos-14 is arm64, and there's no Python 3.8 build for arm64
+        - {python-version: "3.9", os: "macos-latest"}  # macos-14 is arm64, and there's no Python 3.9 build for arm64
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -103,6 +103,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
         - {python-version: "3.8", os: "macos-latest"}  # macos-14 is arm64, and there's no Python 3.8 build for arm64
+        - {python-version: "3.9", os: "macos-latest"}  # macos-14 is arm64, and there's no Python 3.8 build for arm64
 
     steps:
       - uses: actions/checkout@v3

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -193,7 +193,7 @@ class TestModel:
 
         self.assertBackendCalls(harness, [
             ('relation_ids', 'db1'),
-            ('relation_list', relation_id)
+            ('relation_list', relation_id),
         ])
 
     def test_our_unit_is_our(self, harness: ops.testing.Harness[ops.CharmBase]):
@@ -365,7 +365,7 @@ class TestModel:
             ('relation_ids', 'db1'),
             ('relation_list', 0),
             ('relation_get', 0, 'myapp', True),
-            ('update_relation_data', 0, harness.model.app, 'password', 'foo')
+            ('update_relation_data', 0, harness.model.app, 'password', 'foo'),
         ])
 
     def test_app_relation_data_modify_local_as_minion(
@@ -392,7 +392,7 @@ class TestModel:
             ('relation_ids', 'db1'),
             ('relation_list', 0),
             ('relation_get', 0, 'myapp', True),
-            ('is_leader',)
+            ('is_leader',),
         ])
 
     def test_relation_data_access_peer_leader(self, harness: ops.testing.Harness[ops.CharmBase]):
@@ -569,7 +569,7 @@ class TestModel:
 
             self.assertBackendCalls(harness, [
                 ('is_leader',),
-                ('relation_get', 0, 'myapp', True)
+                ('relation_get', 0, 'myapp', True),
             ])
 
             self.resetBackendCalls(harness)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -23,7 +23,7 @@ import tempfile
 import typing
 import unittest
 from collections import OrderedDict
-from test.test_helpers import fake_script, fake_script_calls
+from test.test_helpers import FakeScript
 from textwrap import dedent
 from unittest.mock import MagicMock, patch
 
@@ -36,9 +36,15 @@ from ops._private import yaml
 from ops.model import _ModelBackend
 
 
-class TestModel(unittest.TestCase):
-    def setUp(self):
-        self.harness = ops.testing.Harness(ops.CharmBase, meta='''
+@pytest.fixture
+def fake_script(request: pytest.FixtureRequest) -> FakeScript:
+    return FakeScript(request)
+
+
+class TestModel:
+    @pytest.fixture
+    def harness(self):
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: myapp
             provides:
               db0:
@@ -65,202 +71,222 @@ class TestModel(unittest.TestCase):
             secretfoo:
                 type: secret
         ''')
-        self.addCleanup(self.harness.cleanup)
-        self.relation_id_db0 = self.harness.add_relation('db0', 'db')
-        self.harness._get_backend_calls(reset=True)
-        self.model = self.harness.model
+        yield harness
+        harness.cleanup()
+
+    @pytest.fixture
+    def model(self, harness: ops.testing.Harness[ops.CharmBase]):
+        return harness.model
+
+    @pytest.fixture
+    def relation_id_db0(self, harness: ops.testing.Harness[ops.CharmBase]):
+        rel_id = harness.add_relation('db0', 'db')
+        harness._get_backend_calls(reset=True)
+        return rel_id
 
     def ensure_relation(
             self,
+            model: ops.Model,
             name: str = 'db1',
             relation_id: typing.Optional[int] = None) -> ops.Relation:
-        """Wrapper around self.model.get_relation that enforces that None is not returned."""
-        rel_db1 = self.model.get_relation(name, relation_id)
+        """Wrapper around model.get_relation that enforces that None is not returned."""
+        rel_db1 = model.get_relation(name, relation_id)
         assert rel_db1 is not None
         assert rel_db1 is not None  # Type checkers understand this, but not the previous line.
         return rel_db1
 
-    def test_model_attributes(self):
-        assert self.model.app is self.model.unit.app
-        assert self.model.name is None
+    def test_model_attributes(self, model: ops.Model):
+        assert model.app is model.unit.app
+        assert model.name is None
 
-    def test_unit_immutable(self):
+    def test_unit_immutable(self, model: ops.Model):
         with pytest.raises(AttributeError):
-            self.model.unit = object()  # type: ignore
+            model.unit = object()  # type: ignore
 
-    def test_app_immutable(self):
+    def test_app_immutable(self, model: ops.Model):
         with pytest.raises(AttributeError):
-            self.model.app = object()  # type: ignore
+            model.app = object()  # type: ignore
 
-    def test_model_name_from_backend(self):
-        self.harness.set_model_name('default')
-        m = ops.Model(ops.CharmMeta(), self.harness._backend)
+    def test_model_name_from_backend(self, harness: ops.testing.Harness[ops.CharmBase]):
+        harness.set_model_name('default')
+        m = ops.Model(ops.CharmMeta(), harness._backend)
         assert m.name == 'default'
         with pytest.raises(AttributeError):
             m.name = "changes-disallowed"  # type: ignore
 
-    def test_relations_keys(self):
-        rel_app1 = self.harness.add_relation('db1', 'remoteapp1')
-        self.harness.add_relation_unit(rel_app1, 'remoteapp1/0')
-        self.harness.add_relation_unit(rel_app1, 'remoteapp1/1')
-        rel_app2 = self.harness.add_relation('db1', 'remoteapp2')
-        self.harness.add_relation_unit(rel_app2, 'remoteapp2/0')
+    def test_relations_keys(self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+        rel_app1 = harness.add_relation('db1', 'remoteapp1')
+        harness.add_relation_unit(rel_app1, 'remoteapp1/0')
+        harness.add_relation_unit(rel_app1, 'remoteapp1/1')
+        rel_app2 = harness.add_relation('db1', 'remoteapp2')
+        harness.add_relation_unit(rel_app2, 'remoteapp2/0')
 
         # We invalidate db1 so that it causes us to reload it
-        self.model.relations._invalidate('db1')
-        self.resetBackendCalls()
-        for relation in self.model.relations['db1']:
-            assert self.model.unit in relation.data
+        model.relations._invalidate('db1')
+        self.resetBackendCalls(harness)
+        for relation in model.relations['db1']:
+            assert model.unit in relation.data
             unit_from_rel = next(filter(lambda u: u.name == 'myapp/0', relation.data.keys()))
-            assert self.model.unit is unit_from_rel
+            assert model.unit is unit_from_rel
 
-        self.assertBackendCalls([
+        self.assertBackendCalls(harness, [
             ('relation_ids', 'db1'),
             ('relation_list', rel_app1),
             ('relation_list', rel_app2),
         ])
 
-    def test_relations_immutable(self):
+    def test_relations_immutable(self, model: ops.Model):
         with pytest.raises(AttributeError):
-            self.model.relations = {}  # type: ignore
+            model.relations = {}  # type: ignore
 
-    def test_get_relation(self):
+    def test_get_relation(self,
+                          harness: ops.testing.Harness[ops.CharmBase],
+                          model: ops.Model,
+                          relation_id_db0: int):
         # one relation on db1
         # two relations on db0
         # no relations on db2
-        relation_id_db1 = self.harness.add_relation('db1', 'remoteapp1')
-        self.harness.add_relation_unit(relation_id_db1, 'remoteapp1/0')
-        relation_id_db0_b = self.harness.add_relation('db0', 'another')
-        self.resetBackendCalls()
+        relation_id_db1 = harness.add_relation('db1', 'remoteapp1')
+        harness.add_relation_unit(relation_id_db1, 'remoteapp1/0')
+        relation_id_db0_b = harness.add_relation('db0', 'another')
+        self.resetBackendCalls(harness)
 
         with pytest.raises(ops.ModelError):
             # You have to specify it by just the integer ID
-            self.model.get_relation('db1', f'db1:{relation_id_db1}')  # type: ignore
-        rel_db1 = self.model.get_relation('db1', relation_id_db1)
+            model.get_relation('db1', f'db1:{relation_id_db1}')  # type: ignore
+        rel_db1 = model.get_relation('db1', relation_id_db1)
         assert isinstance(rel_db1, ops.Relation)
-        self.assertBackendCalls([
+        self.assertBackendCalls(harness, [
             ('relation_ids', 'db1'),
             ('relation_list', relation_id_db1),
         ])
-        dead_rel = self.ensure_relation('db1', 7)
+        dead_rel = self.ensure_relation(model, 'db1', 7)
         assert isinstance(dead_rel, ops.Relation)
-        assert set(dead_rel.data.keys()) == {self.model.unit, self.model.unit.app}
-        assert dead_rel.data[self.model.unit] == {}
-        self.assertBackendCalls([
+        assert set(dead_rel.data.keys()) == {model.unit, model.unit.app}
+        assert dead_rel.data[model.unit] == {}
+        self.assertBackendCalls(harness, [
             ('relation_list', 7),
             ('relation_remote_app_name', 7),
             ('relation_get', 7, 'myapp/0', False),
         ])
 
-        assert self.model.get_relation('db2') is None
-        self.assertBackendCalls([
+        assert model.get_relation('db2') is None
+        self.assertBackendCalls(harness, [
             ('relation_ids', 'db2'),
         ])
-        assert self.model.get_relation('db1') is rel_db1
+        assert model.get_relation('db1') is rel_db1
         with pytest.raises(ops.TooManyRelatedAppsError):
-            self.model.get_relation('db0')
+            model.get_relation('db0')
 
-        self.assertBackendCalls([
+        self.assertBackendCalls(harness, [
             ('relation_ids', 'db0'),
-            ('relation_list', self.relation_id_db0),
+            ('relation_list', relation_id_db0),
             ('relation_remote_app_name', 0),
             ('relation_list', relation_id_db0_b),
             ('relation_remote_app_name', 2),
         ])
 
-    def test_peer_relation_app(self):
-        self.harness.add_relation('db2', 'myapp')
-        rel_dbpeer = self.ensure_relation('db2')
-        assert rel_dbpeer.app is self.model.app
+    def test_peer_relation_app(self,
+                               harness: ops.testing.Harness[ops.CharmBase],
+                               model: ops.Model):
+        harness.add_relation('db2', 'myapp')
+        rel_dbpeer = self.ensure_relation(model, 'db2')
+        assert rel_dbpeer.app is model.app
 
-    def test_remote_units_is_our(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/1')
-        self.resetBackendCalls()
+    def test_remote_units_is_our(self,
+                                 harness: ops.testing.Harness[ops.CharmBase],
+                                 model: ops.Model):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        harness.add_relation_unit(relation_id, 'remoteapp1/0')
+        harness.add_relation_unit(relation_id, 'remoteapp1/1')
+        self.resetBackendCalls(harness)
 
-        for u in self.ensure_relation('db1').units:
+        for u in self.ensure_relation(model, 'db1').units:
             assert not u._is_our_unit
             assert not u.app._is_our_app
 
-        self.assertBackendCalls([
+        self.assertBackendCalls(harness, [
             ('relation_ids', 'db1'),
             ('relation_list', relation_id)
         ])
 
-    def test_our_unit_is_our(self):
-        assert self.model.unit._is_our_unit
-        assert self.model.unit.app._is_our_app
+    def test_our_unit_is_our(self, model: ops.Model):
+        assert model.unit._is_our_unit
+        assert model.unit.app._is_our_app
 
-    def test_invalid_type_relation_data(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
+    def test_invalid_type_relation_data(self, harness: ops.testing.Harness[ops.CharmBase]):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        harness.add_relation_unit(relation_id, 'remoteapp1/0')
 
         with pytest.raises(ops.RelationDataError):
-            with self.harness._event_context('foo_event'):
-                self.harness.update_relation_data(
+            with harness._event_context('foo_event'):
+                harness.update_relation_data(
                     relation_id,
                     'remoteapp1/0',
                     {42: 'remoteapp1-0'})  # type: ignore
 
         with pytest.raises(ops.RelationDataError):
-            with self.harness._event_context('foo_event'):
-                self.harness.update_relation_data(
+            with harness._event_context('foo_event'):
+                harness.update_relation_data(
                     relation_id,
                     'remoteapp1/0',
                     {'foo': 42})  # type: ignore
 
-    def test_get_app_relation_data(self):
-        self.harness.begin()
-        relation_id = self.harness.add_relation('db1', 'remote')
-        self.harness.add_relation_unit(relation_id, 'remote/0')
-        local_app = self.harness.model.app.name
-        with self.harness._event_context('foo_event'):
-            self.harness.update_relation_data(
+    def test_get_app_relation_data(self, harness: ops.testing.Harness[ops.CharmBase]):
+        harness.begin()
+        relation_id = harness.add_relation('db1', 'remote')
+        harness.add_relation_unit(relation_id, 'remote/0')
+        local_app = harness.model.app.name
+        with harness._event_context('foo_event'):
+            harness.update_relation_data(
                 relation_id,
                 local_app,
                 {'foo': 'bar'})
-            assert self.harness.get_relation_data(
-                relation_id, self.harness.model.app) == self.harness.get_relation_data(
+            assert harness.get_relation_data(
+                relation_id, harness.model.app) == harness.get_relation_data(
                 relation_id, local_app) == {'foo': 'bar'}
 
-    def test_unit_relation_data(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
-        with self.harness._event_context('foo_event'):
-            self.harness.update_relation_data(
+    def test_unit_relation_data(self,
+                                harness: ops.testing.Harness[ops.CharmBase],
+                                model: ops.Model):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        harness.add_relation_unit(relation_id, 'remoteapp1/0')
+        with harness._event_context('foo_event'):
+            harness.update_relation_data(
                 relation_id,
                 'remoteapp1/0',
                 {'host': 'remoteapp1-0'})
-        self.model.relations._invalidate('db1')
-        self.resetBackendCalls()
+        model.relations._invalidate('db1')
+        self.resetBackendCalls(harness)
 
-        random_unit = self.model.get_unit('randomunit/0')
+        random_unit = model.get_unit('randomunit/0')
         with pytest.raises(KeyError):
-            self.ensure_relation('db1').data[random_unit]
+            self.ensure_relation(model, 'db1').data[random_unit]
         remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0',
-                                   self.ensure_relation('db1').units))
-        assert self.ensure_relation('db1').data[remoteapp1_0] == \
+                                   self.ensure_relation(model, 'db1').units))
+        assert self.ensure_relation(model, 'db1').data[remoteapp1_0] == \
             {'host': 'remoteapp1-0'}
 
-        self.assertBackendCalls([
+        self.assertBackendCalls(harness, [
             ('relation_ids', 'db1'),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'remoteapp1/0', False),
         ])
 
-    def test_remote_app_relation_data(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        with self.harness._event_context('foo_event'):
-            self.harness.update_relation_data(relation_id, 'remoteapp1',
-                                              {'secret': 'cafedeadbeef'})
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/1')
-        self.resetBackendCalls()
+    def test_remote_app_relation_data(self,
+                                      harness: ops.testing.Harness[ops.CharmBase],
+                                      model: ops.Model):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        with harness._event_context('foo_event'):
+            harness.update_relation_data(relation_id, 'remoteapp1',
+                                         {'secret': 'cafedeadbeef'})
+        harness.add_relation_unit(relation_id, 'remoteapp1/0')
+        harness.add_relation_unit(relation_id, 'remoteapp1/1')
+        self.resetBackendCalls(harness)
 
-        rel_db1 = self.ensure_relation('db1')
+        rel_db1 = self.ensure_relation(model, 'db1')
         # Try to get relation data for an invalid remote application.
-        random_app = self.model._cache.get(ops.Application, 'randomapp')
+        random_app = model._cache.get(ops.Application, 'randomapp')
         with pytest.raises(KeyError):
             rel_db1.data[random_app]
 
@@ -270,43 +296,45 @@ class TestModel(unittest.TestCase):
         assert rel_db1.data[remoteapp1] == \
             {'secret': 'cafedeadbeef'}
 
-        self.assertBackendCalls([
+        self.assertBackendCalls(harness, [
             ('relation_ids', 'db1'),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'remoteapp1', True),
         ])
 
-    def test_relation_data_modify_remote(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        with self.harness._event_context('foo_event'):
-            self.harness.update_relation_data(relation_id, 'remoteapp1',
-                                              {'secret': 'cafedeadbeef'})
-            self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
-            self.harness.update_relation_data(relation_id, 'remoteapp1/0',
-                                              {'host': 'remoteapp1/0'})
-        self.model.relations._invalidate('db1')
-        self.resetBackendCalls()
+    def test_relation_data_modify_remote(self,
+                                         harness: ops.testing.Harness[ops.CharmBase],
+                                         model: ops.Model):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        with harness._event_context('foo_event'):
+            harness.update_relation_data(relation_id, 'remoteapp1',
+                                         {'secret': 'cafedeadbeef'})
+            harness.add_relation_unit(relation_id, 'remoteapp1/0')
+            harness.update_relation_data(relation_id, 'remoteapp1/0',
+                                         {'host': 'remoteapp1/0'})
+        model.relations._invalidate('db1')
+        self.resetBackendCalls(harness)
 
-        rel_db1 = self.ensure_relation('db1')
+        rel_db1 = self.ensure_relation(model, 'db1')
         remoteapp1_0 = next(filter(lambda u: u.name == 'remoteapp1/0',
-                                   self.ensure_relation('db1').units))
+                                   self.ensure_relation(model, 'db1').units))
         # Force memory cache to be loaded.
         assert 'host' in rel_db1.data[remoteapp1_0]
         assert repr(rel_db1.data[remoteapp1_0]) == "{'host': 'remoteapp1/0'}"
 
-        with self.harness._event_context('foo_event'):
+        with harness._event_context('foo_event'):
             with pytest.raises(ops.RelationDataError):
                 rel_db1.data[remoteapp1_0]['foo'] = 'bar'
         assert 'foo' not in rel_db1.data[remoteapp1_0]
 
-        self.assertBackendCalls([
+        self.assertBackendCalls(harness, [
             ('relation_ids', 'db1'),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'remoteapp1/0', False),
         ])
 
         # this will fire more backend calls
-        with self.harness._event_context('foo_event'):
+        with harness._event_context('foo_event'):
             data_repr = repr(rel_db1.data)
         assert data_repr == \
             ('{<ops.model.Unit myapp/0>: {}, '
@@ -314,145 +342,154 @@ class TestModel(unittest.TestCase):
              "<ops.model.Unit remoteapp1/0>: {'host': 'remoteapp1/0'}, "
              "<ops.model.Application remoteapp1>: {'secret': 'cafedeadbeef'}}")
 
-    def test_relation_data_modify_our(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
+    def test_relation_data_modify_our(self,
+                                      harness: ops.testing.Harness[ops.CharmBase],
+                                      model: ops.Model):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
 
-        self.harness.update_relation_data(relation_id, 'myapp/0', {'host': 'nothing'})
-        self.resetBackendCalls()
-        with self.harness._event_context('foo_event'):
-            rel_db1 = self.ensure_relation('db1')
+        harness.update_relation_data(relation_id, 'myapp/0', {'host': 'nothing'})
+        self.resetBackendCalls(harness)
+        with harness._event_context('foo_event'):
+            rel_db1 = self.ensure_relation(model, 'db1')
             # update_relation_data will also trigger relation-get, so we
             # invalidate the cache to ensure it will be reloaded
-            rel_db1.data[self.model.unit]._invalidate()
+            rel_db1.data[model.unit]._invalidate()
             # Force memory cache to be loaded.
-            assert 'host' in rel_db1.data[self.model.unit]
-            rel_db1.data[self.model.unit]['host'] = 'bar'
-            assert rel_db1.data[self.model.unit]['host'] == 'bar'
+            assert 'host' in rel_db1.data[model.unit]
+            rel_db1.data[model.unit]['host'] = 'bar'
+            assert rel_db1.data[model.unit]['host'] == 'bar'
 
-        self.assertBackendCalls([
+        self.assertBackendCalls(harness, [
             ('relation_get', relation_id, 'myapp/0', False),
-            ('update_relation_data', relation_id, self.model.unit, 'host', 'bar'),
+            ('update_relation_data', relation_id, model.unit, 'host', 'bar'),
         ])
 
-    def test_app_relation_data_modify_local_as_leader(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        self.harness.update_relation_data(relation_id, 'myapp', {'password': 'deadbeefcafe'})
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
-        self.harness.set_leader(True)
-        self.resetBackendCalls()
+    def test_app_relation_data_modify_local_as_leader(
+            self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        harness.update_relation_data(relation_id, 'myapp', {'password': 'deadbeefcafe'})
+        harness.add_relation_unit(relation_id, 'remoteapp1/0')
+        harness.set_leader(True)
+        self.resetBackendCalls(harness)
 
-        local_app = self.model.unit.app
+        local_app = model.unit.app
 
-        rel_db1 = self.ensure_relation('db1')
+        rel_db1 = self.ensure_relation(model, 'db1')
         assert rel_db1.data[local_app] == {'password': 'deadbeefcafe'}
 
         rel_db1.data[local_app]['password'] = 'foo'
 
         assert rel_db1.data[local_app]['password'] == 'foo'
 
-        self.assertBackendCalls(
-            [('relation_ids', 'db1'),
-             ('relation_list', 1),
-             ('relation_get', 1, 'myapp', True),
-             ('update_relation_data', 1, self.model.app, 'password', 'foo')])
+        self.assertBackendCalls(harness,
+                                [('relation_ids', 'db1'),
+                                 ('relation_list', 0),
+                                    ('relation_get', 0, 'myapp', True),
+                                    ('update_relation_data', 0, model.app, 'password', 'foo')])
 
-    def test_app_relation_data_modify_local_as_minion(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        self.harness.update_relation_data(relation_id, 'myapp', {'password': 'deadbeefcafe'})
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
-        self.harness.set_leader(False)
-        self.resetBackendCalls()
+    def test_app_relation_data_modify_local_as_minion(
+            self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        harness.update_relation_data(relation_id, 'myapp', {'password': 'deadbeefcafe'})
+        harness.add_relation_unit(relation_id, 'remoteapp1/0')
+        harness.set_leader(False)
+        self.resetBackendCalls(harness)
 
-        local_app = self.model.unit.app
+        local_app = model.unit.app
 
-        rel_db1 = self.ensure_relation('db1')
+        rel_db1 = self.ensure_relation(model, 'db1')
         assert rel_db1.data[local_app] == {'password': 'deadbeefcafe'}
 
-        with self.harness._event_context('foo_event'):
+        with harness._event_context('foo_event'):
             # if we were inside an event context, we'd get:
             with pytest.raises(ops.RelationDataError):
                 rel_db1.data[local_app]['password'] = 'foobar'
 
-        self.assertBackendCalls([('relation_ids', 'db1'),
-                                 ('relation_list', 1),
-                                 ('relation_get', 1, 'myapp', True),
-                                 ('is_leader',)])
+        self.assertBackendCalls(harness, [('relation_ids', 'db1'),
+                                          ('relation_list', 0),
+                                          ('relation_get', 0, 'myapp', True),
+                                          ('is_leader',)])
 
-    def test_relation_data_access_peer_leader(self):
-        r_id = self.harness.add_relation('db2', 'myapp')
-        self.harness.add_relation_unit(r_id, 'myapp/1')  # peer!
-        self.harness.update_relation_data(r_id, 'myapp', {'foo': 'bar'})
-        with self.harness._event_context('foo_event'):
+    def test_relation_data_access_peer_leader(self, harness: ops.testing.Harness[ops.CharmBase]):
+        r_id = harness.add_relation('db2', 'myapp')
+        harness.add_relation_unit(r_id, 'myapp/1')  # peer!
+        harness.update_relation_data(r_id, 'myapp', {'foo': 'bar'})
+        with harness._event_context('foo_event'):
             # leaders can read
-            self.harness.set_leader(True)
-            relation = self.harness.model.get_relation('db2')
+            harness.set_leader(True)
+            relation = harness.model.get_relation('db2')
             assert relation is not None and relation.app is not None
             assert relation.data[relation.app]['foo'] == 'bar'
 
-    def test_relation_data_access_peer_minion(self):
-        r_id = self.harness.add_relation('db2', 'myapp')
-        self.harness.add_relation_unit(r_id, 'myapp/1')  # peer!
-        self.harness.update_relation_data(r_id, 'myapp', {'foo': 'bar'})
-        with self.harness._event_context('foo_event'):
+    def test_relation_data_access_peer_minion(self, harness: ops.testing.Harness[ops.CharmBase]):
+        r_id = harness.add_relation('db2', 'myapp')
+        harness.add_relation_unit(r_id, 'myapp/1')  # peer!
+        harness.update_relation_data(r_id, 'myapp', {'foo': 'bar'})
+        with harness._event_context('foo_event'):
             # nonleaders can read
-            self.harness.set_leader(False)
-            relation = self.harness.model.get_relation('db2')
+            harness.set_leader(False)
+            relation = harness.model.get_relation('db2')
             assert relation is not None and relation.app is not None
             assert relation.data[relation.app]['foo'] == 'bar'
 
-    def test_relation_data_del_key(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        with self.harness._event_context('foo_event'):
-            self.harness.update_relation_data(relation_id, 'myapp/0', {'host': 'bar'})
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
-        self.resetBackendCalls()
+    def test_relation_data_del_key(self,
+                                   harness: ops.testing.Harness[ops.CharmBase],
+                                   model: ops.Model):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        with harness._event_context('foo_event'):
+            harness.update_relation_data(relation_id, 'myapp/0', {'host': 'bar'})
+        harness.add_relation_unit(relation_id, 'remoteapp1/0')
+        self.resetBackendCalls(harness)
 
-        rel_db1 = self.ensure_relation('db1')
+        rel_db1 = self.ensure_relation(model, 'db1')
         # Force memory cache to be loaded.
-        assert 'host' in rel_db1.data[self.model.unit]
-        del rel_db1.data[self.model.unit]['host']
-        assert 'host' not in rel_db1.data[self.model.unit]
-        assert self.harness.get_relation_data(relation_id, 'myapp/0') == {}
+        assert 'host' in rel_db1.data[model.unit]
+        del rel_db1.data[model.unit]['host']
+        assert 'host' not in rel_db1.data[model.unit]
+        assert harness.get_relation_data(relation_id, 'myapp/0') == {}
 
-        self.assertBackendCalls([
+        self.assertBackendCalls(harness, [
             ('relation_ids', 'db1'),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'myapp/0', False),
-            ('update_relation_data', relation_id, self.model.unit, 'host', ''),
+            ('update_relation_data', relation_id, model.unit, 'host', ''),
         ])
 
-    def test_relation_data_del_missing_key(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        with self.harness._event_context('foo_event'):
-            self.harness.update_relation_data(relation_id, 'myapp/0', {'host': 'bar'})
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
-        self.resetBackendCalls()
+    def test_relation_data_del_missing_key(
+            self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        with harness._event_context('foo_event'):
+            harness.update_relation_data(relation_id, 'myapp/0', {'host': 'bar'})
+        harness.add_relation_unit(relation_id, 'remoteapp1/0')
+        self.resetBackendCalls(harness)
 
-        rel_db1 = self.ensure_relation('db1')
+        rel_db1 = self.ensure_relation(model, 'db1')
         # Force memory cache to be loaded.
-        assert 'host' in rel_db1.data[self.model.unit]
-        with self.harness._event_context('foo_event'):
-            rel_db1.data[self.model.unit]['port'] = ''   # Same as a delete, should not fail.
-        assert 'port' not in rel_db1.data[self.model.unit]
-        with self.harness._event_context('foo_event'):
-            assert self.harness.get_relation_data(relation_id, 'myapp/0') == \
+        assert 'host' in rel_db1.data[model.unit]
+        with harness._event_context('foo_event'):
+            rel_db1.data[model.unit]['port'] = ''   # Same as a delete, should not fail.
+        assert 'port' not in rel_db1.data[model.unit]
+        with harness._event_context('foo_event'):
+            assert harness.get_relation_data(relation_id, 'myapp/0') == \
                 {'host': 'bar'}
 
-        self.assertBackendCalls([
+        self.assertBackendCalls(harness, [
             ('relation_ids', 'db1'),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'myapp/0', False),
-            ('update_relation_data', relation_id, self.model.unit, 'port', ''),
+            ('update_relation_data', relation_id, model.unit, 'port', ''),
         ])
 
-    def test_relation_set_fail(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        with self.harness._event_context('foo_event'):
-            self.harness.update_relation_data(relation_id, 'myapp/0', {'host': 'myapp-0'})
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
-        self.resetBackendCalls()
+    def test_relation_set_fail(self,
+                               harness: ops.testing.Harness[ops.CharmBase],
+                               model: ops.Model):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        with harness._event_context('foo_event'):
+            harness.update_relation_data(relation_id, 'myapp/0', {'host': 'myapp-0'})
+        harness.add_relation_unit(relation_id, 'remoteapp1/0')
+        self.resetBackendCalls(harness)
 
-        backend = self.harness._backend
+        backend = harness._backend
         # TODO: jam 2020-03-06 This is way too much information about relation_set
         #       The original test forced 'relation-set' to return exit code 2,
         #       but there was nothing illegal about the data that was being set,
@@ -467,33 +504,35 @@ class TestModel(unittest.TestCase):
             raise ops.ModelError()
         backend.update_relation_data = broken_update_relation_data
 
-        rel_db1 = self.ensure_relation('db1')
+        rel_db1 = self.ensure_relation(model, 'db1')
         # Force memory cache to be loaded.
-        assert 'host' in rel_db1.data[self.model.unit]
+        assert 'host' in rel_db1.data[model.unit]
 
-        with self.harness._event_context('foo_event'):
+        with harness._event_context('foo_event'):
             with pytest.raises(ops.ModelError):
-                rel_db1.data[self.model.unit]['host'] = 'bar'
-            assert rel_db1.data[self.model.unit]['host'] == 'myapp-0'
+                rel_db1.data[model.unit]['host'] = 'bar'
+            assert rel_db1.data[model.unit]['host'] == 'myapp-0'
             with pytest.raises(ops.ModelError):
-                del rel_db1.data[self.model.unit]['host']
-            assert 'host' in rel_db1.data[self.model.unit]
+                del rel_db1.data[model.unit]['host']
+            assert 'host' in rel_db1.data[model.unit]
 
-        self.assertBackendCalls([
+        self.assertBackendCalls(harness, [
             ('relation_ids', 'db1'),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'myapp/0', False),
-            ('update_relation_data', relation_id, self.model.unit, 'host', 'bar'),
-            ('update_relation_data', relation_id, self.model.unit, 'host', ''),
+            ('update_relation_data', relation_id, model.unit, 'host', 'bar'),
+            ('update_relation_data', relation_id, model.unit, 'host', ''),
         ])
 
-    def test_relation_data_type_check(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        self.harness.update_relation_data(relation_id, 'myapp/0', {'host': 'myapp-0'})
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
-        self.resetBackendCalls()
+    def test_relation_data_type_check(self,
+                                      harness: ops.testing.Harness[ops.CharmBase],
+                                      model: ops.Model):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        harness.update_relation_data(relation_id, 'myapp/0', {'host': 'myapp-0'})
+        harness.add_relation_unit(relation_id, 'remoteapp1/0')
+        self.resetBackendCalls(harness)
 
-        rel_db1 = self.ensure_relation('db1')
+        rel_db1 = self.ensure_relation(model, 'db1')
         for key, value in (
                 ('foo', 1),
                 ('foo', None),
@@ -505,126 +544,130 @@ class TestModel(unittest.TestCase):
                 (None, None)
         ):
             with pytest.raises(ops.RelationDataError):
-                with self.harness.framework._event_context('foo_event'):
-                    rel_db1.data[self.model.unit][key] = value  # type: ignore
+                with harness.framework._event_context('foo_event'):
+                    rel_db1.data[model.unit][key] = value  # type: ignore
 
         # No data has actually been changed
-        assert dict(rel_db1.data[self.model.unit]) == {'host': 'myapp-0'}
+        assert dict(rel_db1.data[model.unit]) == {'host': 'myapp-0'}
 
-        self.assertBackendCalls([
+        self.assertBackendCalls(harness, [
             ('relation_ids', 'db1'),
             ('relation_list', relation_id),
             ('relation_get', relation_id, 'myapp/0', False),
         ])
 
-    def test_relation_local_app_data_readability_leader(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        self.harness.update_relation_data(relation_id, 'remoteapp1',
-                                          {'secret': 'cafedeadbeef'})
-        self.harness.update_relation_data(relation_id, 'myapp',
-                                          {'local': 'data'})
+    def test_relation_local_app_data_readability_leader(
+            self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        harness.update_relation_data(relation_id, 'remoteapp1',
+                                     {'secret': 'cafedeadbeef'})
+        harness.update_relation_data(relation_id, 'myapp',
+                                     {'local': 'data'})
 
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
-        self.harness.update_relation_data(relation_id, 'remoteapp1/0',
-                                          {'host': 'remoteapp1/0'})
-        self.model.relations._invalidate('db1')
-        self.resetBackendCalls()
+        harness.add_relation_unit(relation_id, 'remoteapp1/0')
+        harness.update_relation_data(relation_id, 'remoteapp1/0',
+                                     {'host': 'remoteapp1/0'})
+        model.relations._invalidate('db1')
+        self.resetBackendCalls(harness)
 
-        rel_db1 = self.ensure_relation('db1')
-        self.harness.begin()
-        self.harness.set_leader(True)
-        self.resetBackendCalls()
+        rel_db1 = self.ensure_relation(model, 'db1')
+        harness.begin()
+        harness.set_leader(True)
+        self.resetBackendCalls(harness)
 
-        local_app = self.harness.charm.app
-        self.resetBackendCalls()
+        local_app = harness.charm.app
+        self.resetBackendCalls(harness)
 
         # addressing the object is OK
         rel_db1.data[local_app]
 
-        self.assertBackendCalls([])
+        self.assertBackendCalls(harness, [])
 
-        with self.harness._event_context('foo_event'):
-            self.resetBackendCalls()
+        with harness._event_context('foo_event'):
+            self.resetBackendCalls(harness)
 
             assert rel_db1.data[local_app]['local'] == 'data'
 
-            self.assertBackendCalls([('is_leader',),
-                                     ('relation_get', 1, 'myapp', True)])
+            self.assertBackendCalls(harness, [('is_leader',),
+                                              ('relation_get', 0, 'myapp', True)])
 
-            self.resetBackendCalls()
+            self.resetBackendCalls(harness)
 
             assert repr(rel_db1.data[local_app]) == repr({'local': 'data'})
 
             # we don't get the data, because we're lazy
-            self.assertBackendCalls([('is_leader',)])
+            self.assertBackendCalls(harness, [('is_leader',)])
 
             # as well as relation data repr() in general:
             assert isinstance(repr(rel_db1.data), str)
 
-    def test_relation_local_app_data_readability_follower(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        with self.harness._event_context('foo_event'):
-            self.harness.update_relation_data(relation_id, 'remoteapp1',
-                                              {'secret': 'cafedeadbeef'})
-            self.harness.update_relation_data(relation_id, 'myapp',
-                                              {'local': 'data'})
+    def test_relation_local_app_data_readability_follower(
+            self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        with harness._event_context('foo_event'):
+            harness.update_relation_data(relation_id, 'remoteapp1',
+                                         {'secret': 'cafedeadbeef'})
+            harness.update_relation_data(relation_id, 'myapp',
+                                         {'local': 'data'})
 
-            self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
-            self.harness.update_relation_data(relation_id, 'remoteapp1/0',
-                                              {'host': 'remoteapp1/0'})
-        self.model.relations._invalidate('db1')
-        self.resetBackendCalls()
+            harness.add_relation_unit(relation_id, 'remoteapp1/0')
+            harness.update_relation_data(relation_id, 'remoteapp1/0',
+                                         {'host': 'remoteapp1/0'})
+        model.relations._invalidate('db1')
+        self.resetBackendCalls(harness)
 
-        rel_db1 = self.ensure_relation('db1')
-        self.harness.begin()
-        self.harness.set_leader(False)
+        rel_db1 = self.ensure_relation(model, 'db1')
+        harness.begin()
+        harness.set_leader(False)
 
-        local_app = self.harness.charm.app
+        local_app = harness.charm.app
         # addressing the object is OK
         rel_db1.data[local_app]
         # nonleader units cannot read their local app databag
         # attempting to read it is not
-        with self.harness._event_context('foo_event'):
-            self.resetBackendCalls()
+        with harness._event_context('foo_event'):
+            self.resetBackendCalls(harness)
 
             with pytest.raises(ops.RelationDataError):
                 # 'local' is there, but still:
                 rel_db1.data[local_app]['local']
 
             # we didn't even get to relation-get
-            self.assertBackendCalls([('is_leader', )])
+            self.assertBackendCalls(harness, [('is_leader', )])
 
             # we can't see it but repr() works
             assert repr(rel_db1.data[local_app]) == '<n/a>'
-            self.assertBackendCalls([('is_leader', )])
+            self.assertBackendCalls(harness, [('is_leader', )])
 
             # as well as relation data repr() in general:
             assert isinstance(repr(rel_db1.data), str)
 
             expected_backend_calls = [
-                ('relation_get', 1, 'myapp/0', False),
+                ('relation_get', 0, 'myapp/0', False),
                 ('is_leader',),
-                ('relation_get', 1, 'remoteapp1/0', False),
+                ('relation_get', 0, 'remoteapp1/0', False),
                 ('is_leader',),
-                ('relation_get', 1, 'remoteapp1', True)]
-            self.assertBackendCalls(expected_backend_calls)
+                ('relation_get', 0, 'remoteapp1', True)]
+            self.assertBackendCalls(harness, expected_backend_calls)
 
-    def test_relation_no_units(self):
-        self.harness.add_relation('db1', 'remoteapp1')
-        rel = self.ensure_relation('db1')
+    def test_relation_no_units(self,
+                               harness: ops.testing.Harness[ops.CharmBase],
+                               model: ops.Model):
+        harness.add_relation('db1', 'remoteapp1')
+        rel = self.ensure_relation(model, 'db1')
         assert rel.units == set()
-        assert rel.app is self.model.get_app('remoteapp1')
-        self.assertBackendCalls([
+        assert rel.app is model.get_app('remoteapp1')
+        self.assertBackendCalls(harness, [
             ('relation_ids', 'db1'),
-            ('relation_list', 1),
-            ('relation_remote_app_name', 1),
+            ('relation_list', 0),
+            ('relation_remote_app_name', 0),
         ])
 
-    def test_config(self):
-        self.harness._get_backend_calls(reset=True)
-        self.harness.update_config({'foo': 'foo', 'bar': 1, 'qux': True,
-                                    'baz': 3.1, 'secretfoo': 'secret:1234'})
-        assert self.model.config == {
+    def test_config(self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+        harness._get_backend_calls(reset=True)
+        harness.update_config({'foo': 'foo', 'bar': 1, 'qux': True,
+                               'baz': 3.1, 'secretfoo': 'secret:1234'})
+        assert model.config == {
             'foo': 'foo',
             'bar': 1,
             'qux': True,
@@ -633,88 +676,92 @@ class TestModel(unittest.TestCase):
         }
         with pytest.raises(TypeError):
             # Confirm that we cannot modify config values.
-            self.model.config['foo'] = 'bar'  # type: ignore
+            model.config['foo'] = 'bar'  # type: ignore
 
-        self.assertBackendCalls([('config_get',)])
+        self.assertBackendCalls(harness, [('config_get',)])
 
-    def test_config_immutable(self):
+    def test_config_immutable(self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
         with pytest.raises(AttributeError):
-            self.model.config = {}  # type: ignore
+            model.config = {}  # type: ignore
 
-    def test_is_leader(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
-        self.harness.set_leader(True)
-        self.resetBackendCalls()
+    def test_is_leader(self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        harness.add_relation_unit(relation_id, 'remoteapp1/0')
+        harness.set_leader(True)
+        self.resetBackendCalls(harness)
 
         def check_remote_units():
             # Cannot determine leadership for remote units.
-            for u in self.ensure_relation('db1').units:
+            for u in self.ensure_relation(model, 'db1').units:
                 with pytest.raises(RuntimeError):
                     u.is_leader()
 
-        assert self.model.unit.is_leader()
+        assert model.unit.is_leader()
 
         check_remote_units()
 
         # Create a new model and backend to drop a cached is-leader output.
-        self.harness.set_leader(False)
-        assert not self.model.unit.is_leader()
+        harness.set_leader(False)
+        assert not model.unit.is_leader()
 
         check_remote_units()
 
-        self.assertBackendCalls([
+        self.assertBackendCalls(harness, [
             ('is_leader',),
             ('relation_ids', 'db1'),
             ('relation_list', relation_id),
             ('is_leader',),
         ])
 
-    def test_workload_version(self):
-        self.model.unit.set_workload_version('1.2.3')
-        self.assertBackendCalls([
+    def test_workload_version(self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+        model.unit.set_workload_version('1.2.3')
+        self.assertBackendCalls(harness, [
             ('application_version_set', '1.2.3'),
         ])
 
-    def test_workload_version_invalid(self):
+    def test_workload_version_invalid(self,
+                                      harness: ops.testing.Harness[ops.CharmBase],
+                                      model: ops.Model):
         with pytest.raises(TypeError) as excinfo:
-            self.model.unit.set_workload_version(5)  # type: ignore
+            model.unit.set_workload_version(5)  # type: ignore
         assert str(excinfo.value) == "workload version must be a str, not int: 5"
-        self.assertBackendCalls([])
+        self.assertBackendCalls(harness, [])
 
-    def test_resources(self):
+    def test_resources(self, harness: ops.testing.Harness[ops.CharmBase]):
         with pytest.raises(ops.ModelError):
-            self.harness.model.resources.fetch('foo')
+            harness.model.resources.fetch('foo')
 
-        self.harness.add_resource('foo', 'foo contents\n')
-        self.harness.add_resource('bar', '')
+        harness.add_resource('foo', 'foo contents\n')
+        harness.add_resource('bar', '')
 
         with pytest.raises(NameError):
-            self.harness.model.resources.fetch('qux')
+            harness.model.resources.fetch('qux')
 
-        assert self.harness.model.resources.fetch('foo').name == 'foo.txt'
-        assert self.harness.model.resources.fetch('bar').name == 'bar.txt'
+        assert harness.model.resources.fetch('foo').name == 'foo.txt'
+        assert harness.model.resources.fetch('bar').name == 'bar.txt'
 
-    def test_resources_immutable(self):
+    def test_resources_immutable(self,
+                                 harness: ops.testing.Harness[ops.CharmBase],
+                                 model: ops.Model):
         with pytest.raises(AttributeError):
-            self.model.resources = object()  # type: ignore
+            model.resources = object()  # type: ignore
 
-    def test_pod_spec(self):
-        self.harness.set_leader(True)
-        self.harness.model.pod.set_spec({'foo': 'bar'})
-        assert self.harness.get_pod_spec() == ({'foo': 'bar'}, None)
+    def test_pod_spec(self, harness: ops.testing.Harness[ops.CharmBase]):
+        harness.set_leader(True)
+        harness.model.pod.set_spec({'foo': 'bar'})
+        assert harness.get_pod_spec() == ({'foo': 'bar'}, None)
 
-        self.harness.model.pod.set_spec({'bar': 'foo'}, {'qux': 'baz'})
-        assert self.harness.get_pod_spec() == ({'bar': 'foo'}, {'qux': 'baz'})
+        harness.model.pod.set_spec({'bar': 'foo'}, {'qux': 'baz'})
+        assert harness.get_pod_spec() == ({'bar': 'foo'}, {'qux': 'baz'})
 
         # no leader -> no set pod spec
-        self.harness.set_leader(False)
+        harness.set_leader(False)
         with pytest.raises(ops.ModelError):
-            self.harness.model.pod.set_spec({'foo': 'bar'})
+            harness.model.pod.set_spec({'foo': 'bar'})
 
-    def test_pod_immutable(self):
+    def test_pod_immutable(self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
         with pytest.raises(AttributeError):
-            self.model.pod = object()  # type: ignore
+            model.pod = object()  # type: ignore
 
     def test_base_status_instance_raises(self):
         with pytest.raises(TypeError):
@@ -758,135 +805,142 @@ class TestModel(unittest.TestCase):
     def test_active_message_default(self):
         assert ops.ActiveStatus().message == ''
 
-    def test_local_set_valid_unit_status(self):
-        self.harness._get_backend_calls(reset=True)
-        test_cases = [(
-            'active',
-            ops.ActiveStatus('Green'),
-            ('status_set', 'active', 'Green', {'is_app': False}),
-        ), (
-            'maintenance',
-            ops.MaintenanceStatus('Yellow'),
-            ('status_set', 'maintenance', 'Yellow', {'is_app': False}),
-        ), (
-            'blocked',
-            ops.BlockedStatus('Red'),
-            ('status_set', 'blocked', 'Red', {'is_app': False}),
-        ), (
-            'waiting',
-            ops.WaitingStatus('White'),
-            ('status_set', 'waiting', 'White', {'is_app': False}),
-        )]
+    @pytest.mark.parametrize("target_status,backend_call", [(
+        ops.ActiveStatus('Green'),
+        ('status_set', 'active', 'Green', {'is_app': False}),
+    ), (
+        ops.MaintenanceStatus('Yellow'),
+        ('status_set', 'maintenance', 'Yellow', {'is_app': False}),
+    ), (
+        ops.BlockedStatus('Red'),
+        ('status_set', 'blocked', 'Red', {'is_app': False}),
+    ), (
+        ops.WaitingStatus('White'),
+        ('status_set', 'waiting', 'White', {'is_app': False}),
+    )])
+    def test_local_set_valid_unit_status(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+        target_status: ops.StatusBase,
+        backend_call: typing.Tuple[str, str, str, typing.Dict[str, bool]],
+    ):
+        harness._get_backend_calls(reset=True)
+        model.unit.status = target_status
+        assert model.unit.status == target_status
+        model.unit._invalidate()
+        assert model.unit.status == target_status
+        self.assertBackendCalls(harness, [backend_call, ('status_get', {'is_app': False})])
 
-        for test_case, target_status, backend_call in test_cases:
-            with self.subTest(test_case):
-                self.model.unit.status = target_status
-                assert self.model.unit.status == target_status
-                self.model.unit._invalidate()
-                assert self.model.unit.status == target_status
-                self.assertBackendCalls([backend_call, ('status_get', {'is_app': False})])
+    @pytest.mark.parametrize("target_status,backend_call", [(
+        ops.ActiveStatus('Green'),
+        ('status_set', 'active', 'Green', {'is_app': True}),
+    ), (
+        ops.MaintenanceStatus('Yellow'),
+        ('status_set', 'maintenance', 'Yellow', {'is_app': True}),
+    ), (
+        ops.BlockedStatus('Red'),
+        ('status_set', 'blocked', 'Red', {'is_app': True}),
+    ), (
+        ops.WaitingStatus('White'),
+        ('status_set', 'waiting', 'White', {'is_app': True}),
+    )])
+    def test_local_set_valid_app_status(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+        target_status: ops.StatusBase,
+        backend_call: typing.Tuple[str, str, str, typing.Dict[str, bool]],
+    ):
+        harness.set_leader(True)
 
-    def test_local_set_valid_app_status(self):
-        self.harness.set_leader(True)
-        test_cases = [(
-            'active',
-            ops.ActiveStatus('Green'),
-            ('status_set', 'active', 'Green', {'is_app': True}),
-        ), (
-            'maintenance',
-            ops.MaintenanceStatus('Yellow'),
-            ('status_set', 'maintenance', 'Yellow', {'is_app': True}),
-        ), (
-            'blocked',
-            ops.BlockedStatus('Red'),
-            ('status_set', 'blocked', 'Red', {'is_app': True}),
-        ), (
-            'waiting',
-            ops.WaitingStatus('White'),
-            ('status_set', 'waiting', 'White', {'is_app': True}),
-        )]
+        model.app.status = target_status
+        assert model.app.status == target_status
+        model.app._invalidate()
+        assert model.app.status == target_status
+        # There is a backend call to check if we can set the value,
+        # and then another check each time we assert the status above
+        expected_calls = [
+            ('is_leader',), backend_call,
+            ('is_leader',),
+            ('is_leader',), ('status_get', {'is_app': True}),
+        ]
+        self.assertBackendCalls(harness, expected_calls)
 
-        for test_case, target_status, backend_call in test_cases:
-            with self.subTest(test_case):
-                self.model.app.status = target_status
-                assert self.model.app.status == target_status
-                self.model.app._invalidate()
-                assert self.model.app.status == target_status
-                # There is a backend call to check if we can set the value,
-                # and then another check each time we assert the status above
-                expected_calls = [
-                    ('is_leader',), backend_call,
-                    ('is_leader',),
-                    ('is_leader',), ('status_get', {'is_app': True}),
-                ]
-                self.assertBackendCalls(expected_calls)
-
-    def test_set_app_status_non_leader_raises(self):
-        self.harness.set_leader(False)
+    def test_set_app_status_non_leader_raises(
+            self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+        harness.set_leader(False)
         with pytest.raises(RuntimeError):
-            self.model.app.status
+            model.app.status
 
         with pytest.raises(RuntimeError):
-            self.model.app.status = ops.ActiveStatus()
+            model.app.status = ops.ActiveStatus()
 
-    def test_set_unit_status_invalid(self):
+    def test_set_unit_status_invalid(self, model: ops.Model):
         with pytest.raises(ops.InvalidStatusError):
-            self.model.unit.status = 'blocked'  # type: ignore
+            model.unit.status = 'blocked'  # type: ignore
 
-    def test_set_app_status_invalid(self):
+    def test_set_app_status_invalid(self, model: ops.Model):
         with pytest.raises(ops.InvalidStatusError):
-            self.model.app.status = 'blocked'  # type: ignore
+            model.app.status = 'blocked'  # type: ignore
 
-    def test_remote_unit_status(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/1')
+    @pytest.mark.parametrize("target_status", [
+        ops.UnknownStatus(),
+        ops.ActiveStatus('Green'),
+        ops.MaintenanceStatus('Yellow'),
+        ops.BlockedStatus('Red'),
+        ops.WaitingStatus('White'),
+    ])
+    def test_remote_unit_status(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+        target_status: ops.StatusBase,
+    ):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        harness.add_relation_unit(relation_id, 'remoteapp1/0')
+        harness.add_relation_unit(relation_id, 'remoteapp1/1')
         remote_unit = next(filter(lambda u: u.name == 'remoteapp1/0',
-                                  self.ensure_relation('db1').units))
-        self.resetBackendCalls()
+                                  self.ensure_relation(model, 'db1').units))
+        self.resetBackendCalls(harness)
 
         # Remote unit status is always unknown.
         assert remote_unit.status == ops.UnknownStatus()
 
-        test_statuses = (
-            ops.UnknownStatus(),
-            ops.ActiveStatus('Green'),
-            ops.MaintenanceStatus('Yellow'),
-            ops.BlockedStatus('Red'),
-            ops.WaitingStatus('White'),
-        )
+        with pytest.raises(RuntimeError):
+            remote_unit.status = target_status
 
-        for target_status in test_statuses:
-            with self.subTest(target_status.name):
-                with pytest.raises(RuntimeError):
-                    remote_unit.status = target_status
-        self.assertBackendCalls([])
+        self.assertBackendCalls(harness, [])
 
-    def test_remote_app_status(self):
-        relation_id = self.harness.add_relation('db1', 'remoteapp1')
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/0')
-        self.harness.add_relation_unit(relation_id, 'remoteapp1/1')
-        remoteapp1 = self.ensure_relation('db1').app
-        self.resetBackendCalls()
+    @pytest.mark.parametrize("target_status", [
+        ops.UnknownStatus(),
+        ops.ActiveStatus(),
+        ops.MaintenanceStatus('Upgrading software'),
+        ops.BlockedStatus('Awaiting manual resolution'),
+        ops.WaitingStatus('Awaiting related app updates'),
+    ])
+    def test_remote_app_status(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+        target_status: ops.StatusBase,
+    ):
+        relation_id = harness.add_relation('db1', 'remoteapp1')
+        harness.add_relation_unit(relation_id, 'remoteapp1/0')
+        harness.add_relation_unit(relation_id, 'remoteapp1/1')
+        remoteapp1 = self.ensure_relation(model, 'db1').app
+        self.resetBackendCalls(harness)
 
         # Remote application status is always unknown.
         assert remoteapp1 is not None
         assert isinstance(remoteapp1.status, ops.UnknownStatus)
 
-        test_statuses = (
-            ops.UnknownStatus(),
-            ops.ActiveStatus(),
-            ops.MaintenanceStatus('Upgrading software'),
-            ops.BlockedStatus('Awaiting manual resolution'),
-            ops.WaitingStatus('Awaiting related app updates'),
-        )
-        for target_status in test_statuses:
-            with self.subTest(target_status.name):
-                with pytest.raises(RuntimeError):
-                    remoteapp1.status = target_status
-        self.assertBackendCalls([])
+        with pytest.raises(RuntimeError):
+            remoteapp1.status = target_status
 
-    def test_storage(self):
+        self.assertBackendCalls(harness, [])
+
+    def test_storage(self, fake_script: FakeScript, model: ops.Model):
         meta = ops.CharmMeta()
         raw: 'ops.charm._StorageMetaDict' = {
             'type': 'test',
@@ -897,14 +951,14 @@ class TestModel(unittest.TestCase):
         }
         model = ops.Model(meta, _ModelBackend('myapp/0'))
 
-        fake_script(self, 'storage-list', '''
+        fake_script.write('storage-list', '''
             if [ "$1" = disks ]; then
                 echo '["disks/0", "disks/1"]'
             else
                 echo '[]'
             fi
         ''')
-        fake_script(self, 'storage-get', '''
+        fake_script.write('storage-get', '''
             if [ "$2" = disks/0 ]; then
                 echo '"/var/srv/disks/0"'
             elif [ "$2" = disks/1 ]; then
@@ -913,7 +967,7 @@ class TestModel(unittest.TestCase):
                 exit 2
             fi
         ''')
-        fake_script(self, 'storage-add', '')
+        fake_script.write('storage-add', '')
 
         assert len(model.storages) == 2
         assert model.storages.keys() == meta.storages.keys()
@@ -932,15 +986,15 @@ class TestModel(unittest.TestCase):
             assert storage.name == test_cases[storage.id]['name']
             assert storage.location == test_cases[storage.id]['location']
 
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['storage-list', 'disks', '--format=json'],
             ['storage-get', '-s', 'disks/0', 'location', '--format=json'],
             ['storage-get', '-s', 'disks/1', 'location', '--format=json'],
         ]
 
-        self.assertSequenceEqual(model.storages['data'], [])
+        assert model.storages['data'] == []
         model.storages.request('data', count=3)
-        assert fake_script_calls(self) == [
+        assert fake_script.calls() == [
             ['storage-list', 'data', '--format=json'],
             ['storage-add', 'data=3'],
         ]
@@ -954,23 +1008,24 @@ class TestModel(unittest.TestCase):
             with pytest.raises(TypeError):
                 model.storages.request('data', count_v)  # type: ignore
 
-    def test_storages_immutable(self):
+    def test_storages_immutable(self, model: ops.Model):
         with pytest.raises(AttributeError):
-            self.model.storages = {}  # type: ignore
+            model.storages = {}  # type: ignore
 
-    def resetBackendCalls(self):  # noqa: N802
-        self.harness._get_backend_calls(reset=True)
+    def resetBackendCalls(self, harness: ops.testing.Harness[ops.CharmBase]):  # noqa: N802
+        harness._get_backend_calls(reset=True)
 
     def assertBackendCalls(  # noqa: N802
             self,
+            harness: ops.testing.Harness[ops.CharmBase],
             expected: typing.List[typing.Tuple[typing.Any, ...]],
             *,
             reset: bool = True):
-        assert expected == self.harness._get_backend_calls(reset=reset)
+        assert expected == harness._get_backend_calls(reset=reset)
 
-    def test_run_error(self):
+    def test_run_error(self, fake_script: FakeScript, model: ops.Model):
         model = ops.Model(ops.CharmMeta(), _ModelBackend('myapp/0'))
-        fake_script(self, 'status-get', """echo 'ERROR cannot get status' >&2; exit 1""")
+        fake_script.write('status-get', """echo 'ERROR cannot get status' >&2; exit 1""")
         with pytest.raises(ops.ModelError) as excinfo:
             _ = model.unit.status.message
         assert str(excinfo.value) == 'ERROR cannot get status\n'
@@ -1001,16 +1056,18 @@ class TestModel(unittest.TestCase):
 class PushPullCase:
     """Test case for table-driven tests."""
 
-    def __init__(self,
-                 *,
-                 name: str,
-                 path: typing.Union[str, typing.List[str]],
-                 files: typing.List[str],
-                 want: typing.Optional[typing.Set[str]] = None,
-                 dst: typing.Optional[str] = None,
-                 errors: typing.Optional[typing.Set[str]] = None,
-                 dirs: typing.Optional[typing.Set[str]] = None,
-                 want_dirs: typing.Optional[typing.Set[str]] = None):
+    def __init__(
+        self,
+        *,
+        name: str,
+        path: typing.Union[str, typing.List[str]],
+        files: typing.List[str],
+        want: typing.Optional[typing.Set[str]] = None,
+        dst: typing.Optional[str] = None,
+        errors: typing.Optional[typing.Set[str]] = None,
+        dirs: typing.Optional[typing.Set[str]] = None,
+        want_dirs: typing.Optional[typing.Set[str]] = None
+    ):
         self.pattern = None
         self.dst = dst
         self.errors = errors or set()
@@ -1334,10 +1391,10 @@ def test_push_path_relative(case: PushPullCase):
             os.chdir(cwd)
 
 
-class TestApplication(unittest.TestCase):
-
-    def setUp(self):
-        self.harness = ops.testing.Harness(ops.CharmBase, meta='''
+class TestApplication:
+    @pytest.fixture
+    def harness(self):
+        harness = ops.testing.Harness(ops.CharmBase, meta='''
             name: myapp
             provides:
               db0:
@@ -1355,15 +1412,22 @@ class TestApplication(unittest.TestCase):
               bar:
                 k: v
         ''')
-        self.peer_rel_id = self.harness.add_relation('db2', 'db2')
-        self.app = self.harness.model.app
-        self.addCleanup(self.harness.cleanup)
+        yield harness
+        harness.cleanup()
+
+    @pytest.fixture
+    def app(self, harness: ops.testing.Harness[ops.CharmBase]):
+        return harness.model.app
+
+    @pytest.fixture
+    def peer_rel_id(self, harness: ops.testing.Harness[ops.CharmBase]):
+        return harness.add_relation('db2', 'db2')
 
     # Tests fix for https://github.com/canonical/operator/issues/694.
-    def test_mocked_get_services(self):
-        self.harness.begin()
-        self.harness.set_can_connect('bar', True)
-        c = self.harness.charm.unit.get_container('bar')
+    def test_mocked_get_services(self, harness: ops.testing.Harness[ops.CharmBase]):
+        harness.begin()
+        harness.set_can_connect('bar', True)
+        c = harness.charm.unit.get_container('bar')
         c.add_layer('layer1', {
             'summary': 'layer',
             'services': {"baz": {'override': 'replace', 'summary': 'echo', 'command': 'echo 1'}},
@@ -1373,53 +1437,61 @@ class TestApplication(unittest.TestCase):
         assert s
         assert 'baz' in c.get_services()
 
-    def test_planned_units(self):
-        rel_id = self.peer_rel_id
-
+    def test_planned_units(self,
+                           harness: ops.testing.Harness[ops.CharmBase],
+                           app: ops.Application,
+                           peer_rel_id: int):
         # Test that we always count ourself.
-        assert self.app.planned_units() == 1
+        assert app.planned_units() == 1
 
         # Add some units, and verify count.
-        self.harness.add_relation_unit(rel_id, 'myapp/1')
-        self.harness.add_relation_unit(rel_id, 'myapp/2')
+        harness.add_relation_unit(peer_rel_id, 'myapp/1')
+        harness.add_relation_unit(peer_rel_id, 'myapp/2')
 
-        assert self.app.planned_units() == 3
+        assert app.planned_units() == 3
 
-        self.harness.add_relation_unit(rel_id, 'myapp/3')
-        assert self.app.planned_units() == 4
+        harness.add_relation_unit(peer_rel_id, 'myapp/3')
+        assert app.planned_units() == 4
 
         # And remove a unit
-        self.harness.remove_relation_unit(rel_id, 'myapp/2')
+        harness.remove_relation_unit(peer_rel_id, 'myapp/2')
 
-        assert self.app.planned_units() == 3
+        assert app.planned_units() == 3
 
-    def test_planned_units_user_set(self):
+    def test_planned_units_user_set(self,
+                                    harness: ops.testing.Harness[ops.CharmBase],
+                                    app: ops.Application):
 
-        self.harness.set_planned_units(1)
-        assert self.app.planned_units() == 1
+        harness.set_planned_units(1)
+        assert app.planned_units() == 1
 
-        self.harness.set_planned_units(2)
-        assert self.app.planned_units() == 2
+        harness.set_planned_units(2)
+        assert app.planned_units() == 2
 
-        self.harness.set_planned_units(100)
-        assert self.app.planned_units() == 100
+        harness.set_planned_units(100)
+        assert app.planned_units() == 100
 
-    def test_planned_units_garbage_values(self):
+    def test_planned_units_garbage_values(self,
+                                          harness: ops.testing.Harness[ops.CharmBase],
+                                          app: ops.Application):
         # Planned units should be a positive integer, or zero.
         with pytest.raises(TypeError):
-            self.harness.set_planned_units(-1)
+            harness.set_planned_units(-1)
         # Verify that we didn't set our value before raising the error.
-        assert self.harness._backend._planned_units is None
+        assert harness._backend._planned_units is None
         # Verify that we still get the default value back from .planned_units.
-        assert self.app.planned_units() == 1
+        assert app.planned_units() == 1
 
         with pytest.raises(TypeError):
-            self.harness.set_planned_units("foo")  # type: ignore
+            harness.set_planned_units("foo")  # type: ignore
 
         with pytest.raises(TypeError):
-            self.harness.set_planned_units(-3423000102312321090)
+            harness.set_planned_units(-3423000102312321090)
 
-    def test_planned_units_override(self):
+    def test_planned_units_override(self,
+                                    harness: ops.testing.Harness[ops.CharmBase],
+                                    app: ops.Application,
+                                    peer_rel_id: int):
         """Verify that we override the calculated value of planned_units when we set it manually.
 
         When a charm author writes a test that explicitly calls set_planned_units, we assume that
@@ -1427,22 +1499,21 @@ class TestApplication(unittest.TestCase):
         charm author is composing a charm without peer relations, and the harness's count of
         planned units, which is based on the number of peer relations, will not be accurate.
         """
-        peer_id = self.peer_rel_id
+        harness.set_planned_units(10)
+        harness.add_relation_unit(peer_rel_id, 'myapp/1')
+        harness.add_relation_unit(peer_rel_id, 'myapp/2')
+        harness.add_relation_unit(peer_rel_id, 'myapp/3')
 
-        self.harness.set_planned_units(10)
-        self.harness.add_relation_unit(peer_id, 'myapp/1')
-        self.harness.add_relation_unit(peer_id, 'myapp/2')
-        self.harness.add_relation_unit(peer_id, 'myapp/3')
-
-        assert self.app.planned_units() == 10
+        assert app.planned_units() == 10
 
         # Verify that we can clear the override.
-        self.harness.reset_planned_units()
-        assert self.app.planned_units() == 4  # self + 3 peers
+        harness.reset_planned_units()
+        assert app.planned_units() == 4  # self + 3 peers
 
 
-class TestContainers(unittest.TestCase):
-    def setUp(self):
+class TestContainers:
+    @pytest.fixture
+    def model(self):
         meta = ops.CharmMeta.from_yaml("""
 name: k8s-charm
 containers:
@@ -1452,10 +1523,10 @@ containers:
     k: v
 """)
         backend = _ModelBackend('myapp/0')
-        self.model = ops.Model(meta, backend)
+        return ops.Model(meta, backend)
 
-    def test_unit_containers(self):
-        containers = self.model.unit.containers
+    def test_unit_containers(self, model: ops.Model):
+        containers = model.unit.containers
         assert sorted(containers) == ['c1', 'c2']
         assert len(containers) == 2
         assert 'c1' in containers
@@ -1470,11 +1541,11 @@ containers:
             containers['c3']
 
         with pytest.raises(RuntimeError):
-            other_unit = self.model.get_unit('other')
+            other_unit = model.get_unit('other')
             other_unit.containers
 
-    def test_unit_get_container(self):
-        unit = self.model.unit
+    def test_unit_get_container(self, model: ops.Model):
+        unit = model.unit
         for name in ['c1', 'c2']:
             container = unit.get_container(name)
             assert isinstance(container, ops.Container)
@@ -1484,521 +1555,8 @@ containers:
             unit.get_container('c3')
 
         with pytest.raises(RuntimeError):
-            other_unit = self.model.get_unit('other')
+            other_unit = model.get_unit('other')
             other_unit.get_container('foo')
-
-
-class TestContainerPebble(unittest.TestCase):
-    def setUp(self):
-        meta = ops.CharmMeta.from_yaml("""
-name: k8s-charm
-containers:
-  c1:
-    k: v
-""")
-        backend = MockPebbleBackend('myapp/0')
-        self.model = ops.Model(meta, backend)
-        self.container = self.model.unit.containers['c1']
-        self.pebble: MockPebbleClient = self.container.pebble  # type: ignore
-
-    def test_socket_path(self):
-        assert self.pebble.socket_path == '/charm/containers/c1/pebble.socket'
-
-    def test_autostart(self):
-        self.container.autostart()
-        assert self.pebble.requests == [('autostart',)]
-
-    def test_replan(self):
-        self.container.replan()
-        assert self.pebble.requests == [('replan',)]
-
-    def test_can_connect(self):
-        self.pebble.responses.append(pebble.SystemInfo.from_dict({'version': '1.0.0'}))
-        assert self.container.can_connect()
-        assert self.pebble.requests == [('get_system_info',)]
-
-    def test_start(self):
-        self.container.start('foo')
-        self.container.start('foo', 'bar')
-        assert self.pebble.requests == [
-            ('start', ('foo',)),
-            ('start', ('foo', 'bar')),
-        ]
-
-    def test_start_no_arguments(self):
-        with pytest.raises(TypeError):
-            self.container.start()
-
-    def test_stop(self):
-        self.container.stop('foo')
-        self.container.stop('foo', 'bar')
-        assert self.pebble.requests == [
-            ('stop', ('foo',)),
-            ('stop', ('foo', 'bar')),
-        ]
-
-    def test_stop_no_arguments(self):
-        with pytest.raises(TypeError):
-            self.container.stop()
-
-    def test_restart(self):
-        self.container.restart('foo')
-        self.container.restart('foo', 'bar')
-        assert self.pebble.requests == [
-            ('restart', ('foo',)),
-            ('restart', ('foo', 'bar')),
-        ]
-
-    def test_restart_fallback(self):
-        def restart_services(service_names: str):
-            self.pebble.requests.append(('restart', service_names))
-            raise pebble.APIError({}, 400, "", "")
-
-        self.pebble.restart_services = restart_services
-        # Setup the Pebble client to respond to a call to get_services()
-        self.pebble.responses.append([
-            pebble.ServiceInfo.from_dict(
-                {'name': 'foo', 'startup': 'enabled', 'current': 'active'}),
-            pebble.ServiceInfo.from_dict(
-                {'name': 'bar', 'startup': 'enabled', 'current': 'inactive'}),
-        ])
-
-        self.container.restart('foo', 'bar')
-        assert self.pebble.requests == [
-            # This is the first request, which in real life fails with APIError on older versions
-            ('restart', ('foo', 'bar')),
-            # Next the code should loop over the started services, and stop them
-            ('get_services', ('foo', 'bar')),
-            ('stop', ('foo',)),
-            # Then start all the specified services
-            ('start', ('foo', 'bar'))
-        ]
-
-    def test_restart_fallback_non_400_error(self):
-        def restart_services(service_names: str):
-            raise pebble.APIError({}, 500, "", "")
-
-        self.pebble.restart_services = restart_services
-        with pytest.raises(pebble.APIError) as excinfo:
-            self.container.restart('foo')
-        assert excinfo.value.code == 500
-
-    def test_restart_no_arguments(self):
-        with pytest.raises(TypeError):
-            self.container.restart()
-
-    def test_type_errors(self):
-        meta = ops.CharmMeta.from_yaml("""
-name: k8s-charm
-containers:
-  c1:
-    k: v
-""")
-        # Only the real pebble Client checks types, so use actual backend class
-        backend = _ModelBackend('myapp/0')
-        model = ops.Model(meta, backend)
-        container = model.unit.containers['c1']
-
-        with pytest.raises(TypeError):
-            container.start(['foo'])  # type: ignore
-
-        with pytest.raises(TypeError):
-            container.stop(['foo'])  # type: ignore
-
-    def test_add_layer(self):
-        self.container.add_layer('a', 'summary: str\n')
-        self.container.add_layer('b', {'summary': 'dict'})
-        self.container.add_layer('c', pebble.Layer('summary: Layer'))
-        self.container.add_layer('d', 'summary: str\n', combine=True)
-        assert self.pebble.requests == [
-            ('add_layer', 'a', 'summary: str\n', False),
-            ('add_layer', 'b', 'summary: dict\n', False),
-            ('add_layer', 'c', 'summary: Layer\n', False),
-            ('add_layer', 'd', 'summary: str\n', True),
-        ]
-
-        # combine is a keyword-only arg (should be combine=True)
-        with pytest.raises(TypeError):
-            self.container.add_layer('x', {}, True)  # type: ignore
-
-    def test_get_plan(self):
-        plan_yaml = 'services:\n foo:\n  override: replace\n  command: bar'
-        self.pebble.responses.append(pebble.Plan(plan_yaml))
-        plan = self.container.get_plan()
-        assert self.pebble.requests == [('get_plan',)]
-        assert isinstance(plan, pebble.Plan)
-        assert plan.to_yaml() == yaml.safe_dump(yaml.safe_load(plan_yaml))
-
-    @staticmethod
-    def _make_service(name: str, startup: str, current: str):
-        return pebble.ServiceInfo.from_dict(
-            {'name': name, 'startup': startup, 'current': current})
-
-    def test_get_services(self):
-        two_services = [
-            self._make_service('s1', 'enabled', 'active'),
-            self._make_service('s2', 'disabled', 'inactive'),
-        ]
-        self.pebble.responses.append(two_services)
-        services = self.container.get_services()
-        assert len(services) == 2
-        assert set(services) == {'s1', 's2'}
-        assert services['s1'].name == 's1'
-        assert services['s1'].startup == pebble.ServiceStartup.ENABLED
-        assert services['s1'].current == pebble.ServiceStatus.ACTIVE
-        assert services['s2'].name == 's2'
-        assert services['s2'].startup == pebble.ServiceStartup.DISABLED
-        assert services['s2'].current == pebble.ServiceStatus.INACTIVE
-
-        self.pebble.responses.append(two_services)
-        services = self.container.get_services('s1', 's2')
-        assert len(services) == 2
-        assert set(services) == {'s1', 's2'}
-        assert services['s1'].name == 's1'
-        assert services['s1'].startup == pebble.ServiceStartup.ENABLED
-        assert services['s1'].current == pebble.ServiceStatus.ACTIVE
-        assert services['s2'].name == 's2'
-        assert services['s2'].startup == pebble.ServiceStartup.DISABLED
-        assert services['s2'].current == pebble.ServiceStatus.INACTIVE
-
-        assert self.pebble.requests == [
-            ('get_services', None),
-            ('get_services', ('s1', 's2')),
-        ]
-
-    def test_get_service(self):
-        # Single service returned successfully
-        self.pebble.responses.append([self._make_service('s1', 'enabled', 'active')])
-        s = self.container.get_service('s1')
-        assert self.pebble.requests == [('get_services', ('s1', ))]
-        assert s.name == 's1'
-        assert s.startup == pebble.ServiceStartup.ENABLED
-        assert s.current == pebble.ServiceStatus.ACTIVE
-
-        # If Pebble returns no services, should be a ops.ModelError
-        self.pebble.responses.append([])
-        with pytest.raises(ops.ModelError) as excinfo:
-            self.container.get_service('s2')
-        assert str(excinfo.value) == "service 's2' not found"
-
-        # If Pebble returns more than one service, RuntimeError is raised
-        self.pebble.responses.append([
-            self._make_service('s1', 'enabled', 'active'),
-            self._make_service('s2', 'disabled', 'inactive'),
-        ])
-        with pytest.raises(RuntimeError):
-            self.container.get_service('s1')
-
-    def test_get_checks(self):
-        response_checks = [
-            pebble.CheckInfo.from_dict({
-                'name': 'c1',
-                'status': 'up',
-                'failures': 0,
-                'threshold': 3,
-            }),  # type: ignore
-            pebble.CheckInfo.from_dict({
-                'name': 'c2',
-                'level': 'alive',
-                'status': 'down',
-                'failures': 2,
-                'threshold': 2,
-            }),
-        ]
-
-        self.pebble.responses.append(response_checks)
-        checks = self.container.get_checks()
-        assert len(checks) == 2
-        assert checks['c1'].name == 'c1'
-        assert checks['c1'].level == pebble.CheckLevel.UNSET
-        assert checks['c1'].status == pebble.CheckStatus.UP
-        assert checks['c1'].failures == 0
-        assert checks['c1'].threshold == 3
-        assert checks['c2'].name == 'c2'
-        assert checks['c2'].level == pebble.CheckLevel.ALIVE
-        assert checks['c2'].status == pebble.CheckStatus.DOWN
-        assert checks['c2'].failures == 2
-        assert checks['c2'].threshold == 2
-
-        self.pebble.responses.append(response_checks[1:2])
-        checks = self.container.get_checks('c1', 'c2', level=pebble.CheckLevel.ALIVE)
-        assert len(checks) == 1
-        assert checks['c2'].name == 'c2'
-        assert checks['c2'].level == pebble.CheckLevel.ALIVE
-        assert checks['c2'].status == pebble.CheckStatus.DOWN
-        assert checks['c2'].failures == 2
-        assert checks['c2'].threshold == 2
-
-        assert self.pebble.requests == [
-            ('get_checks', None, None),
-            ('get_checks', pebble.CheckLevel.ALIVE, ('c1', 'c2')),
-        ]
-
-    def test_get_check(self):
-        # Single check returned successfully
-        self.pebble.responses.append([
-            pebble.CheckInfo.from_dict({
-                'name': 'c1',
-                'status': 'up',
-                'failures': 0,
-                'threshold': 3,
-            })  # type: ignore
-        ])
-        c = self.container.get_check('c1')
-        assert self.pebble.requests == [('get_checks', None, ('c1', ))]
-        assert c.name == 'c1'
-        assert c.level == pebble.CheckLevel.UNSET
-        assert c.status == pebble.CheckStatus.UP
-        assert c.failures == 0
-        assert c.threshold == 3
-
-        # If Pebble returns no checks, should be a ops.ModelError
-        self.pebble.responses.append([])
-        with pytest.raises(ops.ModelError) as excinfo:
-            self.container.get_check('c2')
-        assert str(excinfo.value) == "check 'c2' not found"
-
-        # If Pebble returns more than one check, RuntimeError is raised
-        self.pebble.responses.append([
-            pebble.CheckInfo.from_dict({
-                'name': 'c1',
-                'status': 'up',
-                'failures': 0,
-                'threshold': 3,
-            }),  # type: ignore
-            pebble.CheckInfo.from_dict({
-                'name': 'c2',
-                'level': 'alive',
-                'status': 'down',
-                'failures': 2,
-                'threshold': 2,
-            }),
-        ])
-        with pytest.raises(RuntimeError):
-            self.container.get_check('c1')
-
-    def test_pull(self):
-        self.pebble.responses.append('dummy1')
-        got = self.container.pull('/path/1')
-        assert got == 'dummy1'
-        assert self.pebble.requests == [
-            ('pull', '/path/1', 'utf-8'),
-        ]
-        self.pebble.requests = []
-
-        self.pebble.responses.append(b'dummy2')
-        got = self.container.pull('/path/2', encoding=None)
-        assert got == b'dummy2'
-        assert self.pebble.requests == [
-            ('pull', '/path/2', None),
-        ]
-
-    def test_push(self):
-        self.container.push('/path/1', 'content1')
-        assert self.pebble.requests == [
-            ('push', '/path/1', 'content1', 'utf-8', False, None,
-             None, None, None, None),
-        ]
-        self.pebble.requests = []
-
-        self.container.push('/path/2', b'content2', make_dirs=True,
-                            permissions=0o600, user_id=12, user='bob', group_id=34, group='staff')
-        assert self.pebble.requests == [
-            ('push', '/path/2', b'content2', 'utf-8', True, 0o600, 12, 'bob', 34, 'staff'),
-        ]
-
-    def test_list_files(self):
-        self.pebble.responses.append('dummy1')
-        ret = self.container.list_files('/path/1')
-        assert ret == 'dummy1'
-        assert self.pebble.requests == [
-            ('list_files', '/path/1', None, False),
-        ]
-        self.pebble.requests = []
-
-        self.pebble.responses.append('dummy2')
-        ret = self.container.list_files('/path/2', pattern='*.txt', itself=True)
-        assert ret == 'dummy2'
-        assert self.pebble.requests == [
-            ('list_files', '/path/2', '*.txt', True),
-        ]
-
-    def test_make_dir(self):
-        self.container.make_dir('/path/1')
-        assert self.pebble.requests == [
-            ('make_dir', '/path/1', False, None, None, None, None, None),
-        ]
-        self.pebble.requests = []
-
-        self.container.make_dir('/path/2', make_parents=True, permissions=0o700,
-                                user_id=12, user='bob', group_id=34, group='staff')
-        assert self.pebble.requests == [
-            ('make_dir', '/path/2', True, 0o700, 12, 'bob', 34, 'staff'),
-        ]
-
-    def test_remove_path(self):
-        self.container.remove_path('/path/1')
-        assert self.pebble.requests == [
-            ('remove_path', '/path/1', False),
-        ]
-        self.pebble.requests = []
-
-        self.container.remove_path('/path/2', recursive=True)
-        assert self.pebble.requests == [
-            ('remove_path', '/path/2', True),
-        ]
-
-    def test_can_connect_simple(self):
-        self.pebble.responses.append(pebble.SystemInfo.from_dict({'version': '1.0.0'}))
-        assert self.container.can_connect()
-
-    def test_can_connect_connection_error(self):
-        def raise_error():
-            raise pebble.ConnectionError('connection error!')
-        self.pebble.get_system_info = raise_error
-        with self.assertLogs('ops', level='DEBUG') as cm:
-            assert not self.container.can_connect()
-        assert len(cm.output) == 1
-        assert re.search(r'DEBUG:ops.model:.*: connection error!', cm.output[0])
-
-    def test_can_connect_file_not_found_error(self):
-        def raise_error():
-            raise FileNotFoundError('file not found!')
-        self.pebble.get_system_info = raise_error
-        with self.assertLogs('ops', level='DEBUG') as cm:
-            assert not self.container.can_connect()
-        assert len(cm.output) == 1
-        assert re.search(r'DEBUG:ops.model:.*: file not found!', cm.output[0])
-
-    def test_can_connect_api_error(self):
-        def raise_error():
-            raise pebble.APIError({'body': ''}, 404, 'status', 'api error!')
-        self.pebble.get_system_info = raise_error
-        with self.assertLogs('ops') as cm:
-            assert not self.container.can_connect()
-        assert len(cm.output) == 1
-        assert re.search(r'WARNING:ops.model:.*: api error!', cm.output[0])
-
-    @patch('model.JujuVersion.from_environ', new=lambda: ops.model.JujuVersion('3.1.6'))
-    def test_exec(self):
-        self.pebble.responses.append('fake_exec_process')
-        stdout = io.StringIO('STDOUT')
-        stderr = io.StringIO('STDERR')
-        p = self.container.exec(
-            ['echo', 'foo'],
-            service_context='srv1',
-            environment={'K1': 'V1', 'K2': 'V2'},
-            working_dir='WD',
-            timeout=10.5,
-            user_id=1000,
-            user='bob',
-            group_id=1000,
-            group='staff',
-            stdin='STDIN',
-            stdout=stdout,
-            stderr=stderr,
-            encoding="encoding",
-            combine_stderr=True,
-        )
-        assert self.pebble.requests == [
-            ('exec', ['echo', 'foo'], dict(
-                service_context='srv1',
-                environment={'K1': 'V1', 'K2': 'V2'},
-                working_dir='WD',
-                timeout=10.5,
-                user_id=1000,
-                user='bob',
-                group_id=1000,
-                group='staff',
-                stdin='STDIN',
-                stdout=stdout,
-                stderr=stderr,
-                encoding="encoding",
-                combine_stderr=True,
-            ))
-        ]
-        assert p == 'fake_exec_process'
-
-    @patch('model.JujuVersion.from_environ', new=lambda: ops.model.JujuVersion('3.1.5'))
-    def test_exec_service_context_not_supported(self):
-        with pytest.raises(RuntimeError):
-            self.container.exec(['foo'], service_context='srv1')
-
-    def test_send_signal(self):
-        with pytest.raises(TypeError):
-            self.container.send_signal('SIGHUP')
-
-        self.container.send_signal('SIGHUP', 's1')
-        assert self.pebble.requests == [
-            ('send_signal', 'SIGHUP', ('s1',)),
-        ]
-        self.pebble.requests = []
-
-        self.container.send_signal('SIGHUP', 's1', 's2')
-        assert self.pebble.requests == [
-            ('send_signal', 'SIGHUP', ('s1', 's2')),
-        ]
-        self.pebble.requests = []
-
-    def test_get_notice(self):
-        self.pebble.responses.append(pebble.Notice.from_dict({
-            'id': '123',
-            'user-id': 1000,
-            'type': 'custom',
-            'key': 'example.com/a',
-            'first-occurred': '2023-12-07T17:01:02.123456789Z',
-            'last-occurred': '2023-12-07T17:01:03.123456789Z',
-            'last-repeated': '2023-12-07T17:01:04.123456789Z',
-            'occurrences': 8,
-        }))
-
-        notice = self.container.get_notice('123')
-        assert notice.id == '123'
-        assert notice.type == pebble.NoticeType.CUSTOM
-        assert notice.key == 'example.com/a'
-
-        assert self.pebble.requests == [
-            ('get_notice', '123'),
-        ]
-
-    def test_get_notice_not_found(self):
-        def raise_error(id: str):
-            raise pebble.APIError({'body': ''}, 404, 'status', 'api error!')
-        self.pebble.get_notice = raise_error
-        with pytest.raises(ops.ModelError):
-            self.container.get_notice('123')
-
-    def test_get_notices(self):
-        self.pebble.responses.append([
-            pebble.Notice.from_dict({
-                'id': '124',
-                'user-id': 1000,
-                'type': 'custom',
-                'key': 'example.com/b',
-                'first-occurred': '2023-12-07T17:01:02.123456789Z',
-                'last-occurred': '2023-12-07T17:01:03.123456789Z',
-                'last-repeated': '2023-12-07T17:01:04.123456789Z',
-                'occurrences': 8,
-            }),
-        ])
-
-        notices = self.container.get_notices(
-            user_id=1000,
-            users=pebble.NoticesUsers.ALL,
-            types=[pebble.NoticeType.CUSTOM],
-            keys=['example.com/a', 'example.com/b'],
-        )
-        assert len(notices) == 1
-        assert notices[0].id == '124'
-        assert notices[0].type == pebble.NoticeType.CUSTOM
-        assert notices[0].key == 'example.com/b'
-
-        assert self.pebble.requests == [('get_notices', dict(
-            user_id=1000,
-            users=pebble.NoticesUsers.ALL,
-            types=[pebble.NoticeType.CUSTOM],
-            keys=['example.com/a', 'example.com/b'],
-        ))]
 
 
 class MockPebbleBackend(_ModelBackend):
@@ -2109,9 +1667,546 @@ class MockPebbleClient:
         return self.responses.pop(0)
 
 
-class TestModelBindings(unittest.TestCase):
+class TestContainerPebble:
+    @pytest.fixture
+    def model(self):
+        meta = ops.CharmMeta.from_yaml("""
+name: k8s-charm
+containers:
+  c1:
+    k: v
+""")
+        backend = MockPebbleBackend('myapp/0')
+        return ops.Model(meta, backend)
 
-    def setUp(self):
+    @pytest.fixture
+    def container(self, model: ops.Model):
+        return model.unit.containers['c1']
+
+    @pytest.fixture
+    def container_pebble(self, container: ops.Container):
+        return container.pebble
+
+    def test_socket_path(self, container_pebble: MockPebbleClient):
+        assert container_pebble.socket_path == '/charm/containers/c1/pebble.socket'
+
+    def test_autostart(self, container: ops.Container, container_pebble: MockPebbleClient):
+        container.autostart()
+        assert container_pebble.requests == [('autostart',)]
+
+    def test_replan(self, container: ops.Container, container_pebble: MockPebbleClient):
+        container.replan()
+        assert container_pebble.requests == [('replan',)]
+
+    def test_can_connect(self, container: ops.Container, container_pebble: MockPebbleClient):
+        container_pebble.responses.append(pebble.SystemInfo.from_dict({'version': '1.0.0'}))
+        assert container.can_connect()
+        assert container_pebble.requests == [('get_system_info',)]
+
+    def test_start(self, container: ops.Container, container_pebble: MockPebbleClient):
+        container.start('foo')
+        container.start('foo', 'bar')
+        assert container_pebble.requests == [
+            ('start', ('foo',)),
+            ('start', ('foo', 'bar')),
+        ]
+
+    def test_start_no_arguments(self, container: ops.Container):
+        with pytest.raises(TypeError):
+            container.start()
+
+    def test_stop(self, container: ops.Container, container_pebble: MockPebbleClient):
+        container.stop('foo')
+        container.stop('foo', 'bar')
+        assert container_pebble.requests == [
+            ('stop', ('foo',)),
+            ('stop', ('foo', 'bar')),
+        ]
+
+    def test_stop_no_arguments(self, container: ops.Container):
+        with pytest.raises(TypeError):
+            container.stop()
+
+    def test_restart(self, container: ops.Container, container_pebble: MockPebbleClient):
+        container.restart('foo')
+        container.restart('foo', 'bar')
+        assert container_pebble.requests == [
+            ('restart', ('foo',)),
+            ('restart', ('foo', 'bar')),
+        ]
+
+    def test_restart_fallback(self, container: ops.Container, container_pebble: MockPebbleClient):
+        def restart_services(service_names: str):
+            container_pebble.requests.append(('restart', service_names))
+            raise pebble.APIError({}, 400, "", "")
+
+        container_pebble.restart_services = restart_services
+        # Setup the Pebble client to respond to a call to get_services()
+        container_pebble.responses.append([
+            pebble.ServiceInfo.from_dict(
+                {'name': 'foo', 'startup': 'enabled', 'current': 'active'}),
+            pebble.ServiceInfo.from_dict(
+                {'name': 'bar', 'startup': 'enabled', 'current': 'inactive'}),
+        ])
+
+        container.restart('foo', 'bar')
+        assert container_pebble.requests == [
+            # This is the first request, which in real life fails with APIError on older versions
+            ('restart', ('foo', 'bar')),
+            # Next the code should loop over the started services, and stop them
+            ('get_services', ('foo', 'bar')),
+            ('stop', ('foo',)),
+            # Then start all the specified services
+            ('start', ('foo', 'bar'))
+        ]
+
+    def test_restart_fallback_non_400_error(
+            self,
+            container: ops.Container,
+            container_pebble: MockPebbleClient):
+        def restart_services(service_names: str):
+            raise pebble.APIError({}, 500, "", "")
+
+        container_pebble.restart_services = restart_services
+        with pytest.raises(pebble.APIError) as excinfo:
+            container.restart('foo')
+        assert excinfo.value.code == 500
+
+    def test_restart_no_arguments(self, container: ops.Container):
+        with pytest.raises(TypeError):
+            container.restart()
+
+    def test_type_errors(self, container: ops.Container):
+        meta = ops.CharmMeta.from_yaml("""
+name: k8s-charm
+containers:
+  c1:
+    k: v
+""")
+        # Only the real pebble Client checks types, so use actual backend class
+        backend = _ModelBackend('myapp/0')
+        model = ops.Model(meta, backend)
+        container = model.unit.containers['c1']
+
+        with pytest.raises(TypeError):
+            container.start(['foo'])  # type: ignore
+
+        with pytest.raises(TypeError):
+            container.stop(['foo'])  # type: ignore
+
+    def test_add_layer(self, container: ops.Container, container_pebble: MockPebbleClient):
+        container.add_layer('a', 'summary: str\n')
+        container.add_layer('b', {'summary': 'dict'})
+        container.add_layer('c', pebble.Layer('summary: Layer'))
+        container.add_layer('d', 'summary: str\n', combine=True)
+        assert container_pebble.requests == [
+            ('add_layer', 'a', 'summary: str\n', False),
+            ('add_layer', 'b', 'summary: dict\n', False),
+            ('add_layer', 'c', 'summary: Layer\n', False),
+            ('add_layer', 'd', 'summary: str\n', True),
+        ]
+
+        # combine is a keyword-only arg (should be combine=True)
+        with pytest.raises(TypeError):
+            container.add_layer('x', {}, True)  # type: ignore
+
+    def test_get_plan(self, container: ops.Container, container_pebble: MockPebbleClient):
+        plan_yaml = 'services:\n foo:\n  override: replace\n  command: bar'
+        container_pebble.responses.append(pebble.Plan(plan_yaml))
+        plan = container.get_plan()
+        assert container_pebble.requests == [('get_plan',)]
+        assert isinstance(plan, pebble.Plan)
+        assert plan.to_yaml() == yaml.safe_dump(yaml.safe_load(plan_yaml))
+
+    @staticmethod
+    def _make_service(name: str, startup: str, current: str):
+        return pebble.ServiceInfo.from_dict(
+            {'name': name, 'startup': startup, 'current': current})
+
+    def test_get_services(self, container: ops.Container, container_pebble: MockPebbleClient):
+        two_services = [
+            self._make_service('s1', 'enabled', 'active'),
+            self._make_service('s2', 'disabled', 'inactive'),
+        ]
+        container_pebble.responses.append(two_services)
+        services = container.get_services()
+        assert len(services) == 2
+        assert set(services) == {'s1', 's2'}
+        assert services['s1'].name == 's1'
+        assert services['s1'].startup == pebble.ServiceStartup.ENABLED
+        assert services['s1'].current == pebble.ServiceStatus.ACTIVE
+        assert services['s2'].name == 's2'
+        assert services['s2'].startup == pebble.ServiceStartup.DISABLED
+        assert services['s2'].current == pebble.ServiceStatus.INACTIVE
+
+        container_pebble.responses.append(two_services)
+        services = container.get_services('s1', 's2')
+        assert len(services) == 2
+        assert set(services) == {'s1', 's2'}
+        assert services['s1'].name == 's1'
+        assert services['s1'].startup == pebble.ServiceStartup.ENABLED
+        assert services['s1'].current == pebble.ServiceStatus.ACTIVE
+        assert services['s2'].name == 's2'
+        assert services['s2'].startup == pebble.ServiceStartup.DISABLED
+        assert services['s2'].current == pebble.ServiceStatus.INACTIVE
+
+        assert container_pebble.requests == [
+            ('get_services', None),
+            ('get_services', ('s1', 's2')),
+        ]
+
+    def test_get_service(self, container: ops.Container, container_pebble: MockPebbleClient):
+        # Single service returned successfully
+        container_pebble.responses.append([self._make_service('s1', 'enabled', 'active')])
+        s = container.get_service('s1')
+        assert container_pebble.requests == [('get_services', ('s1', ))]
+        assert s.name == 's1'
+        assert s.startup == pebble.ServiceStartup.ENABLED
+        assert s.current == pebble.ServiceStatus.ACTIVE
+
+        # If Pebble returns no services, should be a ops.ModelError
+        container_pebble.responses.append([])
+        with pytest.raises(ops.ModelError) as excinfo:
+            container.get_service('s2')
+        assert str(excinfo.value) == "service 's2' not found"
+
+        # If Pebble returns more than one service, RuntimeError is raised
+        container_pebble.responses.append([
+            self._make_service('s1', 'enabled', 'active'),
+            self._make_service('s2', 'disabled', 'inactive'),
+        ])
+        with pytest.raises(RuntimeError):
+            container.get_service('s1')
+
+    def test_get_checks(self, container: ops.Container, container_pebble: MockPebbleClient):
+        response_checks = [
+            pebble.CheckInfo.from_dict({
+                'name': 'c1',
+                'status': 'up',
+                'failures': 0,
+                'threshold': 3,
+            }),  # type: ignore
+            pebble.CheckInfo.from_dict({
+                'name': 'c2',
+                'level': 'alive',
+                'status': 'down',
+                'failures': 2,
+                'threshold': 2,
+            }),
+        ]
+
+        container_pebble.responses.append(response_checks)
+        checks = container.get_checks()
+        assert len(checks) == 2
+        assert checks['c1'].name == 'c1'
+        assert checks['c1'].level == pebble.CheckLevel.UNSET
+        assert checks['c1'].status == pebble.CheckStatus.UP
+        assert checks['c1'].failures == 0
+        assert checks['c1'].threshold == 3
+        assert checks['c2'].name == 'c2'
+        assert checks['c2'].level == pebble.CheckLevel.ALIVE
+        assert checks['c2'].status == pebble.CheckStatus.DOWN
+        assert checks['c2'].failures == 2
+        assert checks['c2'].threshold == 2
+
+        container_pebble.responses.append(response_checks[1:2])
+        checks = container.get_checks('c1', 'c2', level=pebble.CheckLevel.ALIVE)
+        assert len(checks) == 1
+        assert checks['c2'].name == 'c2'
+        assert checks['c2'].level == pebble.CheckLevel.ALIVE
+        assert checks['c2'].status == pebble.CheckStatus.DOWN
+        assert checks['c2'].failures == 2
+        assert checks['c2'].threshold == 2
+
+        assert container_pebble.requests == [
+            ('get_checks', None, None),
+            ('get_checks', pebble.CheckLevel.ALIVE, ('c1', 'c2')),
+        ]
+
+    def test_get_check(self, container: ops.Container, container_pebble: MockPebbleClient):
+        # Single check returned successfully
+        container_pebble.responses.append([
+            pebble.CheckInfo.from_dict({
+                'name': 'c1',
+                'status': 'up',
+                'failures': 0,
+                'threshold': 3,
+            })  # type: ignore
+        ])
+        c = container.get_check('c1')
+        assert container_pebble.requests == [('get_checks', None, ('c1', ))]
+        assert c.name == 'c1'
+        assert c.level == pebble.CheckLevel.UNSET
+        assert c.status == pebble.CheckStatus.UP
+        assert c.failures == 0
+        assert c.threshold == 3
+
+        # If Pebble returns no checks, should be a ops.ModelError
+        container_pebble.responses.append([])
+        with pytest.raises(ops.ModelError) as excinfo:
+            container.get_check('c2')
+        assert str(excinfo.value) == "check 'c2' not found"
+
+        # If Pebble returns more than one check, RuntimeError is raised
+        container_pebble.responses.append([
+            pebble.CheckInfo.from_dict({
+                'name': 'c1',
+                'status': 'up',
+                'failures': 0,
+                'threshold': 3,
+            }),  # type: ignore
+            pebble.CheckInfo.from_dict({
+                'name': 'c2',
+                'level': 'alive',
+                'status': 'down',
+                'failures': 2,
+                'threshold': 2,
+            }),
+        ])
+        with pytest.raises(RuntimeError):
+            container.get_check('c1')
+
+    def test_pull(self, container: ops.Container, container_pebble: MockPebbleClient):
+        container_pebble.responses.append('dummy1')
+        got = container.pull('/path/1')
+        assert got == 'dummy1'
+        assert container_pebble.requests == [
+            ('pull', '/path/1', 'utf-8'),
+        ]
+        container_pebble.requests = []
+
+        container_pebble.responses.append(b'dummy2')
+        got = container.pull('/path/2', encoding=None)
+        assert got == b'dummy2'
+        assert container_pebble.requests == [
+            ('pull', '/path/2', None),
+        ]
+
+    def test_push(self, container: ops.Container, container_pebble: MockPebbleClient):
+        container.push('/path/1', 'content1')
+        assert container_pebble.requests == [
+            ('push', '/path/1', 'content1', 'utf-8', False, None,
+             None, None, None, None),
+        ]
+        container_pebble.requests = []
+
+        container.push('/path/2', b'content2', make_dirs=True,
+                       permissions=0o600, user_id=12, user='bob', group_id=34, group='staff')
+        assert container_pebble.requests == [
+            ('push', '/path/2', b'content2', 'utf-8', True, 0o600, 12, 'bob', 34, 'staff'),
+        ]
+
+    def test_list_files(self, container: ops.Container, container_pebble: MockPebbleClient):
+        container_pebble.responses.append('dummy1')
+        ret = container.list_files('/path/1')
+        assert ret == 'dummy1'
+        assert container_pebble.requests == [
+            ('list_files', '/path/1', None, False),
+        ]
+        container_pebble.requests = []
+
+        container_pebble.responses.append('dummy2')
+        ret = container.list_files('/path/2', pattern='*.txt', itself=True)
+        assert ret == 'dummy2'
+        assert container_pebble.requests == [
+            ('list_files', '/path/2', '*.txt', True),
+        ]
+
+    def test_make_dir(self, container: ops.Container, container_pebble: MockPebbleClient):
+        container.make_dir('/path/1')
+        assert container_pebble.requests == [
+            ('make_dir', '/path/1', False, None, None, None, None, None),
+        ]
+        container_pebble.requests = []
+
+        container.make_dir('/path/2', make_parents=True, permissions=0o700,
+                           user_id=12, user='bob', group_id=34, group='staff')
+        assert container_pebble.requests == [
+            ('make_dir', '/path/2', True, 0o700, 12, 'bob', 34, 'staff'),
+        ]
+
+    def test_remove_path(self, container: ops.Container, container_pebble: MockPebbleClient):
+        container.remove_path('/path/1')
+        assert container_pebble.requests == [
+            ('remove_path', '/path/1', False),
+        ]
+        container_pebble.requests = []
+
+        container.remove_path('/path/2', recursive=True)
+        assert container_pebble.requests == [
+            ('remove_path', '/path/2', True),
+        ]
+
+    def test_can_connect_simple(self, container: ops.Container,
+                                container_pebble: MockPebbleClient):
+        container_pebble.responses.append(pebble.SystemInfo.from_dict({'version': '1.0.0'}))
+        assert container.can_connect()
+
+    def test_can_connect_connection_error(
+            self,
+            caplog: pytest.LogCaptureFixture,
+            container: ops.Container,
+            container_pebble: MockPebbleClient):
+        def raise_error():
+            raise pebble.ConnectionError('connection error!')
+        container_pebble.get_system_info = raise_error
+        with caplog.at_level(level='DEBUG', logger='ops'):
+            assert not container.can_connect()
+        assert len(caplog.records) == 1
+        assert re.search(r'connection error!', caplog.text)
+
+    def test_can_connect_file_not_found_error(
+            self,
+            caplog: pytest.LogCaptureFixture,
+            container: ops.Container,
+            container_pebble: MockPebbleClient):
+        def raise_error():
+            raise FileNotFoundError('file not found!')
+        container_pebble.get_system_info = raise_error
+        with caplog.at_level(level='DEBUG', logger='ops'):
+            assert not container.can_connect()
+        assert len(caplog.records) == 1
+        assert re.search(r'file not found!', caplog.text)
+
+    def test_can_connect_api_error(
+            self,
+            caplog: pytest.LogCaptureFixture,
+            container: ops.Container,
+            container_pebble: MockPebbleClient):
+        def raise_error():
+            raise pebble.APIError({'body': ''}, 404, 'status', 'api error!')
+        container_pebble.get_system_info = raise_error
+        with caplog.at_level(level='WARNING', logger='ops'):
+            assert not container.can_connect()
+        assert len(caplog.records) == 1
+        assert re.search(r'api error!', caplog.text)
+
+    @patch('model.JujuVersion.from_environ', new=lambda: ops.model.JujuVersion('3.1.6'))
+    def test_exec(self, container: ops.Container, container_pebble: MockPebbleClient):
+        container_pebble.responses.append('fake_exec_process')
+        stdout = io.StringIO('STDOUT')
+        stderr = io.StringIO('STDERR')
+        p = container.exec(
+            ['echo', 'foo'],
+            service_context='srv1',
+            environment={'K1': 'V1', 'K2': 'V2'},
+            working_dir='WD',
+            timeout=10.5,
+            user_id=1000,
+            user='bob',
+            group_id=1000,
+            group='staff',
+            stdin='STDIN',
+            stdout=stdout,
+            stderr=stderr,
+            encoding="encoding",
+            combine_stderr=True,
+        )
+        assert container_pebble.requests == [
+            ('exec', ['echo', 'foo'], dict(
+                service_context='srv1',
+                environment={'K1': 'V1', 'K2': 'V2'},
+                working_dir='WD',
+                timeout=10.5,
+                user_id=1000,
+                user='bob',
+                group_id=1000,
+                group='staff',
+                stdin='STDIN',
+                stdout=stdout,
+                stderr=stderr,
+                encoding="encoding",
+                combine_stderr=True,
+            ))
+        ]
+        assert p == 'fake_exec_process'
+
+    @patch('model.JujuVersion.from_environ', new=lambda: ops.model.JujuVersion('3.1.5'))
+    def test_exec_service_context_not_supported(self, container: ops.Container):
+        with pytest.raises(RuntimeError):
+            container.exec(['foo'], service_context='srv1')
+
+    def test_send_signal(self, container: ops.Container, container_pebble: MockPebbleClient):
+        with pytest.raises(TypeError):
+            container.send_signal('SIGHUP')
+
+        container.send_signal('SIGHUP', 's1')
+        assert container_pebble.requests == [
+            ('send_signal', 'SIGHUP', ('s1',)),
+        ]
+        container_pebble.requests = []
+
+        container.send_signal('SIGHUP', 's1', 's2')
+        assert container_pebble.requests == [
+            ('send_signal', 'SIGHUP', ('s1', 's2')),
+        ]
+        container_pebble.requests = []
+
+    def test_get_notice(self, container: ops.Container, container_pebble: MockPebbleClient):
+        container_pebble.responses.append(pebble.Notice.from_dict({
+            'id': '123',
+            'user-id': 1000,
+            'type': 'custom',
+            'key': 'example.com/a',
+            'first-occurred': '2023-12-07T17:01:02.123456789Z',
+            'last-occurred': '2023-12-07T17:01:03.123456789Z',
+            'last-repeated': '2023-12-07T17:01:04.123456789Z',
+            'occurrences': 8,
+        }))
+
+        notice = container.get_notice('123')
+        assert notice.id == '123'
+        assert notice.type == pebble.NoticeType.CUSTOM
+        assert notice.key == 'example.com/a'
+
+        assert container_pebble.requests == [
+            ('get_notice', '123'),
+        ]
+
+    def test_get_notice_not_found(self, container: ops.Container,
+                                  container_pebble: MockPebbleClient):
+        def raise_error(id: str):
+            raise pebble.APIError({'body': ''}, 404, 'status', 'api error!')
+        container_pebble.get_notice = raise_error
+        with pytest.raises(ops.ModelError):
+            container.get_notice('123')
+
+    def test_get_notices(self, container: ops.Container, container_pebble: MockPebbleClient):
+        container_pebble.responses.append([
+            pebble.Notice.from_dict({
+                'id': '124',
+                'user-id': 1000,
+                'type': 'custom',
+                'key': 'example.com/b',
+                'first-occurred': '2023-12-07T17:01:02.123456789Z',
+                'last-occurred': '2023-12-07T17:01:03.123456789Z',
+                'last-repeated': '2023-12-07T17:01:04.123456789Z',
+                'occurrences': 8,
+            }),
+        ])
+
+        notices = container.get_notices(
+            user_id=1000,
+            users=pebble.NoticesUsers.ALL,
+            types=[pebble.NoticeType.CUSTOM],
+            keys=['example.com/a', 'example.com/b'],
+        )
+        assert len(notices) == 1
+        assert notices[0].id == '124'
+        assert notices[0].type == pebble.NoticeType.CUSTOM
+        assert notices[0].key == 'example.com/b'
+
+        assert container_pebble.requests == [('get_notices', dict(
+            user_id=1000,
+            users=pebble.NoticesUsers.ALL,
+            types=[pebble.NoticeType.CUSTOM],
+            keys=['example.com/a', 'example.com/b'],
+        ))]
+
+
+class TestModelBindings:
+    @pytest.fixture
+    def model(self, fake_script: FakeScript):
         meta = ops.CharmMeta()
         meta.relations = {
             'db0': ops.RelationMeta(
@@ -2121,12 +2216,12 @@ class TestModelBindings(unittest.TestCase):
             'db2': ops.RelationMeta(
                 ops.RelationRole.peer, 'db2', {'interface': 'db2', 'scope': 'global'}),
         }
-        self.backend = _ModelBackend('myapp/0')
-        self.model = ops.Model(meta, self.backend)
+        backend = _ModelBackend('myapp/0')
+        model = ops.Model(meta, backend)
 
-        fake_script(self, 'relation-ids',
-                    """([ "$1" = db0 ] && echo '["db0:4"]') || echo '[]'""")
-        fake_script(self, 'relation-list', """[ "$2" = 4 ] && echo '["remoteapp1/0"]' || exit 2""")
+        fake_script.write('relation-ids',
+                          """([ "$1" = db0 ] && echo '["db0:4"]') || echo '[]'""")
+        fake_script.write('relation-list', """[ "$2" = 4 ] && echo '["remoteapp1/0"]' || exit 2""")
         self.network_get_out = '''{
   "bind-addresses": [
     {
@@ -2180,16 +2275,18 @@ class TestModelBindings(unittest.TestCase):
     "2001:db8::3"
   ]
 }'''
+        return model
 
-    def ensure_relation(self, name: str = 'db1', relation_id: typing.Optional[int] = None):
+    def ensure_relation(self, model: ops.Model, name: str = 'db1',
+                        relation_id: typing.Optional[int] = None):
         """Wrapper around self.model.get_relation that enforces that None is not returned."""
-        rel_db1 = self.model.get_relation(name, relation_id)
+        rel_db1 = model.get_relation(name, relation_id)
         assert rel_db1 is not None, rel_db1  # Type checkers don't understand `assertIsNotNone`
         return rel_db1
 
-    def ensure_binding(self, binding_key: typing.Union[str, ops.Relation]):
+    def ensure_binding(self, model: ops.Model, binding_key: typing.Union[str, ops.Relation]):
         """Wrapper around self.model.get_binding that enforces that None is not returned."""
-        binding = self.model.get_binding(binding_key)
+        binding = model.get_binding(binding_key)
         assert binding is not None
         assert binding is not None  # Type checkers understand this, but not the previous line.
         return binding
@@ -2224,15 +2321,14 @@ class TestModelBindings(unittest.TestCase):
             assert binding.network.interfaces[i].address == ipaddress.ip_address(address)
             assert binding.network.interfaces[i].subnet == ipaddress.ip_network(subnet)
 
-    def test_invalid_keys(self):
+    def test_invalid_keys(self, model: ops.Model):
         # Basic validation for passing invalid keys.
         for name in (object, 0):
             with pytest.raises(ops.ModelError):
-                self.model.get_binding(name)  # type: ignore
+                model.get_binding(name)  # type: ignore
 
-    def test_dead_relations(self):
-        fake_script(
-            self,
+    def test_dead_relations(self, fake_script: FakeScript, model: ops.Model):
+        fake_script.write(
             'network-get',
             f'''
                 if [ "$1" = db0 ] && [ "$2" = --format=json ]; then
@@ -2243,14 +2339,14 @@ class TestModelBindings(unittest.TestCase):
                 fi
             ''')
         # Validate the behavior for dead relations.
-        binding = ops.Binding('db0', 42, self.model._backend)
+        binding = ops.Binding('db0', 42, model._backend)
         assert binding.network.bind_address == ipaddress.ip_address('192.0.2.2')
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['network-get', 'db0', '-r', '42', '--format=json'],
             ['network-get', 'db0', '--format=json'],
         ]
 
-    def test_broken_relations(self):
+    def test_broken_relations(self, fake_script: FakeScript):
         meta = ops.CharmMeta()
         meta.relations = {
             'db0': ops.RelationMeta(
@@ -2262,8 +2358,8 @@ class TestModelBindings(unittest.TestCase):
         }
         backend = _ModelBackend('myapp/0')
         model = ops.Model(meta, backend, broken_relation_id=8)
-        fake_script(self, 'relation-ids',
-                    """if [ "$1" = "db0" ]; then
+        fake_script.write('relation-ids',
+                          """if [ "$1" = "db0" ]; then
                          echo '["db0:4"]'
                        elif [ "$1" = "db1" ]; then
                          echo '["db1:8"]'
@@ -2273,24 +2369,24 @@ class TestModelBindings(unittest.TestCase):
                          echo '[]'
                        fi
                     """)
-        fake_script(self, 'relation-list', """echo '""'""")
+        fake_script.write('relation-list', """echo '""'""")
         assert model.relations['db0']
         assert not model.relations['db1']
         assert model.relations['db2']
 
-    def test_binding_by_relation_name(self):
-        fake_script(self, 'network-get',
-                    f'''[ "$1" = db0 ] && echo '{self.network_get_out}' || exit 1''')
+    def test_binding_by_relation_name(self, fake_script: FakeScript, model: ops.Model):
+        fake_script.write('network-get',
+                          f'''[ "$1" = db0 ] && echo '{self.network_get_out}' || exit 1''')
         binding_name = 'db0'
         expected_calls = [['network-get', 'db0', '--format=json']]
 
-        binding = self.ensure_binding(binding_name)
+        binding = self.ensure_binding(model, binding_name)
         self._check_binding_data(binding_name, binding)
-        assert fake_script_calls(self, clear=True) == expected_calls
+        assert fake_script.calls(clear=True) == expected_calls
 
-    def test_binding_by_relation(self):
-        fake_script(self, 'network-get',
-                    f'''[ "$1" = db0 ] && echo '{self.network_get_out}' || exit 1''')
+    def test_binding_by_relation(self, fake_script: FakeScript, model: ops.Model):
+        fake_script.write('network-get',
+                          f'''[ "$1" = db0 ] && echo '{self.network_get_out}' || exit 1''')
         binding_name = 'db0'
         expected_calls = [
             ['relation-ids', 'db0', '--format=json'],
@@ -2298,11 +2394,11 @@ class TestModelBindings(unittest.TestCase):
             ['relation-list', '-r', '4', '--format=json'],
             ['network-get', 'db0', '-r', '4', '--format=json'],
         ]
-        binding = self.ensure_binding(self.ensure_relation(binding_name))
+        binding = self.ensure_binding(model, self.ensure_relation(model, binding_name))
         self._check_binding_data(binding_name, binding)
-        assert fake_script_calls(self, clear=True) == expected_calls
+        assert fake_script.calls(clear=True) == expected_calls
 
-    def test_binding_no_iface_name(self):
+    def test_binding_no_iface_name(self, fake_script: FakeScript, model: ops.Model):
         network_get_out_obj = {
             'bind-addresses': [
                 {
@@ -2325,80 +2421,80 @@ class TestModelBindings(unittest.TestCase):
             ]
         }
         network_get_out = json.dumps(network_get_out_obj)
-        fake_script(self, 'network-get',
-                    f'''[ "$1" = db0 ] && echo '{network_get_out}' || exit 1''')
+        fake_script.write('network-get',
+                          f'''[ "$1" = db0 ] && echo '{network_get_out}' || exit 1''')
         binding_name = 'db0'
         expected_calls = [['network-get', 'db0', '--format=json']]
 
-        binding = self.ensure_binding(binding_name)
+        binding = self.ensure_binding(model, binding_name)
         assert binding.name == 'db0'
         assert binding.network.bind_address == ipaddress.ip_address('10.1.89.35')
         assert binding.network.ingress_address == ipaddress.ip_address('10.152.183.158')
-        assert fake_script_calls(self, clear=True) == expected_calls
+        assert fake_script.calls(clear=True) == expected_calls
 
-    def test_missing_bind_addresses(self):
+    def test_missing_bind_addresses(self, fake_script: FakeScript, model: ops.Model):
         network_data = json.dumps({})
-        fake_script(self, 'network-get',
-                    f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
+        fake_script.write('network-get',
+                          f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
         binding_name = 'db0'
-        binding = self.ensure_binding(self.ensure_relation(binding_name))
+        binding = self.ensure_binding(model, self.ensure_relation(model, binding_name))
         assert binding.network.interfaces == []
 
-    def test_empty_bind_addresses(self):
+    def test_empty_bind_addresses(self, fake_script: FakeScript, model: ops.Model):
         network_data = json.dumps({'bind-addresses': [{}]})
-        fake_script(self, 'network-get',
-                    f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
+        fake_script.write('network-get',
+                          f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
         binding_name = 'db0'
-        binding = self.ensure_binding(self.ensure_relation(binding_name))
+        binding = self.ensure_binding(model, self.ensure_relation(model, binding_name))
         assert binding.network.interfaces == []
 
-    def test_no_bind_addresses(self):
+    def test_no_bind_addresses(self, fake_script: FakeScript, model: ops.Model):
         network_data = json.dumps({'bind-addresses': [{'addresses': None}]})
-        fake_script(self, 'network-get',
-                    f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
+        fake_script.write('network-get',
+                          f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
         binding_name = 'db0'
-        binding = self.ensure_binding(self.ensure_relation(binding_name))
+        binding = self.ensure_binding(model, self.ensure_relation(model, binding_name))
         assert binding.network.interfaces == []
 
-    def test_empty_interface_info(self):
+    def test_empty_interface_info(self, fake_script: FakeScript, model: ops.Model):
         network_data = json.dumps({
             'bind-addresses': [{
                 'interface-name': 'eth0',
                 'addresses': [{}],
             }],
         })
-        fake_script(self, 'network-get',
-                    f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
+        fake_script.write('network-get',
+                          f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
         binding_name = 'db0'
-        binding = self.ensure_binding(self.ensure_relation(binding_name))
+        binding = self.ensure_binding(model, self.ensure_relation(model, binding_name))
         assert len(binding.network.interfaces) == 1
         interface = binding.network.interfaces[0]
         assert interface.address is None
         assert interface.subnet is None
 
-    def test_missing_ingress_addresses(self):
+    def test_missing_ingress_addresses(self, fake_script: FakeScript, model: ops.Model):
         network_data = json.dumps({
             'bind-addresses': [],
         })
-        fake_script(self, 'network-get',
-                    f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
+        fake_script.write('network-get',
+                          f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
         binding_name = 'db0'
-        binding = self.ensure_binding(self.ensure_relation(binding_name))
+        binding = self.ensure_binding(model, self.ensure_relation(model, binding_name))
         assert binding.network.ingress_addresses == []
         assert binding.network.ingress_address is None
 
-    def test_missing_egress_subnets(self):
+    def test_missing_egress_subnets(self, fake_script: FakeScript, model: ops.Model):
         network_data = json.dumps({
             'bind-addresses': [],
             'ingress-addresses': [],
         })
-        fake_script(self, 'network-get',
-                    f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
+        fake_script.write('network-get',
+                          f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
         binding_name = 'db0'
-        binding = self.ensure_binding(self.ensure_relation(binding_name))
+        binding = self.ensure_binding(model, self.ensure_relation(model, binding_name))
         assert binding.network.egress_subnets == []
 
-    def test_unresolved_ingress_addresses(self):
+    def test_unresolved_ingress_addresses(self, fake_script: FakeScript, model: ops.Model):
         # sometimes juju fails to resolve an url to an IP, in which case
         # ingress-addresses will be the 'raw' url instead of an IP.
         network_data = json.dumps({
@@ -2406,10 +2502,10 @@ class TestModelBindings(unittest.TestCase):
                 'foo.bar.baz.com'
             ],
         })
-        fake_script(self, 'network-get',
-                    f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
+        fake_script.write('network-get',
+                          f'''[ "$1" = db0 ] && echo '{network_data}' || exit 1''')
         binding_name = 'db0'
-        binding = self.ensure_binding(self.ensure_relation(binding_name))
+        binding = self.ensure_binding(model, self.ensure_relation(model, binding_name))
         assert binding.network.ingress_addresses == ['foo.bar.baz.com']
 
 
@@ -2423,14 +2519,11 @@ _ValidMetricsTestCase = typing.Tuple[
 ]
 
 
-class TestModelBackend(unittest.TestCase):
-
-    def setUp(self):
-        self._backend = None
-
+class TestModelBackend:
     @property
     def backend(self):
-        if self._backend is None:
+        backend_instance = getattr(self, '_backend', None)
+        if backend_instance is None:
             self._backend = _ModelBackend('myapp/0')
         return self._backend
 
@@ -2450,16 +2543,16 @@ class TestModelBackend(unittest.TestCase):
             with pytest.raises(TypeError):
                 self.backend.relation_get(1, 'fooentity', is_app=is_app_v)  # type: ignore
 
-    def test_is_leader_refresh(self):
+    def test_is_leader_refresh(self, fake_script: FakeScript):
         meta = ops.CharmMeta.from_yaml('''
             name: myapp
         ''')
         model = ops.Model(meta, self.backend)
-        fake_script(self, 'is-leader', 'echo false')
+        fake_script.write('is-leader', 'echo false')
         assert not model.unit.is_leader()
 
         # Change the leadership status
-        fake_script(self, 'is-leader', 'echo true')
+        fake_script.write('is-leader', 'echo true')
         # If you don't force it, we don't check, so we won't see the change
         assert not model.unit.is_leader()
         # If we force a recheck, then we notice
@@ -2467,32 +2560,31 @@ class TestModelBackend(unittest.TestCase):
         assert model.unit.is_leader()
 
         # Force a recheck without changing the leadership status.
-        fake_script(self, 'is-leader', 'echo true')
+        fake_script.write('is-leader', 'echo true')
         self.backend._leader_check_time = None
         assert model.unit.is_leader()
 
-    def test_relation_tool_errors(self):
-        self.addCleanup(os.environ.pop, 'JUJU_VERSION', None)
-        os.environ['JUJU_VERSION'] = '2.8.0'
+    def test_relation_tool_errors(self, fake_script: FakeScript, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv('JUJU_VERSION', '2.8.0')
         err_msg = 'ERROR invalid value "$2" for option -r: relation not found'
 
         test_cases = [(
-            lambda: fake_script(self, 'relation-list', 'echo fooerror >&2 ; exit 1'),
+            lambda: fake_script.write('relation-list', 'echo fooerror >&2 ; exit 1'),
             lambda: self.backend.relation_list(3),
             ops.ModelError,
             [['relation-list', '-r', '3', '--format=json']],
         ), (
-            lambda: fake_script(self, 'relation-list', f'echo {err_msg} >&2 ; exit 2'),
+            lambda: fake_script.write('relation-list', f'echo {err_msg} >&2 ; exit 2'),
             lambda: self.backend.relation_list(3),
             ops.RelationNotFoundError,
             [['relation-list', '-r', '3', '--format=json']],
         ), (
-            lambda: fake_script(self, 'relation-set', 'echo fooerror >&2 ; exit 1'),
+            lambda: fake_script.write('relation-set', 'echo fooerror >&2 ; exit 1'),
             lambda: self.backend.relation_set(3, 'foo', 'bar', is_app=False),
             ops.ModelError,
             [['relation-set', '-r', '3', '--file', '-']],
         ), (
-            lambda: fake_script(self, 'relation-set', f'echo {err_msg} >&2 ; exit 2'),
+            lambda: fake_script.write('relation-set', f'echo {err_msg} >&2 ; exit 2'),
             lambda: self.backend.relation_set(3, 'foo', 'bar', is_app=False),
             ops.RelationNotFoundError,
             [['relation-set', '-r', '3', '--file', '-']],
@@ -2502,12 +2594,12 @@ class TestModelBackend(unittest.TestCase):
             ops.RelationNotFoundError,
             [['relation-set', '-r', '3', '--app', '--file', '-']],
         ), (
-            lambda: fake_script(self, 'relation-get', 'echo fooerror >&2 ; exit 1'),
+            lambda: fake_script.write('relation-get', 'echo fooerror >&2 ; exit 1'),
             lambda: self.backend.relation_get(3, 'remote/0', is_app=False),
             ops.ModelError,
             [['relation-get', '-r', '3', '-', 'remote/0', '--format=json']],
         ), (
-            lambda: fake_script(self, 'relation-get', f'echo {err_msg} >&2 ; exit 2'),
+            lambda: fake_script.write('relation-get', f'echo {err_msg} >&2 ; exit 2'),
             lambda: self.backend.relation_get(3, 'remote/0', is_app=False),
             ops.RelationNotFoundError,
             [['relation-get', '-r', '3', '-', 'remote/0', '--format=json']],
@@ -2518,65 +2610,66 @@ class TestModelBackend(unittest.TestCase):
             [['relation-get', '-r', '3', '-', 'remote/0', '--app', '--format=json']],
         )]
 
-        for i, (do_fake, run, exception, calls) in enumerate(test_cases):
-            with self.subTest(i):
-                do_fake()
-                with pytest.raises(exception):
-                    run()
-                assert fake_script_calls(self, clear=True) == calls
+        for _, (do_fake, run, exception, calls) in enumerate(test_cases):
+            do_fake()
+            with pytest.raises(exception):
+                run()
+            assert fake_script.calls(clear=True) == calls
 
-    def test_relation_get_juju_version_quirks(self):
-        self.addCleanup(os.environ.pop, 'JUJU_VERSION', None)
-
-        fake_script(self, 'relation-get', '''echo '{"foo": "bar"}' ''')
+    @pytest.mark.parametrize("version", ['2.8.0', '2.7.0'])
+    def test_relation_get_juju_version_quirks(
+            self,
+            fake_script: FakeScript,
+            monkeypatch: pytest.MonkeyPatch,
+            version: str):
+        fake_script.write('relation-get', '''echo '{"foo": "bar"}' ''')
 
         # on 2.7.0+, things proceed as expected
-        for v in ['2.8.0', '2.7.0']:
-            with self.subTest(v):
-                os.environ['JUJU_VERSION'] = v
-                rel_data = self.backend.relation_get(1, 'foo/0', is_app=True)
-                assert rel_data == {"foo": "bar"}
-                calls = [' '.join(i) for i in fake_script_calls(self, clear=True)]
-                assert calls == ['relation-get -r 1 - foo/0 --app --format=json']
+        monkeypatch.setenv('JUJU_VERSION', version)
+        rel_data = self.backend.relation_get(1, 'foo/0', is_app=True)
+        assert rel_data == {"foo": "bar"}
+        calls = [' '.join(i) for i in fake_script.calls(clear=True)]
+        assert calls == ['relation-get -r 1 - foo/0 --app --format=json']
 
         # before 2.7.0, it just fails (no --app support)
-        os.environ['JUJU_VERSION'] = '2.6.9'
+        monkeypatch.setenv('JUJU_VERSION', '2.6.9')
         with pytest.raises(RuntimeError, match='not supported on Juju version 2.6.9'):
             self.backend.relation_get(1, 'foo/0', is_app=True)
-        assert fake_script_calls(self) == []
+        assert fake_script.calls() == []
 
-    def test_relation_set_juju_version_quirks(self):
-        self.addCleanup(os.environ.pop, 'JUJU_VERSION', None)
-
+    @pytest.mark.parametrize("version", ['2.8.0', '2.7.0'])
+    def test_relation_set_juju_version_quirks(
+            self,
+            fake_script: FakeScript,
+            monkeypatch: pytest.MonkeyPatch,
+            version: str):
         # on 2.7.0+, things proceed as expected
-        for v in ['2.8.0', '2.7.0']:
-            with self.subTest(v):
-                t = tempfile.NamedTemporaryFile()
-                try:
-                    fake_script(self, 'relation-set', dedent("""
-                        cat >> {}
-                        """).format(pathlib.Path(t.name).as_posix()))
-                    os.environ['JUJU_VERSION'] = v
-                    self.backend.relation_set(1, 'foo', 'bar', is_app=True)
-                    calls = [' '.join(i) for i in fake_script_calls(self, clear=True)]
-                    assert calls == ['relation-set -r 1 --app --file -']
-                    t.seek(0)
-                    content = t.read()
-                finally:
-                    t.close()
-                decoded = content.decode('utf-8').replace('\r\n', '\n')
-                assert decoded == 'foo: bar\n'
+        t = tempfile.NamedTemporaryFile()
+        try:
+            fake_script.write('relation-set', dedent("""
+                cat >> {}
+                """).format(pathlib.Path(t.name).as_posix()))
+            monkeypatch.setenv('JUJU_VERSION', version)
+            self.backend.relation_set(1, 'foo', 'bar', is_app=True)
+            calls = [' '.join(i) for i in fake_script.calls(clear=True)]
+            assert calls == ['relation-set -r 1 --app --file -']
+            t.seek(0)
+            content = t.read()
+        finally:
+            t.close()
+        decoded = content.decode('utf-8').replace('\r\n', '\n')
+        assert decoded == 'foo: bar\n'
 
         # before 2.7.0, it just fails always (no --app support)
-        os.environ['JUJU_VERSION'] = '2.6.9'
+        monkeypatch.setenv('JUJU_VERSION', '2.6.9')
         with pytest.raises(RuntimeError, match='not supported on Juju version 2.6.9'):
             self.backend.relation_set(1, 'foo', 'bar', is_app=True)
-        assert fake_script_calls(self) == []
+        assert fake_script.calls() == []
 
-    def test_status_get(self):
+    def test_status_get(self, fake_script: FakeScript):
         # taken from actual Juju output
         content = '{"message": "", "status": "unknown", "status-data": {}}'
-        fake_script(self, 'status-get', f"echo '{content}'")
+        fake_script.write('status-get', f"echo '{content}'")
         s = self.backend.status_get(is_app=False)
         assert s['status'] == "unknown"
         assert s['message'] == ""
@@ -2597,18 +2690,18 @@ class TestModelBackend(unittest.TestCase):
                 }
             }
             """)
-        fake_script(self, 'status-get', f"echo '{content}'")
+        fake_script.write('status-get', f"echo '{content}'")
         s = self.backend.status_get(is_app=True)
         assert s['status'] == "maintenance"
         assert s['message'] == "installing"
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['status-get', '--include-data', '--application=False', '--format=json'],
             ['status-get', '--include-data', '--application=True', '--format=json'],
         ]
 
-    def test_status_is_app_forced_kwargs(self):
-        fake_script(self, 'status-get', 'exit 1')
-        fake_script(self, 'status-set', 'exit 1')
+    def test_status_is_app_forced_kwargs(self, fake_script: FakeScript):
+        fake_script.write('status-get', 'exit 1')
+        fake_script.write('status-set', 'exit 1')
 
         test_cases = (
             lambda: self.backend.status_get(False),  # type: ignore
@@ -2621,21 +2714,21 @@ class TestModelBackend(unittest.TestCase):
             with pytest.raises(TypeError):
                 case()
 
-    def test_local_set_invalid_status(self):
+    def test_local_set_invalid_status(self, fake_script: FakeScript):
         # juju returns exit code 1 if you ask to set status to 'unknown' or 'error'
         meta = ops.CharmMeta.from_yaml('''
             name: myapp
         ''')
         model = ops.Model(meta, self.backend)
-        fake_script(self, 'status-set', 'exit 1')
-        fake_script(self, 'is-leader', 'echo true')
+        fake_script.write('status-set', 'exit 1')
+        fake_script.write('is-leader', 'echo true')
 
         with pytest.raises(ops.ModelError):
             model.unit.status = ops.UnknownStatus()
         with pytest.raises(ops.ModelError):
             model.unit.status = ops.ErrorStatus()
 
-        assert fake_script_calls(self, True) == [
+        assert fake_script.calls(True) == [
             ['status-set', '--application=False', 'unknown', ''],
             ['status-set', '--application=False', 'error', ''],
         ]
@@ -2646,82 +2739,83 @@ class TestModelBackend(unittest.TestCase):
             model.app.status = ops.ErrorStatus()
 
         # A leadership check is needed for application status.
-        assert fake_script_calls(self, True) == [
+        assert fake_script.calls(True) == [
             ['is-leader', '--format=json'],
             ['status-set', '--application=True', 'unknown', ''],
             ['status-set', '--application=True', 'error', ''],
         ]
 
-    def test_local_get_status(self):
-        for name, expected_cls in (
-            ("active", ops.ActiveStatus),
-            ("waiting", ops.WaitingStatus),
-            ("blocked", ops.BlockedStatus),
-            ("maintenance", ops.MaintenanceStatus),
-            ("error", ops.ErrorStatus),
-        ):
-            meta = ops.CharmMeta.from_yaml('''
-                name: myapp
-            ''')
-            model = ops.Model(meta, self.backend)
+    @pytest.mark.parametrize("name", ["active", "waiting", "blocked", "maintenance", "error"])
+    def test_local_get_status(self, fake_script: FakeScript, name: str):
+        expected_cls = {
+            "active": ops.ActiveStatus,
+            "waiting": ops.WaitingStatus,
+            "blocked": ops.BlockedStatus,
+            "maintenance": ops.MaintenanceStatus,
+            "error": ops.ErrorStatus,
+        }
 
-            with self.subTest(name):
-                content = json.dumps({
-                    "message": "foo",
-                    "status": name,
-                    "status-data": {},
-                })
-                fake_script(self, 'status-get', f"echo '{content}'")
+        meta = ops.CharmMeta.from_yaml('''
+            name: myapp
+        ''')
+        model = ops.Model(meta, self.backend)
 
-                assert isinstance(model.unit.status, expected_cls)
-                assert model.unit.status.name == name
-                assert model.unit.status.message == "foo"
+        content = json.dumps({
+            "message": "foo",
+            "status": name,
+            "status-data": {},
+        })
+        fake_script.write('status-get', f"echo '{content}'")
 
-                content = json.dumps({
-                    "application-status": {
-                        "message": "bar",
-                        "status": name,
-                        "status-data": {},
-                    }
-                })
-                fake_script(self, 'status-get', f"echo '{content}'")
-                fake_script(self, 'is-leader', 'echo true')
+        assert isinstance(model.unit.status, expected_cls[name])
+        assert model.unit.status.name == name
+        assert model.unit.status.message == "foo"
 
-                assert isinstance(model.app.status, expected_cls)
-                assert model.app.status.name == name
-                assert model.app.status.message == "bar"
+        content = json.dumps({
+            "application-status": {
+                "message": "bar",
+                "status": name,
+                "status-data": {},
+            }
+        })
+        fake_script.write('status-get', f"echo '{content}'")
+        fake_script.write('is-leader', 'echo true')
+
+        assert isinstance(model.app.status, expected_cls[name])
+        assert model.app.status.name == name
+        assert model.app.status.message == "bar"
 
     def test_status_set_is_app_not_bool_raises(self):
         for is_app_v in [None, 1, 2.0, 'a', b'beef', object]:
             with pytest.raises(TypeError):
                 self.backend.status_set(ops.ActiveStatus, is_app=is_app_v)  # type: ignore
 
-    def test_storage_tool_errors(self):
-        fake_script(self, 'storage-list', 'echo fooerror >&2 ; exit 1')
+    def test_storage_tool_errors(self, fake_script: FakeScript):
+        fake_script.write('storage-list', 'echo fooerror >&2 ; exit 1')
         with pytest.raises(ops.ModelError):
             self.backend.storage_list('foobar')
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['storage-list', 'foobar', '--format=json']]
-        fake_script(self, 'storage-get', 'echo fooerror >&2 ; exit 1')
+        fake_script.write('storage-get', 'echo fooerror >&2 ; exit 1')
         with pytest.raises(ops.ModelError):
             self.backend.storage_get('foobar', 'someattr')
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['storage-get', '-s', 'foobar', 'someattr', '--format=json']]
-        fake_script(self, 'storage-add', 'echo fooerror >&2 ; exit 1')
+        fake_script.write('storage-add', 'echo fooerror >&2 ; exit 1')
         with pytest.raises(ops.ModelError):
             self.backend.storage_add('foobar', count=2)
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['storage-add', 'foobar=2']]
-        fake_script(self, 'storage-add', 'echo fooerror >&2 ; exit 1')
+        fake_script.write('storage-add', 'echo fooerror >&2 ; exit 1')
         with pytest.raises(TypeError):
             self.backend.storage_add('foobar', count=object),  # type: ignore
-        assert fake_script_calls(self, clear=True) == []
-        fake_script(self, 'storage-add', 'echo fooerror >&2 ; exit 1')
+        assert fake_script.calls(clear=True) == []
+        fake_script.write('storage-add', 'echo fooerror >&2 ; exit 1')
         with pytest.raises(TypeError):
             self.backend.storage_add('foobar', count=True)
-        assert fake_script_calls(self, clear=True) == []
+        assert fake_script.calls(clear=True) == []
 
-    def test_network_get(self):
+    def test_network_get(self, fake_script: FakeScript):
         network_get_out = '''{
   "bind-addresses": [
     {
@@ -2743,30 +2837,30 @@ class TestModelBackend(unittest.TestCase):
     "192.0.2.2"
   ]
 }'''
-        fake_script(self, 'network-get',
-                    f'''[ "$1" = deadbeef ] && echo '{network_get_out}' || exit 1''')
+        fake_script.write('network-get',
+                          f'''[ "$1" = deadbeef ] && echo '{network_get_out}' || exit 1''')
         network_info = self.backend.network_get('deadbeef')
         assert network_info == json.loads(network_get_out)
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['network-get', 'deadbeef', '--format=json']]
 
         network_info = self.backend.network_get('deadbeef', 1)
         assert network_info == json.loads(network_get_out)
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['network-get', 'deadbeef', '-r', '1', '--format=json']]
 
-    def test_network_get_errors(self):
+    def test_network_get_errors(self, fake_script: FakeScript):
         err_no_endpoint = 'ERROR no network config found for binding "$2"'
         err_no_rel = 'ERROR invalid value "$3" for option -r: relation not found'
 
         test_cases = [(
-            lambda: fake_script(self, 'network-get',
-                                f'echo {err_no_endpoint} >&2 ; exit 1'),
+            lambda: fake_script.write('network-get',
+                                      f'echo {err_no_endpoint} >&2 ; exit 1'),
             lambda: self.backend.network_get("deadbeef"),
             ops.ModelError,
             [['network-get', 'deadbeef', '--format=json']],
         ), (
-            lambda: fake_script(self, 'network-get', f'echo {err_no_rel} >&2 ; exit 2'),
+            lambda: fake_script.write('network-get', f'echo {err_no_rel} >&2 ; exit 2'),
             lambda: self.backend.network_get("deadbeef", 3),
             ops.RelationNotFoundError,
             [['network-get', 'deadbeef', '-r', '3', '--format=json']],
@@ -2775,46 +2869,46 @@ class TestModelBackend(unittest.TestCase):
             do_fake()
             with pytest.raises(exception):
                 run()
-            assert fake_script_calls(self, clear=True) == calls
+            assert fake_script.calls(clear=True) == calls
 
-    def test_action_get_error(self):
-        fake_script(self, 'action-get', '')
-        fake_script(self, 'action-get', 'echo fooerror >&2 ; exit 1')
+    def test_action_get_error(self, fake_script: FakeScript):
+        fake_script.write('action-get', '')
+        fake_script.write('action-get', 'echo fooerror >&2 ; exit 1')
         with pytest.raises(ops.ModelError):
             self.backend.action_get()
         calls = [['action-get', '--format=json']]
-        assert fake_script_calls(self, clear=True) == calls
+        assert fake_script.calls(clear=True) == calls
 
-    def test_action_set_error(self):
-        fake_script(self, 'action-get', '')
-        fake_script(self, 'action-set', 'echo fooerror >&2 ; exit 1')
+    def test_action_set_error(self, fake_script: FakeScript):
+        fake_script.write('action-get', '')
+        fake_script.write('action-set', 'echo fooerror >&2 ; exit 1')
         with pytest.raises(ops.ModelError):
             self.backend.action_set(OrderedDict([('foo', 'bar'), ('dead', 'beef cafe')]))
-        self.assertCountEqual(
-            ["action-set", "dead=beef cafe", "foo=bar"], fake_script_calls(self, clear=True)[0])
+        assert sorted(["action-set", "dead=beef cafe", "foo=bar"]
+                      ) == sorted(fake_script.calls(clear=True)[0])
 
-    def test_action_log_error(self):
-        fake_script(self, 'action-get', '')
-        fake_script(self, 'action-log', 'echo fooerror >&2 ; exit 1')
+    def test_action_log_error(self, fake_script: FakeScript):
+        fake_script.write('action-get', '')
+        fake_script.write('action-log', 'echo fooerror >&2 ; exit 1')
         with pytest.raises(ops.ModelError):
             self.backend.action_log('log-message')
         calls = [["action-log", "log-message"]]
-        assert fake_script_calls(self, clear=True) == calls
+        assert fake_script.calls(clear=True) == calls
 
-    def test_action_get(self):
-        fake_script(self, 'action-get', """echo '{"foo-name": "bar", "silent": false}'""")
+    def test_action_get(self, fake_script: FakeScript):
+        fake_script.write('action-get', """echo '{"foo-name": "bar", "silent": false}'""")
         params = self.backend.action_get()
         assert params['foo-name'] == 'bar'
         assert not params['silent']
-        assert fake_script_calls(self) == [['action-get', '--format=json']]
+        assert fake_script.calls() == [['action-get', '--format=json']]
 
-    def test_action_set(self):
-        fake_script(self, 'action-get', 'exit 1')
-        fake_script(self, 'action-set', 'exit 0')
+    def test_action_set(self, fake_script: FakeScript):
+        fake_script.write('action-get', 'exit 1')
+        fake_script.write('action-set', 'exit 0')
         self.backend.action_set({'x': 'dead beef', 'y': 1})
-        self.assertCountEqual(['action-set', 'x=dead beef', 'y=1'], fake_script_calls(self)[0])
+        assert sorted(['action-set', 'x=dead beef', 'y=1']), sorted(fake_script.calls()[0])
 
-    def test_action_set_key_validation(self):
+    def test_action_set_key_validation(self, fake_script: FakeScript):
         with pytest.raises(ValueError):
             self.backend.action_set({'X': 'dead beef', 'y': 1})
         with pytest.raises(ValueError):
@@ -2824,76 +2918,76 @@ class TestModelBackend(unittest.TestCase):
         with pytest.raises(ValueError):
             self.backend.action_set({'some_key': 'dead beef', 'y': 1})
 
-    def test_action_set_nested(self):
-        fake_script(self, 'action-get', 'exit 1')
-        fake_script(self, 'action-set', 'exit 0')
+    def test_action_set_nested(self, fake_script: FakeScript):
+        fake_script.write('action-get', 'exit 1')
+        fake_script.write('action-set', 'exit 0')
         self.backend.action_set({'a': {'b': 1, 'c': 2}, 'd': 3})
-        self.assertCountEqual(['action-set', 'a.b=1', 'a.c=2', 'd=3'], fake_script_calls(self)[0])
+        assert sorted(['action-set', 'a.b=1', 'a.c=2', 'd=3']) == sorted(fake_script.calls()[0])
 
-    def test_action_set_more_nested(self):
-        fake_script(self, 'action-get', 'exit 1')
-        fake_script(self, 'action-set', 'exit 0')
+    def test_action_set_more_nested(self, fake_script: FakeScript):
+        fake_script.write('action-get', 'exit 1')
+        fake_script.write('action-set', 'exit 0')
         self.backend.action_set({'a': {'b': 1, 'c': 2, 'd': {'e': 3}}, 'f': 4})
-        self.assertCountEqual(
-            ['action-set', 'a.b=1', 'a.c=2', 'a.d.e=3', 'f=4'], fake_script_calls(self)[0])
+        assert sorted(['action-set', 'a.b=1', 'a.c=2', 'a.d.e=3', 'f=4']
+                      ) == sorted(fake_script.calls()[0])
 
-    def test_action_set_dotted_dict(self):
-        fake_script(self, 'action-get', 'exit 1')
-        fake_script(self, 'action-set', 'exit 0')
+    def test_action_set_dotted_dict(self, fake_script: FakeScript):
+        fake_script.write('action-get', 'exit 1')
+        fake_script.write('action-set', 'exit 0')
         self.backend.action_set({'a.b': 1, 'a': {'c': 2}, 'd': 3})
-        self.assertCountEqual(['action-set', 'a.b=1', 'a.c=2', 'd=3'], fake_script_calls(self)[0])
+        assert sorted(['action-set', 'a.b=1', 'a.c=2', 'd=3']) == sorted(fake_script.calls()[0])
 
-    def test_action_set_duplicated_keys(self):
-        fake_script(self, 'action-get', 'exit 1')
-        fake_script(self, 'action-set', 'exit 0')
+    def test_action_set_duplicated_keys(self, fake_script: FakeScript):
+        fake_script.write('action-get', 'exit 1')
+        fake_script.write('action-set', 'exit 0')
         with pytest.raises(ValueError):
             self.backend.action_set({'a.b': 1, 'a': {'b': 2}, 'd': 3})
         with pytest.raises(ValueError):
             self.backend.action_set({'a': {'b': 1, 'c': 2, 'd': {'e': 3}}, 'f': 4, 'a.d.e': 'foo'})
 
-    def test_action_fail(self):
-        fake_script(self, 'action-get', 'exit 1')
-        fake_script(self, 'action-fail', 'exit 0')
+    def test_action_fail(self, fake_script: FakeScript):
+        fake_script.write('action-get', 'exit 1')
+        fake_script.write('action-fail', 'exit 0')
         self.backend.action_fail('error 42')
-        assert fake_script_calls(self) == [['action-fail', 'error 42']]
+        assert fake_script.calls() == [['action-fail', 'error 42']]
 
-    def test_action_log(self):
-        fake_script(self, 'action-get', 'exit 1')
-        fake_script(self, 'action-log', 'exit 0')
+    def test_action_log(self, fake_script: FakeScript):
+        fake_script.write('action-get', 'exit 1')
+        fake_script.write('action-log', 'exit 0')
         self.backend.action_log('progress: 42%')
-        assert fake_script_calls(self) == [['action-log', 'progress: 42%']]
+        assert fake_script.calls() == [['action-log', 'progress: 42%']]
 
-    def test_application_version_set(self):
-        fake_script(self, 'application-version-set', 'exit 0')
+    def test_application_version_set(self, fake_script: FakeScript):
+        fake_script.write('application-version-set', 'exit 0')
         self.backend.application_version_set('1.2b3')
-        assert fake_script_calls(self) == [['application-version-set', '--', '1.2b3']]
+        assert fake_script.calls() == [['application-version-set', '--', '1.2b3']]
 
-    def test_application_version_set_invalid(self):
-        fake_script(self, 'application-version-set', 'exit 0')
+    def test_application_version_set_invalid(self, fake_script: FakeScript):
+        fake_script.write('application-version-set', 'exit 0')
         with pytest.raises(TypeError):
             self.backend.application_version_set(2)  # type: ignore
         with pytest.raises(TypeError):
             self.backend.application_version_set()  # type: ignore
-        assert fake_script_calls(self) == []
+        assert fake_script.calls() == []
 
-    def test_juju_log(self):
-        fake_script(self, 'juju-log', 'exit 0')
+    def test_juju_log(self, fake_script: FakeScript):
+        fake_script.write('juju-log', 'exit 0')
         self.backend.juju_log('WARNING', 'foo')
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['juju-log', '--log-level', 'WARNING', '--', 'foo']]
 
         with pytest.raises(TypeError):
             self.backend.juju_log('DEBUG')  # type: ignore
-        assert fake_script_calls(self, clear=True) == []
+        assert fake_script.calls(clear=True) == []
 
-        fake_script(self, 'juju-log', 'exit 1')
+        fake_script.write('juju-log', 'exit 1')
         with pytest.raises(ops.ModelError):
             self.backend.juju_log('BAR', 'foo')
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['juju-log', '--log-level', 'BAR', '--', 'foo']]
 
-    def test_valid_metrics(self):
-        fake_script(self, 'add-metric', 'exit 0')
+    def test_valid_metrics(self, fake_script: FakeScript):
+        fake_script.write('add-metric', 'exit 0')
         test_cases: typing.List[_ValidMetricsTestCase] = [(
             OrderedDict([('foo', 42), ('b-ar', 4.5), ('ba_-z', 4.5), ('a', 1)]),
             OrderedDict([('de', 'ad'), ('be', 'ef_ -')]),
@@ -2906,9 +3000,9 @@ class TestModelBackend(unittest.TestCase):
         )]
         for metrics, labels, expected_calls in test_cases:
             self.backend.add_metrics(metrics, labels)
-            assert fake_script_calls(self, clear=True) == expected_calls
+            assert fake_script.calls(clear=True) == expected_calls
 
-    def test_invalid_metric_names(self):
+    def test_invalid_metric_names(self, fake_script: FakeScript):
         invalid_inputs: typing.List[_MetricAndLabelPair] = [
             ({'': 4.2}, {}),
             ({'1': 4.2}, {}),
@@ -2960,70 +3054,65 @@ class TestModelBackend(unittest.TestCase):
             with pytest.raises(ops.ModelError):
                 self.backend.add_metrics(metrics, labels)
 
-    def test_relation_remote_app_name_env(self):
-        self.addCleanup(os.environ.pop, 'JUJU_RELATION_ID', None)
-        self.addCleanup(os.environ.pop, 'JUJU_REMOTE_APP', None)
-
-        os.environ['JUJU_RELATION_ID'] = 'x:5'
-        os.environ['JUJU_REMOTE_APP'] = 'remoteapp1'
+    def test_relation_remote_app_name_env(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv('JUJU_RELATION_ID', 'x:5')
+        monkeypatch.setenv('JUJU_REMOTE_APP', 'remoteapp1')
         assert self.backend.relation_remote_app_name(5) == 'remoteapp1'
         os.environ['JUJU_RELATION_ID'] = '5'
         assert self.backend.relation_remote_app_name(5) == 'remoteapp1'
 
-    def test_relation_remote_app_name_script_success(self):
-        self.addCleanup(os.environ.pop, 'JUJU_RELATION_ID', None)
-        self.addCleanup(os.environ.pop, 'JUJU_REMOTE_APP', None)
-
+    def test_relation_remote_app_name_script_success(
+            self, fake_script: FakeScript, monkeypatch: pytest.MonkeyPatch):
         # JUJU_RELATION_ID and JUJU_REMOTE_APP both unset
-        fake_script(self, 'relation-list', r"""
+        fake_script.write('relation-list', r"""
 echo '"remoteapp2"'
 """)
         assert self.backend.relation_remote_app_name(1) == 'remoteapp2'
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['relation-list', '-r', '1', '--app', '--format=json'],
         ]
 
         # JUJU_RELATION_ID set but JUJU_REMOTE_APP unset
-        os.environ['JUJU_RELATION_ID'] = 'x:5'
+        monkeypatch.setenv('JUJU_RELATION_ID', 'x:5')
         assert self.backend.relation_remote_app_name(5) == 'remoteapp2'
 
         # JUJU_RELATION_ID unset but JUJU_REMOTE_APP set
-        del os.environ['JUJU_RELATION_ID']
+        monkeypatch.delenv('JUJU_RELATION_ID')
         os.environ['JUJU_REMOTE_APP'] = 'remoteapp1'
         assert self.backend.relation_remote_app_name(5) == 'remoteapp2'
 
         # Both set, but JUJU_RELATION_ID a different relation
-        os.environ['JUJU_RELATION_ID'] = 'x:6'
+        monkeypatch.setenv('JUJU_RELATION_ID', 'x:6')
         assert self.backend.relation_remote_app_name(5) == 'remoteapp2'
 
-    def test_relation_remote_app_name_script_errors(self):
-        fake_script(self, 'relation-list', r"""
+    def test_relation_remote_app_name_script_errors(self, fake_script: FakeScript):
+        fake_script.write('relation-list', r"""
 echo "ERROR invalid value \"6\" for option -r: relation not found" >&2  # NOQA
 exit 2
 """)
         assert self.backend.relation_remote_app_name(6) is None
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['relation-list', '-r', '6', '--app', '--format=json'],
         ]
 
-        fake_script(self, 'relation-list', r"""
+        fake_script.write('relation-list', r"""
 echo "ERROR option provided but not defined: --app" >&2
 exit 2
 """)
         assert self.backend.relation_remote_app_name(6) is None
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['relation-list', '-r', '6', '--app', '--format=json'],
         ]
 
-    def test_planned_units(self):
+    def test_planned_units(self, fake_script: FakeScript):
         # no units
-        fake_script(self, 'goal-state', """
+        fake_script.write('goal-state', """
 echo '{"units":{}, "relations":{}}'
 """)
         assert self.backend.planned_units() == 0
 
         # only active units
-        fake_script(self, 'goal-state', """
+        fake_script.write('goal-state', """
 echo '{
     "units":{
         "app/0": {"status":"active","since":"2023-05-23 17:05:05Z"},
@@ -3034,7 +3123,7 @@ echo '{
         assert self.backend.planned_units() == 2
 
         # active and dying units
-        fake_script(self, 'goal-state', """
+        fake_script.write('goal-state', """
 echo '{
     "units":{
         "app/0": {"status":"active","since":"2023-05-23 17:05:05Z"},
@@ -3045,7 +3134,7 @@ echo '{
         assert self.backend.planned_units() == 1
 
 
-class TestLazyMapping(unittest.TestCase):
+class TestLazyMapping:
 
     def test_invalidate(self):
         loaded: typing.List[int] = []
@@ -3065,65 +3154,64 @@ class TestLazyMapping(unittest.TestCase):
         assert loaded == [1, 1]
 
 
-class TestSecrets(unittest.TestCase):
-    def setUp(self):
-        self.model = ops.Model(ops.CharmMeta(), _ModelBackend('myapp/0'))
-        self.app = self.model.app
-        self.unit = self.model.unit
+class TestSecrets:
+    @pytest.fixture
+    def model(self):
+        return ops.Model(ops.CharmMeta(), _ModelBackend('myapp/0'))
 
-    def test_app_add_secret_simple(self):
-        fake_script(self, 'secret-add', 'echo secret:123')
+    def test_app_add_secret_simple(self, fake_script: FakeScript, model: ops.Model):
+        fake_script.write('secret-add', 'echo secret:123')
 
-        secret = self.app.add_secret({'foo': 'x'})
+        secret = model.app.add_secret({'foo': 'x'})
         assert isinstance(secret, ops.Secret)
         assert secret.id == 'secret:123'
         assert secret.label is None
 
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['secret-add', '--owner', 'application', 'foo=x']]
 
-    def test_app_add_secret_args(self):
-        fake_script(self, 'secret-add', 'echo secret:234')
+    def test_app_add_secret_args(self, fake_script: FakeScript, model: ops.Model):
+        fake_script.write('secret-add', 'echo secret:234')
 
         expire = datetime.datetime(2022, 12, 9, 16, 17, 0)
-        secret = self.app.add_secret({'foo': 'x', 'bar': 'y'}, label='lbl', description='desc',
-                                     expire=expire, rotate=ops.SecretRotate.HOURLY)
+        secret = model.app.add_secret({'foo': 'x', 'bar': 'y'}, label='lbl', description='desc',
+                                      expire=expire, rotate=ops.SecretRotate.HOURLY)
         assert secret.id == 'secret:234'
         assert secret.label == 'lbl'
         assert secret.get_content() == {'foo': 'x', 'bar': 'y'}
 
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['secret-add', '--label', 'lbl', '--description', 'desc',
               '--expire', '2022-12-09T16:17:00', '--rotate', 'hourly',
               '--owner', 'application', 'foo=x', 'bar=y']]
 
-    def test_unit_add_secret_simple(self):
-        fake_script(self, 'secret-add', 'echo secret:345')
+    def test_unit_add_secret_simple(self, fake_script: FakeScript, model: ops.Model):
+        fake_script.write('secret-add', 'echo secret:345')
 
-        secret = self.unit.add_secret({'foo': 'x'})
+        secret = model.unit.add_secret({'foo': 'x'})
         assert isinstance(secret, ops.Secret)
         assert secret.id == 'secret:345'
         assert secret.label is None
 
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['secret-add', '--owner', 'unit', 'foo=x']]
 
-    def test_unit_add_secret_args(self):
-        fake_script(self, 'secret-add', 'echo secret:456')
+    def test_unit_add_secret_args(self, fake_script: FakeScript, model: ops.Model):
+        fake_script.write('secret-add', 'echo secret:456')
 
         expire = datetime.datetime(2022, 12, 9, 16, 22, 0)
-        secret = self.unit.add_secret({'foo': 'w', 'bar': 'z'}, label='l2', description='xyz',
-                                      expire=expire, rotate=ops.SecretRotate.YEARLY)
+        secret = model.unit.add_secret({'foo': 'w', 'bar': 'z'}, label='l2', description='xyz',
+                                       expire=expire, rotate=ops.SecretRotate.YEARLY)
         assert secret.id == 'secret:456'
         assert secret.label == 'l2'
         assert secret.get_content() == {'foo': 'w', 'bar': 'z'}
 
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['secret-add', '--label', 'l2', '--description', 'xyz',
               '--expire', '2022-12-09T16:22:00', '--rotate', 'yearly',
               '--owner', 'unit', 'foo=w', 'bar=z']]
 
-    def test_unit_add_secret_errors(self):
+    def test_unit_add_secret_errors(self, model: ops.Model):
         # Additional add_secret tests are done in TestApplication
         errors: typing.Any = [
             ({'xy': 'bar'}, {}, ValueError),
@@ -3131,9 +3219,9 @@ class TestSecrets(unittest.TestCase):
         ]
         for content, kwargs, exc_type in errors:
             with pytest.raises(exc_type):
-                self.unit.add_secret(content, **kwargs)  # type: ignore
+                model.unit.add_secret(content, **kwargs)  # type: ignore
 
-    def test_add_secret_errors(self):
+    def test_add_secret_errors(self, model: ops.Model):
         errors: typing.Any = [
             # Invalid content dict or types
             (None, {}, TypeError),
@@ -3151,82 +3239,82 @@ class TestSecrets(unittest.TestCase):
         ]
         for content, kwargs, exc_type in errors:
             with pytest.raises(exc_type):
-                self.app.add_secret(content, **kwargs)  # type: ignore
+                model.app.add_secret(content, **kwargs)  # type: ignore
             with pytest.raises(exc_type):
-                self.unit.add_secret(content, **kwargs)  # type: ignore
+                model.unit.add_secret(content, **kwargs)  # type: ignore
 
-    def test_get_secret_id(self):
-        fake_script(self, 'secret-get', """echo '{"foo": "g"}'""")
+    def test_get_secret_id(self, fake_script: FakeScript, model: ops.Model):
+        fake_script.write('secret-get', """echo '{"foo": "g"}'""")
 
-        secret = self.model.get_secret(id='123')
+        secret = model.get_secret(id='123')
         assert secret.id == 'secret:123'
         assert secret.label is None
         assert secret.get_content() == {'foo': 'g'}
 
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['secret-get', 'secret:123', '--format=json']]
 
-    def test_get_secret_label(self):
-        fake_script(self, 'secret-get', """echo '{"foo": "g"}'""")
+    def test_get_secret_label(self, fake_script: FakeScript, model: ops.Model):
+        fake_script.write('secret-get', """echo '{"foo": "g"}'""")
 
-        secret = self.model.get_secret(label='lbl')
+        secret = model.get_secret(label='lbl')
         assert secret.id is None
         assert secret.label == 'lbl'
         assert secret.get_content() == {'foo': 'g'}
 
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['secret-get', '--label', 'lbl', '--format=json']]
 
-    def test_get_secret_id_and_label(self):
-        fake_script(self, 'secret-get', """echo '{"foo": "h"}'""")
+    def test_get_secret_id_and_label(self, fake_script: FakeScript, model: ops.Model):
+        fake_script.write('secret-get', """echo '{"foo": "h"}'""")
 
-        secret = self.model.get_secret(id='123', label='l')
+        secret = model.get_secret(id='123', label='l')
         assert secret.id == 'secret:123'
         assert secret.label == 'l'
         assert secret.get_content() == {'foo': 'h'}
 
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['secret-get', 'secret:123', '--label', 'l', '--format=json']]
 
-    def test_get_secret_no_args(self):
+    def test_get_secret_no_args(self, model: ops.Model):
         with pytest.raises(TypeError):
-            self.model.get_secret()
+            model.get_secret()
 
-    def test_get_secret_not_found(self):
+    def test_get_secret_not_found(self, fake_script: FakeScript, model: ops.Model):
         script = """echo 'ERROR secret "123" not found' >&2; exit 1"""
-        fake_script(self, 'secret-get', script)
+        fake_script.write('secret-get', script)
 
         with pytest.raises(ops.SecretNotFoundError):
-            self.model.get_secret(id='123')
+            model.get_secret(id='123')
 
-    def test_get_secret_other_error(self):
+    def test_get_secret_other_error(self, fake_script: FakeScript, model: ops.Model):
         script = """echo 'ERROR other error' >&2; exit 1"""
-        fake_script(self, 'secret-get', script)
+        fake_script.write('secret-get', script)
 
         with pytest.raises(ops.ModelError) as excinfo:
-            self.model.get_secret(id='123')
-        self.assertNotIsInstance(excinfo.value, ops.SecretNotFoundError)
+            model.get_secret(id='123')
+        assert not isinstance(excinfo.value, ops.SecretNotFoundError)
 
-    def test_secret_unique_identifier(self):
-        fake_script(self, 'secret-get', """echo '{"foo": "g"}'""")
+    def test_secret_unique_identifier(self, fake_script: FakeScript, model: ops.Model):
+        fake_script.write('secret-get', """echo '{"foo": "g"}'""")
 
-        secret = self.model.get_secret(label='lbl')
+        secret = model.get_secret(label='lbl')
         assert secret.id is None
         assert secret.unique_identifier is None
 
-        secret = self.model.get_secret(id='123')
+        secret = model.get_secret(id='123')
         assert secret.id == 'secret:123'
         assert secret.unique_identifier == '123'
 
-        secret = self.model.get_secret(id='secret:124')
+        secret = model.get_secret(id='secret:124')
         assert secret.id == 'secret:124'
         assert secret.unique_identifier == '124'
 
-        secret = self.model.get_secret(id='secret://modeluuid/125')
+        secret = model.get_secret(id='secret://modeluuid/125')
         assert secret.id == 'secret://modeluuid/125'
         assert secret.unique_identifier == '125'
 
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['secret-get', '--label', 'lbl', '--format=json'],
             ['secret-get', 'secret:123', '--format=json'],
             ['secret-get', 'secret:124', '--format=json'],
@@ -3234,7 +3322,7 @@ class TestSecrets(unittest.TestCase):
         ]
 
 
-class TestSecretInfo(unittest.TestCase):
+class TestSecretInfo:
     def test_init(self):
         info = ops.SecretInfo(
             id='3',
@@ -3287,140 +3375,144 @@ class TestSecretInfo(unittest.TestCase):
         assert info.revision == 9
 
 
-class TestSecretClass(unittest.TestCase):
+class TestSecretClass:
     maxDiff = 64 * 1024
 
-    def setUp(self):
-        self.model = ops.Model(ops.CharmMeta(), _ModelBackend('myapp/0'))
+    @pytest.fixture
+    def model(self):
+        return ops.Model(ops.CharmMeta(), _ModelBackend('myapp/0'))
 
-    def make_secret(self,
-                    id: typing.Optional[str] = None,
-                    label: typing.Optional[str] = None,
-                    content: typing.Optional[typing.Dict[str, str]] = None):
-        return ops.Secret(self.model._backend, id=id, label=label, content=content)
+    def make_secret(
+        self,
+        model: ops.Model,
+        id: typing.Optional[str] = None,
+        label: typing.Optional[str] = None,
+        content: typing.Optional[typing.Dict[str, str]] = None
+    ) -> ops.Secret:
+        return ops.Secret(model._backend, id=id, label=label, content=content)
 
-    def test_id_and_label(self):
-        secret = self.make_secret(id=' abc ', label='lbl')
+    def test_id_and_label(self, model: ops.Model):
+        secret = self.make_secret(model, id=' abc ', label='lbl')
         assert secret.id == 'secret:abc'
         assert secret.label == 'lbl'
 
-        secret = self.make_secret(id='x')
+        secret = self.make_secret(model, id='x')
         assert secret.id == 'secret:x'
         assert secret.label is None
 
-        secret = self.make_secret(label='y')
+        secret = self.make_secret(model, label='y')
         assert secret.id is None
         assert secret.label == 'y'
 
-    def test_get_content_cached(self):
-        fake_script(self, 'secret-get', """exit 1""")
+    def test_get_content_cached(self, model: ops.Model, fake_script: FakeScript):
+        fake_script.write('secret-get', """exit 1""")
 
-        secret = self.make_secret(id='x', label='y', content={'foo': 'bar'})
+        secret = self.make_secret(model, id='x', label='y', content={'foo': 'bar'})
         content = secret.get_content()  # will use cached content, not run secret-get
         assert content == {'foo': 'bar'}
 
-        assert fake_script_calls(self, clear=True) == []
+        assert fake_script.calls(clear=True) == []
 
-    def test_get_content_refresh(self):
-        fake_script(self, 'secret-get', """echo '{"foo": "refreshed"}'""")
+    def test_get_content_refresh(self, model: ops.Model, fake_script: FakeScript):
+        fake_script.write('secret-get', """echo '{"foo": "refreshed"}'""")
 
-        secret = self.make_secret(id='y', content={'foo': 'bar'})
+        secret = self.make_secret(model, id='y', content={'foo': 'bar'})
         content = secret.get_content(refresh=True)
         assert content == {'foo': 'refreshed'}
 
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['secret-get', 'secret:y', '--refresh', '--format=json']]
 
-    def test_get_content_uncached(self):
-        fake_script(self, 'secret-get', """echo '{"foo": "notcached"}'""")
+    def test_get_content_uncached(self, model: ops.Model, fake_script: FakeScript):
+        fake_script.write('secret-get', """echo '{"foo": "notcached"}'""")
 
-        secret = self.make_secret(id='z')
+        secret = self.make_secret(model, id='z')
         content = secret.get_content()
         assert content == {'foo': 'notcached'}
 
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['secret-get', 'secret:z', '--format=json']]
 
-    def test_get_content_copies_dict(self):
-        fake_script(self, 'secret-get', """echo '{"foo": "bar"}'""")
+    def test_get_content_copies_dict(self, model: ops.Model, fake_script: FakeScript):
+        fake_script.write('secret-get', """echo '{"foo": "bar"}'""")
 
-        secret = self.make_secret(id='z')
+        secret = self.make_secret(model, id='z')
         content = secret.get_content()
         assert content == {'foo': 'bar'}
         content['new'] = 'value'
         assert secret.get_content() == {'foo': 'bar'}
 
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['secret-get', 'secret:z', '--format=json']]
 
-    def test_set_content_invalidates_cache(self):
-        fake_script(self, 'secret-get', """echo '{"foo": "bar"}'""")
-        fake_script(self, 'secret-set', """exit 0""")
+    def test_set_content_invalidates_cache(self, model: ops.Model, fake_script: FakeScript):
+        fake_script.write('secret-get', """echo '{"foo": "bar"}'""")
+        fake_script.write('secret-set', """exit 0""")
 
-        secret = self.make_secret(id='z')
+        secret = self.make_secret(model, id='z')
         old_content = secret.get_content()
         assert old_content == {'foo': 'bar'}
         secret.set_content({'new': 'content'})
-        fake_script(self, 'secret-get', """echo '{"new": "content"}'""")
+        fake_script.write('secret-get', """echo '{"new": "content"}'""")
         new_content = secret.get_content()
         assert new_content == {'new': 'content'}
 
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['secret-get', 'secret:z', '--format=json'],
             ['secret-set', 'secret:z', 'new=content'],
             ['secret-get', 'secret:z', '--format=json'],
         ]
 
-    def test_peek_content(self):
-        fake_script(self, 'secret-get', """echo '{"foo": "peeked"}'""")
+    def test_peek_content(self, model: ops.Model, fake_script: FakeScript):
+        fake_script.write('secret-get', """echo '{"foo": "peeked"}'""")
 
-        secret = self.make_secret(id='a', label='b')
+        secret = self.make_secret(model, id='a', label='b')
         content = secret.peek_content()
         assert content == {'foo': 'peeked'}
 
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [['secret-get', 'secret:a', '--label', 'b', '--peek', '--format=json']]
 
-    def test_get_info(self):
-        fake_script(self, 'secret-info-get', """echo '{"x": {"label": "y", "revision": 7}}'""")
+    def test_get_info(self, model: ops.Model, fake_script: FakeScript):
+        fake_script.write('secret-info-get', """echo '{"x": {"label": "y", "revision": 7}}'""")
 
         # Secret with ID only
-        secret = self.make_secret(id='x')
+        secret = self.make_secret(model, id='x')
         info = secret.get_info()
         assert info.id == 'secret:x'
         assert info.label == 'y'
         assert info.revision == 7
 
         # Secret with label only
-        secret = self.make_secret(label='y')
+        secret = self.make_secret(model, label='y')
         info = secret.get_info()
         assert info.id == 'secret:x'
         assert info.label == 'y'
         assert info.revision == 7
 
         # Secret with ID and label
-        secret = self.make_secret(id='x', label='y')
+        secret = self.make_secret(model, id='x', label='y')
         info = secret.get_info()
         assert info.id == 'secret:x'
         assert info.label == 'y'
         assert info.revision == 7
 
-        assert fake_script_calls(self, clear=True) == \
+        assert fake_script.calls(clear=True) == \
             [
                 ['secret-info-get', 'secret:x', '--format=json'],
                 ['secret-info-get', '--label', 'y', '--format=json'],
                 ['secret-info-get', 'secret:x', '--format=json'],
         ]
 
-    def test_set_content(self):
-        fake_script(self, 'secret-set', """exit 0""")
-        fake_script(self, 'secret-info-get', """echo '{"z": {"label": "y", "revision": 7}}'""")
+    def test_set_content(self, model: ops.Model, fake_script: FakeScript):
+        fake_script.write('secret-set', """exit 0""")
+        fake_script.write('secret-info-get', """echo '{"z": {"label": "y", "revision": 7}}'""")
 
-        secret = self.make_secret(id='x')
+        secret = self.make_secret(model, id='x')
         secret.set_content({'foo': 'bar'})
 
         # If secret doesn't have an ID, we'll run secret-info-get to fetch it
-        secret = self.make_secret(label='y')
+        secret = self.make_secret(model, label='y')
         assert secret.id is None
         secret.set_content({'bar': 'foo'})
         assert secret.id == 'secret:z'
@@ -3428,17 +3520,17 @@ class TestSecretClass(unittest.TestCase):
         with pytest.raises(ValueError):
             secret.set_content({'s': 't'})  # ensure it validates content (key too short)
 
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['secret-set', 'secret:x', 'foo=bar'],
             ['secret-info-get', '--label', 'y', '--format=json'],
             ['secret-set', 'secret:z', 'bar=foo'],
         ]
 
-    def test_set_info(self):
-        fake_script(self, 'secret-set', """exit 0""")
-        fake_script(self, 'secret-info-get', """echo '{"z": {"label": "y", "revision": 7}}'""")
+    def test_set_info(self, model: ops.Model, fake_script: FakeScript):
+        fake_script.write('secret-set', """exit 0""")
+        fake_script.write('secret-info-get', """echo '{"z": {"label": "y", "revision": 7}}'""")
 
-        secret = self.make_secret(id='x')
+        secret = self.make_secret(model, id='x')
         expire = datetime.datetime(2022, 12, 9, 16, 59, 0)
         secret.set_info(
             label='lab',
@@ -3448,12 +3540,12 @@ class TestSecretClass(unittest.TestCase):
         )
 
         # If secret doesn't have an ID, we'll run secret-info-get to fetch it
-        secret = self.make_secret(label='y')
+        secret = self.make_secret(model, label='y')
         assert secret.id is None
         secret.set_info(label='lbl')
         assert secret.id == 'secret:z'
 
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['secret-set', 'secret:x', '--label', 'lab', '--description', 'desc',
              '--expire', '2022-12-09T16:59:00', '--rotate', 'monthly'],
             ['secret-info-get', '--label', 'y', '--format=json'],
@@ -3463,12 +3555,12 @@ class TestSecretClass(unittest.TestCase):
         with pytest.raises(TypeError):
             secret.set_info()  # no args provided
 
-    def test_grant(self):
-        fake_script(self, 'relation-list', """echo '[]'""")
-        fake_script(self, 'secret-grant', """exit 0""")
-        fake_script(self, 'secret-info-get', """echo '{"z": {"label": "y", "revision": 7}}'""")
+    def test_grant(self, model: ops.Model, fake_script: FakeScript):
+        fake_script.write('relation-list', """echo '[]'""")
+        fake_script.write('secret-grant', """exit 0""")
+        fake_script.write('secret-info-get', """echo '{"z": {"label": "y", "revision": 7}}'""")
 
-        secret = self.make_secret(id='x')
+        secret = self.make_secret(model, id='x')
         backend = ops.model._ModelBackend('test', 'test', 'test')
         meta = ops.CharmMeta()
         cache = ops.model._ModelCache(meta, backend)
@@ -3480,13 +3572,13 @@ class TestSecretClass(unittest.TestCase):
         secret.grant(rel234, unit=unit)
 
         # If secret doesn't have an ID, we'll run secret-info-get to fetch it
-        secret = self.make_secret(label='y')
+        secret = self.make_secret(model, label='y')
         assert secret.id is None
         rel345 = ops.Relation('test', 345, True, unit, backend, cache)
         secret.grant(rel345)
         assert secret.id == 'secret:z'
 
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['relation-list', '-r', '123', '--format=json'],
             ['relation-list', '-r', '234', '--format=json'],
             ['secret-grant', 'secret:x', '--relation', '123'],
@@ -3496,27 +3588,27 @@ class TestSecretClass(unittest.TestCase):
             ['secret-grant', 'secret:z', '--relation', '345'],
         ]
 
-    def test_revoke(self):
-        fake_script(self, 'relation-list', """echo '[]'""")
-        fake_script(self, 'secret-revoke', """exit 0""")
-        fake_script(self, 'secret-info-get', """echo '{"z": {"label": "y", "revision": 7}}'""")
+    def test_revoke(self, model: ops.Model, fake_script: FakeScript):
+        fake_script.write('relation-list', """echo '[]'""")
+        fake_script.write('secret-revoke', """exit 0""")
+        fake_script.write('secret-info-get', """echo '{"z": {"label": "y", "revision": 7}}'""")
 
-        secret = self.make_secret(id='x')
-        unit = ops.Unit('test', ops.CharmMeta(), self.model._backend, self.model._cache)
-        rel123 = ops.Relation('test', 123, True, unit, self.model._backend, self.model._cache)
-        rel234 = ops.Relation('test', 234, True, unit, self.model._backend, self.model._cache)
+        secret = self.make_secret(model, id='x')
+        unit = ops.Unit('test', ops.CharmMeta(), model._backend, model._cache)
+        rel123 = ops.Relation('test', 123, True, unit, model._backend, model._cache)
+        rel234 = ops.Relation('test', 234, True, unit, model._backend, model._cache)
         secret.revoke(rel123)
-        unit = ops.Unit('app/0', ops.CharmMeta(), self.model._backend, self.model._cache)
+        unit = ops.Unit('app/0', ops.CharmMeta(), model._backend, model._cache)
         secret.revoke(rel234, unit=unit)
 
         # If secret doesn't have an ID, we'll run secret-info-get to fetch it
-        secret = self.make_secret(label='y')
+        secret = self.make_secret(model, label='y')
         assert secret.id is None
-        rel345 = ops.Relation('test', 345, True, unit, self.model._backend, self.model._cache)
+        rel345 = ops.Relation('test', 345, True, unit, model._backend, model._cache)
         secret.revoke(rel345)
         assert secret.id == 'secret:z'
 
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['relation-list', '-r', '123', '--format=json'],
             ['relation-list', '-r', '234', '--format=json'],
             ['secret-revoke', 'secret:x', '--relation', '123'],
@@ -3526,102 +3618,103 @@ class TestSecretClass(unittest.TestCase):
             ['secret-revoke', 'secret:z', '--relation', '345'],
         ]
 
-    def test_remove_revision(self):
-        fake_script(self, 'secret-remove', """exit 0""")
-        fake_script(self, 'secret-info-get', """echo '{"z": {"label": "y", "revision": 7}}'""")
+    def test_remove_revision(self, model: ops.Model, fake_script: FakeScript):
+        fake_script.write('secret-remove', """exit 0""")
+        fake_script.write('secret-info-get', """echo '{"z": {"label": "y", "revision": 7}}'""")
 
-        secret = self.make_secret(id='x')
+        secret = self.make_secret(model, id='x')
         secret.remove_revision(123)
 
         # If secret doesn't have an ID, we'll run secret-info-get to fetch it
-        secret = self.make_secret(label='y')
+        secret = self.make_secret(model, label='y')
         assert secret.id is None
         secret.remove_revision(234)
         assert secret.id == 'secret:z'
 
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['secret-remove', 'secret:x', '--revision', '123'],
             ['secret-info-get', '--label', 'y', '--format=json'],
             ['secret-remove', 'secret:z', '--revision', '234'],
         ]
 
-    def test_remove_all_revisions(self):
-        fake_script(self, 'secret-remove', """exit 0""")
-        fake_script(self, 'secret-info-get', """echo '{"z": {"label": "y", "revision": 7}}'""")
+    def test_remove_all_revisions(self, model: ops.Model, fake_script: FakeScript):
+        fake_script.write('secret-remove', """exit 0""")
+        fake_script.write('secret-info-get', """echo '{"z": {"label": "y", "revision": 7}}'""")
 
-        secret = self.make_secret(id='x')
+        secret = self.make_secret(model, id='x')
         secret.remove_all_revisions()
 
         # If secret doesn't have an ID, we'll run secret-info-get to fetch it
-        secret = self.make_secret(label='y')
+        secret = self.make_secret(model, label='y')
         assert secret.id is None
         secret.remove_all_revisions()
         assert secret.id == 'secret:z'
 
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['secret-remove', 'secret:x'],
             ['secret-info-get', '--label', 'y', '--format=json'],
             ['secret-remove', 'secret:z'],
         ]
 
 
-class TestPorts(unittest.TestCase):
-    def setUp(self):
-        self.model = ops.model.Model(ops.charm.CharmMeta(), ops.model._ModelBackend('myapp/0'))
-        self.unit = self.model.unit
+class TestPorts:
+    @pytest.fixture
+    def unit(self):
+        model = ops.Model(ops.charm.CharmMeta(), ops.model._ModelBackend('myapp/0'))
+        return model.unit
 
-    def test_open_port(self):
-        fake_script(self, 'open-port', 'exit 0')
+    def test_open_port(self, fake_script: FakeScript, unit: ops.Unit):
+        fake_script.write('open-port', 'exit 0')
 
-        self.unit.open_port('tcp', 8080)
-        self.unit.open_port('UDP', 4000)  # type: ignore
-        self.unit.open_port('icmp')
+        unit.open_port('tcp', 8080)
+        unit.open_port('UDP', 4000)  # type: ignore
+        unit.open_port('icmp')
 
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['open-port', '8080/tcp'],
             ['open-port', '4000/udp'],
             ['open-port', 'icmp'],
         ]
 
-    def test_open_port_error(self):
-        fake_script(self, 'open-port', "echo 'ERROR bad protocol' >&2; exit 1")
+    def test_open_port_error(self, fake_script: FakeScript, unit: ops.Unit):
+        fake_script.write('open-port', "echo 'ERROR bad protocol' >&2; exit 1")
 
         with pytest.raises(ops.ModelError) as excinfo:
-            self.unit.open_port('ftp', 8080)  # type: ignore
+            unit.open_port('ftp', 8080)  # type: ignore
         assert str(excinfo.value) == 'ERROR bad protocol\n'
 
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['open-port', '8080/ftp'],
         ]
 
-    def test_close_port(self):
-        fake_script(self, 'close-port', 'exit 0')
+    def test_close_port(self, fake_script: FakeScript, unit: ops.Unit):
+        fake_script.write('close-port', 'exit 0')
 
-        self.unit.close_port('tcp', 8080)
-        self.unit.close_port('UDP', 4000)  # type: ignore
-        self.unit.close_port('icmp')
+        unit.close_port('tcp', 8080)
+        unit.close_port('UDP', 4000)  # type: ignore
+        unit.close_port('icmp')
 
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['close-port', '8080/tcp'],
             ['close-port', '4000/udp'],
             ['close-port', 'icmp'],
         ]
 
-    def test_close_port_error(self):
-        fake_script(self, 'close-port', "echo 'ERROR bad protocol' >&2; exit 1")
+    def test_close_port_error(self, fake_script: FakeScript, unit: ops.Unit):
+        fake_script.write('close-port', "echo 'ERROR bad protocol' >&2; exit 1")
 
         with pytest.raises(ops.ModelError) as excinfo:
-            self.unit.close_port('ftp', 8080)  # type: ignore
+            unit.close_port('ftp', 8080)  # type: ignore
         assert str(excinfo.value) == 'ERROR bad protocol\n'
 
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['close-port', '8080/ftp'],
         ]
 
-    def test_opened_ports(self):
-        fake_script(self, 'opened-ports', """echo 8080/tcp; echo icmp""")
+    def test_opened_ports(self, fake_script: FakeScript, unit: ops.Unit):
+        fake_script.write('opened-ports', """echo 8080/tcp; echo icmp""")
 
-        ports_set = self.unit.opened_ports()
+        ports_set = unit.opened_ports()
         assert isinstance(ports_set, set)
         ports = sorted(ports_set, key=lambda p: (p.protocol, p.port))
         assert len(ports) == 2
@@ -3632,18 +3725,22 @@ class TestPorts(unittest.TestCase):
         assert ports[1].protocol == 'tcp'
         assert ports[1].port == 8080
 
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['opened-ports', ''],
         ]
 
-    def test_opened_ports_warnings(self):
-        fake_script(self, 'opened-ports', """echo 8080/tcp; echo 1234/ftp; echo 1000-2000/udp""")
+    def test_opened_ports_warnings(
+            self,
+            caplog: pytest.LogCaptureFixture,
+            fake_script: FakeScript,
+            unit: ops.Unit):
+        fake_script.write('opened-ports', """echo 8080/tcp; echo 1234/ftp; echo 1000-2000/udp""")
 
-        with self.assertLogs('ops.model', level='WARNING') as cm:
-            ports_set = self.unit.opened_ports()
-        assert len(cm.output) == 2
-        assert re.search(r'WARNING:ops.model:.*protocol.*', cm.output[0])
-        assert re.search(r'WARNING:ops.model:.*range.*', cm.output[1])
+        with caplog.at_level(level='WARNING', logger='ops.model'):
+            ports_set = unit.opened_ports()
+        assert len(caplog.records) == 2
+        assert re.search(r'.*protocol.*', caplog.records[0].message)
+        assert re.search(r'.*range.*', caplog.records[1].message)
 
         assert isinstance(ports_set, set)
         ports = sorted(ports_set, key=lambda p: (p.protocol, p.port))
@@ -3655,16 +3752,16 @@ class TestPorts(unittest.TestCase):
         assert ports[1].protocol == 'udp'
         assert ports[1].port == 1000
 
-        assert fake_script_calls(self, clear=True) == [
+        assert fake_script.calls(clear=True) == [
             ['opened-ports', ''],
         ]
 
-    def test_set_ports_all_open(self):
-        fake_script(self, 'open-port', 'exit 0')
-        fake_script(self, 'close-port', 'exit 0')
-        fake_script(self, 'opened-ports', 'exit 0')
-        self.unit.set_ports(8000, 8025)
-        calls = fake_script_calls(self, clear=True)
+    def test_set_ports_all_open(self, fake_script: FakeScript, unit: ops.Unit):
+        fake_script.write('open-port', 'exit 0')
+        fake_script.write('close-port', 'exit 0')
+        fake_script.write('opened-ports', 'exit 0')
+        unit.set_ports(8000, 8025)
+        calls = fake_script.calls(clear=True)
         assert calls.pop(0) == ['opened-ports', '']
         calls.sort()  # We make no guarantee on the order the ports are opened.
         assert calls == [
@@ -3672,24 +3769,24 @@ class TestPorts(unittest.TestCase):
             ['open-port', '8025/tcp'],
         ]
 
-    def test_set_ports_mixed(self):
+    def test_set_ports_mixed(self, fake_script: FakeScript, unit: ops.Unit):
         # Two open ports, leave one alone and open another one.
-        fake_script(self, 'open-port', 'exit 0')
-        fake_script(self, 'close-port', 'exit 0')
-        fake_script(self, 'opened-ports', 'echo 8025/tcp; echo 8028/tcp')
-        self.unit.set_ports(ops.Port('udp', 8022), 8028)
-        assert fake_script_calls(self, clear=True) == [
+        fake_script.write('open-port', 'exit 0')
+        fake_script.write('close-port', 'exit 0')
+        fake_script.write('opened-ports', 'echo 8025/tcp; echo 8028/tcp')
+        unit.set_ports(ops.Port('udp', 8022), 8028)
+        assert fake_script.calls(clear=True) == [
             ['opened-ports', ''],
             ['close-port', '8025/tcp'],
             ['open-port', '8022/udp'],
         ]
 
-    def test_set_ports_replace(self):
-        fake_script(self, 'open-port', 'exit 0')
-        fake_script(self, 'close-port', 'exit 0')
-        fake_script(self, 'opened-ports', 'echo 8025/tcp; echo 8028/tcp')
-        self.unit.set_ports(8001, 8002)
-        calls = fake_script_calls(self, clear=True)
+    def test_set_ports_replace(self, fake_script: FakeScript, unit: ops.Unit):
+        fake_script.write('open-port', 'exit 0')
+        fake_script.write('close-port', 'exit 0')
+        fake_script.write('opened-ports', 'echo 8025/tcp; echo 8028/tcp')
+        unit.set_ports(8001, 8002)
+        calls = fake_script.calls(clear=True)
         assert calls.pop(0) == ['opened-ports', '']
         calls.sort()
         assert calls == [
@@ -3699,50 +3796,48 @@ class TestPorts(unittest.TestCase):
             ['open-port', '8002/tcp'],
         ]
 
-    def test_set_ports_close_all(self):
-        fake_script(self, 'open-port', 'exit 0')
-        fake_script(self, 'close-port', 'exit 0')
-        fake_script(self, 'opened-ports', 'echo 8022/udp')
-        self.unit.set_ports()
-        assert fake_script_calls(self, clear=True) == [
+    def test_set_ports_close_all(self, fake_script: FakeScript, unit: ops.Unit):
+        fake_script.write('open-port', 'exit 0')
+        fake_script.write('close-port', 'exit 0')
+        fake_script.write('opened-ports', 'echo 8022/udp')
+        unit.set_ports()
+        assert fake_script.calls(clear=True) == [
             ['opened-ports', ''],
             ['close-port', '8022/udp'],
         ]
 
-    def test_set_ports_noop(self):
-        fake_script(self, 'open-port', 'exit 0')
-        fake_script(self, 'close-port', 'exit 0')
-        fake_script(self, 'opened-ports', 'echo 8000/tcp')
-        self.unit.set_ports(ops.Port('tcp', 8000))
-        assert fake_script_calls(self, clear=True) == [
+    def test_set_ports_noop(self, fake_script: FakeScript, unit: ops.Unit):
+        fake_script.write('open-port', 'exit 0')
+        fake_script.write('close-port', 'exit 0')
+        fake_script.write('opened-ports', 'echo 8000/tcp')
+        unit.set_ports(ops.Port('tcp', 8000))
+        assert fake_script.calls(clear=True) == [
             ['opened-ports', ''],
         ]
 
 
-class TestUnit(unittest.TestCase):
-    def setUp(self):
-        self.model = ops.model.Model(ops.charm.CharmMeta(), ops.model._ModelBackend('myapp/0'))
-        self.unit = self.model.unit
-
-    def test_reboot(self):
-        fake_script(self, 'juju-reboot', 'exit 0')
-        self.unit.reboot()
-        assert fake_script_calls(self, clear=True) == [
+class TestUnit:
+    def test_reboot(self, fake_script: FakeScript):
+        model = ops.model.Model(ops.charm.CharmMeta(), ops.model._ModelBackend('myapp/0'))
+        unit = model.unit
+        fake_script.write('juju-reboot', 'exit 0')
+        unit.reboot()
+        assert fake_script.calls(clear=True) == [
             ['juju-reboot', ''],
         ]
         with pytest.raises(SystemExit):
-            self.unit.reboot(now=True)
-        assert fake_script_calls(self, clear=True) == [
+            unit.reboot(now=True)
+        assert fake_script.calls(clear=True) == [
             ['juju-reboot', '--now'],
         ]
 
         with pytest.raises(RuntimeError):
-            self.model.get_unit('other').reboot()
+            model.get_unit('other').reboot()
         with pytest.raises(RuntimeError):
-            self.model.get_unit('other').reboot(now=True)
+            model.get_unit('other').reboot(now=True)
 
 
-class TestLazyNotice(unittest.TestCase):
+class TestLazyNotice:
     def test_lazy_notice(self):
         calls = 0
         timestamp = datetime.datetime.now()
@@ -3791,7 +3886,7 @@ class TestLazyNotice(unittest.TestCase):
             "LazyNotice(id='123', type='foobar', key='example.com/a')"
 
 
-class TestCloudCredential(unittest.TestCase):
+class TestCloudCredential:
     def test_from_dict(self):
         d = {
             'auth-type': 'certificate',
@@ -3817,7 +3912,7 @@ class TestCloudCredential(unittest.TestCase):
         assert cloud_cred.redacted == d['redacted']
 
 
-class TestCloudSpec(unittest.TestCase):
+class TestCloudSpec:
     def test_from_dict(self):
         cloud_spec = ops.CloudSpec.from_dict(
             {
@@ -3895,25 +3990,24 @@ class TestCloudSpec(unittest.TestCase):
         assert cloud_spec.is_controller_cloud
 
 
-class TestGetCloudSpec(unittest.TestCase):
-    def setUp(self):
-        self.model = ops.Model(ops.CharmMeta(), _ModelBackend('myapp/0'))
+class TestGetCloudSpec:
+    @pytest.fixture
+    def model(self):
+        return ops.Model(ops.CharmMeta(), _ModelBackend('myapp/0'))
 
-    def test_success(self):
-        fake_script(self, 'credential-get', """echo '{"type": "lxd", "name": "localhost"}'""")
-        cloud_spec = self.model.get_cloud_spec()
+    def test_success(self, fake_script: FakeScript, model: ops.Model):
+        fake_script.write('credential-get', """echo '{"type": "lxd", "name": "localhost"}'""")
+        cloud_spec = model.get_cloud_spec()
         assert cloud_spec.type == 'lxd'
         assert cloud_spec.name == 'localhost'
-        assert fake_script_calls(self, clear=True) == \
-            [['credential-get', '--format=json']]
+        assert fake_script.calls(clear=True) == [['credential-get', '--format=json']]
 
-    def test_error(self):
-        fake_script(
-            self,
+    def test_error(self, fake_script: FakeScript, model: ops.Model):
+        fake_script.write(
             'credential-get',
             """echo 'ERROR cannot access cloud credentials' >&2; exit 1""")
         with pytest.raises(ops.ModelError) as excinfo:
-            self.model.get_cloud_spec()
+            model.get_cloud_spec()
         assert str(excinfo.value) == 'ERROR cannot access cloud credentials\n'
 
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -186,16 +186,20 @@ class TestModel:
             ('relation_remote_app_name', 2),
         ])
 
-    def test_peer_relation_app(self,
-                               harness: ops.testing.Harness[ops.CharmBase],
-                               model: ops.Model):
+    def test_peer_relation_app(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         harness.add_relation('db2', 'myapp')
         rel_dbpeer = self.ensure_relation(model, 'db2')
         assert rel_dbpeer.app is model.app
 
-    def test_remote_units_is_our(self,
-                                 harness: ops.testing.Harness[ops.CharmBase],
-                                 model: ops.Model):
+    def test_remote_units_is_our(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         relation_id = harness.add_relation('db1', 'remoteapp1')
         harness.add_relation_unit(relation_id, 'remoteapp1/0')
         harness.add_relation_unit(relation_id, 'remoteapp1/1')
@@ -246,9 +250,11 @@ class TestModel:
                 relation_id, harness.model.app) == harness.get_relation_data(
                 relation_id, local_app) == {'foo': 'bar'}
 
-    def test_unit_relation_data(self,
-                                harness: ops.testing.Harness[ops.CharmBase],
-                                model: ops.Model):
+    def test_unit_relation_data(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         relation_id = harness.add_relation('db1', 'remoteapp1')
         harness.add_relation_unit(relation_id, 'remoteapp1/0')
         with harness._event_context('foo_event'):
@@ -273,9 +279,11 @@ class TestModel:
             ('relation_get', relation_id, 'remoteapp1/0', False),
         ])
 
-    def test_remote_app_relation_data(self,
-                                      harness: ops.testing.Harness[ops.CharmBase],
-                                      model: ops.Model):
+    def test_remote_app_relation_data(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         relation_id = harness.add_relation('db1', 'remoteapp1')
         with harness._event_context('foo_event'):
             harness.update_relation_data(relation_id, 'remoteapp1',
@@ -302,9 +310,11 @@ class TestModel:
             ('relation_get', relation_id, 'remoteapp1', True),
         ])
 
-    def test_relation_data_modify_remote(self,
-                                         harness: ops.testing.Harness[ops.CharmBase],
-                                         model: ops.Model):
+    def test_relation_data_modify_remote(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         relation_id = harness.add_relation('db1', 'remoteapp1')
         with harness._event_context('foo_event'):
             harness.update_relation_data(relation_id, 'remoteapp1',
@@ -342,9 +352,11 @@ class TestModel:
              "<ops.model.Unit remoteapp1/0>: {'host': 'remoteapp1/0'}, "
              "<ops.model.Application remoteapp1>: {'secret': 'cafedeadbeef'}}")
 
-    def test_relation_data_modify_our(self,
-                                      harness: ops.testing.Harness[ops.CharmBase],
-                                      model: ops.Model):
+    def test_relation_data_modify_our(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         relation_id = harness.add_relation('db1', 'remoteapp1')
 
         harness.update_relation_data(relation_id, 'myapp/0', {'host': 'nothing'})
@@ -365,7 +377,10 @@ class TestModel:
         ])
 
     def test_app_relation_data_modify_local_as_leader(
-            self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         relation_id = harness.add_relation('db1', 'remoteapp1')
         harness.update_relation_data(relation_id, 'myapp', {'password': 'deadbeefcafe'})
         harness.add_relation_unit(relation_id, 'remoteapp1/0')
@@ -381,14 +396,18 @@ class TestModel:
 
         assert rel_db1.data[local_app]['password'] == 'foo'
 
-        self.assertBackendCalls(harness,
-                                [('relation_ids', 'db1'),
-                                 ('relation_list', 0),
-                                    ('relation_get', 0, 'myapp', True),
-                                    ('update_relation_data', 0, model.app, 'password', 'foo')])
+        self.assertBackendCalls(harness, [
+            ('relation_ids', 'db1'),
+            ('relation_list', 0),
+            ('relation_get', 0, 'myapp', True),
+            ('update_relation_data', 0, model.app, 'password', 'foo')
+        ])
 
     def test_app_relation_data_modify_local_as_minion(
-            self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         relation_id = harness.add_relation('db1', 'remoteapp1')
         harness.update_relation_data(relation_id, 'myapp', {'password': 'deadbeefcafe'})
         harness.add_relation_unit(relation_id, 'remoteapp1/0')
@@ -405,10 +424,12 @@ class TestModel:
             with pytest.raises(ops.RelationDataError):
                 rel_db1.data[local_app]['password'] = 'foobar'
 
-        self.assertBackendCalls(harness, [('relation_ids', 'db1'),
-                                          ('relation_list', 0),
-                                          ('relation_get', 0, 'myapp', True),
-                                          ('is_leader',)])
+        self.assertBackendCalls(harness, [
+            ('relation_ids', 'db1'),
+            ('relation_list', 0),
+            ('relation_get', 0, 'myapp', True),
+            ('is_leader',)
+        ])
 
     def test_relation_data_access_peer_leader(self, harness: ops.testing.Harness[ops.CharmBase]):
         r_id = harness.add_relation('db2', 'myapp')
@@ -432,9 +453,11 @@ class TestModel:
             assert relation is not None and relation.app is not None
             assert relation.data[relation.app]['foo'] == 'bar'
 
-    def test_relation_data_del_key(self,
-                                   harness: ops.testing.Harness[ops.CharmBase],
-                                   model: ops.Model):
+    def test_relation_data_del_key(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         relation_id = harness.add_relation('db1', 'remoteapp1')
         with harness._event_context('foo_event'):
             harness.update_relation_data(relation_id, 'myapp/0', {'host': 'bar'})
@@ -456,7 +479,10 @@ class TestModel:
         ])
 
     def test_relation_data_del_missing_key(
-            self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         relation_id = harness.add_relation('db1', 'remoteapp1')
         with harness._event_context('foo_event'):
             harness.update_relation_data(relation_id, 'myapp/0', {'host': 'bar'})
@@ -480,9 +506,11 @@ class TestModel:
             ('update_relation_data', relation_id, model.unit, 'port', ''),
         ])
 
-    def test_relation_set_fail(self,
-                               harness: ops.testing.Harness[ops.CharmBase],
-                               model: ops.Model):
+    def test_relation_set_fail(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         relation_id = harness.add_relation('db1', 'remoteapp1')
         with harness._event_context('foo_event'):
             harness.update_relation_data(relation_id, 'myapp/0', {'host': 'myapp-0'})
@@ -496,12 +524,14 @@ class TestModel:
         #       for us to properly test the side effects of relation-set failing.
 
         def broken_update_relation_data(
-                relation_id: int,
-                entity: typing.Union[ops.Unit, ops.Application],
-                key: str,
-                value: str):
+            relation_id: int,
+            entity: typing.Union[ops.Unit, ops.Application],
+            key: str,
+            value: str,
+        ):
             backend._calls.append(('update_relation_data', relation_id, entity, key, value))
             raise ops.ModelError()
+
         backend.update_relation_data = broken_update_relation_data
 
         rel_db1 = self.ensure_relation(model, 'db1')
@@ -524,9 +554,11 @@ class TestModel:
             ('update_relation_data', relation_id, model.unit, 'host', ''),
         ])
 
-    def test_relation_data_type_check(self,
-                                      harness: ops.testing.Harness[ops.CharmBase],
-                                      model: ops.Model):
+    def test_relation_data_type_check(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         relation_id = harness.add_relation('db1', 'remoteapp1')
         harness.update_relation_data(relation_id, 'myapp/0', {'host': 'myapp-0'})
         harness.add_relation_unit(relation_id, 'remoteapp1/0')
@@ -534,14 +566,14 @@ class TestModel:
 
         rel_db1 = self.ensure_relation(model, 'db1')
         for key, value in (
-                ('foo', 1),
-                ('foo', None),
-                ('foo', {'foo': 'bar'}),
-                (1, 'foo'),
-                (None, 'foo'),
-                (('foo', 'bar'), 'foo'),
-                (1, 1),
-                (None, None)
+            ('foo', 1),
+            ('foo', None),
+            ('foo', {'foo': 'bar'}),
+            (1, 'foo'),
+            (None, 'foo'),
+            (('foo', 'bar'), 'foo'),
+            (1, 1),
+            (None, None)
         ):
             with pytest.raises(ops.RelationDataError):
                 with harness.framework._event_context('foo_event'):
@@ -557,16 +589,16 @@ class TestModel:
         ])
 
     def test_relation_local_app_data_readability_leader(
-            self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         relation_id = harness.add_relation('db1', 'remoteapp1')
-        harness.update_relation_data(relation_id, 'remoteapp1',
-                                     {'secret': 'cafedeadbeef'})
-        harness.update_relation_data(relation_id, 'myapp',
-                                     {'local': 'data'})
+        harness.update_relation_data(relation_id, 'remoteapp1', {'secret': 'cafedeadbeef'})
+        harness.update_relation_data(relation_id, 'myapp', {'local': 'data'})
 
         harness.add_relation_unit(relation_id, 'remoteapp1/0')
-        harness.update_relation_data(relation_id, 'remoteapp1/0',
-                                     {'host': 'remoteapp1/0'})
+        harness.update_relation_data(relation_id, 'remoteapp1/0', {'host': 'remoteapp1/0'})
         model.relations._invalidate('db1')
         self.resetBackendCalls(harness)
 
@@ -588,8 +620,10 @@ class TestModel:
 
             assert rel_db1.data[local_app]['local'] == 'data'
 
-            self.assertBackendCalls(harness, [('is_leader',),
-                                              ('relation_get', 0, 'myapp', True)])
+            self.assertBackendCalls(harness, [
+                ('is_leader',),
+                ('relation_get', 0, 'myapp', True)
+            ])
 
             self.resetBackendCalls(harness)
 
@@ -602,17 +636,17 @@ class TestModel:
             assert isinstance(repr(rel_db1.data), str)
 
     def test_relation_local_app_data_readability_follower(
-            self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         relation_id = harness.add_relation('db1', 'remoteapp1')
         with harness._event_context('foo_event'):
-            harness.update_relation_data(relation_id, 'remoteapp1',
-                                         {'secret': 'cafedeadbeef'})
-            harness.update_relation_data(relation_id, 'myapp',
-                                         {'local': 'data'})
+            harness.update_relation_data(relation_id, 'remoteapp1', {'secret': 'cafedeadbeef'})
+            harness.update_relation_data(relation_id, 'myapp', {'local': 'data'})
 
             harness.add_relation_unit(relation_id, 'remoteapp1/0')
-            harness.update_relation_data(relation_id, 'remoteapp1/0',
-                                         {'host': 'remoteapp1/0'})
+            harness.update_relation_data(relation_id, 'remoteapp1/0', {'host': 'remoteapp1/0'})
         model.relations._invalidate('db1')
         self.resetBackendCalls(harness)
 
@@ -650,9 +684,11 @@ class TestModel:
                 ('relation_get', 0, 'remoteapp1', True)]
             self.assertBackendCalls(harness, expected_backend_calls)
 
-    def test_relation_no_units(self,
-                               harness: ops.testing.Harness[ops.CharmBase],
-                               model: ops.Model):
+    def test_relation_no_units(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         harness.add_relation('db1', 'remoteapp1')
         rel = self.ensure_relation(model, 'db1')
         assert rel.units == set()
@@ -665,8 +701,13 @@ class TestModel:
 
     def test_config(self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
         harness._get_backend_calls(reset=True)
-        harness.update_config({'foo': 'foo', 'bar': 1, 'qux': True,
-                               'baz': 3.1, 'secretfoo': 'secret:1234'})
+        harness.update_config({
+            'foo': 'foo',
+            'bar': 1,
+            'qux': True,
+            'baz': 3.1,
+            'secretfoo': 'secret:1234'
+        })
         assert model.config == {
             'foo': 'foo',
             'bar': 1,
@@ -719,9 +760,11 @@ class TestModel:
             ('application_version_set', '1.2.3'),
         ])
 
-    def test_workload_version_invalid(self,
-                                      harness: ops.testing.Harness[ops.CharmBase],
-                                      model: ops.Model):
+    def test_workload_version_invalid(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        model: ops.Model,
+    ):
         with pytest.raises(TypeError) as excinfo:
             model.unit.set_workload_version(5)  # type: ignore
         assert str(excinfo.value) == "workload version must be a str, not int: 5"
@@ -740,9 +783,7 @@ class TestModel:
         assert harness.model.resources.fetch('foo').name == 'foo.txt'
         assert harness.model.resources.fetch('bar').name == 'bar.txt'
 
-    def test_resources_immutable(self,
-                                 harness: ops.testing.Harness[ops.CharmBase],
-                                 model: ops.Model):
+    def test_resources_immutable(self, model: ops.Model):
         with pytest.raises(AttributeError):
             model.resources = object()  # type: ignore
 
@@ -759,7 +800,7 @@ class TestModel:
         with pytest.raises(ops.ModelError):
             harness.model.pod.set_spec({'foo': 'bar'})
 
-    def test_pod_immutable(self, harness: ops.testing.Harness[ops.CharmBase], model: ops.Model):
+    def test_pod_immutable(self, model: ops.Model):
         with pytest.raises(AttributeError):
             model.pod = object()  # type: ignore
 
@@ -900,8 +941,12 @@ class TestModel:
         relation_id = harness.add_relation('db1', 'remoteapp1')
         harness.add_relation_unit(relation_id, 'remoteapp1/0')
         harness.add_relation_unit(relation_id, 'remoteapp1/1')
-        remote_unit = next(filter(lambda u: u.name == 'remoteapp1/0',
-                                  self.ensure_relation(model, 'db1').units))
+        remote_unit = next(
+            filter(
+                lambda u: u.name == 'remoteapp1/0',
+                self.ensure_relation(model, 'db1').units
+            )
+        )
         self.resetBackendCalls(harness)
 
         # Remote unit status is always unknown.
@@ -1066,7 +1111,7 @@ class PushPullCase:
         dst: typing.Optional[str] = None,
         errors: typing.Optional[typing.Set[str]] = None,
         dirs: typing.Optional[typing.Set[str]] = None,
-        want_dirs: typing.Optional[typing.Set[str]] = None
+        want_dirs: typing.Optional[typing.Set[str]] = None,
     ):
         self.pattern = None
         self.dst = dst
@@ -1437,10 +1482,12 @@ class TestApplication:
         assert s
         assert 'baz' in c.get_services()
 
-    def test_planned_units(self,
-                           harness: ops.testing.Harness[ops.CharmBase],
-                           app: ops.Application,
-                           peer_rel_id: int):
+    def test_planned_units(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        app: ops.Application,
+        peer_rel_id: int,
+    ):
         # Test that we always count ourself.
         assert app.planned_units() == 1
 
@@ -1458,10 +1505,11 @@ class TestApplication:
 
         assert app.planned_units() == 3
 
-    def test_planned_units_user_set(self,
-                                    harness: ops.testing.Harness[ops.CharmBase],
-                                    app: ops.Application):
-
+    def test_planned_units_user_set(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        app: ops.Application,
+    ):
         harness.set_planned_units(1)
         assert app.planned_units() == 1
 
@@ -1471,9 +1519,11 @@ class TestApplication:
         harness.set_planned_units(100)
         assert app.planned_units() == 100
 
-    def test_planned_units_garbage_values(self,
-                                          harness: ops.testing.Harness[ops.CharmBase],
-                                          app: ops.Application):
+    def test_planned_units_garbage_values(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        app: ops.Application,
+    ):
         # Planned units should be a positive integer, or zero.
         with pytest.raises(TypeError):
             harness.set_planned_units(-1)
@@ -1488,10 +1538,12 @@ class TestApplication:
         with pytest.raises(TypeError):
             harness.set_planned_units(-3423000102312321090)
 
-    def test_planned_units_override(self,
-                                    harness: ops.testing.Harness[ops.CharmBase],
-                                    app: ops.Application,
-                                    peer_rel_id: int):
+    def test_planned_units_override(
+        self,
+        harness: ops.testing.Harness[ops.CharmBase],
+        app: ops.Application,
+        peer_rel_id: int,
+    ):
         """Verify that we override the calculated value of planned_units when we set it manually.
 
         When a charm author writes a test that explicitly calls set_planned_units, we assume that
@@ -1761,9 +1813,10 @@ containers:
         ]
 
     def test_restart_fallback_non_400_error(
-            self,
-            container: ops.Container,
-            container_pebble: MockPebbleClient):
+        self,
+        container: ops.Container,
+        container_pebble: MockPebbleClient,
+    ):
         def restart_services(service_names: str):
             raise pebble.APIError({}, 500, "", "")
 
@@ -2037,16 +2090,20 @@ containers:
             ('remove_path', '/path/2', True),
         ]
 
-    def test_can_connect_simple(self, container: ops.Container,
-                                container_pebble: MockPebbleClient):
+    def test_can_connect_simple(
+        self,
+        container: ops.Container,
+        container_pebble: MockPebbleClient,
+    ):
         container_pebble.responses.append(pebble.SystemInfo.from_dict({'version': '1.0.0'}))
         assert container.can_connect()
 
     def test_can_connect_connection_error(
-            self,
-            caplog: pytest.LogCaptureFixture,
-            container: ops.Container,
-            container_pebble: MockPebbleClient):
+        self,
+        caplog: pytest.LogCaptureFixture,
+        container: ops.Container,
+        container_pebble: MockPebbleClient,
+    ):
         def raise_error():
             raise pebble.ConnectionError('connection error!')
         container_pebble.get_system_info = raise_error
@@ -2056,10 +2113,11 @@ containers:
         assert re.search(r'connection error!', caplog.text)
 
     def test_can_connect_file_not_found_error(
-            self,
-            caplog: pytest.LogCaptureFixture,
-            container: ops.Container,
-            container_pebble: MockPebbleClient):
+        self,
+        caplog: pytest.LogCaptureFixture,
+        container: ops.Container,
+        container_pebble: MockPebbleClient,
+    ):
         def raise_error():
             raise FileNotFoundError('file not found!')
         container_pebble.get_system_info = raise_error
@@ -2069,10 +2127,11 @@ containers:
         assert re.search(r'file not found!', caplog.text)
 
     def test_can_connect_api_error(
-            self,
-            caplog: pytest.LogCaptureFixture,
-            container: ops.Container,
-            container_pebble: MockPebbleClient):
+        self,
+        caplog: pytest.LogCaptureFixture,
+        container: ops.Container,
+        container_pebble: MockPebbleClient,
+    ):
         def raise_error():
             raise pebble.APIError({'body': ''}, 404, 'status', 'api error!')
         container_pebble.get_system_info = raise_error
@@ -2163,8 +2222,11 @@ containers:
             ('get_notice', '123'),
         ]
 
-    def test_get_notice_not_found(self, container: ops.Container,
-                                  container_pebble: MockPebbleClient):
+    def test_get_notice_not_found(
+        self,
+        container: ops.Container,
+        container_pebble: MockPebbleClient,
+    ):
         def raise_error(id: str):
             raise pebble.APIError({'body': ''}, 404, 'status', 'api error!')
         container_pebble.get_notice = raise_error
@@ -2277,8 +2339,12 @@ class TestModelBindings:
 }'''
         return model
 
-    def ensure_relation(self, model: ops.Model, name: str = 'db1',
-                        relation_id: typing.Optional[int] = None):
+    def ensure_relation(
+        self,
+        model: ops.Model,
+        name: str = 'db1',
+        relation_id: typing.Optional[int] = None
+    ):
         """Wrapper around self.model.get_relation that enforces that None is not returned."""
         rel_db1 = model.get_relation(name, relation_id)
         assert rel_db1 is not None, rel_db1  # Type checkers don't understand `assertIsNotNone`
@@ -2296,27 +2362,31 @@ class TestModelBindings:
         assert binding.network.bind_address == ipaddress.ip_address('192.0.2.2')
         assert binding.network.ingress_address == ipaddress.ip_address('192.0.2.2')
         # /32 and /128 CIDRs are valid one-address networks for IPv{4,6}Network types respectively.
-        assert binding.network.egress_subnets == [ipaddress.ip_network('192.0.2.2/32'),
-                                                  ipaddress.ip_network('192.0.3.0/24'),
-                                                  ipaddress.ip_network('dead:beef::/64'),
-                                                  ipaddress.ip_network('2001:db8::3/128')]
+        assert binding.network.egress_subnets == [
+            ipaddress.ip_network('192.0.2.2/32'),
+            ipaddress.ip_network('192.0.3.0/24'),
+            ipaddress.ip_network('dead:beef::/64'),
+            ipaddress.ip_network('2001:db8::3/128')
+        ]
 
         for (i, (name, address, subnet)) in enumerate([
-                ('lo', '192.0.2.2', '192.0.2.0/24'),
-                ('lo', 'dead:beef::1', 'dead:beef::/64'),
-                ('tun', '192.0.3.3', '192.0.3.3/32'),
-                ('tun', '2001:db8::3', '2001:db8::3/128'),
-                ('tun', 'fe80::1:1', 'fe80::/64')]):
+            ('lo', '192.0.2.2', '192.0.2.0/24'),
+            ('lo', 'dead:beef::1', 'dead:beef::/64'),
+            ('tun', '192.0.3.3', '192.0.3.3/32'),
+            ('tun', '2001:db8::3', '2001:db8::3/128'),
+            ('tun', 'fe80::1:1', 'fe80::/64')
+        ]):
             assert binding.network.interfaces[i].name == name
             assert binding.network.interfaces[i].address == ipaddress.ip_address(address)
             assert binding.network.interfaces[i].subnet == ipaddress.ip_network(subnet)
 
         for (i, (name, address, subnet)) in enumerate([
-                ('lo', '192.0.2.2', '192.0.2.0/24'),
-                ('lo', 'dead:beef::1', 'dead:beef::/64'),
-                ('tun', '192.0.3.3', '192.0.3.3/32'),
-                ('tun', '2001:db8::3', '2001:db8::3/128'),
-                ('tun', 'fe80::1:1', 'fe80::/64')]):
+            ('lo', '192.0.2.2', '192.0.2.0/24'),
+            ('lo', 'dead:beef::1', 'dead:beef::/64'),
+            ('tun', '192.0.3.3', '192.0.3.3/32'),
+            ('tun', '2001:db8::3', '2001:db8::3/128'),
+            ('tun', 'fe80::1:1', 'fe80::/64')
+        ]):
             assert binding.network.interfaces[i].name == name
             assert binding.network.interfaces[i].address == ipaddress.ip_address(address)
             assert binding.network.interfaces[i].subnet == ipaddress.ip_network(subnet)
@@ -2618,10 +2688,11 @@ class TestModelBackend:
 
     @pytest.mark.parametrize("version", ['2.8.0', '2.7.0'])
     def test_relation_get_juju_version_quirks(
-            self,
-            fake_script: FakeScript,
-            monkeypatch: pytest.MonkeyPatch,
-            version: str):
+        self,
+        fake_script: FakeScript,
+        monkeypatch: pytest.MonkeyPatch,
+        version: str,
+    ):
         fake_script.write('relation-get', '''echo '{"foo": "bar"}' ''')
 
         # on 2.7.0+, things proceed as expected
@@ -2639,10 +2710,11 @@ class TestModelBackend:
 
     @pytest.mark.parametrize("version", ['2.8.0', '2.7.0'])
     def test_relation_set_juju_version_quirks(
-            self,
-            fake_script: FakeScript,
-            monkeypatch: pytest.MonkeyPatch,
-            version: str):
+        self,
+        fake_script: FakeScript,
+        monkeypatch: pytest.MonkeyPatch,
+        version: str,
+    ):
         # on 2.7.0+, things proceed as expected
         t = tempfile.NamedTemporaryFile()
         try:
@@ -3167,8 +3239,9 @@ class TestSecrets:
         assert secret.id == 'secret:123'
         assert secret.label is None
 
-        assert fake_script.calls(clear=True) == \
-            [['secret-add', '--owner', 'application', 'foo=x']]
+        assert fake_script.calls(clear=True) == [
+            ['secret-add', '--owner', 'application', 'foo=x']
+        ]
 
     def test_app_add_secret_args(self, fake_script: FakeScript, model: ops.Model):
         fake_script.write('secret-add', 'echo secret:234')
@@ -3193,15 +3266,21 @@ class TestSecrets:
         assert secret.id == 'secret:345'
         assert secret.label is None
 
-        assert fake_script.calls(clear=True) == \
-            [['secret-add', '--owner', 'unit', 'foo=x']]
+        assert fake_script.calls(clear=True) == [
+            ['secret-add', '--owner', 'unit', 'foo=x']
+        ]
 
     def test_unit_add_secret_args(self, fake_script: FakeScript, model: ops.Model):
         fake_script.write('secret-add', 'echo secret:456')
 
         expire = datetime.datetime(2022, 12, 9, 16, 22, 0)
-        secret = model.unit.add_secret({'foo': 'w', 'bar': 'z'}, label='l2', description='xyz',
-                                       expire=expire, rotate=ops.SecretRotate.YEARLY)
+        secret = model.unit.add_secret(
+            {'foo': 'w', 'bar': 'z'},
+            label='l2',
+            description='xyz',
+            expire=expire,
+            rotate=ops.SecretRotate.YEARLY
+        )
         assert secret.id == 'secret:456'
         assert secret.label == 'l2'
         assert secret.get_content() == {'foo': 'w', 'bar': 'z'}
@@ -3251,8 +3330,9 @@ class TestSecrets:
         assert secret.label is None
         assert secret.get_content() == {'foo': 'g'}
 
-        assert fake_script.calls(clear=True) == \
-            [['secret-get', 'secret:123', '--format=json']]
+        assert fake_script.calls(clear=True) == [
+            ['secret-get', 'secret:123', '--format=json']
+        ]
 
     def test_get_secret_label(self, fake_script: FakeScript, model: ops.Model):
         fake_script.write('secret-get', """echo '{"foo": "g"}'""")
@@ -3262,8 +3342,9 @@ class TestSecrets:
         assert secret.label == 'lbl'
         assert secret.get_content() == {'foo': 'g'}
 
-        assert fake_script.calls(clear=True) == \
-            [['secret-get', '--label', 'lbl', '--format=json']]
+        assert fake_script.calls(clear=True) == [
+            ['secret-get', '--label', 'lbl', '--format=json']
+        ]
 
     def test_get_secret_id_and_label(self, fake_script: FakeScript, model: ops.Model):
         fake_script.write('secret-get', """echo '{"foo": "h"}'""")
@@ -3273,8 +3354,9 @@ class TestSecrets:
         assert secret.label == 'l'
         assert secret.get_content() == {'foo': 'h'}
 
-        assert fake_script.calls(clear=True) == \
-            [['secret-get', 'secret:123', '--label', 'l', '--format=json']]
+        assert fake_script.calls(clear=True) == [
+            ['secret-get', 'secret:123', '--label', 'l', '--format=json']
+        ]
 
     def test_get_secret_no_args(self, model: ops.Model):
         with pytest.raises(TypeError):
@@ -3387,7 +3469,7 @@ class TestSecretClass:
         model: ops.Model,
         id: typing.Optional[str] = None,
         label: typing.Optional[str] = None,
-        content: typing.Optional[typing.Dict[str, str]] = None
+        content: typing.Optional[typing.Dict[str, str]] = None,
     ) -> ops.Secret:
         return ops.Secret(model._backend, id=id, label=label, content=content)
 
@@ -3420,8 +3502,9 @@ class TestSecretClass:
         content = secret.get_content(refresh=True)
         assert content == {'foo': 'refreshed'}
 
-        assert fake_script.calls(clear=True) == \
-            [['secret-get', 'secret:y', '--refresh', '--format=json']]
+        assert fake_script.calls(clear=True) == [
+            ['secret-get', 'secret:y', '--refresh', '--format=json']
+        ]
 
     def test_get_content_uncached(self, model: ops.Model, fake_script: FakeScript):
         fake_script.write('secret-get', """echo '{"foo": "notcached"}'""")
@@ -3430,8 +3513,9 @@ class TestSecretClass:
         content = secret.get_content()
         assert content == {'foo': 'notcached'}
 
-        assert fake_script.calls(clear=True) == \
-            [['secret-get', 'secret:z', '--format=json']]
+        assert fake_script.calls(clear=True) == [
+            ['secret-get', 'secret:z', '--format=json']
+        ]
 
     def test_get_content_copies_dict(self, model: ops.Model, fake_script: FakeScript):
         fake_script.write('secret-get', """echo '{"foo": "bar"}'""")
@@ -3442,8 +3526,9 @@ class TestSecretClass:
         content['new'] = 'value'
         assert secret.get_content() == {'foo': 'bar'}
 
-        assert fake_script.calls(clear=True) == \
-            [['secret-get', 'secret:z', '--format=json']]
+        assert fake_script.calls(clear=True) == [
+            ['secret-get', 'secret:z', '--format=json']
+        ]
 
     def test_set_content_invalidates_cache(self, model: ops.Model, fake_script: FakeScript):
         fake_script.write('secret-get', """echo '{"foo": "bar"}'""")
@@ -3470,8 +3555,9 @@ class TestSecretClass:
         content = secret.peek_content()
         assert content == {'foo': 'peeked'}
 
-        assert fake_script.calls(clear=True) == \
-            [['secret-get', 'secret:a', '--label', 'b', '--peek', '--format=json']]
+        assert fake_script.calls(clear=True) == [
+            ['secret-get', 'secret:a', '--label', 'b', '--peek', '--format=json']
+        ]
 
     def test_get_info(self, model: ops.Model, fake_script: FakeScript):
         fake_script.write('secret-info-get', """echo '{"x": {"label": "y", "revision": 7}}'""")
@@ -3497,11 +3583,10 @@ class TestSecretClass:
         assert info.label == 'y'
         assert info.revision == 7
 
-        assert fake_script.calls(clear=True) == \
-            [
-                ['secret-info-get', 'secret:x', '--format=json'],
-                ['secret-info-get', '--label', 'y', '--format=json'],
-                ['secret-info-get', 'secret:x', '--format=json'],
+        assert fake_script.calls(clear=True) == [
+            ['secret-info-get', 'secret:x', '--format=json'],
+            ['secret-info-get', '--label', 'y', '--format=json'],
+            ['secret-info-get', 'secret:x', '--format=json'],
         ]
 
     def test_set_content(self, model: ops.Model, fake_script: FakeScript):


### PR DESCRIPTION
Refactor `test_model.py` to pytest style.

Major changes:
- strip `unittest.TestCase`
- refactor setup functions to fixtures
- use parametrize where possible

## Before Refactor

```bash
$ python -m tox -e unit  -- test/test_model.py
unit: commands[0]> coverage run --source=ops/ -m pytest --ignore=test/smoke -v --tb native test/test_model.py
===================================================================== test session starts ======================================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.5.0 -- /Users/tiexin/work/operator4/.tox/unit/bin/python
cachedir: .tox/unit/.pytest_cache
rootdir: /Users/tiexin/work/operator4
collected 209 items
===================================================================== 209 passed in 55.48s =====================================================================
unit: commands[1]> coverage report
Name                       Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------------
ops/__init__.py               10      0      0      0   100%
ops/_private/__init__.py       0      0      0      0   100%
ops/_private/timeconv.py      61     43     28      2    22%   44, 50-55, 74-114, 122-129
ops/_private/yaml.py           9      0      0      0   100%
ops/charm.py                 643    209    177     24    63%   50-80, 135-136, 147, 154-157, 164, 211, 219, 227, 270, 288, 421, 454, 459-461, 471-479, 486-505, 580-582, 589-592, 603-605, 612-613, 647-648, 655-660, 667-686, 735-737, 744-747, 754-758, 782-783, 790-795, 802-806, 817-819, 824-825, 832, 839-840, 870, 888-889, 894, 901-903, 910-911, 923-924, 929, 936-938, 945-946, 954, 1021-1031, 1167-1168, 1182-1184, 1187-1188, 1208, 1213, 1218, 1226-1235, 1343, 1345, 1347, 1383-1396, 1401, 1404, 1407, 1410, 1413, 1416, 1418->1420, 1441-1443, 1514, 1518, 1564-1571, 1610-1611, 1659-1663, 1672-1678, 1703, 1737->1742, 1743, 1763, 1773-1782, 1799-1800, 1804, 1809, 1819-1821
ops/framework.py             685    340    270     25    44%   62->exit, 64->exit, 65->exit, 66->exit, 123, 126, 129, 147, 157-172, 194, 244-245, 252, 259, 280, 288, 304, 309->311, 318, 363, 391-392, 415, 465, 467, 470, 480-488, 492, 498-500, 508, 534, 559, 562, 597-598, 609-610, 615, 633-635, 654, 670-675, 679, 687, 693, 698-704, 713, 721-737, 743, 746, 749-754, 758, 779-816, 837-847, 849, 859, 878-879, 892-957, 961-963, 981-1001, 1012-1021, 1040, 1044, 1048-1049, 1053-1055, 1062-1066, 1069-1081, 1085, 1089, 1093-1097, 1100-1110, 1114-1116, 1145-1146, 1153, 1160, 1166-1210, 1215-1221, 1225-1227, 1231-1235, 1242-1243, 1246, 1249-1250, 1253-1254, 1257, 1260, 1263-1268, 1277-1278, 1281, 1284-1285, 1288-1289, 1292, 1296-1297, 1301-1302, 1305-1310, 1313-1318, 1321-1326, 1329-1334, 1337-1342, 1351-1352, 1359-1360, 1367-1368, 1371, 1374, 1377, 1388, 1391-1396, 1399-1404, 1407-1412
ops/jujuversion.py            80     37     48      5    47%   42, 53, 57, 61-67, 75-95, 102, 111, 115, 124, 130, 141
ops/lib/__init__.py          176    176     77      0     0%   15-282
ops/log.py                    27     17      4      0    32%   29-30, 38, 55-75
ops/main.py                  262    213     92      0    14%   49-52, 56-62, 75-100, 118-122, 132-143, 147, 152-220, 240-247, 251-264, 272-301, 305-308, 316-317, 328-336, 345, 351-368, 375-376, 406-424, 427-429, 432-439, 442-475, 483-494, 504-511, 515, 519-523, 539-546, 555
ops/model.py                1532     95    628     39    93%   100->exit, 101->exit, 205, 305, 317->exit, 319->exit, 433, 483, 796, 812, 852, 855, 858, 935->938, 942, 945, 948, 974, 1055, 1192, 1201-1206, 1289, 1539, 1576, 1637, 1657, 1682, 1689, 1713->exit, 1727, 1797, 1805, 1825, 1923->1925, 1979->1984, 2005, 2039->2042, 2051, 2076, 2079, 2109->2112, 2175->2177, 2265, 2269, 2513, 2570, 2593, 2602-2605, 2612-2615, 2683, 2705, 2737->2742, 2787, 2836, 2859, 2876, 2882, 2976, 3018, 3042, 3054, 3104, 3153-3154, 3178-3179, 3183-3196, 3251-3261, 3265, 3304, 3377, 3408-3411, 3419->3421, 3462->3465, 3507
ops/pebble.py               1282    779    431     18    34%   172->exit, 184->exit, 186->exit, 190->exit, 192->exit, 194->exit, 204-268, 284->exit, 286->exit, 288->exit, 290->exit, 292->exit, 310-315, 319-324, 336, 346, 351-353, 360, 386-387, 390, 393, 420, 434-435, 438-450, 453, 492-495, 498-507, 537, 552-557, 562, 573, 592-594, 599, 606, 617, 635-643, 648, 662, 679, 698-707, 712, 727, 752, 770, 778, 786, 805-809, 863, 867-872, 939-947, 950, 954-959, 999-1000, 1003-1004, 1012, 1023-1048, 1052-1064, 1067, 1071-1076, 1098-1107, 1111-1119, 1122, 1125-1130, 1205-1209, 1223, 1300-1301, 1304-1305, 1316, 1391-1392, 1464-1478, 1481-1483, 1495-1497, 1500-1532, 1546-1573, 1582-1589, 1594-1600, 1609-1623, 1629-1649, 1656, 1660, 1664-1667, 1671, 1678-1680, 1684, 1688-1717, 1721, 1752, 1753->1755, 1784-1793, 1802-1807, 1816-1844, 1848-1849, 1853-1855, 1859-1861, 1867-1871, 1875-1876, 1880-1882, 1899, 1917, 1980, 1987, 1992->1991, 1995-2002, 2027-2031, 2035-2056, 2060-2075, 2080-2089, 2101-2121, 2125-2126, 2134-2138, 2142, 2146, 2168-2206, 2210-2216, 2249-2268, 2276-2287, 2293-2329, 2350-2360, 2387-2396, 2412-2420, 2442, 2464, 2608-2721, 2724-2729, 2732-2734, 2748-2761, 2779-2785, 2802-2812, 2820-2821, 2854-2864, 2871-2894, 2897-2916, 2919-2937, 2941-2943, 2947, 2950-2952, 2955, 2959, 2963, 2967-2974, 3002-3023, 3027-3069, 3079-3104
ops/storage.py               159     80     30      4    44%   44-47, 59->63, 64, 72-84, 93->exit, 108, 112, 129-130, 145, 153, 157-164, 168, 173, 190-208, 221, 243, 254-258, 265, 269-271, 275-277, 289-293, 301-307, 315, 355-356, 376-382, 393-396, 406, 416
ops/testing.py              1589    857    768     80    41%   166-167, 320->322, 332, 355, 407-481, 502-503, 509->517, 513-514, 518->520, 523-534, 538, 543-545, 549, 552->558, 555-556, 568-569, 576->578, 580->596, 584-586, 589->596, 592-593, 596->599, 600, 615-626, 640, 643, 647, 653-655, 664, 673, 687-694, 721-733, 749-758, 775-787, 805-815, 869, 886->888, 891-896, 899->907, 901->904, 918-952, 968-972, 1002, 1008, 1060, 1075->exit, 1082-1090, 1142-1145, 1155-1159, 1182-1190, 1194, 1206-1209, 1218, 1227-1229, 1259, 1263->1268, 1280-1281, 1283->1278, 1289, 1301, 1307-1319, 1342->1350, 1345->1343, 1348, 1352-1356, 1382, 1476, 1479, 1482, 1485, 1490->1495, 1494, 1495->1497, 1497->1500, 1526->1528, 1547-1549, 1594-1597, 1600-1603, 1613-1623, 1641-1656, 1671-1687, 1691-1696, 1705-1706, 1714-1715, 1729-1734, 1751-1754, 1771-1776, 1826-1827, 1845-1847, 1923-1935, 1943, 1976-2004, 2044, 2054, 2120, 2139, 2146, 2150, 2155, 2163, 2168-2174, 2177, 2272-2273, 2296, 2314, 2329-2348, 2369->2374, 2387, 2401, 2405-2413, 2417-2430, 2435-2446, 2453-2481, 2484, 2490-2493, 2496-2503, 2506-2517, 2520-2521, 2524-2526, 2529-2541, 2544, 2548, 2551, 2556->2567, 2585, 2592, 2595-2598, 2601-2611, 2618-2649, 2653-2656, 2667-2672, 2678-2689, 2704-2730, 2735, 2743-2744, 2755-2770, 2773-2779, 2782-2788, 2791-2804, 2807-2809, 2812-2814, 2817, 2822-2831, 2834-2839, 2842-2845, 2858-2866, 2869-2874, 2877-2888, 2892, 2916-2917, 2921-2923, 2926-2927, 2932, 2935, 2941, 2944, 2947, 2950-2960, 2963, 2970-2984, 2990-3004, 3010-3024, 3029, 3037, 3041-3044, 3050-3069, 3084-3089, 3092-3097, 3100-3105, 3109, 3119-3122, 3127, 3137, 3151-3155, 3168, 3187, 3196-3200, 3218, 3229, 3243, 3249, 3264-3271, 3274-3293, 3296-3300, 3305-3316, 3336-3419, 3422-3446, 3449, 3454-3455, 3464-3509, 3522-3525, 3537-3553, 3562-3568
ops/version.py                 2      0      0      0   100%
----------------------------------------------------------------------
TOTAL                       6517   2846   2553    197    52%
```

## After Refactor

```bash
$ python -m tox -e unit  -- test/test_model.py
unit: commands[0]> coverage run --source=ops/ -m pytest --ignore=test/smoke -v --tb native test/test_model.py
===================================================================== test session starts ======================================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.5.0 -- /Users/tiexin/work/operator4/.tox/unit/bin/python
cachedir: .tox/unit/.pytest_cache
rootdir: /Users/tiexin/work/operator4
collected 229 items
===================================================================== 229 passed in 59.58s =====================================================================
unit: commands[1]> coverage report
Name                       Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------------
ops/__init__.py               10      0      0      0   100%
ops/_private/__init__.py       0      0      0      0   100%
ops/_private/timeconv.py      61     43     28      2    22%   44, 50-55, 74-114, 122-129
ops/_private/yaml.py           9      0      0      0   100%
ops/charm.py                 643    209    177     24    63%   50-80, 135-136, 147, 154-157, 164, 211, 219, 227, 270, 288, 421, 454, 459-461, 471-479, 486-505, 580-582, 589-592, 603-605, 612-613, 647-648, 655-660, 667-686, 735-737, 744-747, 754-758, 782-783, 790-795, 802-806, 817-819, 824-825, 832, 839-840, 870, 888-889, 894, 901-903, 910-911, 923-924, 929, 936-938, 945-946, 954, 1021-1031, 1167-1168, 1182-1184, 1187-1188, 1208, 1213, 1218, 1226-1235, 1343, 1345, 1347, 1383-1396, 1401, 1404, 1407, 1410, 1413, 1416, 1418->1420, 1441-1443, 1514, 1518, 1564-1571, 1610-1611, 1659-1663, 1672-1678, 1703, 1737->1742, 1743, 1763, 1773-1782, 1799-1800, 1804, 1809, 1819-1821
ops/framework.py             685    340    270     25    44%   62->exit, 64->exit, 65->exit, 66->exit, 123, 126, 129, 147, 157-172, 194, 244-245, 252, 259, 280, 288, 304, 309->311, 318, 363, 391-392, 415, 465, 467, 470, 480-488, 492, 498-500, 508, 534, 559, 562, 597-598, 609-610, 615, 633-635, 654, 670-675, 679, 687, 693, 698-704, 713, 721-737, 743, 746, 749-754, 758, 779-816, 837-847, 849, 859, 878-879, 892-957, 961-963, 981-1001, 1012-1021, 1040, 1044, 1048-1049, 1053-1055, 1062-1066, 1069-1081, 1085, 1089, 1093-1097, 1100-1110, 1114-1116, 1145-1146, 1153, 1160, 1166-1210, 1215-1221, 1225-1227, 1231-1235, 1242-1243, 1246, 1249-1250, 1253-1254, 1257, 1260, 1263-1268, 1277-1278, 1281, 1284-1285, 1288-1289, 1292, 1296-1297, 1301-1302, 1305-1310, 1313-1318, 1321-1326, 1329-1334, 1337-1342, 1351-1352, 1359-1360, 1367-1368, 1371, 1374, 1377, 1388, 1391-1396, 1399-1404, 1407-1412
ops/jujuversion.py            80     37     48      5    47%   42, 53, 57, 61-67, 75-95, 102, 111, 115, 124, 130, 141
ops/lib/__init__.py          176    176     77      0     0%   15-282
ops/log.py                    27     17      4      0    32%   29-30, 38, 55-75
ops/main.py                  262    213     92      0    14%   49-52, 56-62, 75-100, 118-122, 132-143, 147, 152-220, 240-247, 251-264, 272-301, 305-308, 316-317, 328-336, 345, 351-368, 375-376, 406-424, 427-429, 432-439, 442-475, 483-494, 504-511, 515, 519-523, 539-546, 555
ops/model.py                1532     95    628     39    93%   100->exit, 101->exit, 205, 305, 317->exit, 319->exit, 433, 483, 796, 812, 852, 855, 858, 935->938, 942, 945, 948, 974, 1055, 1192, 1201-1206, 1289, 1539, 1576, 1637, 1657, 1682, 1689, 1713->exit, 1727, 1797, 1805, 1825, 1923->1925, 1979->1984, 2005, 2039->2042, 2051, 2076, 2079, 2109->2112, 2175->2177, 2265, 2269, 2513, 2570, 2593, 2602-2605, 2612-2615, 2683, 2705, 2737->2742, 2787, 2836, 2859, 2876, 2882, 2976, 3018, 3042, 3054, 3104, 3153-3154, 3178-3179, 3183-3196, 3251-3261, 3265, 3304, 3377, 3408-3411, 3419->3421, 3462->3465, 3507
ops/pebble.py               1282    779    431     18    34%   172->exit, 184->exit, 186->exit, 190->exit, 192->exit, 194->exit, 204-268, 284->exit, 286->exit, 288->exit, 290->exit, 292->exit, 310-315, 319-324, 336, 346, 351-353, 360, 386-387, 390, 393, 420, 434-435, 438-450, 453, 492-495, 498-507, 537, 552-557, 562, 573, 592-594, 599, 606, 617, 635-643, 648, 662, 679, 698-707, 712, 727, 752, 770, 778, 786, 805-809, 863, 867-872, 939-947, 950, 954-959, 999-1000, 1003-1004, 1012, 1023-1048, 1052-1064, 1067, 1071-1076, 1098-1107, 1111-1119, 1122, 1125-1130, 1205-1209, 1223, 1300-1301, 1304-1305, 1316, 1391-1392, 1464-1478, 1481-1483, 1495-1497, 1500-1532, 1546-1573, 1582-1589, 1594-1600, 1609-1623, 1629-1649, 1656, 1660, 1664-1667, 1671, 1678-1680, 1684, 1688-1717, 1721, 1752, 1753->1755, 1784-1793, 1802-1807, 1816-1844, 1848-1849, 1853-1855, 1859-1861, 1867-1871, 1875-1876, 1880-1882, 1899, 1917, 1980, 1987, 1992->1991, 1995-2002, 2027-2031, 2035-2056, 2060-2075, 2080-2089, 2101-2121, 2125-2126, 2134-2138, 2142, 2146, 2168-2206, 2210-2216, 2249-2268, 2276-2287, 2293-2329, 2350-2360, 2387-2396, 2412-2420, 2442, 2464, 2608-2721, 2724-2729, 2732-2734, 2748-2761, 2779-2785, 2802-2812, 2820-2821, 2854-2864, 2871-2894, 2897-2916, 2919-2937, 2941-2943, 2947, 2950-2952, 2955, 2959, 2963, 2967-2974, 3002-3023, 3027-3069, 3079-3104
ops/storage.py               159     80     30      4    44%   44-47, 59->63, 64, 72-84, 93->exit, 108, 112, 129-130, 145, 153, 157-164, 168, 173, 190-208, 221, 243, 254-258, 265, 269-271, 275-277, 289-293, 301-307, 315, 355-356, 376-382, 393-396, 406, 416
ops/testing.py              1589    857    768     80    41%   166-167, 320->322, 332, 355, 407-481, 502-503, 509->517, 513-514, 518->520, 523-534, 538, 543-545, 549, 552->558, 555-556, 568-569, 576->578, 580->596, 584-586, 589->596, 592-593, 596->599, 600, 615-626, 640, 643, 647, 653-655, 664, 673, 687-694, 721-733, 749-758, 775-787, 805-815, 869, 886->888, 891-896, 899->907, 901->904, 918-952, 968-972, 1002, 1008, 1060, 1075->exit, 1082-1090, 1142-1145, 1155-1159, 1182-1190, 1194, 1206-1209, 1218, 1227-1229, 1259, 1263->1268, 1280-1281, 1283->1278, 1289, 1301, 1307-1319, 1342->1350, 1345->1343, 1348, 1352-1356, 1382, 1476, 1479, 1482, 1485, 1490->1495, 1494, 1495->1497, 1497->1500, 1526->1528, 1547-1549, 1594-1597, 1600-1603, 1613-1623, 1641-1656, 1671-1687, 1691-1696, 1705-1706, 1714-1715, 1729-1734, 1751-1754, 1771-1776, 1826-1827, 1845-1847, 1923-1935, 1943, 1976-2004, 2044, 2054, 2120, 2139, 2146, 2150, 2155, 2163, 2168-2174, 2177, 2272-2273, 2296, 2314, 2329-2348, 2369->2374, 2387, 2401, 2405-2413, 2417-2430, 2435-2446, 2453-2481, 2484, 2490-2493, 2496-2503, 2506-2517, 2520-2521, 2524-2526, 2529-2541, 2544, 2548, 2551, 2556->2567, 2585, 2592, 2595-2598, 2601-2611, 2618-2649, 2653-2656, 2667-2672, 2678-2689, 2704-2730, 2735, 2743-2744, 2755-2770, 2773-2779, 2782-2788, 2791-2804, 2807-2809, 2812-2814, 2817, 2822-2831, 2834-2839, 2842-2845, 2858-2866, 2869-2874, 2877-2888, 2892, 2916-2917, 2921-2923, 2926-2927, 2932, 2935, 2941, 2944, 2947, 2950-2960, 2963, 2970-2984, 2990-3004, 3010-3024, 3029, 3037, 3041-3044, 3050-3069, 3084-3089, 3092-3097, 3100-3105, 3109, 3119-3122, 3127, 3137, 3151-3155, 3168, 3187, 3196-3200, 3218, 3229, 3243, 3249, 3264-3271, 3274-3293, 3296-3300, 3305-3316, 3336-3419, 3422-3446, 3449, 3454-3455, 3464-3509, 3522-3525, 3537-3553, 3562-3568
ops/version.py                 2      0      0      0   100%
----------------------------------------------------------------------
TOTAL                       6517   2846   2553    197    52%
```

Test cases number increased because of parametrize, coverage unchanged.