### PR TITLE
docs: security policy change to only support each active major release

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-All ops 2.x versions released within the last year are currently supported with security updates.
+Security updates will be released for all major versions that have had releases in the last year.
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
We strongly encourage charms to use the latest release of ops, and put in a lot of effort to make sure that there are no compatibility issues that would prevent that. As such, rather than promising to do security releases for a year of versions (with our monthly release cadence, this would generally mean 10-12 security releases), only promise to do one for each active major release (so that would be only for 2.x now, and might be 2.x and 3.x at some point in the future).

This is all that we promise, but we could, of course, choose to do more if there was some reason to do so on a case-by-case basis.

This seems to balance the amount of work required to do many small releases and the work that we put into compatibility better than the previous policy.