### PR TITLE
test: disable pytest warnings plugin

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ deps =
     typing_extensions~=4.2
 commands =
     coverage run --source={[vars]src_path} \
-             -m pytest --ignore={[vars]tst_path}smoke -v --tb native {posargs}
+             -m pytest -p no:warnings --ignore={[vars]tst_path}smoke -v --tb native {posargs}
     coverage report
 
 [testenv:pebble]


### PR DESCRIPTION
As discussed in the daily, this PR disables the pytest warnings plugin, so that the ops.log capture warnings' unit test can pass. See discussions [here](https://github.com/canonical/operator/pull/1240) for more detail.

Tested, doesn't affect existing test cases:

```bash
TOTAL                       6508    499   2559    220    90%
  unit: OK (231.42=setup[0.02]+cmd[230.74,0.66] seconds)
  congratulations :) (231.45 seconds)
```