### PR TITLE
doc: adjust the 2.14 changelog to match our style

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,25 +1,23 @@
 # 2.14.0 - 29 May 2024
 
-This release fixes the `RelationDataContent.update` method to follow `dict.update` semantics, that is allow both updating with another dict, an iterable, keyword arguments or a mixture thereof.
-
 ## Features
 
-* feat: add a `__str__` to ActionFailed, for better unexpected failure output in https://github.com/canonical/operator/pull/1209
+* Add a `__str__` to ActionFailed, for better unexpected failure output (#1209)
 
 ## Fixes
 
-* The `other` argument to `RelatationDataContent.update(...)` should be optional by @addyess in https://github.com/canonical/operator/pull/1226
+* The `other` argument to `RelatationDataContent.update(...)` should be optional (#1226)
 
 ## Documentation
 
-* Use the actual emoji character rather than GitHub markup, to show properly on PyPI in https://github.com/canonical/operator/pull/1221
-* Clarify that SecretNotFound may be raised for permission errors in https://github.com/canonical/operator/pull/1231
+* Use the actual emoji character rather than GitHub markup, to show properly on PyPI (#1221)
+* Clarify that SecretNotFound may be raised for permission errors (#1231)
 
 ## Refactoring
 
-* Refactor tests to pytest style in https://github.com/canonical/operator/pull/1199 https://github.com/canonical/operator/pull/1200 https://github.com/canonical/operator/pull/1203 https://github.com/canonical/operator/pull/1206
-* Use `ruff` formatter and reformat all code in https://github.com/canonical/operator/pull/1224
-* Don't use f-strings in logging calls in https://github.com/canonical/operator/pull/1227 https://github.com/canonical/operator/pull/1234
+* Refactor tests to pytest style (#1199, #1200, #1203, #1206)
+* Use `ruff` formatter and reformat all code (#1224)
+* Don't use f-strings in logging calls (#1227, 1234)
 
 # 2.13.0 - 30 Apr 2024
 


### PR DESCRIPTION
* No intro text as found on the GitHub page and various announcements.
* No attribution.
* No links to issues.
* Remove conventional commit type in favour of headings.