### PR TITLE
chore: enable the observability tests again

### DIFF
--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -10,11 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         charm-repo:
-# Disabled until the type checking passes (ops#1183)
-# https://github.com/canonical/alertmanager-k8s-operator/pull/241
-# https://github.com/canonical/prometheus-k8s-operator/pull/587
-#          - "canonical/alertmanager-k8s-operator"
-#          - "canonical/prometheus-k8s-operator"
+          - "canonical/alertmanager-k8s-operator"
+          - "canonical/prometheus-k8s-operator"
           - "canonical/grafana-k8s-operator"
 
     steps:


### PR DESCRIPTION
Now that the upstream fixes are merged, these should pass again.