### PR TITLE
fix: add connect timeout for exec websockets to avoid hanging

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -2832,10 +2832,17 @@ class Client:
 
     def _connect_websocket(self, task_id: str, websocket_id: str) -> '_WebSocket':
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        # Set socket timeout to a short timeout during connection phase, in
+        # case Pebble side times out (5s), so this side doesn't hang. See:
+        # https://github.com/canonical/operator/issues/1246
+        sock.settimeout(self.timeout)
         sock.connect(self.socket_path)
         url = self._websocket_url(task_id, websocket_id)
         ws: _WebSocket = websocket.WebSocket(skip_utf8_validation=True)  # type: ignore
         ws.connect(url, socket=sock)
+        # Reset to no timeout so connection can be "long polling" when data is
+        # being received.
+        sock.settimeout(None)
         return ws
 
     def _websocket_url(self, task_id: str, websocket_id: str) -> str:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -2833,7 +2833,7 @@ class Client:
     def _connect_websocket(self, task_id: str, websocket_id: str) -> '_WebSocket':
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         # Set socket timeout to a short timeout during connection phase, in
-        # case Pebble side times out (5s), so this side doesn't hang. See:
+        # case the Pebble side times out (5s), so this side doesn't hang. See:
         # https://github.com/canonical/operator/issues/1246
         sock.settimeout(self.timeout)
         sock.connect(self.socket_path)


### PR DESCRIPTION
This is the fix for the issue described at https://github.com/canonical/operator/issues/1246. Essentially, if the Pebble timeout has already elapsed, Pebble will happily wait indefinitely for the connect to go through, and the Python side will hang. Add a timeout during the connect phase to cut this short.

Fixes #1246.