### PR TITLE
feat: add a JujuVersion property for Pebble log forwarding to Loki

### DIFF
--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -144,3 +144,13 @@ class JujuVersion:
             # releases have the change (3.2.1 tag was never released).
             return False
         return True
+
+    @property
+    def supports_pebble_log_forwarding(self) -> bool:
+        """Report whether the Pebble bundled with this Juju version supports log forwarding."""
+        # Log forwarding was available from Pebble 1.4, but labels were added in
+        # 1.6, and that's when this became really useful, so we use that as a
+        # cutoff. Juju 3.4.0 was the first to have Pebble 1.6 (actually 1.7).
+        # https://github.com/canonical/pebble/releases/tag/v1.6.0
+        # https://github.com/juju/juju/blob/e1b7dcd7390348c37f8b860011e7436e6ed3f4cc/go.mod#L27
+        return (self.major, self.minor, self.patch) >= (3, 4, 0)

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -101,6 +101,20 @@ def test_supports_exec_service_context():
 
 
 @pytest.mark.parametrize(
+    'version,has_support',
+    [
+        ('2.9.50', False),
+        ('3.3.6', False),
+        ('3.4.0', True),
+        ('3.4.1', True),
+        ('4.0.0', True),
+    ],
+)
+def test_supports_pebble_log_forwarding(version: str, has_support: bool):
+    assert ops.JujuVersion(version).supports_pebble_log_forwarding is has_support
+
+
+@pytest.mark.parametrize(
     'invalid_version',
     [
         'xyz',


### PR DESCRIPTION
Adds a new property to `JujuVersion` indicating if the version of Pebble bundled with Juju supports log forwarding to Loki, with labels.

See discussion in #1230 around which version of log forwarding should be the cutoff for support, which landed on when labels were added.

Fixes #1230