### PR TITLE
docs: use our docs url for the ogp:url properties Sphinx generates

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -91,7 +91,7 @@ copyright = '%s, %s' % (datetime.date.today().year, author)  # noqa: A001
 # don't know yet)
 # NOTE: If no ogp_* variable is defined (e.g. if you remove this section) the
 # sphinxext.opengraph extension will be disabled.
-ogp_site_url = 'https://canonical-starter-pack.readthedocs-hosted.com/'
+ogp_site_url = 'https://ops.readthedocs.io/en/latest/'
 # The documentation website name (usually the same as the product name)
 ogp_site_name = project
 # The URL of an image or logo that is used in the preview


### PR DESCRIPTION
Currently we use the [Open Graph configuration](https://github.com/canonical/operator/blob/df9afbe28a1dff24ffc0e4f58a6fcb1cf5560ac6/docs/custom_conf.py#L88C1-L98C82) from the canonical-starter-pack without any modifications, but we should use the hosting url for our docs instead of theirs.

The Open Graph configuration is used by Sphinx to generate the Open Graph Protocol (ogp) properties in our docs pages. This information is used when generating link previews, for example when linking to our docs in Mattermost messages:
![image](https://github.com/user-attachments/assets/82d5c3ad-86e7-4103-96ad-a4105f825bf0)

The `ogp:url` properties are incorrect, e.g. 
```html
<meta property="og:url" content="https://canonical-starter-pack.readthedocs-hosted.com/state-transition-testing.html" />
```

In practice these urls seem to be ignored in link previews, but let's fix them anyway since it's simple.