### PR TITLE
feat: make the status classes dataclasses

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1809,7 +1809,7 @@ class StatusBase:
     directly use the child class such as :class:`ActiveStatus` to indicate their status.
     """
 
-    _statuses: Dict[str, Type['StatusBase']] = dataclasses.field(default_factory=dict)
+    _statuses: typing.ClassVar[Dict[str, Type['StatusBase']]] = {}
 
     # Subclasses should override this attribute
     name = ''
@@ -1874,11 +1874,6 @@ class StatusBase:
         If there are multiple highest-priority statuses, return the first one.
         """
         return max(statuses, key=lambda status: cls._priorities.get(status.name, 0))
-
-
-# _statuses is a class attribute, but can't be initialised in the usual way,
-# because all class attributes in dataclasses are replaced by instance attributes.
-StatusBase._statuses = {}
 
 
 @dataclasses.dataclass(init=False, repr=False, eq=False)

--- a/ops/model.py
+++ b/ops/model.py
@@ -1812,7 +1812,9 @@ class StatusBase:
     _statuses: typing.ClassVar[Dict[str, Type['StatusBase']]] = {}
 
     # Subclasses should override this attribute
-    name = ''
+    name: str = ''
+
+    message: str = ''
 
     def __init__(self, message: str = ''):
         if self.__class__ is StatusBase:

--- a/ops/model.py
+++ b/ops/model.py
@@ -1801,6 +1801,7 @@ class ConfigData(_GenericLazyMapping[Union[bool, int, float, str]]):
         return self._backend.config_get()
 
 
+@dataclasses.dataclass
 class StatusBase:
     """Status values specific to applications and units.
 
@@ -1808,7 +1809,7 @@ class StatusBase:
     directly use the child class such as :class:`ActiveStatus` to indicate their status.
     """
 
-    _statuses: Dict[str, Type['StatusBase']] = {}
+    _statuses: Dict[str, Type['StatusBase']] = dataclasses.field(default_factory=dict)
 
     # Subclasses should override this attribute
     name = ''
@@ -1875,6 +1876,12 @@ class StatusBase:
         return max(statuses, key=lambda status: cls._priorities.get(status.name, 0))
 
 
+# _statuses is a class attribute, but can't be initialised in the usual way,
+# because all class attributes in dataclasses are replaced by instance attributes.
+StatusBase._statuses = {}
+
+
+@dataclasses.dataclass(init=False, repr=False, eq=False)
 @StatusBase.register
 class UnknownStatus(StatusBase):
     """The unit status is unknown.
@@ -1896,6 +1903,7 @@ class UnknownStatus(StatusBase):
         return 'UnknownStatus()'
 
 
+@dataclasses.dataclass(init=False, repr=False, eq=False)
 @StatusBase.register
 class ErrorStatus(StatusBase):
     """The unit status is error.
@@ -1910,6 +1918,7 @@ class ErrorStatus(StatusBase):
     name = 'error'
 
 
+@dataclasses.dataclass(init=False, repr=False, eq=False)
 @StatusBase.register
 class ActiveStatus(StatusBase):
     """The unit is ready.
@@ -1923,6 +1932,7 @@ class ActiveStatus(StatusBase):
         super().__init__(message)
 
 
+@dataclasses.dataclass(init=False, repr=False, eq=False)
 @StatusBase.register
 class BlockedStatus(StatusBase):
     """The unit requires manual intervention.
@@ -1933,6 +1943,7 @@ class BlockedStatus(StatusBase):
     name = 'blocked'
 
 
+@dataclasses.dataclass(init=False, repr=False, eq=False)
 @StatusBase.register
 class MaintenanceStatus(StatusBase):
     """The unit is performing maintenance tasks.
@@ -1946,6 +1957,7 @@ class MaintenanceStatus(StatusBase):
     name = 'maintenance'
 
 
+@dataclasses.dataclass(init=False, repr=False, eq=False)
 @StatusBase.register
 class WaitingStatus(StatusBase):
     """A unit is unable to progress.


### PR DESCRIPTION
Converts `StatusBase` and child classes to dataclasses.

The only user-facing changes are:
* Methods that only work with dataclasses, like `dataclasses.asdict` will work with statuses.
* Statuses can be used in pattern matching (a `__match_args__` is added to the classes), in Python versions that have pattern matching. This is the default dataclass behaviour, and seems a reasonable addition, and is awkward to disable while keeping 3.8 compatibility.

The primary motivation is that this means that everything in a Scenario State can be a dataclass or an object that can be serialised with the default JSONEncoder, so Scenario.State can use actual ops status classes rather than the awkward `_EntityStatus` class, and retain the ability to do `json.dumps(dataclasses.asdict(state))`.