### PR TITLE
ci: configure the labels for dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"  # This is hard-coded to the 1st of the month
+    labels:
+      - "dependencies"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0  # Security updates only
+    labels:
+      - "dependencies"


### PR DESCRIPTION
For GitHub actions dependabot PRs: only use the `dependencies` label, rather than both that and `github_actions`.

For pip (Python) dependabot PRs: we only have security dependabot PRs enabled, so add the same label restriction (avoiding a `python` label) but this requires adding a section to configure dependabot, and then essentially disabling most of it by setting the maximum PRs to 0 (security PRs will still be opened).