### PR TITLE
divide apps

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -472,6 +472,10 @@ class Application:
             owner='application')
         return Secret(self._backend, id=id, label=label, content=content)
 
+    def __truediv__(self, other: int) -> "Unit":
+        """Syntactic sugar for generating unit pointers from Application objects."""
+        return self._cache.get(Unit, f"{self.name}/{other}")
+
 
 def _calculate_expiry(expire: Optional[Union[datetime.datetime, datetime.timedelta]],
                       ) -> Optional[datetime.datetime]:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -971,7 +971,8 @@ class Harness(Generic[CharmType]):
         app = self._model.get_app(remote_app)
         self._charm.on[relation_name].relation_broken.emit(relation, app)
 
-    def add_relation_unit(self, relation_id: int, remote_unit_name: str) -> None:
+    def add_relation_unit(self, relation_id: int, remote_unit_name: str,
+                          data: Optional[Mapping[str, str]] = None) -> None:
         """Add a new unit to a relation.
 
         This will trigger a `relation_joined` event. This would naturally be
@@ -992,6 +993,7 @@ class Harness(Generic[CharmType]):
         Args:
             relation_id: The integer relation identifier (as returned by :meth:`add_relation`).
             remote_unit_name: A string representing the remote unit that is being added.
+            data: A str:str mapping to put in the unit's databag.
         """
         self._backend._relation_list_map[relation_id].append(remote_unit_name)
         # we can write remote unit data iff we are not in a hook env
@@ -1024,6 +1026,9 @@ class Harness(Generic[CharmType]):
             return
         self._charm.on[relation_name].relation_joined.emit(
             relation, remote_unit.app, remote_unit)
+
+        if data is not None:
+            self.update_relation_data(relation_id, remote_unit_name, data)
 
     def remove_relation_unit(self, relation_id: int, remote_unit_name: str) -> None:
         """Remove a unit from a relation.

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -971,8 +971,7 @@ class Harness(Generic[CharmType]):
         app = self._model.get_app(remote_app)
         self._charm.on[relation_name].relation_broken.emit(relation, app)
 
-    def add_relation_unit(self, relation_id: int, remote_unit_name: str,
-                          data: Optional[Mapping[str, str]] = None) -> None:
+    def add_relation_unit(self, relation_id: int, remote_unit_name: str) -> None:
         """Add a new unit to a relation.
 
         This will trigger a `relation_joined` event. This would naturally be
@@ -993,7 +992,6 @@ class Harness(Generic[CharmType]):
         Args:
             relation_id: The integer relation identifier (as returned by :meth:`add_relation`).
             remote_unit_name: A string representing the remote unit that is being added.
-            data: A str:str mapping to put in the unit's databag.
         """
         self._backend._relation_list_map[relation_id].append(remote_unit_name)
         # we can write remote unit data iff we are not in a hook env
@@ -1026,9 +1024,6 @@ class Harness(Generic[CharmType]):
             return
         self._charm.on[relation_name].relation_joined.emit(
             relation, remote_unit.app, remote_unit)
-
-        if data is not None:
-            self.update_relation_data(relation_id, remote_unit_name, data)
 
     def remove_relation_unit(self, relation_id: int, remote_unit_name: str) -> None:
         """Remove a unit from a relation.

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -276,6 +276,22 @@ class TestModel(unittest.TestCase):
             ('relation_get', relation_id, 'remoteapp1', True),
         ])
 
+    def test_remote_units_get_from_div_app(self):
+        relation_id = self.harness.add_relation(
+            'db1', 'remoteapp',
+            app_data={"app": "data"},
+            unit_data={"unit": "data"}
+        )
+        self.harness.add_relation_unit(relation_id, 'remoteapp/1', data={"some": "other"})
+        self.harness.add_relation_unit(relation_id, 'remoteapp/2', data={"some": "yams"})
+
+        rel_db1 = self.ensure_relation('db1')
+
+        remoteapp = rel_db1.app
+        assert rel_db1.data[remoteapp / 0]['unit'] == 'data'
+        assert rel_db1.data[remoteapp / 1]['some'] == 'other'
+        assert rel_db1.data[remoteapp / 2]['some'] == 'yams'
+
     def test_relation_data_modify_remote(self):
         relation_id = self.harness.add_relation('db1', 'remoteapp1')
         with self.harness._event_context('foo_event'):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -282,8 +282,11 @@ class TestModel(unittest.TestCase):
             app_data={"app": "data"},
             unit_data={"unit": "data"}
         )
-        self.harness.add_relation_unit(relation_id, 'remoteapp/1', data={"some": "other"})
-        self.harness.add_relation_unit(relation_id, 'remoteapp/2', data={"some": "yams"})
+        self.harness.add_relation_unit(relation_id, 'remoteapp/1')
+        self.harness.add_relation_unit(relation_id, 'remoteapp/2')
+
+        self.harness.update_relation_data(relation_id, "remoteapp/1", {"some": "other"})
+        self.harness.update_relation_data(relation_id, "remoteapp/2", {"some": "yams"})
 
         rel_db1 = self.ensure_relation('db1')
 


### PR DESCRIPTION
Typical charm code:
```python

def do_something_with_relation(self, rel:Relation):
    remote_unit_34 = [unit for units in rel.units if unit.app.name == rel.app.name and unit.app.name.endswith("/34")][0]
   
```

now:

```python
def do_something_with_relation(self, rel:Relation):
    remote_unit_34 = rel.app / 34
```


This is useful in tests but also in charm code proper.
