### PR TITLE
docs: add example Juju version markers

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -3,6 +3,8 @@ import datetime
 import pathlib
 import sys
 
+import sphinx.domains.changeset
+
 import furo
 import furo.navigation
 
@@ -334,3 +336,15 @@ nitpick_ignore = [
     ('py:class', 'ops.testing.CharmType'),
     ('py:obj', 'ops.testing.CharmType'),
 ]
+
+# We want to have a custom 'jujuversion' directive, that works like
+# 'versionadded', but with different text. We essentially want the
+# sphinx.domains.changeset.VersionChange class, but it's not really
+# designed for subclassing, so we we would need to copy most of the
+# core "run" method. Instead, we use the same class and just patch in
+# the appropriate keys into the lookup tables it uses.
+sphinx.domains.changeset.versionlabels['jujuversion'] = "Added in Juju version %s"
+sphinx.domains.changeset.versionlabel_classes['jujuversion'] = 'added'
+
+def setup(app):
+    app.add_directive('jujuversion', sphinx.domains.changeset.VersionChange)

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -338,7 +338,8 @@ nitpick_ignore = [
 # requiring extra CSS.
 class JujuVersion(SphinxDirective):
     """Directive to describe in which version of Juju a feature was added or removed."""
-    change = "changed"
+
+    change = 'changed'
 
     has_content = True
     required_arguments = 1

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -355,7 +355,7 @@ class JujuVersion(SphinxDirective):
         # we don't need custom CSS.
         node['type'] = f'version{self.change}'
         node['version'] = self.arguments[0]
-        text = f'{self.change.title()} in Juju version {self.arguments[0]}'
+        text = f'{self.text} in Juju version {self.arguments[0]}'
         if len(self.arguments) == 2:
             inodes, messages = self.state.inline_text(self.arguments[1], self.lineno + 1)
             para = nodes.paragraph(self.arguments[1], '', *inodes, translatable=False)
@@ -401,10 +401,12 @@ class JujuVersion(SphinxDirective):
 
 class JujuAdded(JujuVersion):
     change = 'added'
+    text = 'Added'
 
 
 class JujuRemoved(JujuVersion):
     change = 'removed'
+    text = 'Scheduled for removal'
 
 
 def setup(app):

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -337,7 +337,8 @@ nitpick_ignore = [
 # Unfortunately, the built-in class is not easily subclassable without also
 # requiring extra CSS.
 class JujuVersion(SphinxDirective):
-    """Directive to describe in which version of Juju a feature was added."""
+    """Directive to describe in which version of Juju a feature was added or removed."""
+    change = "changed"
 
     has_content = True
     required_arguments = 1
@@ -349,10 +350,11 @@ class JujuVersion(SphinxDirective):
         node = addnodes.versionmodified()
         node.document = self.state.document
         self.set_source_info(node)
-        # Make the <div> have a 'versionadded' class so that we don't need custom CSS.
-        node['type'] = 'versionadded'
+        # Make the <div> have a class matching the built-in directives so that
+        # we don't need custom CSS.
+        node['type'] = f'version{self.change}'
         node['version'] = self.arguments[0]
-        text = f'Added in Juju version {self.arguments[0]}'
+        text = f'{self.change.title()} in Juju version {self.arguments[0]}'
         if len(self.arguments) == 2:
             inodes, messages = self.state.inline_text(self.arguments[1], self.lineno + 1)
             para = nodes.paragraph(self.arguments[1], '', *inodes, translatable=False)
@@ -362,7 +364,7 @@ class JujuVersion(SphinxDirective):
             messages = []
         if self.content:
             node += self.parse_content_to_nodes()
-        classes = ['versionmodified', 'added', 'jujuversion']
+        classes = ['versionmodified', self.change, 'jujuversion']
         if len(node) > 0 and isinstance(node[0], nodes.paragraph):
             # The contents start with a paragraph.
             if node[0].rawsource:
@@ -396,5 +398,14 @@ class JujuVersion(SphinxDirective):
         return ret
 
 
+class JujuAdded(JujuVersion):
+    change = 'added'
+
+
+class JujuRemoved(JujuVersion):
+    change = 'removed'
+
+
 def setup(app):
-    app.add_directive('jujuversion', JujuVersion)
+    app.add_directive('jujuversion', JujuAdded)
+    app.add_directive('jujuremoved', JujuRemoved)

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -877,7 +877,7 @@ class PebbleCheckFailedEvent(PebbleCheckEvent):
     if the check is currently failing, check the current status with
     ``event.info.status == ops.pebble.CheckStatus.DOWN``.
 
-    .. versionadded:: Juju 3.6
+    .. versionadded:: 3.6 of Juju
     """
 
 

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -877,7 +877,8 @@ class PebbleCheckFailedEvent(PebbleCheckEvent):
     if the check is currently failing, check the current status with
     ``event.info.status == ops.pebble.CheckStatus.DOWN``.
 
-    .. versionadded:: 3.6 of Juju
+    .. versionadded:: 3.6
+       of Juju
     """
 
 

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -937,7 +937,8 @@ class SecretChangedEvent(SecretEvent):
     :meth:`event.secret.get_content() <ops.Secret.get_content>` with ``refresh=True``
     to tell Juju to start tracking the new revision.
 
-    .. versionadded:: Juju 3.0
+    .. versionadded:: 2.0
+        Charm secrets added in Juju 3.0, user secrets added in Juju 3.3
     """
 
 
@@ -1174,16 +1175,10 @@ class CharmEvents(ObjectEvents):
     """Triggered by request to upgrade the charm (see :class:`UpgradeCharmEvent`)."""
 
     pre_series_upgrade = EventSource(PreSeriesUpgradeEvent)
-    """Triggered to prepare a unit for series upgrade (see :class:`PreSeriesUpgradeEvent`).
-
-    .. versionremoved:: Juju 4.0
-    """
+    """Triggered to prepare a unit for series upgrade (see :class:`PreSeriesUpgradeEvent`)."""
 
     post_series_upgrade = EventSource(PostSeriesUpgradeEvent)
-    """Triggered after a series upgrade (see :class:`PostSeriesUpgradeEvent`).
-
-    .. versionremoved:: Juju 4.0
-    """
+    """Triggered after a series upgrade (see :class:`PostSeriesUpgradeEvent`)."""
 
     leader_elected = EventSource(LeaderElectedEvent)
     """Triggered when a new leader has been elected (see :class:`LeaderElectedEvent`)."""
@@ -1196,10 +1191,7 @@ class CharmEvents(ObjectEvents):
     """
 
     collect_metrics = EventSource(CollectMetricsEvent)
-    """Triggered by Juju to collect metrics (see :class:`CollectMetricsEvent`).
-
-    .. versionremoved:: 4.0
-    """
+    """Triggered by Juju to collect metrics (see :class:`CollectMetricsEvent`)."""
 
     secret_changed = EventSource(SecretChangedEvent)
     """Triggered by Juju on the observer when the secret owner changes its contents (see

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -937,7 +937,7 @@ class SecretChangedEvent(SecretEvent):
     :meth:`event.secret.get_content() <ops.Secret.get_content>` with ``refresh=True``
     to tell Juju to start tracking the new revision.
 
-    .. jujuversion:: 2.0
+    .. jujuversion:: 3.0
         Charm secrets added in Juju 3.0, user secrets added in Juju 3.3
     """
 

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -354,6 +354,8 @@ class PreSeriesUpgradeEvent(HookEvent):
     callback method associated with this event, the administrator will initiate
     steps to actually upgrade the series.  After the upgrade has been completed,
     the :class:`PostSeriesUpgradeEvent` will fire.
+
+    .. jujuremoved:: 4.0
     """
 
 
@@ -368,6 +370,8 @@ class PostSeriesUpgradeEvent(HookEvent):
     upgraded version of a database. Note however charms are expected to check if
     the series has actually changed or whether it was rolled back to the
     original series.
+
+    .. jujuremoved:: 4.0
     """
 
 
@@ -403,6 +407,8 @@ class CollectMetricsEvent(HookEvent):
 
     Note that associated callback methods are currently sandboxed in
     how they can interact with Juju.
+
+    .. jujuremoved:: 4.0
     """
 
     def add_metrics(
@@ -1177,10 +1183,16 @@ class CharmEvents(ObjectEvents):
     """Triggered by request to upgrade the charm (see :class:`UpgradeCharmEvent`)."""
 
     pre_series_upgrade = EventSource(PreSeriesUpgradeEvent)
-    """Triggered to prepare a unit for series upgrade (see :class:`PreSeriesUpgradeEvent`)."""
+    """Triggered to prepare a unit for series upgrade (see :class:`PreSeriesUpgradeEvent`).
+
+    .. jujuremoved:: 4.0
+    """
 
     post_series_upgrade = EventSource(PostSeriesUpgradeEvent)
-    """Triggered after a series upgrade (see :class:`PostSeriesUpgradeEvent`)."""
+    """Triggered after a series upgrade (see :class:`PostSeriesUpgradeEvent`).
+
+    .. jujuremoved:: 4.0
+    """
 
     leader_elected = EventSource(LeaderElectedEvent)
     """Triggered when a new leader has been elected (see :class:`LeaderElectedEvent`)."""
@@ -1189,11 +1201,14 @@ class CharmEvents(ObjectEvents):
     """Triggered when leader changes any settings (see
     :class:`LeaderSettingsChangedEvent`).
 
-    .. deprecated: 2.4.0
+    .. deprecated:: 2.4.0
     """
 
     collect_metrics = EventSource(CollectMetricsEvent)
-    """Triggered by Juju to collect metrics (see :class:`CollectMetricsEvent`)."""
+    """Triggered by Juju to collect metrics (see :class:`CollectMetricsEvent`).
+
+    .. jujuremoved:: 4.0
+    """
 
     secret_changed = EventSource(SecretChangedEvent)
     """Triggered by Juju on the observer when the secret owner changes its contents (see

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1020,8 +1020,6 @@ class SecretExpiredEvent(SecretEvent):
     revision by calling :meth:`event.secret.remove_revision() <ops.Secret.remove_revision>`.
 
     .. jujuversion:: 3.0
-
-    .. versionadded:: 3.0
     """
 
     def __init__(self, handle: 'Handle', id: str, label: Optional[str], revision: int):

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -828,7 +828,10 @@ class PebbleNoticeEvent(WorkloadEvent):
 
 
 class PebbleCustomNoticeEvent(PebbleNoticeEvent):
-    """Event triggered when a Pebble notice of type "custom" is created or repeats."""
+    """Event triggered when a Pebble notice of type "custom" is created or repeats.
+
+    .. versionadded:: Juju 3.4
+    """
 
 
 class PebbleCheckEvent(WorkloadEvent):
@@ -873,6 +876,8 @@ class PebbleCheckFailedEvent(PebbleCheckEvent):
     emitted next). If the handler is executing code that should only be done
     if the check is currently failing, check the current status with
     ``event.info.status == ops.pebble.CheckStatus.DOWN``.
+
+    .. versionadded:: Juju 3.6
     """
 
 
@@ -882,6 +887,8 @@ class PebbleCheckRecoveredEvent(PebbleCheckEvent):
     This event is only triggered when the check has previously reached a failure
     state (not simply failed, but failed at least as many times as the
     configured threshold).
+
+    .. versionadded:: Juju 3.6
     """
 
 
@@ -929,6 +936,8 @@ class SecretChangedEvent(SecretEvent):
     Typically, the charm will fetch the new content by calling
     :meth:`event.secret.get_content() <ops.Secret.get_content>` with ``refresh=True``
     to tell Juju to start tracking the new revision.
+
+    .. versionadded:: Juju 3.0
     """
 
 
@@ -938,6 +947,8 @@ class SecretRotateEvent(SecretEvent):
     This event is fired on the secret owner to inform it that the secret must
     be rotated. The event will keep firing until the owner creates a new
     revision by calling :meth:`event.secret.set_content() <ops.Secret.set_content>`.
+
+    .. note:: Added in Juju 3.0
     """
 
     def defer(self) -> NoReturn:
@@ -963,6 +974,8 @@ class SecretRemoveEvent(SecretEvent):
     :meth:`event.secret.remove_revision() <ops.Secret.remove_revision>` to
     remove the now-unused revision. If the charm does not, then the event will
     be emitted again, when further revisions are ready for removal.
+
+    .. tip:: Added in Juju 3.0
     """
 
     def __init__(self, handle: 'Handle', id: str, label: Optional[str], revision: int):
@@ -998,6 +1011,8 @@ class SecretExpiredEvent(SecretEvent):
     This event is fired on the secret owner to inform it that the secret revision
     must be removed. The event will keep firing until the owner removes the
     revision by calling :meth:`event.secret.remove_revision() <ops.Secret.remove_revision>`.
+
+    *Added in Juju 3.0*
     """
 
     def __init__(self, handle: 'Handle', id: str, label: Optional[str], revision: int):
@@ -1159,10 +1174,16 @@ class CharmEvents(ObjectEvents):
     """Triggered by request to upgrade the charm (see :class:`UpgradeCharmEvent`)."""
 
     pre_series_upgrade = EventSource(PreSeriesUpgradeEvent)
-    """Triggered to prepare a unit for series upgrade (see :class:`PreSeriesUpgradeEvent`)."""
+    """Triggered to prepare a unit for series upgrade (see :class:`PreSeriesUpgradeEvent`).
+
+    .. versionremoved:: Juju 4.0
+    """
 
     post_series_upgrade = EventSource(PostSeriesUpgradeEvent)
-    """Triggered after a series upgrade (see :class:`PostSeriesUpgradeEvent`)."""
+    """Triggered after a series upgrade (see :class:`PostSeriesUpgradeEvent`).
+
+    .. versionremoved:: Juju 4.0
+    """
 
     leader_elected = EventSource(LeaderElectedEvent)
     """Triggered when a new leader has been elected (see :class:`LeaderElectedEvent`)."""
@@ -1175,26 +1196,37 @@ class CharmEvents(ObjectEvents):
     """
 
     collect_metrics = EventSource(CollectMetricsEvent)
-    """Triggered by Juju to collect metrics (see :class:`CollectMetricsEvent`)."""
+    """Triggered by Juju to collect metrics (see :class:`CollectMetricsEvent`).
+
+    .. versionremoved:: 4.0
+    """
 
     secret_changed = EventSource(SecretChangedEvent)
     """Triggered by Juju on the observer when the secret owner changes its contents (see
     :class:`SecretChangedEvent`).
+
+    .. versionadded:: Juju 3.0
     """
 
     secret_expired = EventSource(SecretExpiredEvent)
     """Triggered by Juju on the owner when a secret's expiration time elapses (see
     :class:`SecretExpiredEvent`).
+
+    .. versionadded:: Juju 3.0
     """
 
     secret_rotate = EventSource(SecretRotateEvent)
     """Triggered by Juju on the owner when the secret's rotation policy elapses (see
     :class:`SecretRotateEvent`).
+
+    .. versionadded:: Juju 3.0
     """
 
     secret_remove = EventSource(SecretRemoveEvent)
     """Triggered by Juju on the owner when a secret revision can be removed (see
     :class:`SecretRemoveEvent`).
+
+    .. versionadded:: Juju 3.0
     """
 
     collect_app_status = EventSource(CollectStatusEvent)

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -830,7 +830,7 @@ class PebbleNoticeEvent(WorkloadEvent):
 class PebbleCustomNoticeEvent(PebbleNoticeEvent):
     """Event triggered when a Pebble notice of type "custom" is created or repeats.
 
-    .. versionadded:: Juju 3.4
+    .. jujuversion:: 3.4
     """
 
 
@@ -877,8 +877,7 @@ class PebbleCheckFailedEvent(PebbleCheckEvent):
     if the check is currently failing, check the current status with
     ``event.info.status == ops.pebble.CheckStatus.DOWN``.
 
-    .. versionadded:: 3.6
-       of Juju
+    .. jujuversion:: 3.6
     """
 
 
@@ -889,7 +888,7 @@ class PebbleCheckRecoveredEvent(PebbleCheckEvent):
     state (not simply failed, but failed at least as many times as the
     configured threshold).
 
-    .. versionadded:: Juju 3.6
+    .. jujuversion:: 3.6
     """
 
 
@@ -938,7 +937,7 @@ class SecretChangedEvent(SecretEvent):
     :meth:`event.secret.get_content() <ops.Secret.get_content>` with ``refresh=True``
     to tell Juju to start tracking the new revision.
 
-    .. versionadded:: 2.0
+    .. jujuversion:: 2.0
         Charm secrets added in Juju 3.0, user secrets added in Juju 3.3
     """
 
@@ -950,7 +949,7 @@ class SecretRotateEvent(SecretEvent):
     be rotated. The event will keep firing until the owner creates a new
     revision by calling :meth:`event.secret.set_content() <ops.Secret.set_content>`.
 
-    .. note:: Added in Juju 3.0
+    .. jujuversion:: 3.0
     """
 
     def defer(self) -> NoReturn:
@@ -977,7 +976,7 @@ class SecretRemoveEvent(SecretEvent):
     remove the now-unused revision. If the charm does not, then the event will
     be emitted again, when further revisions are ready for removal.
 
-    .. tip:: Added in Juju 3.0
+    .. jujuversion:: 3.0
     """
 
     def __init__(self, handle: 'Handle', id: str, label: Optional[str], revision: int):
@@ -1014,7 +1013,9 @@ class SecretExpiredEvent(SecretEvent):
     must be removed. The event will keep firing until the owner removes the
     revision by calling :meth:`event.secret.remove_revision() <ops.Secret.remove_revision>`.
 
-    *Added in Juju 3.0*
+    .. jujuversion:: 3.0
+
+    .. versionadded:: 3.0
     """
 
     def __init__(self, handle: 'Handle', id: str, label: Optional[str], revision: int):
@@ -1198,28 +1199,29 @@ class CharmEvents(ObjectEvents):
     """Triggered by Juju on the observer when the secret owner changes its contents (see
     :class:`SecretChangedEvent`).
 
-    .. versionadded:: Juju 3.0
+    .. jujuversion:: 3.0
+        Charm secrets added in Juju 3.0, user secrets added in Juju 3.3
     """
 
     secret_expired = EventSource(SecretExpiredEvent)
     """Triggered by Juju on the owner when a secret's expiration time elapses (see
     :class:`SecretExpiredEvent`).
 
-    .. versionadded:: Juju 3.0
+    .. jujuversion:: 3.0
     """
 
     secret_rotate = EventSource(SecretRotateEvent)
     """Triggered by Juju on the owner when the secret's rotation policy elapses (see
     :class:`SecretRotateEvent`).
 
-    .. versionadded:: Juju 3.0
+    .. jujuversion:: 3.0
     """
 
     secret_remove = EventSource(SecretRemoveEvent)
     """Triggered by Juju on the owner when a secret revision can be removed (see
     :class:`SecretRemoveEvent`).
 
-    .. versionadded:: Juju 3.0
+    .. jujuversion:: 3.0
     """
 
     collect_app_status = EventSource(CollectStatusEvent)

--- a/ops/main.py
+++ b/ops/main.py
@@ -538,6 +538,9 @@ def main(charm_class: Type[ops.charm.CharmBase], use_juju_for_storage: Optional[
 
     The event name is based on the way this executable was called (argv[0]).
 
+    .. jujuremoved:: 4.0
+        The ``use_juju_for_storage`` argument is not available from Juju 4.0
+
     Args:
         charm_class: the charm class to instantiate and receive the event.
         use_juju_for_storage: whether to use controller-side storage. If not specified

--- a/ops/model.py
+++ b/ops/model.py
@@ -683,6 +683,8 @@ class Unit:
         Use :meth:`set_ports` for a more declarative approach where all of
         the ports that should be open are provided in a single call.
 
+        .. jujuversion:: 3.1
+
         Args:
             protocol: String representing the protocol; must be one of
                 'tcp', 'udp', or 'icmp' (lowercase is recommended, but
@@ -711,6 +713,8 @@ class Unit:
         Use :meth:`set_ports` for a more declarative approach where all
         of the ports that should be open are provided in a single call.
         For example, ``set_ports()`` will close all open ports.
+
+        .. jujuversion: 3.1
 
         Args:
             protocol: String representing the protocol; must be one of
@@ -741,6 +745,8 @@ class Unit:
 
         Use :meth:`open_port` and :meth:`close_port` to manage ports
         individually.
+
+        .. jujuversion:: 3.1
 
         Args:
             ports: The ports to open. Provide an int to open a TCP port, or
@@ -789,7 +795,10 @@ class Unit:
 
 @dataclasses.dataclass(frozen=True)
 class Port:
-    """Represents a port opened by :meth:`Unit.open_port` or :meth:`Unit.set_ports`."""
+    """Represents a port opened by :meth:`Unit.open_port` or :meth:`Unit.set_ports`.
+
+    .. jujuversion:: 3.1
+    """
 
     protocol: typing.Literal['tcp', 'udp', 'icmp']
     """The IP protocol."""

--- a/ops/model.py
+++ b/ops/model.py
@@ -683,8 +683,6 @@ class Unit:
         Use :meth:`set_ports` for a more declarative approach where all of
         the ports that should be open are provided in a single call.
 
-        .. jujuversion:: 3.1
-
         Args:
             protocol: String representing the protocol; must be one of
                 'tcp', 'udp', or 'icmp' (lowercase is recommended, but
@@ -713,8 +711,6 @@ class Unit:
         Use :meth:`set_ports` for a more declarative approach where all
         of the ports that should be open are provided in a single call.
         For example, ``set_ports()`` will close all open ports.
-
-        .. jujuversion: 3.1
 
         Args:
             protocol: String representing the protocol; must be one of
@@ -745,8 +741,6 @@ class Unit:
 
         Use :meth:`open_port` and :meth:`close_port` to manage ports
         individually.
-
-        .. jujuversion:: 3.1
 
         Args:
             ports: The ports to open. Provide an int to open a TCP port, or
@@ -795,10 +789,7 @@ class Unit:
 
 @dataclasses.dataclass(frozen=True)
 class Port:
-    """Represents a port opened by :meth:`Unit.open_port` or :meth:`Unit.set_ports`.
-
-    .. jujuversion:: 3.1
-    """
+    """Represents a port opened by :meth:`Unit.open_port` or :meth:`Unit.set_ports`."""
 
     protocol: typing.Literal['tcp', 'udp', 'icmp']
     """The IP protocol."""

--- a/ops/model.py
+++ b/ops/model.py
@@ -274,6 +274,9 @@ class Model:
         again, unless ``refresh=True`` is used, or :meth:`Secret.set_content`
         has been called.
 
+        .. versionadded:: Juju 3.0
+           (User secrets added in Juju 3.3)
+
         Args:
             id: Secret ID if fetching by ID.
             label: Secret label if fetching by label (or updating it).
@@ -455,6 +458,8 @@ class Application:
         rotate: Optional['SecretRotate'] = None,
     ) -> 'Secret':
         """Create a :class:`Secret` owned by this application.
+
+        .. versionadded:: Juju 3.0
 
         Args:
             content: A key-value mapping containing the payload of the secret,
@@ -1218,6 +1223,9 @@ class Secret:
 
     All secret events have a :code:`.secret` attribute which provides the
     :class:`Secret` associated with that event.
+
+    .. versionadded:: Juju 3.0
+       (User secrets added in Juju 3.3)
     """
 
     _key_re = re.compile(r'^([a-z](?:-?[a-z0-9]){2,})$')  # copied from Juju code
@@ -2906,6 +2914,8 @@ class Container:
     def get_notice(self, id: str) -> pebble.Notice:
         """Get details about a single notice by ID.
 
+        .. versionadded:: Juju 3.4
+
         Raises:
             ModelError: if a notice with the given ID is not found
         """
@@ -2928,6 +2938,8 @@ class Container:
 
         See :meth:`ops.pebble.Client.get_notices` for documentation of the
         parameters.
+
+        .. versionadded:: Juju 3.4
         """
         return self._pebble.get_notices(
             users=users,

--- a/ops/model.py
+++ b/ops/model.py
@@ -274,8 +274,8 @@ class Model:
         again, unless ``refresh=True`` is used, or :meth:`Secret.set_content`
         has been called.
 
-        .. versionadded:: Juju 3.0
-           (User secrets added in Juju 3.3)
+        .. jujuversion:: 3.0
+            Charm secrets added in Juju 3.0, user secrets added in Juju 3.3
 
         Args:
             id: Secret ID if fetching by ID.
@@ -459,7 +459,7 @@ class Application:
     ) -> 'Secret':
         """Create a :class:`Secret` owned by this application.
 
-        .. versionadded:: Juju 3.0
+        .. jujuversion:: 3.0
 
         Args:
             content: A key-value mapping containing the payload of the secret,
@@ -1224,8 +1224,8 @@ class Secret:
     All secret events have a :code:`.secret` attribute which provides the
     :class:`Secret` associated with that event.
 
-    .. versionadded:: Juju 3.0
-       (User secrets added in Juju 3.3)
+    .. jujuversion:: 3.0
+        Charm secrets added in Juju 3.0, user secrets added in Juju 3.3
     """
 
     _key_re = re.compile(r'^([a-z](?:-?[a-z0-9]){2,})$')  # copied from Juju code
@@ -2914,7 +2914,7 @@ class Container:
     def get_notice(self, id: str) -> pebble.Notice:
         """Get details about a single notice by ID.
 
-        .. versionadded:: Juju 3.4
+        .. jujuversion:: 3.4
 
         Raises:
             ModelError: if a notice with the given ID is not found
@@ -2939,7 +2939,7 @@ class Container:
         See :meth:`ops.pebble.Client.get_notices` for documentation of the
         parameters.
 
-        .. versionadded:: Juju 3.4
+        .. jujuversion:: 3.4
         """
         return self._pebble.get_notices(
             users=users,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ aggressive = 3
 [tool.ruff]
 line-length = 99
 target-version = "py38"
-extend-exclude = ["docs"]
+extend-exclude = ["docs/conf.py", "docs/.sphinx/"]
 
 # Ruff formatter configuration
 [tool.ruff.format]


### PR DESCRIPTION
Adds the version features were added in Juju to the API reference docs (other than ops.testing).

No version tags are added for anything older than 3.0 - meaning that if there's no version tag, then it was available in the oldest supported Juju version.

Unfortunately, the built-in Sphinx `versionadded` directive does not support customising the text, so while otherwise suitable, it results in "Added in version 3.0" (seems like it's referring to ops 3.0) or "Added in version Juju 3.0". Instead, a new pair of custom directives are added, `jujuversion` and `jujuremoved`. These are very heavily based on `versionadded` and `versionremoved` but have custom text (and we could customise them further, e.g. linking to revision notes) if we wanted to in future). In order to avoid having to also add custom CSS, they use the same classes as the `versionadded` and `versionremoved` directives.

The features being removed in Juju 4.0 also have `jujuremoved` tags added.

I also ran `ruff format` over [custom_conf.py](docs/custom_conf.py), which is why there are some unrelated formatting changes.

Fixes #1305