### PR TITLE
test: minor tests fix to run tests without tox

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -2075,7 +2075,7 @@ containers:
         assert len(caplog.records) == 1
         assert re.search(r'api error!', caplog.text)
 
-    @patch('model.JujuVersion.from_environ', new=lambda: ops.model.JujuVersion('3.1.6'))
+    @patch('ops.model.JujuVersion.from_environ', new=lambda: ops.model.JujuVersion('3.1.6'))
     def test_exec(self, container: ops.Container):
         container.pebble.responses.append('fake_exec_process')  # type: ignore
         stdout = io.StringIO('STDOUT')
@@ -2119,7 +2119,7 @@ containers:
         ]
         assert p == 'fake_exec_process'
 
-    @patch('model.JujuVersion.from_environ', new=lambda: ops.model.JujuVersion('3.1.5'))
+    @patch('ops.model.JujuVersion.from_environ', new=lambda: ops.model.JujuVersion('3.1.5'))
     def test_exec_service_context_not_supported(self, container: ops.Container):
         with pytest.raises(RuntimeError):
             container.exec(['foo'], service_context='srv1')


### PR DESCRIPTION
Below is the failure when running the tests in a venv (without Tox). This PR fixes that.

```
(.ahh-venv) dima@colima-ahh /c/operator (main)> pytest --ignore=test/smoke -vx -k test_exec
==================================================== test session starts =====================================================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.5.0 -- /code/operator/.ahh-venv/bin/python
cachedir: .pytest_cache
rootdir: /code/operator
collected 1190 items / 1176 deselected / 14 selected

test/test_model.py::TestContainerPebble::test_exec FAILED                                                              [  7%]

========================================================== FAILURES ==========================================================
_______________________________________________ TestContainerPebble.test_exec ________________________________________________

args = (<test.test_model.TestContainerPebble object at 0xe48b8f41ab70>,)
keywargs = {'container': <ops.model.Container object at 0xe48b8f076270>}

    @wraps(func)
    def patched(*args, **keywargs):
>       with self.decoration_helper(patched,
                                    args,
                                    keywargs) as (newargs, newkeywargs):

/usr/lib/python3.12/unittest/mock.py:1387:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/lib/python3.12/contextlib.py:137: in __enter__
    return next(self.gen)
/usr/lib/python3.12/unittest/mock.py:1369: in decoration_helper
    arg = exit_stack.enter_context(patching)
/usr/lib/python3.12/contextlib.py:526: in enter_context
    result = _enter(cm)
/usr/lib/python3.12/unittest/mock.py:1442: in __enter__
    self.target = self.getter()
/usr/lib/python3.12/pkgutil.py:513: in resolve_name
    mod = importlib.import_module(modname)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'model', package = None

    def import_module(name, package=None):
        """Import a module.

        The 'package' argument is required when performing a relative import. It
        specifies the package to use as the anchor point from which to resolve the
        relative import to an absolute import.

        """
        level = 0
        if name.startswith('.'):
            if not package:
                raise TypeError("the 'package' argument is required to perform a "
                                f"relative import for {name!r}")
            for character in name:
                if character != '.':
                    break
                level += 1
>       return _bootstrap._gcd_import(name[level:], package, level)
E       ModuleNotFoundError: No module named 'model'

/usr/lib/python3.12/importlib/__init__.py:90: ModuleNotFoundError
================================================== short test summary info ===================================================
FAILED test/test_model.py::TestContainerPebble::test_exec - ModuleNotFoundError: No module named 'model'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================= 1 failed, 1176 deselected in 0.26s =============================================
```