### PR TITLE
chore: add git blame ignore revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# You can configure git to automatically use this file with the following config:
+# git config --global blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Code reformatting with Ruff formatter
+d8148ab41869f6119683cf42b7e6e574f1a99bf1


### PR DESCRIPTION
Ignore bulk changes done by the Ruff formatter.

PR: https://github.com/canonical/operator/pull/1224

Commit: https://github.com/canonical/operator/commit/d8148ab41869f6119683cf42b7e6e574f1a99bf1

To configure git to use this file, run:

``` bash
git config --global blame.ignoreRevsFile .git-blame-ignore-revs
```
