### PR TITLE
docs: fix rtd ad placement

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -139,8 +139,15 @@ html_context = {
     'sequential_nav': 'none',
 }
 # Addons-by-default, see: https://about.readthedocs.com/blog/2024/07/addons-by-default/
-# if os.environ.get('READTHEDOCS', '') == 'True':
-#     html_context['READTHEDOCS'] = True
+if os.environ.get('READTHEDOCS', '') == 'True':
+    html_context['READTHEDOCS'] = True
+    html_context["current_version"] = "latest"
+    html_context["conf_py_path"] = "/docs/"
+    html_context["display_github"] = True
+    html_context["github_user"] = "canonical"
+    html_context["github_repo"] = "operator"
+    html_context["github_version"] = "main"
+    html_context["slug"] = "operator"
 
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -139,8 +139,8 @@ html_context = {
     'sequential_nav': 'none',
 }
 # Addons-by-default, see: https://about.readthedocs.com/blog/2024/07/addons-by-default/
-if os.environ.get('READTHEDOCS', '') == 'True':
-    html_context['READTHEDOCS'] = True
+# if os.environ.get('READTHEDOCS', '') == 'True':
+#     html_context['READTHEDOCS'] = True
 
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -141,13 +141,14 @@ html_context = {
 # Addons-by-default, see: https://about.readthedocs.com/blog/2024/07/addons-by-default/
 if os.environ.get('READTHEDOCS', '') == 'True':
     html_context['READTHEDOCS'] = True
-    html_context["current_version"] = "latest"
-    html_context["conf_py_path"] = "/docs/"
-    html_context["display_github"] = True
-    html_context["github_user"] = "canonical"
-    html_context["github_repo"] = "operator"
-    html_context["github_version"] = "main"
-    html_context["slug"] = "operator"
+    # The following are needed, see: https://github.com/pradyunsg/furo/blob/main/docs/conf.py#L135.
+    html_context['current_version'] = 'latest'
+    html_context['conf_py_path'] = '/docs/'
+    html_context['display_github'] = True
+    html_context['github_user'] = 'canonical'
+    html_context['github_repo'] = 'operator'
+    html_context['github_version'] = 'main'
+    html_context['slug'] = 'operator'
 
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.


### PR DESCRIPTION
Fixing the issue where the ad doesn't show up on the left navigation bar even if there is empty space for it.

See the issue here: https://github.com/canonical/operator/issues/1393, and the related PR: https://github.com/canonical/operator/pull/1410.

Preview: https://ops--1414.org.readthedocs.build/en/1414/.