### PR TITLE
fix: fix TypeError when running test.pebble_cli

### DIFF
--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -246,9 +246,8 @@ def main():
                     if stderr:
                         print(repr(stderr), end='', file=sys.stderr)
                 sys.exit(0)
-            # The `[str]` here is to resolve the same issue as above.
-            except pebble.ExecError[str] as e:
-                print('ExecError:', e, file=sys.stderr)
+            except pebble.ExecError as e:  # type: ignore
+                print('ExecError:', e, file=sys.stderr)  # type: ignore
                 sys.exit(e.exit_code)
 
         elif args.command == 'ls':


### PR DESCRIPTION
Without this fix, running this raises the following:

```
TypeError: catching classes that do not inherit from BaseException is not allowed
```

Not sure how to silence pyright without the type: ignores.

I guess we haven't used this script in a while. :-)
