### PR TITLE
docs: add top-level intro and module-level intros

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -159,7 +159,7 @@
 
 ## Features
 
-* `StopEvent`, `RemoveEvent`, and all `LifeCycleEvent`s are no longer deferrable, and will raise a `RuntimeError` if `defer()` is called on the event object (#1122)
+* `StopEvent`, `RemoveEvent`, and all `LifecycleEvent`s are no longer deferrable, and will raise a `RuntimeError` if `defer()` is called on the event object (#1122)
 * Add `ActionEvent.id`, exposing the JUJU_ACTION_UUID environment variable (#1124)
 * Add support for creating `pebble.Plan` objects by passing in a `pebble.PlanDict`, the
   ability to compare two `Plan` objects with `==`, and the ability to create an empty Plan with `Plan()` (#1134)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,15 +10,26 @@ consistent readable charms, reuse code via charm libs, and separate typical char
 concerns, such as application state management from integration management and
 lifecycle management from testability.
 
-- ``ops`` is the API to respond to Juju events and manage the application
-  [units, relations, storage, secrets and resources].
-- ``ops.pebble`` is the interface to control services and respond to their
-  events in the workload container for Kubernetes charms.  
-- ``ops.testing`` is the unit testing framework for your charm.
+- :ref:`ops_main_entry_point` used to initialise and run your charm.
+- :ref:`ops_module`, the API to respond to Juju events and manage the application.
+- :ref:`ops_pebble_module` to control services and respond to their events for Kubernetes charms.  
+- :ref:`ops_testing_module`, the framework for unit testing charms in a simulated environment.
+
+You can write a charm in any way you want, but with the `ops` library you get a
+framework that helps you write consistent readable charms following the latest
+best practices, reuse code via charm libs, and separate typical charm concerns
+--- application state management from integration management or lifecycle
+management from testability.
+
+Whether you are a machine or a Kubernetes charm author, `ops` is the recommended way to go.
+
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
+
+
+.. _ops_module:
 
 ops module
 ==========
@@ -27,8 +38,11 @@ ops module
    :exclude-members: main
 
 
+.. _ops_main_entry_point:
+
 ops.main entry point
 ====================
+
 .. autofunction:: ops.main
 
 
@@ -39,11 +53,15 @@ legacy main module
    :noindex:
 
 
+.. _ops_pebble_module:
+
 ops.pebble module
 =================
 
 .. automodule:: ops.pebble
 
+
+.. _ops_testing_module:
 
 ops.testing module
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,19 +3,18 @@ ops library API reference
 =========================
 
 The `ops` library is a Python framework for writing and testing Juju charms.
+
 It is the recommended way to write charms for both Kubernetes and machines.
+The framework encapsulates the best charming practice and helps you write
+consistent readable charms, reuse code via charm libs, and separate typical charm
+concerns, such as application state management from integration management and
+lifecycle management from testability.
 
-The `ops` library provides powerful constructs for charm developers: FIXME fixme fixme the ops library provides structure that makes blah blah easier to reason.
-Easier to write charms, read other charms, and reuse aspects like individual integration handling via charm libs.
-
-- ``ops`` offers the API to respond to Juju events and manage application units, relations, storage, secrets and resources.
-
-- **Interact with Juju**: `ops` offers the API to respond to Juju events
-  and manage application units, relations, storage, secrets and resources.
-- **Manage workloads**: For Kubernetes charms, `ops.pebble`
-  provides an interface to control services inside the workload containers.
-- **Write unit tests**: `ops.testing` is the unit testing framework for
-  your charm.
+- ``ops`` is the API to respond to Juju events and manage the application
+  [units, relations, storage, secrets and resources].
+- ``ops.pebble`` is the interface to control services and respond to their
+  events in the workload container for Kubernetes charms.  
+- ``ops.testing`` is the unit testing framework for your charm.
 
 .. toctree::
    :maxdepth: 2
@@ -23,38 +22,6 @@ Easier to write charms, read other charms, and reuse aspects like individual int
 
 ops module
 ==========
-
-Provides APIs for managing the given Juju application, focusing on:
-
-- Lifecycle
-- State management and event response
-- Handling of units, relations, and resources
-
-Here’s a simple charm example using the `ops` library:
-
-.. code-block:: python
-
-    #!/usr/bin/env python3
-    import ops
-
-
-    class FastAPIDemoCharm(ops.CharmBase):
-        """Charm the service."""
-
-        def __init__(self, framework):
-            super().__init__(framework)
-            # let's try to on.started...
-            self.framework.observe(self.on.demo_server_pebble_ready, self._on_demo_server_pebble_ready)
-
-        def _on_demo_server_pebble_ready(self, event):
-            event.workload.container.add_layer(...)
-            event.workload.container.replan()
-            self.unit.status = ops.ActiveStatus()
-
-
-    if __name__ == "__main__":  # pragma: nocover
-        ops.main(FastAPIDemoCharm)
-
 
 .. automodule:: ops
    :exclude-members: main
@@ -75,73 +42,11 @@ legacy main module
 ops.pebble module
 =================
 
-An example of configuring workload container using pebble.
-
-.. code-block:: python
-
-        def _on_demo_server_pebble_ready(self, event):
-            event.workload.container.add_layer(self._pebble_layer())
-            event.workload.container.replan()
-            self.unit.status = ops.ActiveStatus()
-
-        def _pebble_layer(self) -> ops.pebble.Layer:
-            return ops.pebble.Layer({
-                "services": {
-                    "demo_service": {
-                        "override": "replace",
-                        "startup": "enabled",
-                        "command": ["/some/command", "--some-arg"],
-                        "environment": {
-                            "SOME_ENV_VAR": "some value",
-                        },
-                        # Let the container die if things go wrong
-                        "on-success": "shutdown",
-                        "on-failure": "shutdown",
-                        "on-check-failure": {
-                            "online": "shutdown"
-                        }
-                    }
-                },
-                "checks": {
-                    # A custom check called "online"
-                    "online": {
-                        "override": "replace",
-                        "exec": {
-                            "command": ["/another/command", "--another-arg"],
-                        },
-                        "period": "3s"
-                    }
-                },
-            })
-
 .. automodule:: ops.pebble
 
 
 ops.testing module
 ==================
-
-Framework for unit testing charms in a simulated environment, enabling:
-
-- Testing against mocked Juju events and states
-- Validation of charm behavior prior to live deployment
-
-An example testing a charm using the Harness framework.
-
-.. code-block:: python
-
-    @pytest.fixture
-    def harness():
-        harness = ops.testing.Harness(FastAPIDemoCharm)
-        harness.begin()
-        yield harness
-        harness.cleanup()
-
-
-    def test_pebble_ready(harness):
-        assert harness.model.unit.status == ops.MaintenanceStatus("")
-
-        harness.container_pebble_ready("demo_server")
-        assert harness.model.unit.status == ops.ActiveStatus()
 
 .. automodule:: ops.testing
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,11 +4,9 @@ ops library API reference
 
 The `ops` library is a Python framework for writing and testing Juju charms.
 
-It is the recommended way to write charms for both Kubernetes and machines.
-The framework encapsulates the best charming practice and helps you write
-consistent readable charms, reuse code via charm libs, and separate typical charm
-concerns, such as application state management from integration management and
-lifecycle management from testability.
+For more about the Charm SDK, see https://juju.is/docs/sdk.
+
+The library provides:
 
 - :ref:`ops_main_entry_point` used to initialise and run your charm.
 - :ref:`ops_module`, the API to respond to Juju events and manage the application.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,8 +19,6 @@ best practices, reuse code via charm libs, and separate typical charm concerns
 --- application state management from integration management or lifecycle
 management from testability.
 
-Whether your charm is for machines or Kubernetes, `ops` is the recommended way to go.
-
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,10 +13,11 @@ The library provides:
 - :ref:`ops_pebble_module`, the Pebble client, a low-level API for Kubernetes containers;
 - :ref:`ops_testing_module`, the framework for unit testing charms in a simulated environment;
 
-You can write a charm in any way you want, but with the `ops` library you get a
-framework that helps you write consistent and readable charms following the latest
-best practices, reuse code, and separate typical charm concerns --- application
-state management from integration management or lifecycle management from testability.
+You can structure your charm however you like, but with the `ops` library, you
+get a framework that promotes consistency and readability by following best
+practices. It also helps you organize your code better by separating different
+aspects of the charm, such as managing the application’s state, handling
+integrations with other services, and making the charm easier to test.
 
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The library provides:
 
 You can write a charm in any way you want, but with the `ops` library you get a
 framework that helps you write consistent and readable charms following the latest
-best practices, reuse code via charm libs, and separate typical charm concerns
+best practices, reuse code via charm libraries, and separate typical charm concerns
 --- application state management from integration management or lifecycle
 management from testability.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ The library provides:
 
 - :ref:`ops_main_entry_point`, used to initialise and run your charm;
 - :ref:`ops_module`, the API to respond to Juju events and manage the application;
-- :ref:`ops_pebble_module`, the low-level API for Pebble in Kubernetes containers;
+- :ref:`ops_pebble_module`, the Pebble client, a low-level API for Kubernetes containers;
 - :ref:`ops_testing_module`, the framework for unit testing charms in a simulated environment;
 
 You can write a charm in any way you want, but with the `ops` library you get a

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,8 @@ ops module
 ops.main entry point
 ====================
 
+The main entry point to initialise and run your charm.
+
 .. autofunction:: ops.main
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ The library provides:
 - :ref:`ops_testing_module`, the framework for unit testing charms in a simulated environment;
 
 You can write a charm in any way you want, but with the `ops` library you get a
-framework that helps you write consistent readable charms following the latest
+framework that helps you write consistent and readable charms following the latest
 best practices, reuse code via charm libs, and separate typical charm concerns
 --- application state management from integration management or lifecycle
 management from testability.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ ops library API reference
 
 The `ops` library is a Python framework for writing and testing Juju charms.
 
-For more about the Charm SDK, see https://juju.is/docs/sdk.
+  See more: `Charm SDK documentation <https://juju.is/docs/sdk>`_
 
 The library provides:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,10 +8,10 @@ The `ops` library is a Python framework for writing and testing Juju charms.
 
 The library provides:
 
-- :ref:`ops_main_entry_point` used to initialise and run your charm.
-- :ref:`ops_module`, the API to respond to Juju events and manage the application.
-- :ref:`ops_pebble_module`, the low-level API for Pebble in Kubernetes containers.
-- :ref:`ops_testing_module`, the framework for unit testing charms in a simulated environment.
+- :ref:`ops_main_entry_point`, used to initialise and run your charm;
+- :ref:`ops_module`, the API to respond to Juju events and manage the application;
+- :ref:`ops_pebble_module`, the low-level API for Pebble in Kubernetes containers;
+- :ref:`ops_testing_module`, the framework for unit testing charms in a simulated environment;
 
 You can write a charm in any way you want, but with the `ops` library you get a
 framework that helps you write consistent readable charms following the latest
@@ -19,7 +19,7 @@ best practices, reuse code via charm libs, and separate typical charm concerns
 --- application state management from integration management or lifecycle
 management from testability.
 
-Whether you are a machine or a Kubernetes charm author, `ops` is the recommended way to go.
+Whether your charm is for machines or Kubernetes, `ops` is the recommended way to go.
 
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ The library provides:
 
 - :ref:`ops_main_entry_point` used to initialise and run your charm.
 - :ref:`ops_module`, the API to respond to Juju events and manage the application.
-- :ref:`ops_pebble_module` low-level API for Pebble in Kubernetes containers.
+- :ref:`ops_pebble_module`, the low-level API for Pebble in Kubernetes containers.
 - :ref:`ops_testing_module`, the framework for unit testing charms in a simulated environment.
 
 You can write a charm in any way you want, but with the `ops` library you get a

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ The library provides:
 
 - :ref:`ops_main_entry_point` used to initialise and run your charm.
 - :ref:`ops_module`, the API to respond to Juju events and manage the application.
-- :ref:`ops_pebble_module` to control services and respond to their events for Kubernetes charms.  
+- :ref:`ops_pebble_module` low-level API for Pebble in Kubernetes containers.
 - :ref:`ops_testing_module`, the framework for unit testing charms in a simulated environment.
 
 You can write a charm in any way you want, but with the `ops` library you get a

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,9 +15,8 @@ The library provides:
 
 You can write a charm in any way you want, but with the `ops` library you get a
 framework that helps you write consistent and readable charms following the latest
-best practices, reuse code via charm libraries, and separate typical charm concerns
---- application state management from integration management or lifecycle
-management from testability.
+best practices, reuse code, and separate typical charm concerns --- application
+state management from integration management or lifecycle management from testability.
 
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The library provides:
 
 You can structure your charm however you like, but with the `ops` library, you
 get a framework that promotes consistency and readability by following best
-practices. It also helps you organize your code better by separating different
+practices. It also helps you organise your code better by separating different
 aspects of the charm, such as managing the application’s state, handling
 integrations with other services, and making the charm easier to test.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,12 +2,59 @@
 ops library API reference
 =========================
 
+The `ops` library is a Python framework for writing and testing Juju charms.
+It is the recommended way to write charms for both Kubernetes and machines.
+
+The `ops` library provides powerful constructs for charm developers: FIXME fixme fixme the ops library provides structure that makes blah blah easier to reason.
+Easier to write charms, read other charms, and reuse aspects like individual integration handling via charm libs.
+
+- ``ops`` offers the API to respond to Juju events and manage application units, relations, storage, secrets and resources.
+
+- **Interact with Juju**: `ops` offers the API to respond to Juju events
+  and manage application units, relations, storage, secrets and resources.
+- **Manage workloads**: For Kubernetes charms, `ops.pebble`
+  provides an interface to control services inside the workload containers.
+- **Write unit tests**: `ops.testing` is the unit testing framework for
+  your charm.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
 ops module
 ==========
+
+Provides APIs for managing the given Juju application, focusing on:
+
+- Lifecycle
+- State management and event response
+- Handling of units, relations, and resources
+
+Here’s a simple charm example using the `ops` library:
+
+.. code-block:: python
+
+    #!/usr/bin/env python3
+    import ops
+
+
+    class FastAPIDemoCharm(ops.CharmBase):
+        """Charm the service."""
+
+        def __init__(self, framework):
+            super().__init__(framework)
+            # let's try to on.started...
+            self.framework.observe(self.on.demo_server_pebble_ready, self._on_demo_server_pebble_ready)
+
+        def _on_demo_server_pebble_ready(self, event):
+            event.workload.container.add_layer(...)
+            event.workload.container.replan()
+            self.unit.status = ops.ActiveStatus()
+
+
+    if __name__ == "__main__":  # pragma: nocover
+        ops.main(FastAPIDemoCharm)
+
 
 .. automodule:: ops
    :exclude-members: main
@@ -28,11 +75,73 @@ legacy main module
 ops.pebble module
 =================
 
+An example of configuring workload container using pebble.
+
+.. code-block:: python
+
+        def _on_demo_server_pebble_ready(self, event):
+            event.workload.container.add_layer(self._pebble_layer())
+            event.workload.container.replan()
+            self.unit.status = ops.ActiveStatus()
+
+        def _pebble_layer(self) -> ops.pebble.Layer:
+            return ops.pebble.Layer({
+                "services": {
+                    "demo_service": {
+                        "override": "replace",
+                        "startup": "enabled",
+                        "command": ["/some/command", "--some-arg"],
+                        "environment": {
+                            "SOME_ENV_VAR": "some value",
+                        },
+                        # Let the container die if things go wrong
+                        "on-success": "shutdown",
+                        "on-failure": "shutdown",
+                        "on-check-failure": {
+                            "online": "shutdown"
+                        }
+                    }
+                },
+                "checks": {
+                    # A custom check called "online"
+                    "online": {
+                        "override": "replace",
+                        "exec": {
+                            "command": ["/another/command", "--another-arg"],
+                        },
+                        "period": "3s"
+                    }
+                },
+            })
+
 .. automodule:: ops.pebble
 
 
 ops.testing module
 ==================
+
+Framework for unit testing charms in a simulated environment, enabling:
+
+- Testing against mocked Juju events and states
+- Validation of charm behavior prior to live deployment
+
+An example testing a charm using the Harness framework.
+
+.. code-block:: python
+
+    @pytest.fixture
+    def harness():
+        harness = ops.testing.Harness(FastAPIDemoCharm)
+        harness.begin()
+        yield harness
+        harness.cleanup()
+
+
+    def test_pebble_ready(harness):
+        assert harness.model.unit.status == ops.MaintenanceStatus("")
+
+        harness.container_pebble_ready("demo_server")
+        assert harness.model.unit.status == ops.ActiveStatus()
 
 .. automodule:: ops.testing
 

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -23,7 +23,7 @@ This module provides:
 - [OPT2] :class:`~ops.framework.EventBase` and its subclasses:
 
   - :class:`~ops.HookEvent` class for Juju events, like the
-    :class:`~ops.ActionEvent` class.
+    :class:`~ops.StartEvent` class.
   - :class:`~ops.LifecycleEvent` class for synthetic events, like the
     :class:`~ops.CollectStatusEvent` class.
 
@@ -44,6 +44,15 @@ This module provides:
     defined in the charm, allowing interaction with other applications.
   - :meth:`~ops.Model.get_secret` method, to access Juju :class:`~ops.Secret`
     objects.
+
+- :class:`~ops.Container` class to control Kubernetes workloads, including:
+
+  - :meth:`~ops.Container.add_layer` and :meth:`~ops.Container.replan` methods
+    to update Pebble configuration.
+  - :meth:`~ops.Container.pull` and :meth:`~ops.Container.push` methods to copy
+    data to and from container, respectively.
+  - :meth:`~ops.Container.exec` method to run arbitrary commands inside the
+    container.
 
 - :class:`~ops.StatusBase` class and individual status types, like
   :class:`~ops.ActiveStatus` class.

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -17,15 +17,23 @@
 This module provides:
 
 - :class:`~ops.CharmBase` and :class:`~ops.Object` to register the charm or
-  a charm lib with the framework.
-- :class:`~ops.framework.EventBase` class and individual event types, like
+  a charm lib, respectively, with the framework.
+- [OPT1] :class:`~ops.framework.EventBase` class and individual event types, like
   :class:`~ops.ActionEvent` class.
+- [OPT2] :class:`~ops.framework.EventBase` and its subclasses:
+
+  - :class:`~ops.HookEvent` class for Juju events, like the
+    :class:`~ops.ActionEvent` class.
+  - :class:`~ops.LifecycleEvent` class for synthetic events, like the
+    :class:`~ops.CollectStatusEvent` class.
+
 - :class:`~ops.Framework` class, accessible as ``self.framework`` in a charm,
   the main interface for the charm to `ops` library infrastructure, including:
 
   - :meth:`~ops.Framework.on` shorthand property used to
     :meth:`~ops.Framework.observe` and react to Juju events.
   - :attr:`~ops.Framework.model` attribute to get hold of the Model instance.
+
 - :class:`~ops.model.Model` class that represents the Juju Model, including:
 
   - :attr:`~ops.Model.app` attribute, representing the application associated
@@ -36,27 +44,9 @@ This module provides:
     defined in the charm, allowing interaction with other applications.
   - :meth:`~ops.Model.get_secret` method, to access Juju :class:`~ops.Secret`
     objects.
+
 - :class:`~ops.StatusBase` class and individual status types, like
   :class:`~ops.ActiveStatus` class.
-
-
-A charm is an operator -- business logic encapsulated in a reusable software
-package that automates every aspect of an application's life.
-
-Charms written with ops support Kubernetes using Juju's "sidecar charm"
-pattern, as well as charms that deploy to Linux-based machines and containers.
-
-Charms should do one thing and do it well. Each charm drives a single
-application and can be integrated with other charms to deliver a complex
-system. A charm handles creating the application in addition to scaling,
-configuration, optimisation, networking, service mesh, observability, and other
-day-2 operations specific to the application.
-
-The ops library is part of the Charm SDK (the other part being Charmcraft).
-Full developer documentation for the Charm SDK is available at
-https://juju.is/docs/sdk.
-
-To learn more about Juju, visit https://juju.is/docs/olm.
 """
 
 # The "from .X import Y" imports below don't explicitly tell Pyright (or MyPy)

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -16,14 +16,14 @@
 
 This module provides:
 
-- :class:`~ops.CharmBase` and :class:`~ops.Object` to register the charm or
-  a charm lib, respectively, with the framework.
+- :class:`~ops.CharmBase`, the base class for charms and :class:`~ops.Object`,
+  the base class for charm libraries.
 - :class:`~ops.framework.EventBase` class and individual event types, like
-  :class:`~ops.ActionEvent` class.
+  the :class:`~ops.ActionEvent` class.
 - :class:`~ops.Framework` class, accessible as ``self.framework`` in a charm,
   the main interface for the charm to `ops` library infrastructure, including:
 
-  - :meth:`~ops.Framework.on` shorthand property used to
+  - :attr:`~ops.Framework.on` shorthand property used to
     :meth:`~ops.Framework.observe` and react to Juju events.
   - :attr:`~ops.Framework.model` attribute to get hold of the Model instance.
 
@@ -35,9 +35,7 @@ This module provides:
   - :attr:`~ops.Model.unit` attribute, representing the unit of the application
     the charm is running on.
   - :attr:`~ops.Model.relations` attribute, which provides access to relations
-    defined in the charm, allowing interaction with other applications.
-  - :meth:`~ops.Model.get_secret` method, to access Juju :class:`~ops.Secret`
-    objects.
+    (integrations) defined in the charm, allowing interaction with other applications.
 
 - :class:`~ops.Container` class to control Kubernetes workloads, including:
 
@@ -48,7 +46,7 @@ This module provides:
   - :meth:`~ops.Container.exec` method to run arbitrary commands inside the
     container.
 
-- :class:`~ops.StatusBase` class and individual status types, like
+- :class:`~ops.StatusBase` class and individual status types, like the
   :class:`~ops.ActiveStatus` class.
 """
 

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -18,15 +18,8 @@ This module provides:
 
 - :class:`~ops.CharmBase` and :class:`~ops.Object` to register the charm or
   a charm lib, respectively, with the framework.
-- [OPT1] :class:`~ops.framework.EventBase` class and individual event types, like
+- :class:`~ops.framework.EventBase` class and individual event types, like
   :class:`~ops.ActionEvent` class.
-- [OPT2] :class:`~ops.framework.EventBase` and its subclasses:
-
-  - :class:`~ops.HookEvent` class for Juju events, like the
-    :class:`~ops.StartEvent` class.
-  - :class:`~ops.LifecycleEvent` class for synthetic events, like the
-    :class:`~ops.CollectStatusEvent` class.
-
 - :class:`~ops.Framework` class, accessible as ``self.framework`` in a charm,
   the main interface for the charm to `ops` library infrastructure, including:
 

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -14,7 +14,7 @@
 
 """The API to respond to Juju events and manage the application.
 
-This module provides:
+This module provides code freatures to your charm, including:
 
 - :class:`~ops.CharmBase`, the base class for charms and :class:`~ops.Object`,
   the base class for charm libraries.

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -27,7 +27,8 @@ This module provides:
     :meth:`~ops.Framework.observe` and react to Juju events.
   - :attr:`~ops.Framework.model` attribute to get hold of the Model instance.
 
-- :class:`~ops.model.Model` class that represents the Juju model, including:
+- :class:`~ops.model.Model` class that represents the Juju model, accessible as
+  ``self.model`` in a charm, including:
 
   - :attr:`~ops.Model.app` attribute, representing the application associated
     with the charm.

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The ops library: a Python framework for writing Juju charms.
+"""The API for managing a Juju application.
 
-The ops library is a Python framework (`available on PyPI`_) for developing
-and testing Juju charms in a consistent way, using standard Python constructs
-to allow for clean, maintainable, and reusable code.
+- lifecycle fixme fixme
+- state managment
+- responding to events
+- handling of units, relatiuons and resources
 
 A charm is an operator -- business logic encapsulated in a reusable software
 package that automates every aspect of an application's life.
@@ -35,8 +36,6 @@ Full developer documentation for the Charm SDK is available at
 https://juju.is/docs/sdk.
 
 To learn more about Juju, visit https://juju.is/docs/olm.
-
-.. _available on PyPI: https://pypi.org/project/ops/
 """
 
 # The "from .X import Y" imports below don't explicitly tell Pyright (or MyPy)

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -12,12 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The API for managing a Juju application.
+"""The API to respond to Juju events and manage the application.
 
-- lifecycle fixme fixme
-- state managment
-- responding to events
-- handling of units, relatiuons and resources
+This module provides:
+
+- :class:`~ops.CharmBase` and :class:`~ops.Object` classes that charms and
+  charm libs extend, respectively, to register with the framework.
+- :class:`~ops.framework.EventBase` class and individual event types, like
+  :class:`~ops.ActionEvent` class.
+- :class:`~ops.Framework` class, accessible as ``self.framework`` in a charm,
+  the main interface for the charm to `ops` library infrastructure, including:
+
+  - :meth:`~ops.Framework.on` shorthand property used to
+    :meth:`~ops.Framework.observe` and react to Juju events.
+  - :attr:`~ops.Framework.model` attribute to get hold of the Model instance.
+- :class:`~ops.model.Model` class that represents the Juju Model, including:
+
+  - :attr:`~ops.Model.app` attribute, fixme
+  - unit fixme
+  - relations fixme
+  - secrets fixme
+- Status
 
 A charm is an operator -- business logic encapsulated in a reusable software
 package that automates every aspect of an application's life.

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -27,7 +27,7 @@ This module provides:
     :meth:`~ops.Framework.observe` and react to Juju events.
   - :attr:`~ops.Framework.model` attribute to get hold of the Model instance.
 
-- :class:`~ops.model.Model` class that represents the Juju Model, including:
+- :class:`~ops.model.Model` class that represents the Juju model, including:
 
   - :attr:`~ops.Model.app` attribute, representing the application associated
     with the charm.

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -16,8 +16,8 @@
 
 This module provides:
 
-- :class:`~ops.CharmBase` and :class:`~ops.Object` classes that charms and
-  charm libs extend, respectively, to register with the framework.
+- :class:`~ops.CharmBase` and :class:`~ops.Object` to register the charm or
+  a charm lib with the framework.
 - :class:`~ops.framework.EventBase` class and individual event types, like
   :class:`~ops.ActionEvent` class.
 - :class:`~ops.Framework` class, accessible as ``self.framework`` in a charm,
@@ -28,11 +28,17 @@ This module provides:
   - :attr:`~ops.Framework.model` attribute to get hold of the Model instance.
 - :class:`~ops.model.Model` class that represents the Juju Model, including:
 
-  - :attr:`~ops.Model.app` attribute, fixme
-  - unit fixme
-  - relations fixme
-  - secrets fixme
-- Status
+  - :attr:`~ops.Model.app` attribute, representing the application associated
+    with the charm.
+  - :attr:`~ops.Model.unit` attribute, representing the unit of the application
+    the charm is running on.
+  - :attr:`~ops.Model.relations` attribute, which provides access to relations
+    defined in the charm, allowing interaction with other applications.
+  - :meth:`~ops.Model.get_secret` method, to access Juju :class:`~ops.Secret`
+    objects.
+- :class:`~ops.StatusBase` class and individual status types, like
+  :class:`~ops.ActiveStatus` class.
+
 
 A charm is an operator -- business logic encapsulated in a reusable software
 package that automates every aspect of an application's life.

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -43,7 +43,7 @@ This module provides:
   - :meth:`~ops.Container.add_layer` and :meth:`~ops.Container.replan` methods
     to update Pebble configuration.
   - :meth:`~ops.Container.pull` and :meth:`~ops.Container.push` methods to copy
-    data to and from container, respectively.
+    data to and from a container, respectively.
   - :meth:`~ops.Container.exec` method to run arbitrary commands inside the
     container.
 

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -520,7 +520,8 @@ class PrefixedEvents:
 class LifecycleEvent(EventBase):
     """Events tied to the lifecycle of the Framework object.
 
-    Note: Here, "lifecycle" has nothing to do with the Juju [application] lifecycle.
+    Note: Here, "lifecycle" was poorly named and has nothing to do with the
+    Juju [application] lifecycle.
     """
 
     def defer(self) -> NoReturn:

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -518,7 +518,10 @@ class PrefixedEvents:
 
 
 class LifecycleEvent(EventBase):
-    """Events tied to the lifecycle of the Framework object."""
+    """Events tied to the lifecycle of the Framework object.
+
+    Note: it is totally different from Juju [application] lifecycle.
+    """
 
     def defer(self) -> NoReturn:
         """Lifecycle events are not deferrable like other events.

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -520,7 +520,7 @@ class PrefixedEvents:
 class LifecycleEvent(EventBase):
     """Events tied to the lifecycle of the Framework object.
 
-    Note: it is totally different from Juju [application] lifecycle.
+    Note: Here, "lifecycle" has nothing to do with the Juju [application] lifecycle.
     """
 
     def defer(self) -> NoReturn:

--- a/ops/model.py
+++ b/ops/model.py
@@ -2304,7 +2304,11 @@ class Container:
         self._pebble.start_services(service_names)
 
     def restart(self, *service_names: str):
-        """Restart the given service(s) by name."""
+        """Restart the given service(s) by name.
+
+        Listed running services will be stopped and restarted, and listed stopped
+        services will be started.
+        """
         if not service_names:
             raise TypeError('restart expected at least 1 argument, got 0')
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Client for the Pebble API (HTTP over Unix socket).
+"""Low-level Pebble API.
+
+This module provides:
+
+- :class:`~ops.pebble.Client` class to communicate directly Pebble.
+- :class:`~ops.pebble.Layer` class to define Pebble configuration layers,
+  including:
+
+  - :class:`~ops.pebble.Check` class to represent Pebble checks.
+  - :class:`~ops.pebble.LogTarget` class to represent Pebble log targets.
+  - :class:`~ops.pebble.Service` class to represent Pebble service descriptions.
 
 For a command-line interface for local testing, see test/pebble_cli.py.
 """
@@ -2186,6 +2196,9 @@ class Client:
         delay: float = 0.1,
     ) -> ChangeID:
         """Restart services by name and wait (poll) for them to be started.
+
+        Listed running services will be stopped and restarted, and listed stopped
+        services will be started.
 
         Args:
             services: Non-empty list of services to restart.

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Low-level Pebble API.
+"""Client for the Pebble API.
 
 This module provides:
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -16,7 +16,7 @@
 
 This module provides:
 
-- :class:`~ops.pebble.Client` class to communicate directly Pebble.
+- :class:`~ops.pebble.Client`; communicates directly with the Pebble API.
 - :class:`~ops.pebble.Layer` class to define Pebble configuration layers,
   including:
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -24,7 +24,9 @@ This module provides:
   - :class:`~ops.pebble.LogTarget` class to represent Pebble log targets.
   - :class:`~ops.pebble.Service` class to represent Pebble service descriptions.
 
-For a command-line interface for local testing, see test/pebble_cli.py.
+For a command-line interface for local testing, see ``test/pebble_cli.py``.
+
+  See more: `Pebble documentation <https://canonical-pebble.readthedocs-hosted.com/>`_
 """
 
 from __future__ import annotations

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -14,7 +14,7 @@
 
 """Client for the Pebble API.
 
-This module provides:
+This module provides a way to interact with Pebble, including:
 
 - :class:`~ops.pebble.Client`; communicates directly with the Pebble API.
 - :class:`~ops.pebble.Layer` class to define Pebble configuration layers,

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -17,9 +17,9 @@ The module provides:
 
 - :class:`ops.testing.Harness`, a class to set up the environment for charms, and its:
 
-  - :meth:`~ops.testing.Harness.begin_with_initial_hooks` convenience method for declarative
-    test setup.
-  - individual :meth:`~ops.testing.Harness.begin` and :meth:`~ops.testing.Harness.cleanup`
+  - :meth:`~ops.testing.Harness.add_relation` method, to declare a relation
+    (integration) with another app.
+  - :meth:`~ops.testing.Harness.begin` and :meth:`~ops.testing.Harness.cleanup`
     methods to start and end the testing lifecycle.
   - :meth:`~ops.testing.Harness.evaluate_status` method, which aggregates the
     status of the charm after test interactions.

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 """Framework for unit testing charms in a simulated Juju environment.
 
-The module provides:
+The module includes:
 
-- :class:`ops.testing.Harness`, a class to set up the environment for charms, and its:
+- :class:`ops.testing.Harness`, a class to set up the simulated environment,
+  that provides:
 
   - :meth:`~ops.testing.Harness.add_relation` method, to declare a relation
     (integration) with another app.

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -13,26 +13,21 @@
 # limitations under the License.
 """Framework for unit testing charms in a simulated environment.
 
-The recommended structure delineates three kinds of tests:
+The module provides:
 
-- **Unit Tests**: Test charm code against mock Juju APIs and mocked-out
-  workloads using this module, ``ops.testing``. Validate isolated behavior
-  without external interactions.
-- **Interface Tests**: Validate charm library behavior without individual
-  charm code against mock Juju APIs. For more information, see
-  `Interface Tests <https://juju.is/docs/sdk/interface-tests>`_.
-- **Integration Tests**: Spin up several charms in a test model in a real Juju
-  controller, set up the integrations between the charms, and validate the
-  workload behavior and connections between the integrated workloads. See
-  `Integration Tests <https://juju.is/docs/sdk/write-integration-tests-for-a-charm>`_.
+- :class:`ops.testing.Harness`, a class to set up the environment for charms, and its:
+- :meth:`~ops.testing.Harness.begin_with_initial_hooks` convenience method for declarative
+  test setup.
+- individual :meth:`~ops.testing.Harness.begin` and :meth:`~ops.testing.Harness.cleanup`
+  methods to start and end the testing lifecycle.
+- :meth:`~ops.testing.Harness.evaluate_status` method, which aggregates the
+  status of the charm after test interactions.
+- :attr:`~ops.testing.Harness.model` attribute, which exposes e.g. the
+  :attr:`~ops.Model.unit` attribute for detailed assertions on the unit's state.
 
-The key elements of this module are the :class:`ops.testing.Harness` class, the
-convenience entrypoint :meth:`~ops.testing.Harness.begin_with_initial_hooks` as
-well as individual lifecycle methods :meth:`~ops.testing.Harness.begin` and
-:meth:`~ops.testing.Harness.cleanup`; collection functionality via
-:meth:`~ops.testing.Harness.evaluate_status`, along with individual Model properties
-like :attr:`~ops.Model.unit` exposed via :attr:`~ops.testing.Harness.model` that's
-driven by Harness.
+.. note::
+    Unit testing is only one aspect of a comprehensive testing strategy. For more
+    on testing charms, see `Testing Strategies <https://juju.is/docs/sdk/testing>`_.
 """
 
 import dataclasses

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -11,8 +11,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Framework for unit testing charms in a simulated environment.
 
-"""Infrastructure to build unit tests for charms using the ops library."""
+The recommended structure delineates three kinds of tests:
+
+- **Unit Tests**: Test charm code against mock Juju APIs and mocked-out
+  workloads using this module, ``ops.testing``. Validate isolated behavior
+  without external interactions.
+- **Interface Tests**: Validate charm library behavior without individual
+  charm code against mock Juju APIs. For more information, see
+  `Interface Tests <https://juju.is/docs/sdk/interface-tests>`_.
+- **Integration Tests**: Spin up several charms in a test model in a real Juju
+  controller, set up the integrations between the charms, and validate the
+  workload behavior and connections between the integrated workloads. See
+  `Integration Tests <https://juju.is/docs/sdk/write-integration-tests-for-a-charm>`_.
+
+The key elements of this module are the :class:`ops.testing.Harness` class, the
+convenience entrypoint :meth:`~ops.testing.Harness.begin_with_initial_hooks` as
+well as individual lifecycle methods :meth:`~ops.testing.Harness.begin` and
+:meth:`~ops.testing.Harness.cleanup`; collection functionality via
+:meth:`~ops.testing.Harness.evaluate_status`, along with individual Model properties
+like :attr:`~ops.Model.unit` exposed via :attr:`~ops.testing.Harness.model` that's
+driven by Harness.
+"""
 
 import dataclasses
 import datetime

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -16,14 +16,15 @@
 The module provides:
 
 - :class:`ops.testing.Harness`, a class to set up the environment for charms, and its:
-- :meth:`~ops.testing.Harness.begin_with_initial_hooks` convenience method for declarative
-  test setup.
-- individual :meth:`~ops.testing.Harness.begin` and :meth:`~ops.testing.Harness.cleanup`
-  methods to start and end the testing lifecycle.
-- :meth:`~ops.testing.Harness.evaluate_status` method, which aggregates the
-  status of the charm after test interactions.
-- :attr:`~ops.testing.Harness.model` attribute, which exposes e.g. the
-  :attr:`~ops.Model.unit` attribute for detailed assertions on the unit's state.
+
+  - :meth:`~ops.testing.Harness.begin_with_initial_hooks` convenience method for declarative
+    test setup.
+  - individual :meth:`~ops.testing.Harness.begin` and :meth:`~ops.testing.Harness.cleanup`
+    methods to start and end the testing lifecycle.
+  - :meth:`~ops.testing.Harness.evaluate_status` method, which aggregates the
+    status of the charm after test interactions.
+  - :attr:`~ops.testing.Harness.model` attribute, which exposes e.g. the
+    :attr:`~ops.Model.unit` attribute for detailed assertions on the unit's state.
 
 .. note::
     Unit testing is only one aspect of a comprehensive testing strategy. For more

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Framework for unit testing charms in a simulated environment.
+"""Framework for unit testing charms in a simulated Juju environment.
 
 The module provides:
 
@@ -28,7 +28,7 @@ The module provides:
 
 .. note::
     Unit testing is only one aspect of a comprehensive testing strategy. For more
-    on testing charms, see `Testing Strategies <https://juju.is/docs/sdk/testing>`_.
+    on testing charms, see `Charm SDK | Testing <https://juju.is/docs/sdk/testing>`_.
 """
 
 import dataclasses


### PR DESCRIPTION
Docs: Ops: Add top-level intro, clean up ops.module intro in light of that, flesh out ops.pebble and ops.testing intros a bit more

https://warthogs.atlassian.net/browse/CHARMTECH-183

- [x] "home page" library reference
- [x] ops module
- [x] ops.main entry point
- [x] ops.pebble module
- [x] ops.testing module