### PR TITLE
fix: adjust Harness secret behaviour to align with Juju

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -905,9 +905,10 @@ class SecretRemoveEvent(SecretEvent):
     observers have updated to that new revision, this event will be fired to
     inform the secret owner that the old revision can be removed.
 
-    Typically, the charm will call
+    After any required cleanup, the charm should call
     :meth:`event.secret.remove_revision() <ops.Secret.remove_revision>` to
-    remove the now-unused revision.
+    remove the now-unused revision. If the charm does not, then the event will
+    be emitted again, when further revisions are ready for removal.
     """
 
     def __init__(self, handle: 'Handle', id: str, label: Optional[str], revision: int):

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -841,7 +841,10 @@ class SecretEvent(HookEvent):
 
     @property
     def secret(self) -> model.Secret:
-        """The secret instance this event refers to."""
+        """The secret instance this event refers to.
+        
+        Note that the secret content is not retrieved from the secret storage
+        until :meth:`Secret.get_content()` is called."""
         backend = self.framework.model._backend
         return model.Secret(backend=backend, id=self._id, label=self._label)
 

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -842,9 +842,10 @@ class SecretEvent(HookEvent):
     @property
     def secret(self) -> model.Secret:
         """The secret instance this event refers to.
-        
+
         Note that the secret content is not retrieved from the secret storage
-        until :meth:`Secret.get_content()` is called."""
+        until :meth:`Secret.get_content()` is called.
+        """
         backend = self.framework.model._backend
         return model.Secret(backend=backend, id=self._id, label=self._label)
 

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -953,7 +953,8 @@ class Framework(Object):
                 logger.warning(
                     'Reference to ops.Object at path %s has been garbage collected '
                     'between when the charm was initialised and when the event was emitted. '
-                    'Make sure sure you store a reference to the observer.', observer_path
+                    'Make sure sure you store a reference to the observer.',
+                    observer_path,
                 )
 
             if event.deferred:

--- a/ops/model.py
+++ b/ops/model.py
@@ -1436,9 +1436,8 @@ class Secret:
         if self._id is None:
             self._id = self.get_info().id
         self._backend.secret_set(typing.cast(str, self.id), content=content)
-        # TODO: won't this just get the same content anyway? Unless we refresh
-        # (which ignores the cache) then the tracked revision won't be different.
-        self._content = None  # invalidate cache so it's refetched next get_content()
+        # We do not need to invalidate the cache here, as the content is the
+        # same until `refresh` is used, at which point the cache is invalidated.
 
     def set_info(
         self,

--- a/ops/model.py
+++ b/ops/model.py
@@ -1514,7 +1514,7 @@ class Secret:
     def remove_revision(self, revision: int):
         """Remove the given secret revision.
 
-        This is normally called when handling
+        This is normally only called when handling
         :class:`ops.SecretRemoveEvent <ops.charm.SecretRemoveEvent>` or
         :class:`ops.SecretExpiredEvent <ops.charm.SecretExpiredEvent>`.
 
@@ -1522,14 +1522,9 @@ class Secret:
         longer exists, this method will succeed, but the unit will go into error
         state on completion of the current Juju hook.
 
-        If the tracked revision is removed, then :meth:`get_content` should
-        be called immediately afterwards with ``refresh=True``, to avoid
-        leaving the unit in a 'stuck' state.
-
         Args:
-            revision: The secret revision to remove. If being called from a
-                secret event, this should usually be set to
-                :attr:`SecretRemoveEvent.revision`.
+            revision: The secret revision to remove. This should usually be set to
+                :attr:`SecretRemoveEvent.revision` or :attr:`SecretExpiredEvent.revision`.
         """
         if self._id is None:
             self._id = self.get_info().id

--- a/ops/model.py
+++ b/ops/model.py
@@ -1522,6 +1522,10 @@ class Secret:
         longer exists, this method will succeed, but the unit will go into error
         state on completion of the current Juju hook.
 
+        If the tracked revision is removed, then :meth:`get_content` should
+        be called immediately afterwards with ``refresh=True``, to avoid
+        leaving the unit in a 'stuck' state.
+
         Args:
             revision: The secret revision to remove. If being called from a
                 secret event, this should usually be set to

--- a/ops/model.py
+++ b/ops/model.py
@@ -1382,6 +1382,7 @@ class Secret:
             refresh: If true, fetch the latest revision's content and tell
                 Juju to update to tracking that revision. The default is to
                 get the content of the currently-tracked revision.
+
         Raises:
             SecretNotFoundError: if the secret no longer exists.
             ModelError: if the charm does not have permission to access the

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -59,7 +59,7 @@ from typing import (
 from ops import charm, framework, model, pebble, storage
 from ops._private import yaml
 from ops.charm import CharmBase, CharmMeta, RelationRole
-from ops.model import Container, RelationNotFoundError, SecretNotFoundError, _NetworkDict
+from ops.model import Container, RelationNotFoundError, _NetworkDict
 from ops.pebble import ExecProcess
 
 ReadableBuffer = Union[bytes, str, StringIO, BytesIO, BinaryIO]
@@ -2869,7 +2869,7 @@ class _TestingModelBackend:
     def secret_grant(self, id: str, relation_id: int, *, unit: Optional[str] = None) -> None:
         secret = self._ensure_secret(id)
         if not self._has_secret_owner_permission(secret):
-            raise SecretNotFoundError(
+            raise model.SecretNotFoundError(
                 f'You must own secret {secret.id!r} to perform this operation'
             )
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -3663,24 +3663,6 @@ class TestSecretClass:
 
         assert fake_script.calls(clear=True) == [['secret-get', 'secret:z', '--format=json']]
 
-    def test_set_content_invalidates_cache(self, model: ops.Model, fake_script: FakeScript):
-        fake_script.write('secret-get', """echo '{"foo": "bar"}'""")
-        fake_script.write('secret-set', """exit 0""")
-
-        secret = self.make_secret(model, id='z')
-        old_content = secret.get_content()
-        assert old_content == {'foo': 'bar'}
-        secret.set_content({'new': 'content'})
-        fake_script.write('secret-get', """echo '{"new": "content"}'""")
-        new_content = secret.get_content()
-        assert new_content == {'new': 'content'}
-
-        assert fake_script.calls(clear=True) == [
-            ['secret-get', 'secret:z', '--format=json'],
-            ['secret-set', 'secret:z', 'new=content'],
-            ['secret-get', 'secret:z', '--format=json'],
-        ]
-
     def test_peek_content(self, model: ops.Model, fake_script: FakeScript):
         fake_script.write('secret-get', """echo '{"foo": "peeked"}'""")
 


### PR DESCRIPTION
Adjust Harness so that the errors match what Juju does in practice (I tested each case - the results are in a table in a comment in #1229).
* When Juju responds with a message including "not found", we raise `SecretNotFoundError`
* When Juju responds with any other message (such as "permission denied"), we raise `ModelError`
* When Juju succeeds and only fails at the completion of the hook, we raise `RuntimeError` - in production, the charm cannot catch this, but we do want to surface this error, so `RuntimeError` seems most approprate

In addition:
* Update the documentation to clarify when secret content is cached (this was a request from the discussion with the data platform team in Madrid)
* Correct the documentation regarding when `ModelError` and when `SecretNotFoundError` will be raised with the secret methods
* Don't clear the `Secret` object local cache of the secret content on `set_contents`. The contents won't change until `refresh` is used, so there's no point forcing the next call to get the content from Juju.

Juju may change the responses so that there is increased consistency (probably via [this bug](https://bugs.launchpad.net/juju/+bug/2067336)) but it seems best if we fix the behaviour to match now, and then if Juju changes in the future, we can update ops then (also deciding at that time how to handle the issue that different Juju versions will have different behaviour).

Fixes #1229.