### PR TITLE
docs: move Pebble to a separate page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ The library (`available on PyPI`_) provides:
 
 - :ref:`ops_module`, the API to respond to Juju events and manage the application;
 - :ref:`ops_main_entry_point`, used to initialise and run your charm;
-- :ref:`ops_pebble_module`, the Pebble client, a low-level API for Kubernetes containers;
+- :doc:`ops.pebble </pebble>`, the Pebble client, a low-level API for Kubernetes containers;
 - the APIs for unit testing charms in a simulated environment:
 
   - :doc:`State-transition testing </state-transition-testing>`. This is the
@@ -30,6 +30,7 @@ integrations with other services, and making the charm easier to test.
    :maxdepth: 2
 
    self
+   pebble
    state-transition-testing
    harness
 
@@ -55,15 +56,6 @@ legacy main module
 
 .. automodule:: ops.main
    :noindex:
-
-.. _ops_pebble_module:
-
-ops.pebble
-----------
-
-.. automodule:: ops.pebble
-
-.. _ops_testing_module:
 
 
 Indices

--- a/docs/pebble.rst
+++ b/docs/pebble.rst
@@ -1,6 +1,6 @@
 .. _ops_pebble_module:
 
-ops.pebble
-==========
+Pebble client
+=============
 
 .. automodule:: ops.pebble

--- a/docs/pebble.rst
+++ b/docs/pebble.rst
@@ -1,0 +1,6 @@
+.. _ops_pebble_module:
+
+ops.pebble
+==========
+
+.. automodule:: ops.pebble

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -14,7 +14,7 @@
 
 """The API to respond to Juju events and manage the application.
 
-This module provides core features to your charm, including:
+This API provides core features to your charm, including:
 
 - :class:`~ops.CharmBase`, the base class for charms and :class:`~ops.Object`,
   the base class for charm libraries.


### PR DESCRIPTION
Pros:
 * Significantly reduces the length of the right-hand sidebar for the main API reference
 * Clearly delineates ops.pebble, which could legitimately used independently of ops as a Python Pebble API
 * Separates duplication between ops.Container and ops.pebble into separate pages

Cons:
* Browser search-on-page is less useful (although we already started this process by splitting ops.testing out)
* Existing deep links into the docs will break (we should be able to find and fix the ones on juju.is/docs at least)