### PR TITLE
[DO NOT MERGE] POC middlewares

### DIFF
--- a/ops/main.py
+++ b/ops/main.py
@@ -26,12 +26,13 @@ import subprocess
 import sys
 import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast, Sequence
 
 import ops.charm
 import ops.framework
 import ops.model
 import ops.storage
+from middlewares import Middleware
 from ops.charm import CharmMeta
 from ops.jujuversion import JujuVersion
 from ops.log import setup_root_logging
@@ -530,13 +531,15 @@ class _Manager:
             self.framework.close()
 
 
-def main(charm_class: Type[ops.charm.CharmBase], use_juju_for_storage: Optional[bool] = None):
+def main(charm_class: Type[ops.charm.CharmBase], use_juju_for_storage: Optional[bool] = None,
+         middlewares: Sequence[Type[Middleware]]=None):
     """Set up the charm and dispatch the observed event.
 
     The event name is based on the way this executable was called (argv[0]).
 
     Args:
         charm_class: the charm class to instantiate and receive the event.
+        middlewares: operator framework middleware used to extend the framework's own functionality.
         use_juju_for_storage: whether to use controller-side storage. If not specified
             then Kubernetes charms that haven't previously used local storage and that
             are running on a new enough Juju default to controller-side storage,

--- a/ops/middlewares.py
+++ b/ops/middlewares.py
@@ -1,0 +1,36 @@
+import typing
+from abc import ABC
+
+if typing.TYPE_CHECKING:
+    from ops import CharmBase
+
+
+class Middleware(ABC):
+    """Ops middleware abstract base class.
+
+    Can be used to define middlewares for the operator framework.
+    Pass any subclass to ``ops.main.main(middlewares=[...])`` to apply the
+    middleware to the charm execution.
+    """
+
+    def setup_class(self, charm_type: typing.Type["CharmBase"]):
+        """Override this method to manipulate the charm type before it's instantiated."""
+
+        # insert charm-type-hook code here
+
+    def pre_init(self, charm: "CharmBase"):
+        """Override this method to hook into the charm `__init__`.
+
+        This will be called before any initialization beyond super() takes place.
+        """
+
+        # insert pre-charm-init code here
+
+
+    def post_init(self, charm: "CharmBase"):
+        """Override this method to hook into the charm `__init__`.
+
+        This will be called after the charm's `__init__` has returned.
+        """
+
+        # insert post-charm-init-code here

--- a/test/test_middlewares.py
+++ b/test/test_middlewares.py
@@ -1,0 +1,32 @@
+from unittest.mock import patch, MagicMock
+
+# impossible to test with harness ATM since harness doesn't mock at the level of `main`.
+from scenario import Context
+from scenario.state import State
+
+from middlewares import Middleware
+from ops import CharmBase, Framework
+
+
+class MyCharm(CharmBase):
+    def __init__(self, framework: Framework):
+        super().__init__(framework)
+
+        self.foo = 1
+
+
+class MyMiddleware(Middleware):
+    def pre_init(self, charm: CharmBase):
+        assert not hasattr(charm, "foo")  # not yet, anyway
+
+    def post_init(self, charm: CharmBase):
+        assert charm.foo
+
+
+def test_middleware_setup_called():
+    for name in ("pre_init", "post_init"):
+        with patch.object(MyMiddleware, name, new=MagicMock()) as p:
+            c = Context(MyCharm, meta={"name": "middleman"},
+                        middlewares=[MyMiddleware()]
+                        ).run("update-status", State())
+        assert p.called


### PR DESCRIPTION
This POC is meant to explore the possibility of adding a functionality to ops called Middlewares.
The idea is to offer to charmers an easier way to decorate charms and effectively inject pre-charm-init, and post-charm-init hooks, without touching the charm code itself.

Charm libs such as [charm_tracing](https://github.com/canonical/tempo-k8s-operator/blob/main/lib/charms/tempo_k8s/v1/charm_tracing.py) and [charm_logging](https://github.com/canonical/loki-k8s-operator/blob/main/lib/charms/loki_k8s/v0/charm_logging.py) at the moment expose class decorators that have to do some rather hacky stuff in order to override the charm's `__init__` to do very important things. Middlewares would allow us to skip some of those shenanigans and hook into the charm initialization sequence with fewer risks. 

In the future we're planning to add more decorators, what is going to happen when we have four, five decorators each one of them monkey-patching the charm's __init__ method in different ways? Can't wait to find out.

tandems:
- charm code: https://github.com/canonical/tempo-k8s-operator/pull/146
- testing: https://github.com/canonical/ops-scenario/pull/146