### PR TITLE
fix: don't use f-strings in logging calls

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -985,7 +985,7 @@ def _cast_network_address(raw: str) -> Union[ipaddress.IPv4Address, ipaddress.IP
     try:
         return ipaddress.ip_address(raw)
     except ValueError:
-        logger.debug(f"could not cast {raw} to IPv4/v6 address")
+        logger.debug("could not cast %s to IPv4/v6 address", raw)
         return raw
 
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1639,7 +1639,7 @@ def _websocket_to_writer(ws: '_WebSocket', writer: '_WebsocketWriter',
             command = payload.get('command')
             if command != 'end':
                 # A command we don't recognize, keep going
-                logger.warning(f'Invalid I/O command {command!r}')
+                logger.warning('Invalid I/O command %r', command)
                 continue
             # Received "end" command (EOF signal), stop thread
             break
@@ -1702,7 +1702,7 @@ class _WebsocketReader(io.BufferedIOBase):
                 command = payload.get('command')
                 if command != 'end':
                     # A command we don't recognize, keep going
-                    logger.warning(f'Invalid I/O command {command!r}')
+                    logger.warning('Invalid I/O command %r', command)
                     continue
                 # Received "end" command, return EOF designator
                 self.eof = True

--- a/ops/storage.py
+++ b/ops/storage.py
@@ -58,7 +58,7 @@ class SQLiteStorage:
 
         if not os.path.exists(str(filename)):
             # sqlite3.connect creates the file silently if it does not exist
-            logger.debug(f"Initializing SQLite local storage: {filename}.")
+            logger.debug("Initializing SQLite local storage: %s.", filename)
 
         if filename != ":memory:":
             self._ensure_db_permissions(str(filename))


### PR DESCRIPTION
Removes use of f-strings in `logging.debug` and `logging.warning` calls.

Calls to `logging.*` should provide a format string and arguments (generally we use `%` style, but `{` or `$'` would be ok, if inconsistent). There are two main reasons:

* Some log handlers (most well known is Sentry, but I believe there are others) will aggregate messages using the format string, and this breaks if the string is pre-interpolated.
* Interpolation/formatting is done lazily - for example, a debug level message may never get formatted - so there is a (very small) efficiency gain by avoiding it when possible.

Theoretically, there are also safety concerns in having user-provided content, but that's not relevant for any of these cases here, and I think you'd have to _also_ provide an argument to exploit that.