### PR TITLE
chore: changelog and version bump for 2.16.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 2.16.1 - 5 Sep 2024
+
+## Fixes
+
+* Don't alter os.environ when creating a Harness in https://github.com/canonical/operator/pull/1359
+
 # 2.16.0 - 29 Aug 2024
 
 ## Features

--- a/ops/version.py
+++ b/ops/version.py
@@ -17,4 +17,4 @@
 This module is NOT to be used when developing charms using ops.
 """
 
-version: str = '2.16.0'
+version: str = '2.16.1'


### PR DESCRIPTION
Normal preparation for a release, but for a maintenance branch - to get the os.environ change out.