### PR TITLE
feat: poc parsing juju env in one place - alternative draft

### DIFF
--- a/ops/main.py
+++ b/ops/main.py
@@ -19,6 +19,7 @@ This is so that :code:`import ops` followed by :code:`ops.main(MyCharm)` works
 as expected.
 """
 
+import dataclasses
 import logging
 import os
 import shutil
@@ -42,6 +43,38 @@ CHARM_STATE_FILE = '.unit-state.db'
 logger = logging.getLogger()
 
 
+@dataclasses.dataclass(frozen=True)
+class _JujuContext:
+    # source: https://juju.is/docs/juju/charm-environment-variables
+    # the HookVars function: https://github.com/juju/juju/blob/3.6/worker/uniter/runner/context/context.go#L1398
+    # only allow accesing these vars because these are the currently used vars in main.py
+
+    juju_relation: str = ''
+    juju_relation_id: str = ''
+    juju_secret_revision: str = ''
+    juju_workload_name: str = ''
+    juju_action_name: Optional[str] = None
+    juju_action_uuid: Optional[str] = None
+    juju_charm_dir: Optional[str] = None
+    juju_debug: Optional[str] = None
+    juju_departing_unit: Optional[str] = None
+    juju_dispatch_path: Optional[str] = None
+    juju_notice_id: Optional[str] = None
+    juju_notice_key: Optional[str] = None
+    juju_notice_type: Optional[str] = None
+    juju_pebble_check_name: Optional[str] = None
+    juju_remote_app: Optional[str] = None
+    juju_remote_unit: Optional[str] = None
+    juju_secret_id: Optional[str] = None
+    juju_secret_label: Optional[str] = None
+    juju_storage_id: Optional[str] = ''
+
+    @classmethod
+    def from_environ(cls) -> '_JujuContext':
+        kwargs: Dict[str, Any] = {name: os.getenv(name.upper()) for name in cls.__annotations__}
+        return cls(**kwargs)
+
+
 def _exe_path(path: Path) -> Optional[Path]:
     """Find and return the full path to the given binary.
 
@@ -53,9 +86,9 @@ def _exe_path(path: Path) -> Optional[Path]:
     return Path(p)
 
 
-def _get_charm_dir():
-    charm_dir = os.environ.get('JUJU_CHARM_DIR')
-    if charm_dir is None:
+def _get_charm_dir(juju_context: _JujuContext):
+    charm_dir = juju_context.juju_charm_dir
+    if not charm_dir:
         # Assume $JUJU_CHARM_DIR/lib/op/main.py structure.
         charm_dir = Path(f'{__file__}/../../..').resolve()
     else:
@@ -104,7 +137,7 @@ def _create_event_link(
         event_path.symlink_to(target_path)
 
 
-def _setup_event_links(charm_dir: Path, charm: 'ops.charm.CharmBase'):
+def _setup_event_links(charm_dir: Path, charm: 'ops.charm.CharmBase', juju_context: _JujuContext):
     """Set up links for supported events that originate from Juju.
 
     Whether a charm can handle an event or not can be determined by
@@ -117,21 +150,22 @@ def _setup_event_links(charm_dir: Path, charm: 'ops.charm.CharmBase'):
     Args:
         charm_dir: A root directory of the charm.
         charm: An instance of the Charm class.
-
+        juju_context: An instance of the _JujuContext class.
     """
-    link_to = os.path.realpath(os.environ.get('JUJU_DISPATCH_PATH', sys.argv[0]))
+    link_to = os.path.realpath(juju_context.juju_dispatch_path or sys.argv[0])
     for bound_event in charm.on.events().values():
         # Only events that originate from Juju need symlinks.
         if issubclass(bound_event.event_type, (ops.charm.HookEvent, ops.charm.ActionEvent)):
             _create_event_link(charm, bound_event, link_to)
 
 
-def _emit_charm_event(charm: 'ops.charm.CharmBase', event_name: str):
+def _emit_charm_event(charm: 'ops.charm.CharmBase', event_name: str, juju_context: _JujuContext):
     """Emits a charm event based on a Juju event name.
 
     Args:
         charm: A charm instance to emit an event from.
         event_name: A Juju event name to emit on a charm.
+        juju_context: An instance of class _JujuContext.
     """
     event_to_emit = None
     try:
@@ -142,45 +176,47 @@ def _emit_charm_event(charm: 'ops.charm.CharmBase', event_name: str):
     # If the event is not supported by the charm implementation, do
     # not error out or try to emit it. This is to support rollbacks.
     if event_to_emit is not None:
-        args, kwargs = _get_event_args(charm, event_to_emit)
+        args, kwargs = _get_event_args(charm, event_to_emit, juju_context)
         logger.debug('Emitting Juju event %s.', event_name)
         event_to_emit.emit(*args, **kwargs)
 
 
-def _get_juju_relation_id():
-    return int(os.environ['JUJU_RELATION_ID'].split(':')[-1])
+def _get_juju_relation_id(juju_context: _JujuContext):
+    return int(juju_context.juju_relation_id.split(':')[-1])
 
 
 def _get_event_args(
-    charm: 'ops.charm.CharmBase', bound_event: 'ops.framework.BoundEvent'
+    charm: 'ops.charm.CharmBase',
+    bound_event: 'ops.framework.BoundEvent',
+    juju_context: _JujuContext,
 ) -> Tuple[List[Any], Dict[str, Any]]:
     event_type = bound_event.event_type
     model = charm.framework.model
 
     relation = None
     if issubclass(event_type, ops.charm.WorkloadEvent):
-        workload_name = os.environ['JUJU_WORKLOAD_NAME']
+        workload_name = juju_context.juju_workload_name
         container = model.unit.get_container(workload_name)
         args: List[Any] = [container]
         if issubclass(event_type, ops.charm.PebbleNoticeEvent):
-            notice_id = os.environ['JUJU_NOTICE_ID']
-            notice_type = os.environ['JUJU_NOTICE_TYPE']
-            notice_key = os.environ['JUJU_NOTICE_KEY']
+            notice_id = juju_context.juju_notice_id
+            notice_type = juju_context.juju_notice_type
+            notice_key = juju_context.juju_notice_key
             args.extend([notice_id, notice_type, notice_key])
         elif issubclass(event_type, ops.charm.PebbleCheckEvent):
-            check_name = os.environ['JUJU_PEBBLE_CHECK_NAME']
+            check_name = juju_context.juju_pebble_check_name
             args.append(check_name)
         return args, {}
     elif issubclass(event_type, ops.charm.SecretEvent):
         args: List[Any] = [
-            os.environ['JUJU_SECRET_ID'],
-            os.environ.get('JUJU_SECRET_LABEL'),
+            juju_context.juju_secret_id,
+            juju_context.juju_secret_label,
         ]
         if issubclass(event_type, (ops.charm.SecretRemoveEvent, ops.charm.SecretExpiredEvent)):
-            args.append(int(os.environ['JUJU_SECRET_REVISION']))
+            args.append(int(juju_context.juju_secret_revision))
         return args, {}
     elif issubclass(event_type, ops.charm.StorageEvent):
-        storage_id = os.environ.get('JUJU_STORAGE_ID', '')
+        storage_id = juju_context.juju_storage_id
         if storage_id:
             storage_name = storage_id.split('/')[0]
         else:
@@ -199,16 +235,16 @@ def _get_event_args(
         storage.location = storage_location  # type: ignore
         return [storage], {}
     elif issubclass(event_type, ops.charm.ActionEvent):
-        args: List[Any] = [os.environ['JUJU_ACTION_UUID']]
+        args: List[Any] = [juju_context.juju_action_uuid]
         return args, {}
     elif issubclass(event_type, ops.charm.RelationEvent):
-        relation_name = os.environ['JUJU_RELATION']
-        relation_id = _get_juju_relation_id()
+        relation_name = juju_context.juju_relation
+        relation_id = _get_juju_relation_id(juju_context)
         relation: Optional[ops.model.Relation] = model.get_relation(relation_name, relation_id)
 
-    remote_app_name = os.environ.get('JUJU_REMOTE_APP', '')
-    remote_unit_name = os.environ.get('JUJU_REMOTE_UNIT', '')
-    departing_unit_name = os.environ.get('JUJU_DEPARTING_UNIT', '')
+    remote_app_name = juju_context.juju_remote_app
+    remote_unit_name = juju_context.juju_remote_unit
+    departing_unit_name = juju_context.juju_departing_unit
 
     if not remote_app_name and remote_unit_name:
         if '/' not in remote_unit_name:
@@ -244,9 +280,10 @@ class _Dispatcher:
 
     """
 
-    def __init__(self, charm_dir: Path):
+    def __init__(self, charm_dir: Path, juju_context: _JujuContext):
+        self._juju_context = juju_context
         self._charm_dir = charm_dir
-        self._exec_path = Path(os.environ.get('JUJU_DISPATCH_PATH', sys.argv[0]))
+        self._exec_path = Path(self._juju_context.juju_dispatch_path or sys.argv[0])
 
         dispatch = charm_dir / 'dispatch'
         if JujuVersion.from_environ().is_dispatch_aware() and _exe_path(dispatch) is not None:
@@ -270,7 +307,7 @@ class _Dispatcher:
         if self.event_name in ('install', 'start', 'upgrade_charm') or self.event_name.endswith(
             '_storage_attached'
         ):
-            _setup_event_links(self._charm_dir, charm)
+            _setup_event_links(self._charm_dir, charm, self._juju_context)
 
     def run_any_legacy_hook(self):
         """Run any extant legacy hook.
@@ -334,7 +371,12 @@ class _Dispatcher:
         JUJU_DISPATCH_PATH will be set to the wanted hook, e.g. hooks/install,
         in both cases.
         """
-        self._dispatch_path = Path(os.environ['JUJU_DISPATCH_PATH'])
+        juju_dispatch_path = (
+            str(self._juju_context.juju_dispatch_path)
+            if self._juju_context.juju_dispatch_path
+            else ''
+        )
+        self._dispatch_path = Path(juju_dispatch_path)
 
         if 'OPERATOR_DISPATCH' in os.environ:
             logger.debug('Charm called itself via %s.', self._dispatch_path)
@@ -411,6 +453,7 @@ class _Manager:
         use_juju_for_storage: Optional[bool] = None,
         charm_state_path: str = CHARM_STATE_FILE,
     ):
+        self._juju_context = _JujuContext.from_environ()
         self._charm_state_path = charm_state_path
         self._charm_class = charm_class
         if model_backend is None:
@@ -420,12 +463,12 @@ class _Manager:
         # Do this as early as possible to be sure to catch the most logs.
         self._setup_root_logging()
 
-        self._charm_root = _get_charm_dir()
+        self._charm_root = _get_charm_dir(self._juju_context)
         self._charm_meta = CharmMeta.from_charm_root(self._charm_root)
         self._use_juju_for_storage = use_juju_for_storage
 
         # Set up dispatcher, framework and charm objects.
-        self.dispatcher = _Dispatcher(self._charm_root)
+        self.dispatcher = _Dispatcher(self._charm_root, self._juju_context)
         self.dispatcher.run_any_legacy_hook()
 
         self.framework = self._make_framework(self.dispatcher)
@@ -437,11 +480,11 @@ class _Manager:
         return charm
 
     def _setup_root_logging(self):
-        debug = 'JUJU_DEBUG' in os.environ
+        debug = self._juju_context.juju_debug is not None
         # For actions, there is a communication channel with the user running the
         # action, so we want to send exception details through stderr, rather than
         # only to juju-log as normal.
-        handling_action = 'JUJU_ACTION_NAME' in os.environ
+        handling_action = self._juju_context.juju_action_name is not None
         setup_root_logging(self._model_backend, debug=debug, exc_stderr=handling_action)
 
         logger.debug('ops %s up and running.', ops.__version__)  # type:ignore
@@ -488,8 +531,13 @@ class _Manager:
     def _make_framework(self, dispatcher: _Dispatcher):
         # If we are in a RelationBroken event, we want to know which relation is
         # broken within the model, not only in the event's `.relation` attribute.
-        if os.environ.get('JUJU_DISPATCH_PATH', '').endswith('-relation-broken'):
-            broken_relation_id = _get_juju_relation_id()
+        juju_dispatch_path = (
+            str(self._juju_context.juju_dispatch_path)
+            if self._juju_context.juju_dispatch_path
+            else ''
+        )
+        if juju_dispatch_path.endswith('-relation-broken'):
+            broken_relation_id = _get_juju_relation_id(self._juju_context)
         else:
             broken_relation_id = None
 
@@ -516,7 +564,7 @@ class _Manager:
             self.framework.reemit()
 
         # Emit the Juju event.
-        _emit_charm_event(self.charm, self.dispatcher.event_name)
+        _emit_charm_event(self.charm, self.dispatcher.event_name, self._juju_context)
         # Emit collect-status events.
         ops.charm._evaluate_status(self.charm)
 


### PR DESCRIPTION
Parse all `JUJU_*` env vars in one place.

Closes https://github.com/canonical/operator/issues/1075.

Alternative version where variables are grouped with explicit types.

See the first version here: https://github.com/canonical/operator/pull/1313.

Typing is explicitly not `None` except `juju_charm_dir`, `juju_debug`, and `juju_dispatch_path` because the original code tests whether they are in `os.environ` or not.