### PR TITLE
chore: generate warnings for events that will be removed in Juju 4.0

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -18,6 +18,7 @@ import dataclasses
 import enum
 import logging
 import pathlib
+import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -359,6 +360,14 @@ class PreSeriesUpgradeEvent(HookEvent):
     .. jujuremoved:: 4.0
     """
 
+    def __init__(self, handle: 'Handle'):
+        warnings.warn(
+            'pre-series-upgrade events will not be emitted from Juju 4.0 onwards',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(handle)
+
 
 class PostSeriesUpgradeEvent(HookEvent):
     """Event triggered after a series upgrade.
@@ -374,6 +383,14 @@ class PostSeriesUpgradeEvent(HookEvent):
 
     .. jujuremoved:: 4.0
     """
+
+    def __init__(self, handle: 'Handle'):
+        warnings.warn(
+            'post-series-upgrade events will not be emitted from Juju 4.0 onwards',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(handle)
 
 
 class LeaderElectedEvent(HookEvent):
@@ -411,6 +428,15 @@ class CollectMetricsEvent(HookEvent):
 
     .. jujuremoved:: 4.0
     """
+
+    def __init__(self, handle: 'Handle'):
+        warnings.warn(
+            'collect-metrics events will not be emitted from Juju 4.0 onwards - '
+            'consider using the Canonical Observability Stack',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(handle)
 
     def add_metrics(
         self, metrics: Mapping[str, Union[int, float]], labels: Optional[Mapping[str, str]] = None

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -364,7 +364,7 @@ class PreSeriesUpgradeEvent(HookEvent):
         warnings.warn(
             'pre-series-upgrade events will not be emitted from Juju 4.0 onwards',
             DeprecationWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         super().__init__(handle)
 
@@ -388,7 +388,7 @@ class PostSeriesUpgradeEvent(HookEvent):
         warnings.warn(
             'post-series-upgrade events will not be emitted from Juju 4.0 onwards',
             DeprecationWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         super().__init__(handle)
 
@@ -434,7 +434,7 @@ class CollectMetricsEvent(HookEvent):
             'collect-metrics events will not be emitted from Juju 4.0 onwards - '
             'consider using the Canonical Observability Stack',
             DeprecationWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         super().__init__(handle)
 


### PR DESCRIPTION
A `DeprecationWarning` is emitted whenever an instance of `CollectMetricsEvent`, `PreSeriesUpgradeEvent`, or `PostSeriesUpgradeEvent` is created (which should only be whenever there is an observed event of that type).

Documentation warnings were already added in an earlier PR.

Fixes #1280