### PR TITLE
ci: bump the Go version to match Pebble

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -75,10 +75,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set up Go 1.20
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.22"
 
       - name: Install tox
         run: pip install tox~=4.2


### PR DESCRIPTION
[Pebble now requires Go 1.22](https://github.com/canonical/pebble/releases/tag/v1.15.0), so bump the CI real Pebble tests to match.