### PR TITLE
fix: properly clean up after running setup_root_logging in test_log

### DIFF
--- a/test/test_log.py
+++ b/test/test_log.py
@@ -15,6 +15,7 @@
 import io
 import logging
 import re
+import sys
 import typing
 import unittest
 from unittest.mock import patch
@@ -50,6 +51,7 @@ def logger():
     logger = logging.getLogger()
     yield logger
     logging.getLogger().handlers.clear()
+    sys.excepthook = sys.__excepthook__
 
 
 class TestLogging:


### PR DESCRIPTION
Calling `setup_root_logging` changes `sys.excepthook`. The tests should undo this in the same way that they clear out the logging handlers that `setup_root_logging` adds.