### PR TITLE
test: run pytest in parallel with pytest xdist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -73,10 +73,11 @@ deps =
     websocket-client==1.*
     coverage[toml]~=7.0
     pytest~=7.2
+    pytest-xdist~=3.6
     typing_extensions~=4.2
 commands =
     coverage run --source={[vars]src_path} \
-             -m pytest --ignore={[vars]tst_path}smoke -v --tb native {posargs}
+             -m pytest -n auto --ignore={[vars]tst_path}smoke -v --tb native {posargs}
     coverage report
 
 [testenv:pebble]

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ commands =
     pyright {posargs}
 
 [testenv:unit]
-description = Run unit tests
+description = Run unit tests in parallel without coverage
 passenv =
     RUN_REAL_PEBBLE_TESTS
     PEBBLE
@@ -76,6 +76,22 @@ deps =
     typing_extensions~=4.2
 commands =
     pytest -n auto --ignore={[vars]tst_path}smoke -v --tb native {posargs}
+
+[testenv:coverage]
+description = Run unit tests with coverage
+passenv =
+    RUN_REAL_PEBBLE_TESTS
+    PEBBLE
+deps =
+    PyYAML==6.*
+    websocket-client==1.*
+    coverage[toml]~=7.0
+    pytest~=7.2
+    typing_extensions~=4.2
+commands =
+    coverage run --source={[vars]src_path} \
+             -m pytest --ignore={[vars]tst_path}smoke -v --tb native {posargs}
+    coverage report
 
 [testenv:pebble]
 description = Run real pebble tests

--- a/tox.ini
+++ b/tox.ini
@@ -71,14 +71,11 @@ passenv =
 deps =
     PyYAML==6.*
     websocket-client==1.*
-    coverage[toml]~=7.0
     pytest~=7.2
     pytest-xdist~=3.6
     typing_extensions~=4.2
 commands =
-    coverage run --source={[vars]src_path} \
-             -m pytest -n auto --ignore={[vars]tst_path}smoke -v --tb native {posargs}
-    coverage report
+    pytest -n auto --ignore={[vars]tst_path}smoke -v --tb native {posargs}
 
 [testenv:pebble]
 description = Run real pebble tests


### PR DESCRIPTION
Distributing tests across multiple CPUs to speed up test execution.

On my 10-core mac m1, time is reduced by a little more than a third (~4m39s to ~3m3s). According to GitHub Actions it also speeds up proportionally to that (see [this run](https://github.com/canonical/operator/actions/runs/10417030729/job/28850433850?pr=1313) without pytest xdist and [this run](https://github.com/canonical/operator/actions/runs/10417133297/job/28850745589?pr=1319) with it).