### PR TITLE
chore: run ruff format over charm pin update code

### DIFF
--- a/.github/actions/update-charm-pins/main.py
+++ b/.github/actions/update-charm-pins/main.py
@@ -9,14 +9,14 @@ import sys
 from httpx import Client
 from ruamel.yaml import YAML
 
-yaml = YAML(typ="rt")
+yaml = YAML(typ='rt')
 yaml.indent(mapping=2, sequence=4, offset=2)
 
 github = Client(
-    base_url="https://api.github.com/repos",
+    base_url='https://api.github.com/repos',
     headers={
-        "Authorization": f'token {os.getenv("GITHUB_TOKEN")}',
-        "Accept": "application/vnd.github.v3+json",
+        'Authorization': f'token {os.getenv("GITHUB_TOKEN")}',
+        'Accept': 'application/vnd.github.v3+json',
     },
 )
 
@@ -27,29 +27,27 @@ def update_charm_pins(workflow):
         doc = yaml.load(file)
 
     # Assume the workflow has a single job or the first job is parameterized with charm repos
-    job_name = next(iter(doc["jobs"]))
+    job_name = next(iter(doc['jobs']))
 
-    for idx, item in enumerate(doc["jobs"][job_name]["strategy"]["matrix"]["include"]):
-        charm_repo = item["charm-repo"]
-        commit = github.get(f"{charm_repo}/commits").raise_for_status().json()[0]
-        data = github.get(f"{charm_repo}/tags").raise_for_status().json()
-        comment = " ".join(
-            [tag["name"] for tag in data if tag["commit"]["sha"] == commit["sha"]]
-            + [commit["commit"]["committer"]["date"]]
+    for idx, item in enumerate(doc['jobs'][job_name]['strategy']['matrix']['include']):
+        charm_repo = item['charm-repo']
+        commit = github.get(f'{charm_repo}/commits').raise_for_status().json()[0]
+        data = github.get(f'{charm_repo}/tags').raise_for_status().json()
+        comment = ' '.join(
+            [tag['name'] for tag in data if tag['commit']['sha'] == commit['sha']]
+            + [commit['commit']['committer']['date']]
         )
 
         # A YAML node, as opposed to a plain value, can be updated in place to tweak comments
-        node = doc.mlget(
-            ["jobs", job_name, "strategy", "matrix", "include", idx], list_ok=True
-        )
-        node["commit"] = commit["sha"]
-        node.yaml_add_eol_comment(comment, key="commit")
+        node = doc.mlget(['jobs', job_name, 'strategy', 'matrix', 'include', idx], list_ok=True)
+        node['commit'] = commit['sha']
+        node.yaml_add_eol_comment(comment, key='commit')
 
-    with open(workflow, "w") as file:
+    with open(workflow, 'w') as file:
         yaml.dump(doc, file)
 
 
-if __name__ == "__main__":
-    logging.basicConfig(level="INFO")
-    for workflow in " ".join(sys.argv[1:]).split():
+if __name__ == '__main__':
+    logging.basicConfig(level='INFO')
+    for workflow in ' '.join(sys.argv[1:]).split():
         update_charm_pins(workflow)

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ deps =
     ruff==0.4.5
 commands =
     ruff check --preview
+    ruff format --preview --check
 
 [testenv:static]
 description = Run static type checker


### PR DESCRIPTION
The only changes are from running `tox -e fmt`, and adding `ruff format --preview check` to the `tox -e lint` commands.

I don't think these changes are generally important, being in a separate file only used in CI, but ideally running `tox -e fmt` doesn't bring in unrelated changes when working on a branch, and we might as well be consistent.