### PR TITLE
ci: add artefact attestation (using GitHub / SigStore)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      attestations: write
+      contents: read
     needs: [framework-tests, observability-charm-tests, hello-charm-tests]
     steps:
       - uses: actions/checkout@v4
@@ -25,5 +27,9 @@ jobs:
         run: pip install wheel build
       - name: Build
         run: python -m build
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1.3.2
+        with:
+          subject-path: 'dist/*'
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -13,17 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      attestations: write
+      contents: read
     needs: [framework-tests, observability-charm-tests, hello-charm-tests]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Install wheel
-        run: pip install wheel
+      - name: Install build dependencies
+        run: pip install wheel build
       - name: Build
-        run: python setup.py sdist bdist_wheel
+        run: python -m build
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1.3.2
+        with:
+          subject-path: 'dist/*'
       - name: Publish to test.pypi.org
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
This PR adds [artefact attestation](https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/) to the ops builds. Essentially: users are able to verify that the wheel and source dist tarball produced by the build script were actually generated by the workflow in this repo (and not, for example, uploaded by someone else that got access to the PyPI account).

The `test-publish` workflow is also updated to use the `build` backend, which was missed when the main script was migrated.  Annoyingly, [we are still waiting for access to the operator package on test.pypi.org](https://github.com/pypi/support/issues/3349).