### PR TITLE
docs: add a basic security policy

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"  # This is hard-coded to the 1st of the month

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -1,6 +1,10 @@
 name: Charmcraft Pack Test
 
-on: [push, pull_request, workflow_call]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   charmcraft-pack:

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -37,7 +37,7 @@ jobs:
           cat requirements.txt
 
       - name: Set up LXD
-        uses: canonical/setup-lxd@e815787b53c690d006e582ef03e43f08d56d64ba
+        uses: canonical/setup-lxd@87f9a0dbf8855632e12fad0a45795338e4e97d12
         with:
           channel: 5.0/stable
 

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -33,7 +33,7 @@ jobs:
           cat requirements.txt
 
       - name: Set up LXD
-        uses: canonical/setup-lxd@7be523c4c2724a31218a627809044c6a2f0870ad
+        uses: canonical/setup-lxd@e815787b53c690d006e582ef03e43f08d56d64ba
         with:
           channel: 5.0/stable
 

--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -10,13 +10,13 @@ jobs:
       matrix:
         include:
           - charm-repo: canonical/postgresql-operator
-            commit: ce40968c98da939c13dc92dfc21f2c763ec6d4f1  # rev413 2024-05-27T17:19:14Z
+            commit: 85f92e9a7121a1f506a550662c066343612a29e6  # 2024-05-31T11:54:37Z
           - charm-repo: canonical/postgresql-k8s-operator
-            commit: 582b3b9975b66fb4d1faa3163c485876998b0b91  # rev257 2024-05-25T14:09:32Z
+            commit: 7e8862e2f02cfe1f8e768d6ad54a281833afdfda  # rev268 2024-05-31T11:54:09Z
           - charm-repo: canonical/mysql-operator
             commit: 19633f3e904d1c3296477b3df191d1ca265fc0d5  # rev234 2024-05-06T12:13:54Z
           - charm-repo: canonical/mysql-k8s-operator
-            commit: 6c09910bc3bd88eb632793d08fa17340c6903cb2  # rev138 2024-05-01T18:08:13Z
+            commit: d310ba925b667345dc2d1b9b5c953881dd14322a  # 2024-05-29T12:07:56Z
     steps:
       - name: Checkout the ${{ matrix.charm-repo }} repository
         uses: actions/checkout@v4

--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -1,6 +1,11 @@
 name: Data Charm Tests
 
-on: [push, pull_request, workflow_call]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_call:
 
 jobs:
   db-charm-tests:

--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -15,13 +15,13 @@ jobs:
       matrix:
         include:
           - charm-repo: canonical/postgresql-operator
-            commit: 85f92e9a7121a1f506a550662c066343612a29e6  # 2024-05-31T11:54:37Z
+            commit: 8c47bae588ba2c77c95a33f613a6d2ebe82197a9  # 2024-06-05T11:40:02Z
           - charm-repo: canonical/postgresql-k8s-operator
-            commit: 7e8862e2f02cfe1f8e768d6ad54a281833afdfda  # rev268 2024-05-31T11:54:09Z
+            commit: 04c217e70b2e41d5a68fdc604404edc3dcb0d5b7  # rev274 2024-06-07T22:08:29Z
           - charm-repo: canonical/mysql-operator
-            commit: 19633f3e904d1c3296477b3df191d1ca265fc0d5  # rev234 2024-05-06T12:13:54Z
+            commit: 14c06ff88c4e564cd6d098aa213bd03e78e84b52  # rev237 2024-06-08T20:53:52Z
           - charm-repo: canonical/mysql-k8s-operator
-            commit: d310ba925b667345dc2d1b9b5c953881dd14322a  # 2024-05-29T12:07:56Z
+            commit: 59ccbb42ce4cf5acb381c08c8fbc125b7740cb6f  # rev145 2024-06-07T19:58:49Z
     steps:
       - name: Checkout the ${{ matrix.charm-repo }} repository
         uses: actions/checkout@v4

--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -44,7 +44,7 @@ jobs:
             echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
           else
             sed -i -e "s/^ops[ ><=].*/ops = {path = \"myops\"}/" pyproject.toml
-            poetry lock
+            poetry lock --no-update
           fi
 
       - name: Install dependencies

--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         include:
           - charm-repo: canonical/postgresql-operator
-            commit: 4feeaeee102cbf5e3dada3c05d44e0495ca68f9a  # rev409 2024-05-21T12:52:24Z
+            commit: ce40968c98da939c13dc92dfc21f2c763ec6d4f1  # rev413 2024-05-27T17:19:14Z
           - charm-repo: canonical/postgresql-k8s-operator
-            commit: 1a25c3929747beea7e78467b169b2b345b29d470  # 2024-05-21T12:40:19Z
+            commit: 582b3b9975b66fb4d1faa3163c485876998b0b91  # rev257 2024-05-25T14:09:32Z
           - charm-repo: canonical/mysql-operator
             commit: 19633f3e904d1c3296477b3df191d1ca265fc0d5  # rev234 2024-05-06T12:13:54Z
           - charm-repo: canonical/mysql-k8s-operator

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -1,6 +1,11 @@
 name: ops Tests
 
-on: [push, pull_request, workflow_call]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/hello-charm-tests.yaml
+++ b/.github/workflows/hello-charm-tests.yaml
@@ -1,6 +1,11 @@
 name: Hello Charm Tests
 
-on: [push, pull_request, workflow_call]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_call:
 
 jobs:
   hello-charm-tests:

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -1,6 +1,11 @@
 name: Observability Charm Tests
 
-on: [push, pull_request, workflow_call]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_call:
 
 jobs:
   o11y-charm-tests:

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -11,11 +11,11 @@ jobs:
       matrix:
         include:
           - charm-repo: canonical/alertmanager-k8s-operator
-            commit: 75bb9766eb22b2a0d6447d0e41969c930fc3940d  # rev115 2024-05-28T11:25:11Z
+            commit: 81612b18bf4e9cee072387e75ebd34dff3c189ce  # rev119 2024-06-02T12:08:25Z
           - charm-repo: canonical/prometheus-k8s-operator
             commit: 41b10003b2e7aba34e26fa387af4297d97ecb535  # rev189 2024-05-21T21:25:20Z
           - charm-repo: canonical/grafana-k8s-operator
-            commit: ec74910fc60848594ce44da3b549ad18aa6528aa  # rev113 2024-05-21T14:31:49Z
+            commit: fd6a7da88fa044709be69a4c733d879eb7175b54  # rev114 2024-05-29T09:55:04Z
     steps:
       - name: Checkout the ${{ matrix.charm-repo }} repository
         uses: actions/checkout@v4

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         include:
           - charm-repo: canonical/alertmanager-k8s-operator
-            commit: 90b85c79dfdeeeedcc538c92dcbc26fb2b931088  # rev114 2024-05-23T12:09:22Z
+            commit: 75bb9766eb22b2a0d6447d0e41969c930fc3940d  # rev115 2024-05-28T11:25:11Z
           - charm-repo: canonical/prometheus-k8s-operator
             commit: 41b10003b2e7aba34e26fa387af4297d97ecb535  # rev189 2024-05-21T21:25:20Z
           - charm-repo: canonical/grafana-k8s-operator

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -16,11 +16,11 @@ jobs:
       matrix:
         include:
           - charm-repo: canonical/alertmanager-k8s-operator
-            commit: 81612b18bf4e9cee072387e75ebd34dff3c189ce  # rev119 2024-06-02T12:08:25Z
+            commit: 537183470450e231db1568c1462445ef2ef4a02a  # rev120 2024-06-07T12:11:09Z
           - charm-repo: canonical/prometheus-k8s-operator
-            commit: 41b10003b2e7aba34e26fa387af4297d97ecb535  # rev189 2024-05-21T21:25:20Z
+            commit: 051a3a750e057bf97ba44335b3a66261dd3e78a6  # rev196 2024-06-07T16:01:22Z
           - charm-repo: canonical/grafana-k8s-operator
-            commit: fd6a7da88fa044709be69a4c733d879eb7175b54  # rev114 2024-05-29T09:55:04Z
+            commit: c9eca75596bee7b5e5bf977bf0f6b8b4c3116e5e  # 2024-06-03T20:26:50Z
     steps:
       - name: Checkout the ${{ matrix.charm-repo }} repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      attestations: write
+      contents: read
     needs: [framework-tests, observability-charm-tests, hello-charm-tests]
     steps:
       - uses: actions/checkout@v4
@@ -25,5 +27,9 @@ jobs:
         run: pip install wheel build
       - name: Build
         run: python -m build
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1.3.2
+        with:
+          subject-path: 'dist/*'
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -13,17 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      attestations: write
+      contents: read
     needs: [framework-tests, observability-charm-tests, hello-charm-tests]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Install wheel
-        run: pip install wheel
+      - name: Install build dependencies
+        run: pip install wheel build
       - name: Build
-        run: python setup.py sdist bdist_wheel
+        run: python -m build
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1.3.2
+        with:
+          subject-path: 'dist/*'
       - name: Publish to test.pypi.org
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/update-charm-tests.yaml
+++ b/.github/workflows/update-charm-tests.yaml
@@ -5,7 +5,7 @@ on:
   # NOTE: to avoid infinite loop, exclude the branch created by this workflow if triggering on push or pull_request
   workflow_dispatch:
   schedule:
-    - cron: '0 18 * * SUN' # Sunday 6pm UTC, before international day starts
+    - cron: '0 0 25 * *' # On the 25th of each month
 
 jobs:
   update-pins:

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,0 +1,37 @@
+---
+name: "Validate PR Title"
+# Ensure that the PR title conforms to the Conventional Commits and our choice of types and scopes, so that library version bumps can be detected automatically
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            test
+          scopes: |
+            harness
+          requireScope: false

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,25 +1,23 @@
 # 2.14.0 - 29 May 2024
 
-This release fixes the `RelationDataContent.update` method to follow `dict.update` semantics, that is allow both updating with another dict, an iterable, keyword arguments or a mixture thereof.
-
 ## Features
 
-* feat: add a `__str__` to ActionFailed, for better unexpected failure output in https://github.com/canonical/operator/pull/1209
+* Add a `__str__` to ActionFailed, for better unexpected failure output (#1209)
 
 ## Fixes
 
-* The `other` argument to `RelatationDataContent.update(...)` should be optional by @addyess in https://github.com/canonical/operator/pull/1226
+* The `other` argument to `RelatationDataContent.update(...)` should be optional (#1226)
 
 ## Documentation
 
-* Use the actual emoji character rather than GitHub markup, to show properly on PyPI in https://github.com/canonical/operator/pull/1221
-* Clarify that SecretNotFound may be raised for permission errors in https://github.com/canonical/operator/pull/1231
+* Use the actual emoji character rather than GitHub markup, to show properly on PyPI (#1221)
+* Clarify that SecretNotFound may be raised for permission errors (#1231)
 
 ## Refactoring
 
-* Refactor tests to pytest style in https://github.com/canonical/operator/pull/1199 https://github.com/canonical/operator/pull/1200 https://github.com/canonical/operator/pull/1203 https://github.com/canonical/operator/pull/1206
-* Use `ruff` formatter and reformat all code in https://github.com/canonical/operator/pull/1224
-* Don't use f-strings in logging calls in https://github.com/canonical/operator/pull/1227 https://github.com/canonical/operator/pull/1234
+* Refactor tests to pytest style (#1199, #1200, #1203, #1206)
+* Use `ruff` formatter and reformat all code (#1224)
+* Don't use f-strings in logging calls (#1227, 1234)
 
 # 2.13.0 - 30 Apr 2024
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -293,13 +293,16 @@ To make a release of the ops library, do the following:
    link to the full changelog.
 8. Change [version.py][ops/version.py]'s `version` to the
    [appropriate string](https://semver.org/).
-9. Add, commit, and push, and open a PR to get the changelog and version bump
+9. Check if there's a `chore: update charm pins` auto-generated PR in the queue. If it looks
+   good, merge it and check that tests still pass. If needed, you can re-trigger the
+   `Update Charm Pins` workflow manually to ensure latest charms and ops get tested.
+10. Add, commit, and push, and open a PR to get the changelog and version bump
    into main (and get it merged).
-10. Back in the GitHub releases page, tweak the release notes - for example,
+11. Back in the GitHub releases page, tweak the release notes - for example,
    you might want to have a short paragraph at the intro on particularly
    noteworthy changes.
-11. Have someone else in the Charm-Tech team proofread the release notes.
-12. When you are ready, click "Publish". (If you are not ready, click "Save as Draft".)
+12. Have someone else in the Charm-Tech team proofread the release notes.
+13. When you are ready, click "Publish". (If you are not ready, click "Save as Draft".)
 
 This will trigger an automatic build for the Python package and publish it to
 [PyPI](https://pypi.org/project/ops/)) (authorisation is handled via a

--- a/HACKING.md
+++ b/HACKING.md
@@ -291,7 +291,7 @@ To make a release of the ops library, do the following:
 7. Create a new branch, and copy this text to the [CHANGES.md](CHANGES.md) file,
    stripping out links, who did each commit, the new contributor list, and the
    link to the full changelog.
-8. Change [version.py][ops/version.py]'s `version` to the
+8. Change [version.py](ops/version.py)'s `version` to the
    [appropriate string](https://semver.org/).
 9. Check if there's a `chore: update charm pins` auto-generated PR in the queue. If it looks
    good, merge it and check that tests still pass. If needed, you can re-trigger the
@@ -315,6 +315,6 @@ You can troubleshoot errors on the [Actions Tab](https://github.com/canonical/op
 
 13. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)
 
-14. Open a PR to change [version.py][ops/version.py]'s `version` to the expected
-   next version, with "+dev" appended (for example, if 3.14.1 is the next expected version, use
+14. Open a PR to change [version.py](ops/version.py)'s `version` to the expected
+   next version, with ".dev0" appended (for example, if 3.14.1 is the next expected version, use
    `'3.14.1.dev0'`).

--- a/HACKING.md
+++ b/HACKING.md
@@ -160,6 +160,36 @@ your charm to a controller using that version of Juju. For example, with microk8
 We rely on automation to [update charm pins](.github/actions/update-charm-pins/) of
 a bunch of charms that use the operator framework. The script can be run locally too.
 
+# Contributing
+
+Changes are proposed as [pull requests on GitHub](https://github.com/canonical/operator/pulls).
+
+Pull requests should have a short title that follows the
+[conventional commit style](https://www.conventionalcommits.org/en/) using one of these types:
+
+* chore
+* ci
+* docs
+* feat
+* fix
+* perf
+* refactor
+* revert
+* test
+
+If the PR is limited to changes in ops.testing (Harness), also include the scope
+`(harness)` in the title. At present, we do not add a scope in any other cases.
+
+For example:
+
+* feat: add the ability to observe change-updated events
+* fix!: correct the type hinting for config data
+* docs(harness): clarify the types of exceptions that Harness.add_user_secret may raise
+
+Note that the commit messages to the PR's branch do not need to follow the
+conventional commit format, as these will be squashed into a single commit to `main`
+using the PR title as the commit message.
+
 # Documentation
 
 In general, new functionality

--- a/README.md
+++ b/README.md
@@ -173,5 +173,5 @@ Read our [Code of conduct](https://ubuntu.com/community/code-of-conduct) and:
 ### Make your mark
 
 - Read our [documentation contributor guidelines](https://discourse.charmhub.io/t/documentation-guidelines-for-contributors/1245) and help improve a doc
-- Read our [codebase contributor guidelines](HACKING.md) and help improve the codebase
+- Read our [codebase contributor guidelines](https://github.com/canonical/operator/blob/main/HACKING.md) and help improve the codebase
 - Write a charm and publish it on [Charmhub](https://charmhub.io/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ create the issue, affected versions, and, if known, mitigations for
 the issue.
 
 The easiest way to report a security issue is through
-[GitHub](https://github.com/canonical/operator/security/advisories/new). See
+[GitHub's security advisory for this project](https://github.com/canonical/operator/security/advisories/new). See
 [Privately reporting a security
 vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
 for instructions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,7 @@
 
 ## Supported versions
 
-All ops 2.x versions are currently supported with security updates.
-
-| Version | Supported |
-| - | - |
-| 2.x.y | :white_check_mark: |
-| < 2.0 | :x: |
+All ops 2.x versions released within the last year are currently supported with security updates.
 
 ## Reporting a vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,8 +23,8 @@ for instructions.
 
 The ops GitHub admins will be notified of the issue and will work with you
 to determine whether the issue qualifies as a security issue and, if so, in
-which component. We will then handle figuring out a fix, getting a CVE
-assigned and coordinating the release of the fix.
+which component. We will then figure out a fix, get a CVE
+assigned, and coordinate the release of the fix.
 
 You may also send email to security@ubuntu.com. Email may optionally be
 encrypted to OpenPGP key

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ The easiest way to report a security issue is through
 [GitHub's security advisory for this project](https://github.com/canonical/operator/security/advisories/new). See
 [Privately reporting a security
 vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
-for instructions.
+for instructions on reporting using GitHub's security advisory feature.
 
 The ops GitHub admins will be notified of the issue and will work with you
 to determine whether the issue qualifies as a security issue and, if so, in

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,10 @@ All ops 2.x versions are currently supported with security updates.
 
 ## Reporting a vulnerability
 
+Please provide a description of the issue, the steps you took to
+create the issue, affected versions, and, if known, mitigations for
+the issue.
+
 The easiest way to report a security issue is through
 [GitHub](https://github.com/canonical/operator/security/advisories/new). See
 [Privately reporting a security
@@ -25,9 +29,6 @@ assigned and coordinating the release of the fix.
 You may also send email to security@ubuntu.com. Email may optionally be
 encrypted to OpenPGP key
 [`4072 60F7 616E CE4D 9D12 4627 98E9 740D C345 39E0`](https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x407260f7616ece4d9d12462798e9740dc34539e0)
-Please provide a description of the issue, the steps you took to
-create the issue, affected versions, and, if known, mitigations for
-the issue.
 
 If you have a deadline for public disclosure, please let us know.
 Our vulnerability management team intends to respond within 3 working

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security policy
+
+## Supported versions
+
+All ops 2.x versions are currently supported with security updates.
+
+| Version | Supported |
+| - | - |
+| 2.x.y | :white_check_mark: |
+| < 2.0 | :x: |
+
+## Reporting a vulnerability
+
+The easiest way to report a security issue is through
+[GitHub](https://github.com/canonical/operator/security/advisories/new). See
+[Privately reporting a security
+vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+for instructions.
+
+The ops GitHub admins will be notified of the issue and will work with you
+to determine whether the issue qualifies as a security issue and, if so, in
+which component. We will then handle figuring out a fix, getting a CVE
+assigned and coordinating the release of the fix.
+
+You may also send email to security@ubuntu.com. Email may optionally be
+encrypted to OpenPGP key
+[`4072 60F7 616E CE4D 9D12 4627 98E9 740D C345 39E0`](https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x407260f7616ece4d9d12462798e9740dc34539e0)
+Please provide a description of the issue, the steps you took to
+create the issue, affected versions, and, if known, mitigations for
+the issue.
+
+If you have a deadline for public disclosure, please let us know.
+Our vulnerability management team intends to respond within 3 working
+days of your report. This project aims to resolve all vulnerabilities
+within 90 days.
+
+The [Ubuntu Security disclosure and embargo
+policy](https://ubuntu.com/security/disclosure-policy) contains more
+information about what you can expect when you contact us, and what we
+expect from you.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -131,7 +131,7 @@ sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
 sphinxext-opengraph==0.9.1
     # via ops (pyproject.toml)
-tornado==6.4
+tornado==6.4.1
     # via livereload
 uc-micro-py==1.0.3
     # via linkify-it-py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -135,7 +135,7 @@ tornado==6.4.1
     # via livereload
 uc-micro-py==1.0.3
     # via linkify-it-py
-urllib3==2.2.1
+urllib3==2.2.2
     # via requests
 wcmatch==8.5.1
     # via pyspelling

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -841,7 +841,11 @@ class SecretEvent(HookEvent):
 
     @property
     def secret(self) -> model.Secret:
-        """The secret instance this event refers to."""
+        """The secret instance this event refers to.
+
+        Note that the secret content is not retrieved from the secret storage
+        until :meth:`Secret.get_content()` is called.
+        """
         backend = self.framework.model._backend
         return model.Secret(backend=backend, id=self._id, label=self._label)
 
@@ -901,9 +905,10 @@ class SecretRemoveEvent(SecretEvent):
     observers have updated to that new revision, this event will be fired to
     inform the secret owner that the old revision can be removed.
 
-    Typically, the charm will call
+    After any required cleanup, the charm should call
     :meth:`event.secret.remove_revision() <ops.Secret.remove_revision>` to
-    remove the now-unused revision.
+    remove the now-unused revision. If the charm does not, then the event will
+    be emitted again, when further revisions are ready for removal.
     """
 
     def __init__(self, handle: 'Handle', id: str, label: Optional[str], revision: int):

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -953,7 +953,8 @@ class Framework(Object):
                 logger.warning(
                     'Reference to ops.Object at path %s has been garbage collected '
                     'between when the charm was initialised and when the event was emitted. '
-                    'Make sure sure you store a reference to the observer.', observer_path
+                    'Make sure sure you store a reference to the observer.',
+                    observer_path,
                 )
 
             if event.deferred:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -2832,10 +2832,17 @@ class Client:
 
     def _connect_websocket(self, task_id: str, websocket_id: str) -> '_WebSocket':
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        # Set socket timeout to a short timeout during connection phase, in
+        # case the Pebble side times out (5s), so this side doesn't hang. See:
+        # https://github.com/canonical/operator/issues/1246
+        sock.settimeout(self.timeout)
         sock.connect(self.socket_path)
         url = self._websocket_url(task_id, websocket_id)
         ws: _WebSocket = websocket.WebSocket(skip_utf8_validation=True)  # type: ignore
         ws.connect(url, socket=sock)
+        # Reset to no timeout so connection can be "long polling" when data is
+        # being received.
+        sock.settimeout(None)
         return ws
 
     def _websocket_url(self, task_id: str, websocket_id: str) -> str:

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2741,29 +2741,30 @@ class _TestingModelBackend:
                 return relation_id
         return None
 
-    def _ensure_secret_owner(self, secret: _Secret):
+    def _has_secret_owner_permission(self, secret: _Secret) -> bool:
         # For unit secrets, the owner unit has manage permissions. For app
         # secrets, the leader has manage permissions and other units only have
         # view permissions.
         # https://discourse.charmhub.io/t/secret-access-permissions/12627
         # For user secrets the secret owner is the model, that is,
-        # `secret.owner_name == self.model.uuid`, only model admins have
+        # when `secret.owner_name == self.model.uuid`, only model admins have
         # manage permissions: https://juju.is/docs/juju/secret.
 
         unit_secret = secret.owner_name == self.unit_name
         app_secret = secret.owner_name == self.app_name
 
         if unit_secret or (app_secret and self.is_leader()):
-            return
-        raise model.SecretNotFoundError(
-            f'You must own secret {secret.id!r} to perform this operation'
-        )
+            return True
+        return False
 
     def secret_info_get(
         self, *, id: Optional[str] = None, label: Optional[str] = None
     ) -> model.SecretInfo:
         secret = self._ensure_secret_id_or_label(id, label)
-        self._ensure_secret_owner(secret)
+        if not self._has_secret_owner_permission(secret):
+            raise model.SecretNotFoundError(
+                f'You must own secret {secret.id!r} to perform this operation'
+            )
 
         rotates = None
         rotation = None
@@ -2793,7 +2794,8 @@ class _TestingModelBackend:
         rotate: Optional[model.SecretRotate] = None,
     ) -> None:
         secret = self._ensure_secret(id)
-        self._ensure_secret_owner(secret)
+        if not self._has_secret_owner_permission(secret):
+            raise RuntimeError(f'You must own secret {secret.id!r} to perform this operation')
 
         if content is None:
             content = secret.revisions[-1].content
@@ -2866,7 +2868,10 @@ class _TestingModelBackend:
 
     def secret_grant(self, id: str, relation_id: int, *, unit: Optional[str] = None) -> None:
         secret = self._ensure_secret(id)
-        self._ensure_secret_owner(secret)
+        if not self._has_secret_owner_permission(secret):
+            raise model.SecretNotFoundError(
+                f'You must own secret {secret.id!r} to perform this operation'
+            )
 
         if relation_id not in secret.grants:
             secret.grants[relation_id] = set()
@@ -2875,7 +2880,8 @@ class _TestingModelBackend:
 
     def secret_revoke(self, id: str, relation_id: int, *, unit: Optional[str] = None) -> None:
         secret = self._ensure_secret(id)
-        self._ensure_secret_owner(secret)
+        if not self._has_secret_owner_permission(secret):
+            raise RuntimeError(f'You must own secret {secret.id!r} to perform this operation')
 
         if relation_id not in secret.grants:
             return
@@ -2884,7 +2890,8 @@ class _TestingModelBackend:
 
     def secret_remove(self, id: str, *, revision: Optional[int] = None) -> None:
         secret = self._ensure_secret(id)
-        self._ensure_secret_owner(secret)
+        if not self._has_secret_owner_permission(secret):
+            raise RuntimeError(f'You must own secret {secret.id!r} to perform this operation')
 
         if revision is not None:
             revisions = [r for r in secret.revisions if r.revision != revision]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "The Python library behind great charms"
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [
-    {name="The Charm Tech team at Canonical Ltd.", email="charm-tech@lists.launchpad.com"},
+    {name="The Charm Tech team at Canonical Ltd.", email="charm-tech@lists.launchpad.net"},
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/test/pebble_cli.py
+++ b/test/pebble_cli.py
@@ -246,9 +246,8 @@ def main():
                     if stderr:
                         print(repr(stderr), end='', file=sys.stderr)
                 sys.exit(0)
-            # The `[str]` here is to resolve the same issue as above.
-            except pebble.ExecError[str] as e:
-                print('ExecError:', e, file=sys.stderr)
+            except pebble.ExecError as e:  # type: ignore
+                print('ExecError:', e, file=sys.stderr)  # type: ignore
                 sys.exit(e.exit_code)
 
         elif args.command == 'ls':

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -560,27 +560,42 @@ def test_invalid_action_results(
         charm.on.foo_bar_action.emit(id='1')
 
 
-def test_action_event_defer_fails(
-    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch, fake_script: FakeScript
+@pytest.mark.parametrize(
+    'event,kwargs',
+    [
+        ('start_action', {'id': 2}),
+        ('stop', {}),
+        ('remove', {}),
+        ('secret_expired', {'id': 'secret:123', 'label': None, 'revision': 0}),
+        ('secret_rotate', {'id': 'secret:234', 'label': 'my-secret'}),
+    ],
+)
+def test_inappropriate_event_defer_fails(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_script: FakeScript,
+    event: str,
+    kwargs: typing.Dict[str, typing.Any],
 ):
-    cmd_type = 'action'
-
     class MyCharm(ops.CharmBase):
         def __init__(self, framework: ops.Framework):
             super().__init__(framework)
-            framework.observe(self.on.start_action, self._on_start_action)
+            framework.observe(getattr(self.on, event), self._call_defer)
 
-        def _on_start_action(self, event: ops.ActionEvent):
+        def _call_defer(self, event: ops.EventBase):
             event.defer()
 
+    # This is only necessary for the action event, but is ignored by the others.
+    cmd_type = 'action'
     fake_script.write(f'{cmd_type}-get', """echo '{"foo-name": "name", "silent": true}'""")
     monkeypatch.setenv(f'JUJU_{cmd_type.upper()}_NAME', 'start')
     meta = _get_action_test_meta()
+
     framework = create_framework(request, meta=meta)
     charm = MyCharm(framework)
 
     with pytest.raises(RuntimeError):
-        charm.on.start_action.emit(id='2')
+        getattr(charm.on, event).emit(**kwargs)
 
 
 def test_containers():

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -15,6 +15,7 @@
 import io
 import logging
 import re
+import sys
 import typing
 import unittest
 from unittest.mock import patch
@@ -50,6 +51,7 @@ def logger():
     logger = logging.getLogger()
     yield logger
     logging.getLogger().handlers.clear()
+    sys.excepthook = sys.__excepthook__
 
 
 class TestLogging:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -3663,24 +3663,6 @@ class TestSecretClass:
 
         assert fake_script.calls(clear=True) == [['secret-get', 'secret:z', '--format=json']]
 
-    def test_set_content_invalidates_cache(self, model: ops.Model, fake_script: FakeScript):
-        fake_script.write('secret-get', """echo '{"foo": "bar"}'""")
-        fake_script.write('secret-set', """exit 0""")
-
-        secret = self.make_secret(model, id='z')
-        old_content = secret.get_content()
-        assert old_content == {'foo': 'bar'}
-        secret.set_content({'new': 'content'})
-        fake_script.write('secret-get', """echo '{"new": "content"}'""")
-        new_content = secret.get_content()
-        assert new_content == {'new': 'content'}
-
-        assert fake_script.calls(clear=True) == [
-            ['secret-get', 'secret:z', '--format=json'],
-            ['secret-set', 'secret:z', 'new=content'],
-            ['secret-get', 'secret:z', '--format=json'],
-        ]
-
     def test_peek_content(self, model: ops.Model, fake_script: FakeScript):
         fake_script.write('secret-get', """echo '{"foo": "peeked"}'""")
 


### PR DESCRIPTION
Adds a simple security policy, so that users can easily find out how to privately report security issues.

The policy states that 2.x will get security updates, which seems reasonable to me, but we could make that more recent versions if that was better.

The policy offers reporting via GitHub (which would need to be turned on) and to the security@ubuntu.com address - I think it's important to still offer an email (particularly encrypted email) mechanism, not just the GitHub one.

This is based on the [LXD policy](https://github.com/canonical/lxd/blob/main/SECURITY.md), and the [work to develop a Canonical security policy template](https://warthogs.atlassian.net/browse/SEC-4238) (internal link only, sorry).

See also [this Mattermost discussion](https://chat.canonical.com/canonical/pl/gnk4rsorrpgr3yetka9suh5bpa) (also internal only, sorry).