### PR TITLE
ci: run jobs on maintenance branches

### DIFF
--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-*
   pull_request:
 
 jobs:

--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-*
   pull_request:
   workflow_call:
 

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-*
   pull_request:
   workflow_call:
 

--- a/.github/workflows/hello-charm-tests.yaml
+++ b/.github/workflows/hello-charm-tests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-*
   pull_request:
   workflow_call:
 

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-*
   pull_request:
   workflow_call:
 


### PR DESCRIPTION
In preparation for releasing 2.14.2, I've
- made the maintenance branch `release-2.14`, branched off the 2.14.1 tag
- enabling CI on this branch in this PR