### PR TITLE
fix: correct email address in PyPI project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "The Python library behind great charms"
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [
-    {name="The Charm Tech team at Canonical Ltd.", email="charm-tech@lists.launchpad.com"},
+    {name="The Charm Tech team at Canonical Ltd.", email="charm-tech@lists.launchpad.net"},
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
We had originally included the wrong email address (.com instead of .net). This fixes that. All the thousands of fan mails that have been inevitably sent to us have been lost forever. ;-)