### PR TITLE
docs: use the actual emoji character rather than GitHub markup, to show properly on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The `ops` library is a Python framework for developing and testing Kubernetes an
 ||||
 || [Charmhub](https://charmhub.io/) | Sample our existing charms on Charmhub. <br> _A charm can be a cluster ([OpenStack](https://charmhub.io/openstack-base), [Kubernetes](https://charmhub.io/charmed-kubernetes)), a data platform ([PostgreSQL](https://charmhub.io/postgresql-k8s), [MongoDB](https://charmhub.io/mongodb), etc.), an observability stack ([Canonical Observability Stack](https://charmhub.io/cos-lite)), an MLOps solution ([Kubeflow](https://charmhub.io/kubeflow)), and so much more._ |
 ||||
-|:point_right:| [Charm&nbsp;SDK](https://juju.is/docs/sdk)  | Write your own charm! <br> _Juju is written in Go, but our SDK supports easy charm development in Python._  |
+|👉| [Charm&nbsp;SDK](https://juju.is/docs/sdk)  | Write your own charm! <br> _Juju is written in Go, but our SDK supports easy charm development in Python._  |
 
 ## Give it a try
 


### PR DESCRIPTION
Currently, [ops on PyPI](https://pypi.org/project/ops/) looks like this:

![image](https://github.com/canonical/operator/assets/826522/3e534d97-8ce4-4f6d-bb81-9c81d41f607b)

This PR replaces the `:point-right:` GitHub-specific markup with the actual emoji character so that it shows as expected in both places.