### PR TITLE
docs: config-changed is triggered by Juju trust

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -304,6 +304,7 @@ class ConfigChangedEvent(HookEvent):
       rescheduling, on unit upgrade or refresh, and so on.
     - As a specific instance of the above point: when networking changes
       (if the machine reboots and comes up with a different IP).
+    - When the app config changes, for example when `juju trust` is run.
 
     Any callback method bound to this event cannot assume that the
     software has already been started; it should not start stopped


### PR DESCRIPTION
Note that `juju trust` changes will trigger a config-changed event.

I couldn't find any other cases that aren't already mentioned in the `ConfigChangedEvent` doc that would trigger config-changed, so I hope this is all.

Fixes #1211.