### PR TITLE
feat: include warnings in logs sent to juju

### DIFF
--- a/ops/log.py
+++ b/ops/log.py
@@ -53,6 +53,7 @@ def setup_root_logging(
         debug: if True, write logs to stderr as well as to juju-log.
         exc_stderr: if True, write uncaught exceptions to stderr as well as to juju-log.
     """
+    logging.captureWarnings(True)
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
     logger.addHandler(JujuLogHandler(model_backend))

--- a/test/test_log_warning.py
+++ b/test/test_log_warning.py
@@ -17,12 +17,12 @@ import logging
 import sys
 import warnings
 from typing import Any, Callable, Type
-from unittest.mock import Mock, ANY
+from unittest.mock import ANY, Mock
+
+import pytest
 
 from ops.log import setup_root_logging
 from ops.model import _ModelBackend
-
-import pytest
 
 
 def deprecated(msg: str, *, category: Type[Warning] = DeprecationWarning, stacklevel: int = 1):
@@ -62,9 +62,9 @@ def reset_warnings():
 
 
 def test_fixme(monkeypatch: Any, reset_warnings: Any):
-    monkeypatch.setenv("JUJU_UNIT_NAME", "dummy")
+    monkeypatch.setenv('JUJU_UNIT_NAME', 'dummy')
     # I'd rather use pytest-subprocess instead of this crude mock
-    monkeypatch.setattr(_ModelBackend, "_run", (run_mock := Mock()))
+    monkeypatch.setattr(_ModelBackend, '_run', (run_mock := Mock()))
     logging.basicConfig()
     setup_root_logging(_ModelBackend())
     dummy_charm_function()
@@ -72,9 +72,9 @@ def test_fixme(monkeypatch: Any, reset_warnings: Any):
 
 
 def test_another(monkeypatch: Any, reset_warnings: Any):
-    monkeypatch.setenv("JUJU_UNIT_NAME", "dummy")
+    monkeypatch.setenv('JUJU_UNIT_NAME', 'dummy')
     # I'd rather use pytest-subprocess instead of this crude mock
-    monkeypatch.setattr(_ModelBackend, "_run", (run_mock := Mock()))
+    monkeypatch.setattr(_ModelBackend, '_run', (run_mock := Mock()))
     logging.basicConfig()
     setup_root_logging(_ModelBackend())
     dummy_charm_function()

--- a/test/test_log_warning.py
+++ b/test/test_log_warning.py
@@ -1,0 +1,81 @@
+# Copyright 2020 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import logging
+import sys
+import warnings
+from typing import Any, Callable, Type
+from unittest.mock import Mock, ANY
+
+from ops.log import setup_root_logging
+from ops.model import _ModelBackend
+
+import pytest
+
+
+def deprecated(msg: str, *, category: Type[Warning] = DeprecationWarning, stacklevel: int = 1):
+    def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
+        @functools.wraps(f)
+        def inner(*args: Any, **kwargs: Any):
+            warnings.warn(category(msg), stacklevel=2)
+            return f(*args, **kwargs)
+
+        return inner
+
+    return decorator
+
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated  # type: ignore
+
+
+@deprecated('Use new_library_function instead')
+def deprecated_library_function():
+    pass
+
+
+def dummy_charm_function():
+    deprecated_library_function()
+
+
+@pytest.fixture
+def reset_warnings():
+    del logging.root.handlers[:]
+    logging.captureWarnings(False)
+    warnings._onceregistry.clear()  # type: ignore
+    yield
+    del logging.root.handlers[:]
+    logging.captureWarnings(False)
+    warnings._onceregistry.clear()  # type: ignore
+
+
+def test_fixme(monkeypatch: Any, reset_warnings: Any):
+    monkeypatch.setenv("JUJU_UNIT_NAME", "dummy")
+    # I'd rather use pytest-subprocess instead of this crude mock
+    monkeypatch.setattr(_ModelBackend, "_run", (run_mock := Mock()))
+    logging.basicConfig()
+    setup_root_logging(_ModelBackend())
+    dummy_charm_function()
+    assert run_mock.call_args == [('juju-log', '--log-level', 'WARNING', '--', ANY)]
+
+
+def test_another(monkeypatch: Any, reset_warnings: Any):
+    monkeypatch.setenv("JUJU_UNIT_NAME", "dummy")
+    # I'd rather use pytest-subprocess instead of this crude mock
+    monkeypatch.setattr(_ModelBackend, "_run", (run_mock := Mock()))
+    logging.basicConfig()
+    setup_root_logging(_ModelBackend())
+    dummy_charm_function()
+    assert run_mock.call_args == [('juju-log', '--log-level', 'WARNING', '--', ANY)]

--- a/test/test_log_warning.py
+++ b/test/test_log_warning.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Alternative PR to #1077 
- same ops change
- clearer requirements for charm code
- figured out why repeated tests failed in #1077 n worked around that
- open question about tooling we'd want to use