### PR TITLE
docs: set the READTHEDOCS context variable

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -139,8 +139,8 @@ html_context = {
     'sequential_nav': 'none',
 }
 # Addons-by-default, see: https://about.readthedocs.com/blog/2024/07/addons-by-default/
-if os.environ.get("READTHEDOCS", "") == "True":
-    html_context["READTHEDOCS"] = True
+if os.environ.get('READTHEDOCS', '') == 'True':
+    html_context['READTHEDOCS'] = True
 
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import os
 import pathlib
 import sys
 
@@ -137,6 +138,9 @@ html_context = {
     # Valid options: none, prev, next, both
     'sequential_nav': 'none',
 }
+# Addons-by-default, see: https://about.readthedocs.com/blog/2024/07/addons-by-default/
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
 
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.


### PR DESCRIPTION
As of October 7th, the `html_context` dictionary is meant to contain a `READTHEDOCS` key set to True if that's in the environment variables, so this change does that.

We may see small changes in the visual look of the docs but everything should keep working with this small adjustment.

[Instructions from Read the Docs](https://about.readthedocs.com/blog/2024/07/addons-by-default/)

Fixes #1393