### PR TITLE
ci: validate PR title against conventional commit rules

### DIFF
--- a/.github/workflows/semantic-pr-check.yaml
+++ b/.github/workflows/semantic-pr-check.yaml
@@ -1,0 +1,40 @@
+---
+name: "Semantic PR Title Check"
+# Ensure that the PR title conforms to the Conventional Commits and our choice of types and scopes, so that library version bumps can be detected automatically
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            test
+          scopes: |
+            harness
+            deps
+            testing
+            pebble
+            model
+            framework
+            typing
+            charm
+          requireScope: false

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -34,5 +34,4 @@ jobs:
             test
           scopes: |
             harness
-            [a-z]{3,20}
           requireScope: false

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,5 +1,5 @@
 ---
-name: "Semantic PR Title Check"
+name: "Validate PR Title"
 # Ensure that the PR title conforms to the Conventional Commits and our choice of types and scopes, so that library version bumps can be detected automatically
 
 on:
@@ -30,11 +30,5 @@ jobs:
             test
           scopes: |
             harness
-            deps
-            testing
-            pebble
-            model
-            framework
-            typing
-            charm
+            [a-z]{3,20}
           requireScope: false

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -9,6 +9,10 @@ on:
 permissions:
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
As documented in #1252

- types taken from the doc PR
- scopes were scraped from project PR history