### PR TITLE
ci: disable the automatic ops-scenario releasing

### DIFF
--- a/.github/workflows/build_scenario_wheels.yaml
+++ b/.github/workflows/build_scenario_wheels.yaml
@@ -1,9 +1,10 @@
 name: Build ops-scenario wheels
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch
+#  push:
+#    branches:
+#      - main
 
 jobs:
   build_wheel:

--- a/.github/workflows/build_scenario_wheels.yaml
+++ b/.github/workflows/build_scenario_wheels.yaml
@@ -1,5 +1,8 @@
 name: Build ops-scenario wheels
 
+# TODO: adjust this workflow to properly build ops-scenario from the operator repo
+# and then this should be adjusted to run when appropriate (not on push to main
+# any more, but as part of the releasing workflow we agree on).
 on:
   workflow_dispatch
 #  push:


### PR DESCRIPTION
This hasn't been fully updated to handle the location in the merged repo, but has been enough to wrongly release an `ops.version.version` release (and tag) on merge to main.

Disable this for now so that we don't accidentally have another `ops.version.version` release. I'll do a follow-up PR that properly implements ops-scenario releasing alongside ops releases.