### PR TITLE
fix: Juju passes the expiry in a field 'expiry', not 'expires'

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1182,7 +1182,7 @@ class SecretInfo:
     @classmethod
     def from_dict(cls, id: str, d: Dict[str, Any]) -> 'SecretInfo':
         """Create new SecretInfo object from ID and dict parsed from JSON."""
-        expires = typing.cast(Optional[str], d.get('expires'))
+        expires = typing.cast(Optional[str], d.get('expiry'))
         try:
             rotation = SecretRotate(typing.cast(Optional[str], d.get('rotation')))
         except ValueError:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -3568,7 +3568,7 @@ class TestSecretInfo:
             {
                 'label': 'fromdict',
                 'revision': 8,
-                'expires': '2022-12-09T14:10:00Z',
+                'expiry': '2022-12-09T14:10:00Z',
                 'rotation': 'yearly',
                 'rotates': '2023-01-09T14:10:00Z',
             },


### PR DESCRIPTION
`secret-info-get` gives the expiry back in a field called "expiry":

```
$ juju exec --unit thirteensixteen/0 -- secret-info-get cqv88thtvhl393c8hs20
cqv88thtvhl393c8hs20:
  revision: 1
  label: food
  owner: application
  rotation: daily
  expiry: 2024-09-04T23:12:09Z
  rotates: 2024-08-16T23:12:10Z
```

We were incorrectly looking for it in a field called "expires", which is the attribute name we use.

Fixes #1316