### PR TITLE
fix: Secret.set_info and Secret.set_content can be called in the same hook

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -941,7 +941,12 @@ class SecretEvent(HookEvent):
         until :meth:`Secret.get_content()` is called.
         """
         backend = self.framework.model._backend
-        return model.Secret(backend=backend, id=self._id, label=self._label)
+        return model.Secret(
+            backend=backend,
+            id=self._id,
+            label=self._label,
+            _secret_set_cache=self.framework.model._cache._secret_set_cache,
+        )
 
     def snapshot(self) -> Dict[str, Any]:
         """Used by the framework to serialize the event to disk.

--- a/ops/model.py
+++ b/ops/model.py
@@ -109,10 +109,6 @@ _NetworkDict = TypedDict(
 )
 
 
-class _SecretSetSequenceError(Exception):
-    """Raised when calling secret-set without content after previously calling it with content."""
-
-
 logger = logging.getLogger(__name__)
 
 MAX_LOG_LINE_LEN = 131071  # Max length of strings to pass to subshell.
@@ -1517,7 +1513,6 @@ class Secret:
                 effect only after the currently-scheduled rotation.
 
         Raises:
-            TypeError: if no attributes are provided.
             ModelError: if used after previously using :meth:`set_content` in the
                 same hook.
         """
@@ -1527,18 +1522,13 @@ class Secret:
             )
         if self._id is None:
             self._id = self.get_info().id
-        try:
-            self._backend.secret_set(
-                typing.cast(str, self.id),
-                label=label,
-                description=description,
-                expire=_calculate_expiry(expire),
-                rotate=rotate,
-            )
-        except _SecretSetSequenceError:
-            raise ModelError(
-                "Can't set secret info after setting content in the same hook."
-            ) from None
+        self._backend.secret_set(
+            typing.cast(str, self.id),
+            label=label,
+            description=description,
+            expire=_calculate_expiry(expire),
+            rotate=rotate,
+        )
 
     def grant(self, relation: 'Relation', *, unit: Optional[Unit] = None):
         """Grant read access to this secret.
@@ -3694,9 +3684,8 @@ class _ModelBackend:
         elif 'rotate' in self._secret_cache[id]:
             args += ['--rotate', self._secret_cache[id]['rotate'].value]
         if content is None and 'content' in self._secret_cache[id]:
-            raise _SecretSetSequenceError(
-                'secret-set called without content, and previously used in this hook'
-            )
+            # Get the previous content from the unit agent's cache.
+            content = self.secret_get(id=id, peek=True)
         elif content is not None:
             self._secret_cache[id]['content'] = object()
         with tempfile.TemporaryDirectory() as tmp:

--- a/ops/model.py
+++ b/ops/model.py
@@ -1511,10 +1511,6 @@ class Secret:
             expire: New expiration time (or timedelta from now) to apply.
             rotate: New rotation policy to apply. The new policy will take
                 effect only after the currently-scheduled rotation.
-
-        Raises:
-            ModelError: if used after previously using :meth:`set_content` in the
-                same hook.
         """
         if label is None and description is None and expire is None and rotate is None:
             raise TypeError(

--- a/ops/model.py
+++ b/ops/model.py
@@ -340,7 +340,9 @@ class _ModelCache:
     def __init__(self, meta: 'ops.charm.CharmMeta', backend: '_ModelBackend'):
         self._meta = meta
         self._backend = backend
-        self._secret_set_cache: Dict[str, Dict[str, Any]] = collections.defaultdict(dict)
+        self._secret_set_cache: collections.defaultdict[str, Dict[str, Any]] = (
+            collections.defaultdict(dict)
+        )
         self._weakrefs: _WeakCacheType = weakref.WeakValueDictionary()
 
     @typing.overload
@@ -1290,7 +1292,7 @@ class Secret:
         id: Optional[str] = None,
         label: Optional[str] = None,
         content: Optional[Dict[str, str]] = None,
-        _secret_set_cache: Optional[Dict[str, Dict[str, Any]]] = None,
+        _secret_set_cache: Optional['collections.defaultdict[str, Dict[str, Any]]'] = None,
     ):
         if not (id or label):
             raise TypeError('Must provide an id or label, or both')
@@ -1300,7 +1302,9 @@ class Secret:
         self._id = id
         self._label = label
         self._content = content
-        self._secret_set_cache = _secret_set_cache or collections.defaultdict(dict)
+        self._secret_set_cache: collections.defaultdict[str, Dict[str, Any]] = (
+            collections.defaultdict(dict) if _secret_set_cache is None else _secret_set_cache
+        )
 
     def __repr__(self):
         fields: List[str] = []

--- a/ops/model.py
+++ b/ops/model.py
@@ -3687,6 +3687,8 @@ class _ModelBackend:
             # Get the previous content from the unit agent's cache.
             content = self.secret_get(id=id, peek=True)
         elif content is not None:
+            # Don't store the actual secret content in memory, but put a sentinel there to indicate
+            # that the content has been set during this hook.
             self._secret_cache[id]['content'] = object()
         with tempfile.TemporaryDirectory() as tmp:
             # The content is None or has already been validated with Secret._validate_content

--- a/ops/model.py
+++ b/ops/model.py
@@ -3679,13 +3679,15 @@ class _ModelBackend:
             self._secret_cache[id]['rotate'] = rotate
         elif 'rotate' in self._secret_cache[id]:
             args += ['--rotate', self._secret_cache[id]['rotate'].value]
-        if content is None and 'content' in self._secret_cache[id]:
-            # Get the previous content from the unit agent's cache.
-            content = self.secret_get(id=id, peek=True)
-        elif content is not None:
+
+        if content is not None:
             # Don't store the actual secret content in memory, but put a sentinel there to indicate
             # that the content has been set during this hook.
             self._secret_cache[id]['content'] = object()
+        elif content is None and 'content' in self._secret_cache[id]:
+            # Get the previous content from the unit agent's cache.
+            content = self.secret_get(id=id, peek=True)
+
         with tempfile.TemporaryDirectory() as tmp:
             # The content is None or has already been validated with Secret._validate_content
             for k, v in (content or {}).items():

--- a/ops/model.py
+++ b/ops/model.py
@@ -3675,10 +3675,10 @@ class _ModelBackend:
         elif 'expire' in self._secret_cache[id]:
             args.extend(['--expire', self._secret_cache[id]['expire'].isoformat()])
         if rotate is not None:
-            args += ['--rotate', rotate.value]
+            args.extend(['--rotate', rotate.value])
             self._secret_cache[id]['rotate'] = rotate
         elif 'rotate' in self._secret_cache[id]:
-            args += ['--rotate', self._secret_cache[id]['rotate'].value]
+            args.extend(['--rotate', self._secret_cache[id]['rotate'].value])
 
         if content is not None:
             # Don't store the actual secret content in memory, but put a sentinel there to indicate
@@ -3714,9 +3714,9 @@ class _ModelBackend:
         if expire is not None:
             args.extend(['--expire', expire.isoformat()])
         if rotate is not None:
-            args += ['--rotate', rotate.value]
+            args.extend(['--rotate', rotate.value])
         if owner is not None:
-            args += ['--owner', owner]
+            args.extend(['--owner', owner])
         with tempfile.TemporaryDirectory() as tmp:
             # The content has already been validated with Secret._validate_content
             for k, v in content.items():

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -3834,14 +3834,14 @@ class TestSecretClass:
 
         calls = fake_script.calls(clear=True)
         assert calls == [
-            ['secret-set', f'secret://{model._backend.model_uuid}/q', ANY],
+            ['secret-set', f'secret://{model._backend.model_uuid}/q', mock.ANY],
             ['secret-get', f'secret://{model._backend.model_uuid}/q', '--peek', '--format=json'],
             [
                 'secret-set',
                 f'secret://{model._backend.model_uuid}/q',
                 '--description',
                 description,
-                ANY,
+                mock.ANY,
             ],
         ]
         # For this test we don't need to check that the content was in the temporary file, but we
@@ -3871,7 +3871,7 @@ class TestSecretClass:
                 f'secret://{model._backend.model_uuid}/q',
                 '--description',
                 description,
-                ANY,
+                mock.ANY,
             ],
         ]
         # For this test we don't need to check that the content was in the temporary file, but we

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -3787,6 +3787,7 @@ class TestSecretClass:
     def test_set_info(self, model: ops.Model, fake_script: FakeScript):
         fake_script.write('secret-set', """exit 0""")
         fake_script.write('secret-info-get', """echo '{"z": {"label": "y", "revision": 7}}'""")
+        ops.Secret._secret_set_cache.clear()
 
         secret = self.make_secret(model, id='x')
         expire = datetime.datetime(2022, 12, 9, 16, 59, 0)
@@ -3826,6 +3827,7 @@ class TestSecretClass:
     def test_set_content_then_info(self, model: ops.Model, fake_script: FakeScript):
         fake_script.write('secret-set', """exit 0""")
         fake_script.write('secret-get', """echo '{"foo": "bar"}'""")
+        ops.Secret._secret_set_cache.clear()
 
         secret = self.make_secret(model, id='q')
         secret.set_content({'foo': 'bar'})
@@ -3852,6 +3854,7 @@ class TestSecretClass:
 
     def test_set_info_then_content(self, model: ops.Model, fake_script: FakeScript):
         fake_script.write('secret-set', """exit 0""")
+        ops.Secret._secret_set_cache.clear()
 
         secret = self.make_secret(model, id='q')
         description = 'desc'

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -3787,7 +3787,6 @@ class TestSecretClass:
     def test_set_info(self, model: ops.Model, fake_script: FakeScript):
         fake_script.write('secret-set', """exit 0""")
         fake_script.write('secret-info-get', """echo '{"z": {"label": "y", "revision": 7}}'""")
-        ops.Secret._secret_set_cache.clear()
 
         secret = self.make_secret(model, id='x')
         expire = datetime.datetime(2022, 12, 9, 16, 59, 0)
@@ -3827,7 +3826,6 @@ class TestSecretClass:
     def test_set_content_then_info(self, model: ops.Model, fake_script: FakeScript):
         fake_script.write('secret-set', """exit 0""")
         fake_script.write('secret-get', """echo '{"foo": "bar"}'""")
-        ops.Secret._secret_set_cache.clear()
 
         secret = self.make_secret(model, id='q')
         secret.set_content({'foo': 'bar'})
@@ -3854,7 +3852,6 @@ class TestSecretClass:
 
     def test_set_info_then_content(self, model: ops.Model, fake_script: FakeScript):
         fake_script.write('secret-set', """exit 0""")
-        ops.Secret._secret_set_cache.clear()
 
         secret = self.make_secret(model, id='q')
         description = 'desc'


### PR DESCRIPTION
Each call to `secret-set` replaces the values in any previous `secret-set` call in the same hook. Since both `Secret.set_content` and `Secret.set_info` use `secret-set`, this means that doing both in the same hook would only retain the change from whichever was done last.

This PR changes the model backend to cache the secret metadata (from `set_info`) and add it into any subsequent `secret-set` calls. Although the metadata is only available to the secret owner, it does not seem so private that it is unsafe to keep it in memory for the duration of the hook execution.

There is an additional behaviour change here: previously calling `set_info` twice in the same hook would 'undo' setting metadata. For example:

```python
secret.set_info(label="foo")
secret.set_info(description="bar")
# With main, the secret will end up with a description and no label
# With the PR branch, the secret will end up with a description and a label
```

I believe this is a bug fix also, because it seems likely that a charmer would expect both values to be set with code such as the above, and the documentation states:

> Once attributes are set, they cannot be unset.

For the secret content, I believe we should not cache this in the charm process's memory, so this PR only sets a sentinel that the content has been set, and if there is a subsequent `set_info` call, the content is retrieved via a `secret-get` call (I believe this is from the in-memory cache in the unit agent, but, in any case, it's the un-committed value in an existing location, so does not increase the secret content exposure).

There is an example charm in #1288 that can be used to verify the behaviour in a real Juju model.

No updates to Harness because it already has the behaviour that we're changing to.

Fixes #1288