### PR TITLE
fix: Use a TypeVar to fix annotations for StatusBase.register

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -334,6 +334,7 @@ nitpick_ignore = [
     ('py:class', 'ops.model._ModelBackend'),
     ('py:class', 'ops.model._ModelCache'),
     ('py:class', 'ops.model._NetworkDict'),
+    ('py:class', 'ops.model._StatusClass'),
     ('py:class', 'ops.model._SupportsKeysAndGetItem'),
     ('py:class', 'ops.pebble._FileLikeIO'),
     ('py:class', 'ops.pebble._IOSource'),

--- a/ops/model.py
+++ b/ops/model.py
@@ -78,7 +78,7 @@ _StatusDict = TypedDict('_StatusDict', {'status': StatusName, 'message': str})
 _SETTABLE_STATUS_NAMES: Tuple[_SettableStatusName, ...] = get_args(_SettableStatusName)
 
 # for the StatusBase.register class decorator
-_StatusBaseType = typing.TypeVar('_StatusBaseType', bound=Type['StatusBase'])
+_StatusClass = typing.TypeVar('_StatusClass', bound='StatusBase')
 
 # mapping from relation name to a list of relation objects
 _RelationMapping_Raw = Dict[str, Optional[List['Relation']]]
@@ -1940,8 +1940,19 @@ class StatusBase:
             return cls._statuses[typing.cast(StatusName, name)](message)
 
     @classmethod
-    def register(cls, child: _StatusBaseType) -> _StatusBaseType:
-        """Register a Status for the child's name."""
+    def register(cls, child: Type[_StatusClass]) -> Type[_StatusClass]:
+        """Class decorator to register a subclass for lookup using :meth:`from_name`.
+
+        .. code-block:: python
+
+            _StatusClass = typing.TypeVar('_StatusClass', bound='StatusBase')
+
+        Args:
+            child: A subclass of StatusBase, with a ``name`` attribute of type ``str``.
+
+        Returns:
+            The decorated class, unmodified.
+        """
         if not (hasattr(child, 'name') and isinstance(child.name, str)):
             raise TypeError(
                 f"Can't register StatusBase subclass {child}: ",

--- a/ops/model.py
+++ b/ops/model.py
@@ -77,6 +77,9 @@ StatusName = Union[_SettableStatusName, _ReadOnlyStatusName]
 _StatusDict = TypedDict('_StatusDict', {'status': StatusName, 'message': str})
 _SETTABLE_STATUS_NAMES: Tuple[_SettableStatusName, ...] = get_args(_SettableStatusName)
 
+# for the StatusBase.register class decorator
+_StatusBaseType = typing.TypeVar("_StatusBaseType", bound="Type[StatusBase]")
+
 # mapping from relation name to a list of relation objects
 _RelationMapping_Raw = Dict[str, Optional[List['Relation']]]
 # mapping from container name to container metadata
@@ -1937,7 +1940,7 @@ class StatusBase:
             return cls._statuses[typing.cast(StatusName, name)](message)
 
     @classmethod
-    def register(cls, child: Type['StatusBase']):
+    def register(cls, child: _StatusBaseType) -> _StatusBaseType:
         """Register a Status for the child's name."""
         if not (hasattr(child, 'name') and isinstance(child.name, str)):
             raise TypeError(

--- a/ops/model.py
+++ b/ops/model.py
@@ -1944,11 +1944,7 @@ class StatusBase:
         """Class decorator to register a subclass for lookup using :meth:`from_name`.
 
         Note: this method is intended for internal use only.
-        It is used to make the six valid Juju statuses available by name.
-
-        .. code-block:: python
-
-            _StatusClass = typing.TypeVar('_StatusClass', bound='StatusBase')
+        It is used to make the valid Juju statuses available by name.
 
         Args:
             child: A subclass of StatusBase, with a ``name`` attribute of type ``str``.

--- a/ops/model.py
+++ b/ops/model.py
@@ -78,7 +78,7 @@ _StatusDict = TypedDict('_StatusDict', {'status': StatusName, 'message': str})
 _SETTABLE_STATUS_NAMES: Tuple[_SettableStatusName, ...] = get_args(_SettableStatusName)
 
 # for the StatusBase.register class decorator
-_StatusBaseType = typing.TypeVar("_StatusBaseType", bound="Type[StatusBase]")
+_StatusBaseType = typing.TypeVar('_StatusBaseType', bound=Type['StatusBase'])
 
 # mapping from relation name to a list of relation objects
 _RelationMapping_Raw = Dict[str, Optional[List['Relation']]]

--- a/ops/model.py
+++ b/ops/model.py
@@ -1943,6 +1943,9 @@ class StatusBase:
     def register(cls, child: Type[_StatusClass]) -> Type[_StatusClass]:
         """Class decorator to register a subclass for lookup using :meth:`from_name`.
 
+        Note: this method is intended for internal use only.
+        It is used to make the six valid Juju statuses available by name.
+
         .. code-block:: python
 
             _StatusClass = typing.TypeVar('_StatusClass', bound='StatusBase')

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3232,6 +3232,9 @@ class TestHarness:
 
     def test_evaluate_status(self):
         class TestCharm(ops.CharmBase):
+            app_status_to_add: ops.StatusBase
+            unit_status_to_add: ops.StatusBase
+
             def __init__(self, framework: ops.Framework):
                 super().__init__(framework)
                 self.framework.observe(self.on.collect_app_status, self._on_collect_app_status)


### PR DESCRIPTION
Previously `StatusBase.register` obscured the type of decorated classes. The classes would all end up typed as `Type[StatusBase]`, and when instantiated they would be typed as `StatusBase` instead of their actual class (see #1380). This PR fixes the typing to align with the actual decorator behaviour, which returns the decorated class unmodified.

---

This change will produce a type checking error if you were doing something like this (as one of our tests did):
```python
status = BlockedStatus("msg")
...
status = ActiveStatus()
```
Here the author's intent is for `status` to have a type of `StatusBase` (or they're making a mistake). Previously, `status` would implicitly be typed as `StatusBase` due to the `StatusBase.register` class decorator applied to `BlockedStatus` (etc) changing its type to `Type[StatusBase]`. Now `status` is instead accurately typed as `BlockedStatus`, so `status = ops.ActiveStatus()` is an error, and the author would need to write this instead:
```python
status: StatusBase = BlockedStatus("msg")
...
status = ActiveStatus()
```

---

Initially this PR broke docs generation, because sphinx has trouble with type variables. I think this open [issue](https://github.com/sphinx-doc/sphinx/issues/10974) for sphinx (Nov 2022) is related. See also the related known [issue](https://github.com/sphinx-doc/sphinx/issues/10785) with autodoc (Aug 2022). Our current workaround is to list our type variables in the `nitpick_ignore`s in `docs/custom_conf.py`.

This is what the generated docs look like. I put a copy of the TypeVar declaration in the docstring since sphinx refuses to link to it.
![image](https://github.com/user-attachments/assets/58ca3fa5-9f9f-4a33-985f-db30bca0da87)

---

Resolves #1380.