### PR TITLE
ci: only run tests once on push to pr

### DIFF
--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -1,6 +1,10 @@
 name: Charmcraft Pack Test
 
-on: [push, pull_request, workflow_call]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   charmcraft-pack:

--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -1,6 +1,11 @@
 name: Data Charm Tests
 
-on: [push, pull_request, workflow_call]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_call:
 
 jobs:
   db-charm-tests:

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -1,6 +1,11 @@
 name: ops Tests
 
-on: [push, pull_request, workflow_call]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/hello-charm-tests.yaml
+++ b/.github/workflows/hello-charm-tests.yaml
@@ -1,6 +1,11 @@
 name: Hello Charm Tests
 
-on: [push, pull_request, workflow_call]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_call:
 
 jobs:
   hello-charm-tests:

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -1,6 +1,11 @@
 name: Observability Charm Tests
 
-on: [push, pull_request, workflow_call]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_call:
 
 jobs:
   o11y-charm-tests:


### PR DESCRIPTION
I've noticed that when a new commit is pushed to a PR, the same tests are run twice: once triggered by `on: push` and another by `on: pull_request: synchronize`

---

Note that the two runs are not exactly same, if the target (main) branch has received updates in the meantime, because:

### on: push Trigger:

This workflow runs the tests on the new commit in the feature branch as it stands alone.
It doesn't consider any changes that might have been merged into the main branch since the feature branch was last updated.

### on: pull_request: synchronize Trigger:

This workflow runs the tests on the combined state of the feature branch and the main branch.
It effectively simulates a merge between the feature branch and the main branch to see if the combined state would pass the tests.

---

to do

- [x] agree on approach
- [x] apply to other workflows