### PR TITLE
feat: add a `__str__` to ActionFailed, for better unexpected failure output

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -166,6 +166,11 @@ class ActionFailed(Exception):  # noqa
         self.message = message
         self.output = output
 
+    def __str__(self):
+        if self.message:
+            return self.message
+        return "Event handler called `fail()` with no additional details."
+
 
 @dataclasses.dataclass()
 class _RunningAction:


### PR DESCRIPTION
Add a `__str__` to `ops.testing.ActionFailed` so that an uncaught `event.fail()` in tests produces a more informative traceback.

Currently, `event.fail()` and `event.fail(message)` will look somewhat like:

```python
Traceback (most recent call last):
  File "/tmp/1204.py", line 18, in <module>
    harness.run_action("act")
  File "/home/tameyer/code/operator/ops/testing.py", line 2001, in run_action
    raise ActionFailed(
ops.testing.ActionFailed
```

After this PR, `event.fail()` will look like:

```python
Traceback (most recent call last):
  File "/tmp/1204.py", line 19, in <module>
    harness.run_action("act")
  File "/home/tameyer/code/operator/ops/testing.py", line 2006, in run_action
    raise ActionFailed(
ops.testing.ActionFailed: Event handler called `fail()` with no additional details.
```

and `event.fail("Message")` will look like:

```python
Traceback (most recent call last):
  File "/tmp/1204.py", line 18, in <module>
    harness.run_action("act")
  File "/home/tameyer/code/operator/ops/testing.py", line 2006, in run_action
    raise ActionFailed(
ops.testing.ActionFailed: Message

```

Fixes #1204