### PR TITLE
chore: ruff setting renamed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,10 +161,11 @@ ignore = [
     "RUF015",
     # Mutable class attributes should be annotated with `typing.ClassVar`
     "RUF012",
-    # Unnecessary dict comprehension for iterable; use `dict.fromkeys` instead
-    "RUF025",
+
     # Unnecessary `tuple` call (rewrite as a literal)
     "C408",
+    # Unnecessary dict comprehension for iterable; use `dict.fromkeys` instead
+    "C420",
 ]
 
 [tool.ruff.lint.pyupgrade]


### PR DESCRIPTION
> Remapped rules
> The following rules have been remapped to new rule codes:
> unnecessary-dict-comprehension-for-iterable: RUF025 to C420

https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#remapped-rules

https://docs.astral.sh/ruff/rules/unnecessary-dict-comprehension-for-iterable/