### PR TITLE
chore: make dependabot and update-charm-tests only happen monthly

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"  # This is hard-coded to the 1st of the month

--- a/.github/workflows/update-charm-tests.yaml
+++ b/.github/workflows/update-charm-tests.yaml
@@ -5,7 +5,7 @@ on:
   # NOTE: to avoid infinite loop, exclude the branch created by this workflow if triggering on push or pull_request
   workflow_dispatch:
   schedule:
-    - cron: '0 18 * * SUN' # Sunday 6pm UTC, before international day starts
+    - cron: '0 0 25 * *' # On the 25th of each month
 
 jobs:
   update-pins:


### PR DESCRIPTION
Unfortunately dependabot.yaml doesn't support saying "25th of each month", just "monthly" which is hard-coded to the 1st. But that's probably okay for that one.