### PR TITLE
docs: the very start of a team Python style guide

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -23,7 +23,7 @@ tox
 tox -e unit
 tox -e unit test/test_charm.py
 
-# Format the code using isort and autopep8
+# Format the code using Ruff
 tox -e fmt
 
 # Compile the requirements.txt file for docs
@@ -164,6 +164,8 @@ a bunch of charms that use the operator framework. The script can be run locally
 
 Changes are proposed as [pull requests on GitHub](https://github.com/canonical/operator/pulls).
 
+For coding style, we follow [PEP 8](https://peps.python.org/pep-0008/) as well as a team [Python style guide](./STYLE.md).
+
 Pull requests should have a short title that follows the
 [conventional commit style](https://www.conventionalcommits.org/en/) using one of these types:
 
@@ -293,12 +295,7 @@ Static type checking is done using [pyright](https://github.com/microsoft/pyrigh
 and extends the Python 3.8 type hinting support through the
 [typing_extensions](https://pypi.org/project/typing-extensions/) package.
 
-Formatting uses [isort](https://pypi.org/project/isort/) and
-[autopep8](https://pypi.org/project/autopep8/), with linting also using
-[flake8](https://github.com/PyCQA/flake8), including the
-[docstrings](https://pypi.org/project/flake8-docstrings/),
-[builtins](https://pypi.org/project/flake8-builtins/) and
-[pep8-naming](https://pypi.org/project/pep8-naming/) extensions.
+Formatting uses [Ruff](https://docs.astral.sh/ruff/).
 
 All tool configuration is kept in [project.toml](pyproject.toml). The list of
 dependencies can be found in the relevant `tox.ini` environment `deps` field.

--- a/STYLE.md
+++ b/STYLE.md
@@ -18,7 +18,7 @@ Of course, this is just a start! We add to this list as things come up in code r
 
 ## Simplicity
 
-### Avoid nested comprehensions and generators
+### Avoid nested comprehensions and generator expressions
 
 "Flat is better than nested."
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -78,4 +78,4 @@ if status != pebble.ServiceStatus.ACTIVE:
 
 ### Spell out abbreviations
 
-Prefer spelling out abbreviations and acronymns in docstrings, for example, "for example" rather than "e.g.", "that is" rather than "i.e.", and "unit testing" rather than UT.
+Prefer spelling out abbreviations and acronyms in docstrings, for example, "for example" rather than "e.g.", "that is" rather than "i.e.", and "unit testing" rather than UT.

--- a/STYLE.md
+++ b/STYLE.md
@@ -17,7 +17,7 @@ Of course, this is just a start! We add to this list as things come up in code r
 
 ## Simplicity
 
-### Avoid nested loops and comprehensions
+### Avoid nested comprehensions
 
 "Flat is better than nested."
 
@@ -51,6 +51,8 @@ for current in active_statuses:
 
 This is six of one, half a dozen of the other, but we've decided that saying `if color == Color.RED` is nicer than `if color is Color.RED` as `==` is more typical for integer- and string-like values, and if you do use an `IntEnum` or `StrEnum` you should use `==` anyway.
 
+Note that the [Enum HOWTO](https://docs.python.org/3/howto/enum.html#comparisons) first says they should be compared by identity, but then shows that equality is defined too, and so kind of adds to the confusion. See also this [StackOverflow question](https://stackoverflow.com/questions/25858497/should-enum-instances-be-compared-by-identity-or-equality) and [some discussion/disagreement](https://github.com/pylint-dev/pylint/issues/5356).
+
 **Don't:**
 
 ```python
@@ -70,8 +72,6 @@ if status == pebble.ServiceStatus.ACTIVE:
 if status != pebble.ServiceStatus.ACTIVE:
 	print('Stopped')
 ```
-
-The [Enum HOWTO](https://docs.python.org/3/howto/enum.html#comparisons) first says they should be compared by identity, but then shows that equality is defined too, and so kind of adds to the confusion. See also this [StackOverflow question](https://stackoverflow.com/questions/25858497/should-enum-instances-be-compared-by-identity-or-equality) and [some discussion/disagreement](https://github.com/pylint-dev/pylint/issues/5356).
 
 
 ## Docs and docstrings

--- a/STYLE.md
+++ b/STYLE.md
@@ -6,7 +6,7 @@ We use Ruff for formatting, and run our code through the Pyright type checker. W
 
 New code should follow these guidelines, unless there's a good reason not to. Sometimes existing code doesn't follow these, but we're happy for it to be updated to do so (either all at once, or as you change nearby code).
 
-Of course, this is just a start! We add to this list as things come up in code review; this list reflects our team decision.
+Of course, this is just a start! We add to this list as things come up in code review; this list reflects our team decisions.
 
 
 **Table of contents:**
@@ -28,13 +28,10 @@ An exception is names from `typing` -- type annotations get too verbose if these
 **Don't:**
 
 ```python
-from subprocess import run
 from ops import CharmBase, PebbleReadyEvent
-import typing
+from subprocess import run
 
 class MyCharm(CharmBase):
-    counts: typing.Optional[typing.Tuple[str, int]]
-
     def _pebble_ready(self, event: PebbleReadyEvent):
         run(['echo', 'foo'])
 ```
@@ -42,15 +39,16 @@ class MyCharm(CharmBase):
 **Do:**
 
 ```python
-import subprocess
 import ops
-from typing import Optional, Tuple
+import subprocess
 
 class MyCharm(ops.CharmBase):
-    counts: Optional[Tuple[str, int]]
-
     def _pebble_ready(self, event: ops.PebbleReadyEvent):
-        run(['echo', 'foo'])
+        subprocess.run(['echo', 'foo'])
+
+# However, "from typing import Foo" is okay to avoid verbosity
+from typing import Optional, Tuple
+counts: Optional[Tuple[str, int]]
 ```
 
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -11,41 +11,9 @@ Of course, this is just a start! We add to this list as things come up in code r
 
 **Table of contents:**
 
-* [Simplicity](#simplicity)
 * [Specific decisions](#specific-decisions)
 * [Docs and docstrings](#docs-and-docstrings)
 
-
-## Simplicity
-
-### Avoid nested comprehensions and generator expressions
-
-"Flat is better than nested."
-
-**Don't:**
-
-```python
-units = [units for app in model.apps for unit in app.units]
-
-for current in (
-    status for status in pebble.ServiceStatus if status != pebble.ServiceStatus.ACTIVE
-):
-    ...
-```
-
-**Do:**
-
-```python
-units = []
-for app in model.apps:
-    for unit in app.units:
-        units.append(unit)
-
-for current in pebble.ServiceStatus:
-    if status == pebble.ServiceStatus.ACTIVE:
-        continue
-    ...
-```
 
 ## Specific decisions
 
@@ -83,6 +51,36 @@ class MyCharm(ops.CharmBase):
 
 	def _pebble_ready(self, event: ops.PebbleReadyEvent):
 		run(['echo', 'foo'])
+```
+
+
+### Avoid nested comprehensions and generator expressions
+
+"Flat is better than nested."
+
+**Don't:**
+
+```python
+units = [units for app in model.apps for unit in app.units]
+
+for current in (
+    status for status in pebble.ServiceStatus if status != pebble.ServiceStatus.ACTIVE
+):
+    ...
+```
+
+**Do:**
+
+```python
+units = []
+for app in model.apps:
+    for unit in app.units:
+        units.append(unit)
+
+for current in pebble.ServiceStatus:
+    if status == pebble.ServiceStatus.ACTIVE:
+        continue
+    ...
 ```
 
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -2,7 +2,7 @@
 
 This is the Python style guide we use for the Ops project. It's also the style we're converging on for other projects maintained by the Charm Tech team.
 
-We use Ruff for formatting, and run our code through the Pyright type checker. We also try to follow [PEP 8](https://peps.python.org/pep-0008/), the official Python style guide. However, PEP 8 is fairly low-level, so in addition we've come up with the following style guidelines.
+We use Ruff for formatting, and run our code through the Pyright type checker. We try to follow [PEP 8](https://peps.python.org/pep-0008/), the official Python style guide. However, PEP 8 is fairly low-level, so in addition we've come up with the following style guidelines.
 
 New code should follow these guidelines, unless there's a good reason not to. Sometimes existing code doesn't follow these, but we're happy for it to be updated to do so (either all at once, or as you change nearby code).
 
@@ -62,7 +62,7 @@ counts: Optional[Tuple[str, int]]
 units = [units for app in model.apps for unit in app.units]
 
 for current in (
-    status for status in pebble.ServiceStatus if status != pebble.ServiceStatus.ACTIVE
+    status for status in pebble.ServiceStatus if status is not pebble.ServiceStatus.ACTIVE
 ):
     ...
 ```
@@ -75,36 +75,34 @@ for app in model.apps:
     for unit in app.units:
         units.append(unit)
 
-for current in pebble.ServiceStatus:
-    if status == pebble.ServiceStatus.ACTIVE:
+for status in pebble.ServiceStatus:
+    if status is pebble.ServiceStatus.ACTIVE:
         continue
     ...
 ```
 
 
-### Compare enum values by equality
+### Compare enum values by identity
 
-This is six of one, half a dozen of the other, but we've decided that saying `if color == Color.RED` is nicer than `if color is Color.RED` as `==` is more typical for integer- and string-like values, and if you do use an `IntEnum` or `StrEnum` you should use `==` anyway.
-
-Note that the [Enum HOWTO](https://docs.python.org/3/howto/enum.html#comparisons) first says they should be compared by identity, but then shows that equality is defined too, and so kind of adds to the confusion. See also this [StackOverflow question](https://stackoverflow.com/questions/25858497/should-enum-instances-be-compared-by-identity-or-equality) and [some discussion/disagreement](https://github.com/pylint-dev/pylint/issues/5356).
+The [Enum HOWTO](https://docs.python.org/3/howto/enum.html#comparisons) says that "enum values are compared by identity", so we've decided to follow that. Note that this decision applies to regular `enum.Enum` values, not to `enum.IntEnum` or `enum.StrEnum` (the latter is only available from Python 3.11).
 
 **Don't:**
-
-```python
-if status is pebble.ServiceStatus.ACTIVE:
-    print('Running')
-
-if status is not pebble.ServiceStatus.ACTIVE:
-    print('Stopped')
-```
-
-**Do:**
 
 ```python
 if status == pebble.ServiceStatus.ACTIVE:
     print('Running')
 
 if status != pebble.ServiceStatus.ACTIVE:
+    print('Stopped')
+```
+
+**Do:**
+
+```python
+if status is pebble.ServiceStatus.ACTIVE:
+    print('Running')
+
+if status is not pebble.ServiceStatus.ACTIVE:
     print('Stopped')
 ```
 
@@ -120,4 +118,6 @@ It's a bit less clear when we're dealing with code and APIs, as those normally u
 
 ### Spell out abbreviations
 
-Prefer spelling out abbreviations and acronyms in docstrings, for example, "for example" rather than "e.g.", "that is" rather than "i.e.", "and so on" rather than "etc", and "unit testing" rather than UT.
+Abbreviations and acronyms in docstrings should usually be spelled out, for example, "for example" rather than "e.g.", "that is" rather than "i.e.", "and so on" rather than "etc", and "unit testing" rather than UT.
+
+However, it's okay to use acronyms that are very well known in our domain, like HTTP or JSON or RPC.

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,0 +1,81 @@
+
+# Ops Python style guide
+
+This is the Python style guide we use for the Ops project. However, it's also the style we're converging on for other projects maintained by the Charm Tech team.
+
+We use Ruff for formatting, and run our code through the Pyright type checker. We also try to follow [PEP 8](https://peps.python.org/pep-0008/), the official Python style guide. However, PEP 8 is fairly low-level, so in addition we've come up with the following style guidelines.
+
+Of course, this is just a start! We add to this list as things come up in code review and we make a team decision.
+
+
+**Table of contents:**
+
+* [Simplicity](#simplicity)
+* [Specific decisions](#specific-decisions)
+* [Docs and docstrings](#docs-and-docstrings)
+
+
+## Simplicity
+
+### Avoid nested loops and comprehensions
+
+"Flat is better than nested."
+
+**Don't:**
+
+```python
+units = [units for app in model.apps for unit in app.units]
+
+for current in (
+	status for status in pebble.ServiceStatus if status is not pebble.ServiceStatus.ACTIVE
+):
+	...
+```
+
+**Do:**
+
+```python
+units = []
+for app in model.apps:
+	for unit in app.units:
+		units.append(unit)
+
+active_statuses = [status for status in pebble.ServiceStatus if status != pebble.ServiceStatus.ACTIVE]
+for current in active_statuses:
+	...
+```
+
+## Specific decisions
+
+### Compare enum values by equality
+
+This is six of one, half a dozen of the other, but we've decided that saying `if color == Color.RED` is nicer than `if color is Color.RED` as `==` is more typical for integer- and string-like values, and if you do use an `IntEnum` or `StrEnum` you should use `==` anyway.
+
+**Don't:**
+
+```python
+if status is pebble.ServiceStatus.ACTIVE:
+	print('Running')
+
+if status is not pebble.ServiceStatus.ACTIVE:
+	print('Stopped')
+```
+
+**Do:**
+
+```python
+if status == pebble.ServiceStatus.ACTIVE:
+	print('Running')
+
+if status != pebble.ServiceStatus.ACTIVE:
+	print('Stopped')
+```
+
+The [Enum HOWTO](https://docs.python.org/3/howto/enum.html#comparisons) first says they should be compared by identity, but then shows that equality is defined too, and so kind of adds to the confusion. See also this [StackOverflow question](https://stackoverflow.com/questions/25858497/should-enum-instances-be-compared-by-identity-or-equality) and [some discussion/disagreement](https://github.com/pylint-dev/pylint/issues/5356).
+
+
+## Docs and docstrings
+
+### Spell out abbreviations
+
+Prefer spelling out abbreviations and acronymns in docstrings, for example, "for example" rather than "e.g.", "that is" rather than "i.e.", and "unit testing" rather than UT.

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,21 +1,21 @@
 # Ops Python style guide
 
-This is the Python style guide we use for the Ops project. However, it's also the style we're converging on for other projects maintained by the Charm Tech team.
+This is the Python style guide we use for the Ops project. It's also the style we're converging on for other projects maintained by the Charm Tech team.
 
 We use Ruff for formatting, and run our code through the Pyright type checker. We also try to follow [PEP 8](https://peps.python.org/pep-0008/), the official Python style guide. However, PEP 8 is fairly low-level, so in addition we've come up with the following style guidelines.
 
-New code should follow these guidelines, unless there's a good reason not to. Sometimes existing code doesn't follow these rules, but we're happy for it to be updated to do so (either all at once or as nearby code is changed).
+New code should follow these guidelines, unless there's a good reason not to. Sometimes existing code doesn't follow these, but we're happy for it to be updated to do so (either all at once, or as you change nearby code).
 
-Of course, this is just a start! We add to this list as things come up in code review and we make a team decision.
+Of course, this is just a start! We add to this list as things come up in code review; this list reflects our team decision.
 
 
 **Table of contents:**
 
-* [Specific decisions](#specific-decisions)
+* [Code decisions](#code-decisions)
 * [Docs and docstrings](#docs-and-docstrings)
 
 
-## Specific decisions
+## Code decisions
 
 ### Import modules, not objects
 
@@ -33,10 +33,10 @@ from ops import CharmBase, PebbleReadyEvent
 import typing
 
 class MyCharm(CharmBase):
-	counts: typing.Optional[typing.Tuple[str, int]]
+    counts: typing.Optional[typing.Tuple[str, int]]
 
-	def _pebble_ready(self, event: PebbleReadyEvent):
-		run(['echo', 'foo'])
+    def _pebble_ready(self, event: PebbleReadyEvent):
+        run(['echo', 'foo'])
 ```
 
 **Do:**
@@ -47,10 +47,10 @@ import ops
 from typing import Optional, Tuple
 
 class MyCharm(ops.CharmBase):
-	counts: Optional[Tuple[str, int]]
+    counts: Optional[Tuple[str, int]]
 
-	def _pebble_ready(self, event: ops.PebbleReadyEvent):
-		run(['echo', 'foo'])
+    def _pebble_ready(self, event: ops.PebbleReadyEvent):
+        run(['echo', 'foo'])
 ```
 
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -111,7 +111,7 @@ if status is not pebble.ServiceStatus.ACTIVE:
 
 ### Use British English
 
-[Canonical's documentation style](https://docs.ubuntu.com/styleguide/en/) is to use British spellings, and we try to follow that here. For example, "colour" rather than "color", "labelled" rather than "labeled", "serialise" rather than "serialize", and so on.
+[Canonical's documentation style](https://docs.ubuntu.com/styleguide/en/) uses British spelling, which we try to follow here. For example: "colour" rather than "color", "labelled" rather than "labeled", "serialise" rather than "serialize", and so on.
 
 It's a bit less clear when we're dealing with code and APIs, as those normally use US English, for example, `pytest.mark.parametrize`, and `color: #fff`.
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -27,9 +27,9 @@ Of course, this is just a start! We add to this list as things come up in code r
 units = [units for app in model.apps for unit in app.units]
 
 for current in (
-	status for status in pebble.ServiceStatus if status is not pebble.ServiceStatus.ACTIVE
+    status for status in pebble.ServiceStatus if status is not pebble.ServiceStatus.ACTIVE
 ):
-	...
+    ...
 ```
 
 **Do:**
@@ -37,12 +37,12 @@ for current in (
 ```python
 units = []
 for app in model.apps:
-	for unit in app.units:
-		units.append(unit)
+    for unit in app.units:
+        units.append(unit)
 
 active_statuses = [status for status in pebble.ServiceStatus if status != pebble.ServiceStatus.ACTIVE]
 for current in active_statuses:
-	...
+    ...
 ```
 
 ## Specific decisions
@@ -57,20 +57,20 @@ Note that the [Enum HOWTO](https://docs.python.org/3/howto/enum.html#comparisons
 
 ```python
 if status is pebble.ServiceStatus.ACTIVE:
-	print('Running')
+    print('Running')
 
 if status is not pebble.ServiceStatus.ACTIVE:
-	print('Stopped')
+    print('Stopped')
 ```
 
 **Do:**
 
 ```python
 if status == pebble.ServiceStatus.ACTIVE:
-	print('Running')
+    print('Running')
 
 if status != pebble.ServiceStatus.ACTIVE:
-	print('Stopped')
+    print('Stopped')
 ```
 
 


### PR DESCRIPTION
This adds the very start of a team Python style guide, with a few items we've discussed recently. The idea is to add as things come up (more than once) in PRs and we feel it's worth adding them to the style guide to avoid having to make a specific decision each time.

The specifics in this PR are up for debate. I feel fairly strongly about "avoid nested comprehensions" and "spell out abbreviations", but quite weakly about "Compare enum values by equality".

Another thing that's up for debate is where this should live. It's kind of a team style guide, but we don't really have a place for team stuff like this (yet), and I'd much prefer it in a .md file in a repo than a Google doc.