### PR TITLE
ci: only update ops, not all dependencies

### DIFF
--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -44,7 +44,7 @@ jobs:
             echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
           else
             sed -i -e "s/^ops[ ><=].*/ops = {path = \"myops\"}/" pyproject.toml
-            poetry lock
+            poetry lock --no-update
           fi
 
       - name: Install dependencies


### PR DESCRIPTION
When running `poetry lock` in the CI workloads, only update the ops dependency, not all dependencies. We want to know whether the proposed changes to ops would break the charm's tests, not whether updating all dependencies, including the proposed ops changes, would do so.

This is one of the suggestions in #1272. Using `poetry add --lock` seems slightly cleaner than the `sed` system we currently use, but I wasn't able to easily figure out how to do that with a `ops = { path = "ci/path/for/ops/branch" }` type specifier. It seems like this approach is at least an improvement on the existing one, even if not perfect. (It also will unblock other PRs, given that the tests fail because we're re-locking in entirety).

Fixes #1272.