### PR TITLE
docs: typo on CharmBase inheritance example

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1260,7 +1260,7 @@ class CharmBase(Object):
 
         import ops
 
-        def MyCharm(ops.CharmBase):
+        class MyCharm(ops.CharmBase):
             def __init__(self, *args):
                 super().__init__(*args)
                 self.framework.observe(self.on.config_changed, self._on_config_changed)


### PR DESCRIPTION
typo: the CharmBase inheritance example should be an object, not a function