### PR TITLE
fix: the `other` argument to `RelatationDataContent.update(...)` should be optional

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1722,8 +1722,10 @@ class RelationDataContent(LazyMapping, MutableMapping[str, str]):
         self._validate_read()
         return super().__getitem__(key)
 
-    def update(self, other: _SupportsKeysAndGetItem[str, str], **kwargs: str):
+    def update(self, other: Optional[_SupportsKeysAndGetItem[str, str]] = None, *_, **kwargs: str):
         """Update the data from dict/iterable other and the kwargs."""
+        if other is None:
+            other = {}
         super().update(other, **kwargs)
 
     def __delitem__(self, key: str):

--- a/ops/model.py
+++ b/ops/model.py
@@ -91,16 +91,6 @@ _NetworkDict = TypedDict('_NetworkDict', {
 })
 
 
-# Copied from typeshed.
-_KT = typing.TypeVar("_KT")
-_VT_co = typing.TypeVar("_VT_co", covariant=True)
-
-
-class _SupportsKeysAndGetItem(typing.Protocol[_KT, _VT_co]):
-    def keys(self) -> typing.Iterable[_KT]: ...
-    def __getitem__(self, __key: _KT) -> _VT_co: ...
-
-
 logger = logging.getLogger(__name__)
 
 MAX_LOG_LINE_LEN = 131071  # Max length of strings to pass to subshell.
@@ -1722,10 +1712,8 @@ class RelationDataContent(LazyMapping, MutableMapping[str, str]):
         self._validate_read()
         return super().__getitem__(key)
 
-    def update(self, other: Optional[_SupportsKeysAndGetItem[str, str]] = None, *_, **kwargs: str):
+    def update(self, other: typing.Any = (), /, **kwargs: str):
         """Update the data from dict/iterable other and the kwargs."""
-        if other is None:
-            other = {}
         super().update(other, **kwargs)
 
     def __delitem__(self, key: str):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -232,6 +232,23 @@ class TestModel:
                 relation_id, harness.model.app) == harness.get_relation_data(
                 relation_id, local_app) == {'foo': 'bar'}
 
+    def test_update_app_relation_data(self, harness: ops.testing.Harness[ops.CharmBase]):
+        harness.set_leader(True)
+        harness.begin()
+        relation_id = harness.add_relation('db1', 'remote')
+        harness.add_relation_unit(relation_id, 'remote/0')
+        with harness._event_context('foo_event'):
+            harness.update_relation_data(
+                relation_id,
+                harness.model.app.name,
+                {'foo': 'bar'})
+            rel = harness.model.get_relation('db1', relation_id)
+            assert rel is not None
+            rel.data[harness.model.app].update(foo='baz')
+            assert harness.get_relation_data(
+                relation_id, harness.model.app) == harness.get_relation_data(
+                relation_id, harness.model.app.name) == {'foo': 'baz'}
+
     def test_unit_relation_data(self, harness: ops.testing.Harness[ops.CharmBase]):
         relation_id = harness.add_relation('db1', 'remoteapp1')
         harness.add_relation_unit(relation_id, 'remoteapp1/0')

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -232,7 +232,17 @@ class TestModel:
                 relation_id, harness.model.app) == harness.get_relation_data(
                 relation_id, local_app) == {'foo': 'bar'}
 
-    def test_update_app_relation_data_other_map(self, harness: ops.testing.Harness[ops.CharmBase]):
+    @pytest.mark.parametrize('args,kwargs', [
+        (({'foo': 'baz'}, ), {}),
+        (([('foo', 'baz')], ), {}),
+        ((), {'foo': 'baz'})
+    ])
+    def test_update_app_relation_data(
+        self,
+        args: typing.Tuple[typing.Any, ...],
+        kwargs: typing.Dict[str, str],
+        harness: ops.testing.Harness[ops.CharmBase],
+    ):
         harness.set_leader(True)
         harness.begin()
         relation_id = harness.add_relation('db1', 'remote')
@@ -244,45 +254,9 @@ class TestModel:
                 {'foo': 'bar'})
             rel = harness.model.get_relation('db1', relation_id)
             assert rel is not None
-            rel.data[harness.model.app].update({'foo': 'baz'})
+            rel.data[harness.model.app].update(*args, **kwargs)
             assert harness.get_relation_data(
-                relation_id, harness.model.app) == harness.get_relation_data(
-                relation_id, harness.model.app.name) == {'foo': 'baz'}
-
-    def test_update_app_relation_data_other_iter(
-            self, harness: ops.testing.Harness[ops.CharmBase]):
-        harness.set_leader(True)
-        harness.begin()
-        relation_id = harness.add_relation('db1', 'remote')
-        harness.add_relation_unit(relation_id, 'remote/0')
-        with harness._event_context('foo_event'):
-            harness.update_relation_data(
-                relation_id,
-                harness.model.app.name,
-                {'foo': 'bar'})
-            rel = harness.model.get_relation('db1', relation_id)
-            assert rel is not None
-            rel.data[harness.model.app].update((('foo', 'baz'), ))
-            assert harness.get_relation_data(
-                relation_id, harness.model.app) == harness.get_relation_data(
-                relation_id, harness.model.app.name) == {'foo': 'baz'}
-
-    def test_update_app_relation_data_kwarg(self, harness: ops.testing.Harness[ops.CharmBase]):
-        harness.set_leader(True)
-        harness.begin()
-        relation_id = harness.add_relation('db1', 'remote')
-        harness.add_relation_unit(relation_id, 'remote/0')
-        with harness._event_context('foo_event'):
-            harness.update_relation_data(
-                relation_id,
-                harness.model.app.name,
-                {'foo': 'bar'})
-            rel = harness.model.get_relation('db1', relation_id)
-            assert rel is not None
-            rel.data[harness.model.app].update(foo='baz')
-            assert harness.get_relation_data(
-                relation_id, harness.model.app) == harness.get_relation_data(
-                relation_id, harness.model.app.name) == {'foo': 'baz'}
+                relation_id, harness.model.app) == {'foo': 'baz'}
 
     def test_unit_relation_data(self, harness: ops.testing.Harness[ops.CharmBase]):
         relation_id = harness.add_relation('db1', 'remoteapp1')

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1605,8 +1605,7 @@ containers:
         assert container.pebble.requests == [('replan',)]  # type: ignore
 
     def test_can_connect(self, container: ops.Container):
-        container.pebble.responses.append(
-            pebble.SystemInfo.from_dict({'version': '1.0.0'}))  # type: ignore
+        container.pebble.responses.append(pebble.SystemInfo.from_dict({'version': '1.0.0'}))  # type: ignore
         assert container.can_connect()
         assert container.pebble.requests == [('get_system_info',)]  # type: ignore
 
@@ -1761,8 +1760,7 @@ containers:
 
     def test_get_service(self, container: ops.Container):
         # Single service returned successfully
-        container.pebble.responses.append(
-            [self._make_service('s1', 'enabled', 'active')])  # type: ignore
+        container.pebble.responses.append([self._make_service('s1', 'enabled', 'active')])  # type: ignore
         s = container.get_service('s1')
         assert container.pebble.requests == [('get_services', ('s1', ))]  # type: ignore
         assert s.name == 's1'
@@ -1943,8 +1941,7 @@ containers:
         ]
 
     def test_can_connect_simple(self, container: ops.Container):
-        container.pebble.responses.append(
-            pebble.SystemInfo.from_dict({'version': '1.0.0'}))  # type: ignore
+        container.pebble.responses.append(pebble.SystemInfo.from_dict({'version': '1.0.0'}))  # type: ignore
         assert container.can_connect()
 
     def test_can_connect_connection_error(

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -232,7 +232,42 @@ class TestModel:
                 relation_id, harness.model.app) == harness.get_relation_data(
                 relation_id, local_app) == {'foo': 'bar'}
 
-    def test_update_app_relation_data(self, harness: ops.testing.Harness[ops.CharmBase]):
+    def test_update_app_relation_data_other_map(self, harness: ops.testing.Harness[ops.CharmBase]):
+        harness.set_leader(True)
+        harness.begin()
+        relation_id = harness.add_relation('db1', 'remote')
+        harness.add_relation_unit(relation_id, 'remote/0')
+        with harness._event_context('foo_event'):
+            harness.update_relation_data(
+                relation_id,
+                harness.model.app.name,
+                {'foo': 'bar'})
+            rel = harness.model.get_relation('db1', relation_id)
+            assert rel is not None
+            rel.data[harness.model.app].update({'foo': 'baz'})
+            assert harness.get_relation_data(
+                relation_id, harness.model.app) == harness.get_relation_data(
+                relation_id, harness.model.app.name) == {'foo': 'baz'}
+
+    def test_update_app_relation_data_other_iter(
+            self, harness: ops.testing.Harness[ops.CharmBase]):
+        harness.set_leader(True)
+        harness.begin()
+        relation_id = harness.add_relation('db1', 'remote')
+        harness.add_relation_unit(relation_id, 'remote/0')
+        with harness._event_context('foo_event'):
+            harness.update_relation_data(
+                relation_id,
+                harness.model.app.name,
+                {'foo': 'bar'})
+            rel = harness.model.get_relation('db1', relation_id)
+            assert rel is not None
+            rel.data[harness.model.app].update((('foo', 'baz'), ))
+            assert harness.get_relation_data(
+                relation_id, harness.model.app) == harness.get_relation_data(
+                relation_id, harness.model.app.name) == {'foo': 'baz'}
+
+    def test_update_app_relation_data_kwarg(self, harness: ops.testing.Harness[ops.CharmBase]):
         harness.set_leader(True)
         harness.begin()
         relation_id = harness.add_relation('db1', 'remote')
@@ -1570,7 +1605,8 @@ containers:
         assert container.pebble.requests == [('replan',)]  # type: ignore
 
     def test_can_connect(self, container: ops.Container):
-        container.pebble.responses.append(pebble.SystemInfo.from_dict({'version': '1.0.0'}))  # type: ignore
+        container.pebble.responses.append(
+            pebble.SystemInfo.from_dict({'version': '1.0.0'}))  # type: ignore
         assert container.can_connect()
         assert container.pebble.requests == [('get_system_info',)]  # type: ignore
 
@@ -1725,7 +1761,8 @@ containers:
 
     def test_get_service(self, container: ops.Container):
         # Single service returned successfully
-        container.pebble.responses.append([self._make_service('s1', 'enabled', 'active')])  # type: ignore
+        container.pebble.responses.append(
+            [self._make_service('s1', 'enabled', 'active')])  # type: ignore
         s = container.get_service('s1')
         assert container.pebble.requests == [('get_services', ('s1', ))]  # type: ignore
         assert s.name == 's1'
@@ -1906,7 +1943,8 @@ containers:
         ]
 
     def test_can_connect_simple(self, container: ops.Container):
-        container.pebble.responses.append(pebble.SystemInfo.from_dict({'version': '1.0.0'}))  # type: ignore
+        container.pebble.responses.append(
+            pebble.SystemInfo.from_dict({'version': '1.0.0'}))  # type: ignore
         assert container.can_connect()
 
     def test_can_connect_connection_error(


### PR DESCRIPTION
Fixes the signature for `RelationDataContent.update` to match `MutableMapping`, where `other` is optional (a regression introduced in #1883).

The type for `other` has been simplified to `Any`. It should really be `Mapping|_SupportsKeysAndGetItem[str,str]` plus a minimal type that supports `.values`, but it was already messy pulling in `_SupportsKeysAndGetItem` in #1183, and we're just passing this through to `MutableMapping` so it doesn't seem like the tight typing is providing enough benefit to justify the complexity of the signature. [typeshed has three overloads](https://github.com/python/typeshed/blob/f7c03486ee01c8ea74823db75e017341bf3c2ad0/stdlib/typing.pyi#L726), so we could match that (as we did in #1883, just incompletely), if that is desirable.

Fixes: #1225