### PR TITLE
feat: add the description field to SecretInfo

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1181,6 +1181,7 @@ class SecretInfo:
         expires: Optional[datetime.datetime],
         rotation: Optional[SecretRotate],
         rotates: Optional[datetime.datetime],
+        description: Optional[str] = None,
     ):
         self.id = Secret._canonicalize_id(id)
         self.label = label
@@ -1188,6 +1189,7 @@ class SecretInfo:
         self.expires = expires
         self.rotation = rotation
         self.rotates = rotates
+        self.description = description
 
     @classmethod
     def from_dict(cls, id: str, d: Dict[str, Any]) -> 'SecretInfo':
@@ -1205,6 +1207,7 @@ class SecretInfo:
             expires=timeconv.parse_rfc3339(expires) if expires is not None else None,
             rotation=rotation,
             rotates=timeconv.parse_rfc3339(rotates) if rotates is not None else None,
+            description=typing.cast(Optional[str], d.get('description')),
         )
 
     def __repr__(self):
@@ -1215,7 +1218,8 @@ class SecretInfo:
             f'revision={self.revision}, '
             f'expires={self.expires!r}, '
             f'rotation={self.rotation}, '
-            f'rotates={self.rotates!r})'
+            f'rotates={self.rotates!r}, '
+            f'description={self.description!r})'
         )
 
 

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -2814,6 +2814,7 @@ class _TestingModelBackend:
             expires=secret.expire_time,
             rotation=rotation,
             rotates=rotates,
+            description=secret.description,
         )
 
     def secret_set(

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -3565,6 +3565,7 @@ class TestSecretInfo:
             expires=datetime.datetime(2022, 12, 9, 14, 10, 0),
             rotation=ops.SecretRotate.MONTHLY,
             rotates=datetime.datetime(2023, 1, 9, 14, 10, 0),
+            description='desc',
         )
         assert info.id == 'secret:3'
         assert info.label == 'lbl'
@@ -3572,6 +3573,7 @@ class TestSecretInfo:
         assert info.expires == datetime.datetime(2022, 12, 9, 14, 10, 0)
         assert info.rotation == ops.SecretRotate.MONTHLY
         assert info.rotates == datetime.datetime(2023, 1, 9, 14, 10, 0)
+        assert info.description == 'desc'
 
         assert repr(info).startswith('SecretInfo(')
         assert repr(info).endswith(')')
@@ -3586,6 +3588,7 @@ class TestSecretInfo:
                 'expiry': '2022-12-09T14:10:00Z',
                 'rotation': 'yearly',
                 'rotates': '2023-01-09T14:10:00Z',
+                'description': 'desc',
             },
         )
         assert info.id == 'secret:4'
@@ -3594,6 +3597,7 @@ class TestSecretInfo:
         assert info.expires == datetime.datetime(2022, 12, 9, 14, 10, 0, tzinfo=utc)
         assert info.rotation == ops.SecretRotate.YEARLY
         assert info.rotates == datetime.datetime(2023, 1, 9, 14, 10, 0, tzinfo=utc)
+        assert info.description == 'desc'
 
         info = ops.SecretInfo.from_dict(
             'secret:4',
@@ -3609,6 +3613,7 @@ class TestSecretInfo:
         assert info.expires is None
         assert info.rotation is None
         assert info.rotates is None
+        assert info.description is None
 
         info = ops.SecretInfo.from_dict('5', {'revision': 9})
         assert info.id == 'secret:5'


### PR DESCRIPTION
The `SecretInfo` class exposed all the fields from `secret-info-get` exception `description`. This PR adds that field as well.

Fixes #1289.