### PR TITLE
ci: run the smoke tests on a schedule

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -1,0 +1,36 @@
+name: ops Smoke Tests
+
+on:
+  workflow_dispatch:
+    schedule:
+      - cron:  '0 7 25 * *'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        juju-version: ['2.9', '3', '4.0']
+        charmcraft-version: ['2.x', '3.x']
+
+    steps:
+      - name: Set up Juju
+        run: sudo snap install juju --channel=${{ matrix.juju-version }}
+
+      - name: Set up LXD
+        uses: canonical/setup-lxd@ce8decb3609c0a03c5abd5034d02a6c145e2076f
+        with:
+          channel: 5.0/stable
+
+      - name: Bootstrap Juju controller
+        run: juju bootstrap localhost
+
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --channel=${{ matrix.charmcraft-version }}
+
+      - name: Install tox
+        run: pip install tox~=4.2
+
+      - name: Run smoke tests
+        run: tox -e smoke

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       matrix:
         # pylibjuju does not currently support Juju 4.x
-        juju-version: ['2.9', '3.5']
+        # The smoke tests do not yet work on Juju 2.9.
+        juju-version: ['3.5']
         charmcraft-version: ['2.x', '3.x']
         cloud: ['lxd', 'microk8s']
 

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -29,6 +29,12 @@ jobs:
       - name: Install charmcraft
         run: sudo snap install charmcraft --channel=${{ matrix.charmcraft-version }} --classic
 
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+
       - name: Install tox
         run: pip install tox~=4.2
 

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -30,10 +30,11 @@ jobs:
 
       - name: Set up Microk8s
         if: matrix.cloud == 'microk8s'
-        run: |
-          sudo snap install microk8s --classic
-          sudo microk8s status --wait-ready
-          sudo microk8s enable hostpath-storage dns
+        uses: balchua/microk8s-actions@v0.3.2
+        with:
+          channel: '1.26-strict/stable'
+          devMode: 'true'
+          addons: '["dns", "hostpath-storage"]'
 
       - name: Set up Juju
         run: sudo snap install juju --channel=${{ matrix.juju-version }}

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -32,11 +32,9 @@ jobs:
         if: matrix.cloud == 'microk8s'
         run: |
           sudo snap install microk8s --classic
-          sudo adduser $USER snap_microk8s
           sudo chown -f -R $USER ~/.kube
           sudo microk8s status --wait-ready
           sudo microk8s enable hostpath-storage dns
-          newgrp snap_microk8s
 
       - name: Set up Juju
         run: sudo snap install juju --channel=${{ matrix.juju-version }}

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -23,8 +23,9 @@ jobs:
         cloud: ['microk8s']
 
     steps:
+      # LXD is required for charmcraft to pack, even if it's not used as the
+      # Juju cloud.
       - name: Set up LXD
-        if: matrix.cloud == 'lxd'
         uses: canonical/setup-lxd@ce8decb3609c0a03c5abd5034d02a6c145e2076f
         with:
           channel: 5.0/stable

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -24,7 +24,7 @@ jobs:
       # LXD is required for charmcraft to pack, even if it's not used as the
       # Juju cloud.
       - name: Set up LXD
-        uses: canonical/setup-lxd@ce8decb3609c0a03c5abd5034d02a6c145e2076f
+        uses: canonical/setup-lxd@8fb85546a934dfb994becf81341dd387ffe6aabb
         with:
           channel: 5.0/stable
 

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -13,15 +13,21 @@ jobs:
       matrix:
         juju-version: ['2.9 --classic', '3', '4.0/beta']
         charmcraft-version: ['2.x', '3.x']
+        cloud: ['lxd', 'microk8s']
 
     steps:
       - name: Set up Juju
         run: sudo snap install juju --channel=${{ matrix.juju-version }}
 
       - name: Set up LXD
+        if: ${{ matrix.cloud }} == 'lxd'
         uses: canonical/setup-lxd@ce8decb3609c0a03c5abd5034d02a6c145e2076f
         with:
           channel: 5.0/stable
+
+      - name: Set up Microk8s
+        if: ${{ matrix.cloud }} == 'microk8s'
+        run: snap install microk8s
 
       - name: Bootstrap Juju controller
         run: juju bootstrap localhost

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -12,15 +12,12 @@ jobs:
     strategy:
       matrix:
         # pylibjuju does not currently support Juju 4.x
-        # TODO: we should run against 2.9, but that means installing pylibjuju
-        # "<3", and we need to do that inside the tox environment, so that's a
-        # bit more complex than having everything inside this workflow.
-        # Note that Juju 2.9 needs to be '2.9 --classic' because the snap is
-        # only available with classic confinement.
-        juju-version: ['3']
+        juju-version: ['2.9', '3.5']
         charmcraft-version: ['2.x', '3.x']
-#        cloud: ['lxd', 'microk8s']
-        cloud: ['microk8s']
+        cloud: ['lxd', 'microk8s']
+
+    env:
+      JUJU_VERSION: "${{ matrix.juju-version }}"
 
     steps:
       # LXD is required for charmcraft to pack, even if it's not used as the
@@ -38,7 +35,12 @@ jobs:
           devMode: 'true'
           addons: '["dns", "hostpath-storage"]'
 
+      - name: Set up Juju (classic)
+        if: matrix.juju-version == '2.9'
+        run: sudo snap install juju --classic --channel=${{ matrix.juju-version }}
+
       - name: Set up Juju
+        if: matrix.juju-version != '2.9'
         run: sudo snap install juju --channel=${{ matrix.juju-version }}
 
       - name: Bootstrap Juju controller (k8s)

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -11,7 +11,13 @@ jobs:
 
     strategy:
       matrix:
-        juju-version: ['2.9 --classic', '3', '4.0/beta']
+        # pylibjuju does not currently support Juju 4.x
+        # TODO: we should run against 2.9, but that means installing pylibjuju
+        # "<3", and we need to do that inside the tox environment, so that's a
+        # bit more complex than having everything inside this workflow.
+        # Note that Juju 2.9 needs to be '2.9 --classic' because the snap is
+        # only available with classic confinement.
+        juju-version: ['3']
         charmcraft-version: ['2.x', '3.x']
         cloud: ['lxd', 'microk8s']
 

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Bootstrap Juju controller (k8s)
         if: matrix.cloud == 'microk8s'
-        run: juju bootstrap localhost
+        run: juju bootstrap microk8s
 
       - name: Bootstrap Juju controller (lxd)
         if: matrix.cloud == 'lxd'

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -27,7 +27,7 @@ jobs:
         run: juju bootstrap localhost
 
       - name: Install charmcraft
-        run: sudo snap install charmcraft --channel=${{ matrix.charmcraft-version }}
+        run: sudo snap install charmcraft --channel=${{ matrix.charmcraft-version }} --classic
 
       - name: Install tox
         run: pip install tox~=4.2

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Microk8s
         if: ${{ matrix.cloud }} == 'microk8s'
         run: |
-          sudo snap install microk8s
+          sudo snap install microk8s --classic
           sudo adduser $USER snap_microk8s
           sudo chown -f -R $USER ~/.kube
           sudo microk8s status --wait-ready

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Bootstrap Juju controller (k8s)
         if: matrix.cloud == 'microk8s'
-        run: juju bootstrap microk8s
+        run: sudo juju bootstrap microk8s
 
       - name: Bootstrap Juju controller (lxd)
         if: matrix.cloud == 'lxd'

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        juju-version: ['2.9 --classic', '3', '4.0']
+        juju-version: ['2.9 --classic', '3', '4.0/beta']
         charmcraft-version: ['2.x', '3.x']
 
     steps:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -32,7 +32,6 @@ jobs:
         if: matrix.cloud == 'microk8s'
         run: |
           sudo snap install microk8s --classic
-          sudo chown -f -R $USER ~/.kube
           sudo microk8s status --wait-ready
           sudo microk8s enable hostpath-storage dns
 

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -33,7 +33,13 @@ jobs:
 
       - name: Set up Microk8s
         if: ${{ matrix.cloud }} == 'microk8s'
-        run: snap install microk8s
+        run: |
+          sudo snap install microk8s
+          sudo adduser $USER snap_microk8s
+          sudo chown -f -R $USER ~/.kube
+          sudo microk8s status --wait-ready
+          sudo microk8s enable hostpath-storage dns
+          newgrp snap_microk8s
 
       - name: Bootstrap Juju controller
         run: juju bootstrap localhost

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -60,4 +60,6 @@ jobs:
         run: pip install tox~=4.2
 
       - name: Run smoke tests
-        run: tox -e smoke
+        # pytest-operator runs charmcraft pack with `sg lxd`, which seems to
+        # prompt for a password, so bypass that.
+        run: sudo tox -e smoke

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Bootstrap Juju controller (k8s)
         if: matrix.cloud == 'microk8s'
+        # TODO: instead of sudo, use `sg` to do this? `sudo usermod -a -G snap_microk8s runner`
         run: sudo juju bootstrap microk8s
 
       - name: Bootstrap Juju controller (lxd)

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -19,7 +19,8 @@ jobs:
         # only available with classic confinement.
         juju-version: ['3']
         charmcraft-version: ['2.x', '3.x']
-        cloud: ['lxd', 'microk8s']
+#        cloud: ['lxd', 'microk8s']
+        cloud: ['microk8s']
 
     steps:
       - name: Set up LXD
@@ -41,8 +42,7 @@ jobs:
 
       - name: Bootstrap Juju controller (k8s)
         if: matrix.cloud == 'microk8s'
-        # TODO: instead of sudo, use `sg` to do this? `sudo usermod -a -G snap_microk8s runner`
-        run: sudo juju bootstrap microk8s
+        run: sg snap_microk8s -c 'juju bootstrap microk8s'
 
       - name: Bootstrap Juju controller (lxd)
         if: matrix.cloud == 'lxd'
@@ -58,9 +58,7 @@ jobs:
         uses: actions/setup-python@v5
 
       - name: Install tox
-        run: sudo pip install tox~=4.2
+        run: pip install tox~=4.2
 
       - name: Run smoke tests
-        # pytest-operator runs charmcraft pack with `sg lxd`, which seems to
-        # prompt for a password, so bypass that.
-        run: sudo tox -e smoke
+        run: tox -e smoke

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-python@v5
 
       - name: Install tox
-        run: pip install tox~=4.2
+        run: sudo pip install tox~=4.2
 
       - name: Run smoke tests
         # pytest-operator runs charmcraft pack with `sg lxd`, which seems to

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -22,9 +22,6 @@ jobs:
         cloud: ['lxd', 'microk8s']
 
     steps:
-      - name: Set up Juju
-        run: sudo snap install juju --channel=${{ matrix.juju-version }}
-
       - name: Set up LXD
         if: ${{ matrix.cloud }} == 'lxd'
         uses: canonical/setup-lxd@ce8decb3609c0a03c5abd5034d02a6c145e2076f
@@ -40,6 +37,9 @@ jobs:
           sudo microk8s status --wait-ready
           sudo microk8s enable hostpath-storage dns
           newgrp snap_microk8s
+
+      - name: Set up Juju
+        run: sudo snap install juju --channel=${{ matrix.juju-version }}
 
       - name: Bootstrap Juju controller
         run: juju bootstrap localhost

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        juju-version: ['2.9', '3', '4.0']
+        juju-version: ['2.9 --classic', '3', '4.0']
         charmcraft-version: ['2.x', '3.x']
 
     steps:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -23,13 +23,13 @@ jobs:
 
     steps:
       - name: Set up LXD
-        if: ${{ matrix.cloud }} == 'lxd'
+        if: matrix.cloud == 'lxd'
         uses: canonical/setup-lxd@ce8decb3609c0a03c5abd5034d02a6c145e2076f
         with:
           channel: 5.0/stable
 
       - name: Set up Microk8s
-        if: ${{ matrix.cloud }} == 'microk8s'
+        if: matrix.cloud == 'microk8s'
         run: |
           sudo snap install microk8s --classic
           sudo adduser $USER snap_microk8s
@@ -41,7 +41,12 @@ jobs:
       - name: Set up Juju
         run: sudo snap install juju --channel=${{ matrix.juju-version }}
 
-      - name: Bootstrap Juju controller
+      - name: Bootstrap Juju controller (k8s)
+        if: matrix.cloud == 'microk8s'
+        run: juju bootstrap localhost
+
+      - name: Bootstrap Juju controller (lxd)
+        if: matrix.cloud == 'lxd'
         run: juju bootstrap localhost
 
       - name: Install charmcraft

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -87,14 +87,14 @@ def pack(charm_dir: pathlib.Path):
 async def test_smoke(ops_test: OpsTest, base: str, charmcraft_version: int, name: str):
     """Verify that we can build and deploy charms from supported bases."""
     available_charmcraft_version = (
-        subprocess.run(['charmcraft', '--version'], check=True, capture_output=True)  # noqa: S607
+        subprocess.run(['charmcraft', 'version'], check=True, capture_output=True)  # noqa: S607
         .stdout.decode()
         .strip()
-        .rsplit()[1]
+        .rsplit()[-1]
         .split('.')
     )
-    if available_charmcraft_version[0] > str(charmcraft_version):
-        pytest.skip(f'charmcraft version {available_charmcraft_version} is too new for this test')
+    if int(available_charmcraft_version[0]) < charmcraft_version:
+        pytest.skip(f'charmcraft version {available_charmcraft_version} is too old for this test')
         return
     charmcraft_yaml = {
         2: CHARMCRAFT2_YAML,

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -86,6 +86,16 @@ def pack(charm_dir: pathlib.Path):
 )
 async def test_smoke(ops_test: OpsTest, base: str, charmcraft_version: int, name: str):
     """Verify that we can build and deploy charms from supported bases."""
+    available_charmcraft_version = (
+        subprocess.run(['charmcraft', '--version'], check=True, capture_output=True)  # noqa: S607
+        .stdout.decode()
+        .strip()
+        .rsplit()[1]
+        .split('.')
+    )
+    if available_charmcraft_version[0] > str(charmcraft_version):
+        pytest.skip(f'charmcraft version {available_charmcraft_version} is too new for this test')
+        return
     charmcraft_yaml = {
         2: CHARMCRAFT2_YAML,
         3: CHARMCRAFT3_YAML,

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -73,7 +73,7 @@ def pack(charm_dir: pathlib.Path):
         dest_name = charm_dir / charm.name
         charm.rename(dest_name)
     # With the way we use charmcraft, we know that there will only be one.
-    return dest_name
+    return dest_name.absolute()
 
 
 @pytest.mark.parametrize(

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -56,7 +56,7 @@ def pack(charm_dir: pathlib.Path):
     box in GitHub actions, and there isn't really any reason that it should be
     part of the plugin, so we just have a simple subprocess here.
     """
-    cmd = ['charmcraft', 'pack']
+    cmd = ['charmcraft', 'pack', '--verbose']
     # We need to use `sudo` in the GitHub actions environment, just as in
     # the pack test. `sg lxd -c` should work, but does not - perhaps because of
     # the way we are installing LXD?

--- a/tox.ini
+++ b/tox.ini
@@ -136,6 +136,7 @@ description = Run a smoke test against a Juju controller.
 allowlist_externals = juju
                       charmcraft
                       bash
+passenv = JUJU_VERSION
 deps =
     build
     coverage[toml]~=7.0
@@ -147,6 +148,8 @@ commands =
     python -m build --sdist --outdir={toxinidir}/test/charms/test_smoke/
     # Inject the tarball into the smoke test charm's requirements.
     bash -c 'echo "./$(ls -1 ./test/charms/test_smoke/ | grep tar.gz)" > ./test/charms/test_smoke/requirements.txt'
+    # If a specific Juju version is set, then make sure we are using that version of pylibjuju.
+    bash -c 'if [ -n "$JUJU_VERSION" ]; then pip install "juju ~= $JUJU_VERSION"; fi'
 
     # Run our smoke tests (this will build the charm, then run the tests).
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {toxinidir}/test/smoke/


### PR DESCRIPTION
We have some basic smoke tests, which are currently the only tests we regularly run against an actual Juju model. The tests deploy a basic charm and verify that it goes to `active` status (which happens in an `install` handler). However, these are currently only run if someone manually runs `tox -e smoke`. This PR adds running the tests on a schedule (currently monthly, in the days before we will likely do a release).

This tests:
 * Juju 3.5 (latest stable 3.x - I suggest we *change* this to 3.6 when that's released, rather than *adding* 3.6). The smoke tests do not currently work with Juju 2.9 (I'm not sure if it's worth adding that at this point), but if that changes, it should only require a matrix change in the workload. The smoke tests use python-libjuju, which doesn't yet support Juju 4.0, but when that changes, this should also only require a matrix change.
 * Charmcraft 2.x and 3.x.
 * LXD and MicroK8s.

The smoke test is changed to use a plain `subprocess.run` to pack the charm, rather than use pytest-operator for this. The `pytest-operator` approach doesn't work out-of-the-box in the workflow, and it seems cleaner to just do the pack ourselves.

There's an [example run on my fork](https://github.com/tonyandrewmeyer/operator/actions/runs/11006199263/job/30560942709).

This could be optimised in the future to store the packed charms and share them across Juju versions and cloud types, but it doesn't seem worth doing that for now.

Fixes #1322