### PR TITLE
docs: use MaintenanceStatus for local issues

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -2352,7 +2352,7 @@ class Container:
             # Check that Pebble is still reachable now.
             container = self.unit.get_container("example")
             if not container.can_connect():
-                event.add_status(ops.WaitingStatus("Waiting for Pebble..."))
+                event.add_status(ops.MaintenanceStatus("Waiting for Pebble..."))
         """
         try:
             self._pebble.get_system_info()


### PR DESCRIPTION
`WaitingStatus` should be used when waiting on an integrated charm. `MaintenanceStatus` should be used when waiting for something local to the charm. We missed an example in `can_connect()` when clarifying the statuses earlier in the year.