### PR TITLE
ci: update the TIOBE reporting for the changes in coverage calculation

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -18,8 +18,7 @@ jobs:
         run: pip install tox~=4.2 coverage[toml] flake8 pylint websocket-client==1.* pyyaml==6.* pytest~=7.2 pytest-operator~=0.23
       - name: Generate coverage report
         run: |
-          tox -e unit
-          coverage xml
+          tox -e coverage
           # Annoyingly, the coverage.xml file needs to be in a .coverage folder.
           rm .coverage
           mkdir .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ venv
 /docsenv
 .vscode
 .coverage
+coverage.xml
 /.tox
 .*.swp
 

--- a/tox.ini
+++ b/tox.ini
@@ -113,6 +113,7 @@ deps =
 commands =
     coverage run --source={[vars]src_path} \
              -m pytest --ignore={[vars]tst_path}smoke -v --tb native {posargs}
+    coverage xml
     coverage report
 
 [testenv:pebble]


### PR DESCRIPTION
We recently changed `tox -e unit` to not produce a coverage report. This PR adjust the TIOBE workflow to account for that - running `tox -e coverage` instead.

Since this will now be one of the main uses for that command, I've also moved the `coverage xml` command into the tox steps rather than being in the workflow, and adjusted the `.gitignore` accordingly.