### PR TITLE
docs: clarify that SecretNotFound may be raised for permission errors

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -274,7 +274,8 @@ class Model:
             label: Secret label if fetching by label (or updating it).
 
         Raises:
-            SecretNotFoundError: If a secret with this ID or label doesn't exist.
+            SecretNotFoundError: If a secret with this ID or label doesn't exist,
+                or the caller does not have permission to view it.
         """
         if not (id or label):
             raise TypeError('Must provide an id or label, or both')


### PR DESCRIPTION
As noticed in #1229, `get_secret()` may raise `SecretNotFoundError` if the secret does exist but the caller does not have permission to view it, so make this explicit in the documentation.