### PR TITLE
chore: Python 3.13 has been released, remove allow-prerelease

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.10", "3.12", "3.13"]
+        python-version: ["3.8", "3.10", "3.12", "3.13", "3.14.0a1"]
         exclude:
         - {python-version: "3.8", os: "macos-latest"}  # macos-14 is arm64, and there's no Python 3.8 build for arm64
 
@@ -55,6 +55,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install tox
         run: pip install tox~=4.2
@@ -68,7 +69,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.10", "3.12", "3.13"]
+        python-version: ["3.8", "3.10", "3.12", "3.13", "3.14.0a1"]
 
     steps:
       - uses: actions/checkout@v4
@@ -76,6 +77,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.10", "3.12", "3.13", "3.14.0a1"]
+        python-version: ["3.8", "3.10", "3.12", "3.13", "3.14.0-alpha.1"]
         exclude:
         - {python-version: "3.8", os: "macos-latest"}  # macos-14 is arm64, and there's no Python 3.8 build for arm64
 
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.10", "3.12", "3.13", "3.14.0a1"]
+        python-version: ["3.8", "3.10", "3.12", "3.13", "3.14.0-alpha.1"]
 
     steps:
       - uses: actions/checkout@v4
@@ -122,7 +122,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
 
       - name: Install build dependencies
         run: pip install wheel build

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.10", "3.12", "3.13", "3.14.0-alpha.1"]
+        python-version: ["3.8", "3.10", "3.12"]
         exclude:
         - {python-version: "3.8", os: "macos-latest"}  # macos-14 is arm64, and there's no Python 3.8 build for arm64
 
@@ -55,7 +55,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
 
       - name: Install tox
         run: pip install tox~=4.2
@@ -69,7 +68,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.10", "3.12", "3.13", "3.14.0-alpha.1"]
+        python-version: ["3.8", "3.10", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -77,7 +76,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.10", "3.12"]
+        python-version: ["3.8", "3.10", "3.12", "3.13"]
         exclude:
         - {python-version: "3.8", os: "macos-latest"}  # macos-14 is arm64, and there's no Python 3.8 build for arm64
 
@@ -68,7 +68,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.10", "3.12"]
+        python-version: ["3.8", "3.10", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Python 3.13 has been released yesterday.
Let's enable it in our CI.