### PR TITLE
docs: add main to ops api reference

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ ops module
 .. automodule:: ops
 
 
-`ops.main`
+ops.main
 -----------
 
 .. automodule:: ops.main

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ ops module
 .. automodule:: ops
 
 
-ops.main
+main
 -----------
 
 .. automodule:: ops.main

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,12 @@ ops module
 .. automodule:: ops
 
 
+`ops.main`
+-----------
+
+.. automodule:: ops.main
+
+
 ops.pebble module
 =================
 


### PR DESCRIPTION
The docstring of `main` is missing from RTD, this adds it back.

According to Dora, it would be nice to link to `main` in [here](https://juju.is/docs/sdk/ops#opsmain-1).

I don't have a very good solution to add it, did some testing, this is the best I can do, preview [here](https://ops--1273.org.readthedocs.build/en/1273/#module-ops.main).

Tried to put it in front of the first entry of the ops module but then the indentation for following items are wrong, since they are handled automatically by autodoc.

Also tried to add only the function `ops.main.main` instead of the module, in this way we can put it in front of [`ops.ActionEvent`](https://ops--1273.org.readthedocs.build/en/1273/#ops.ActionEvent), but it is still before [the big paragraph](https://ops--1273.org.readthedocs.build/en/1273/#module-ops) that comes from `__init__.py`, which looks even worse.

So, the current preview looks the best, although having `main` at the bottom seems not so good.