### PR TITLE
docs: clarify where StoredState is stored, and the upgrade behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Things to note:
 ```python
 import ops
 
+
 class OpsExampleCharm(ops.CharmBase):
     """Charm the service."""
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Things to note:
 ```python
 import ops
 
-
 class OpsExampleCharm(ops.CharmBase):
     """Charm the service."""
 

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -371,7 +371,4 @@ Args:
         Podspec charms that haven't previously used local storage and that
         are running on a new enough Juju default to controller-side storage,
         and local storage otherwise.
-
-.. jujuremoved:: 4.0
-    The ``use_juju_for_storage`` argument is not available from Juju 4.0
 """

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -1148,9 +1148,9 @@ class StoredState:
                 self._stored.seen.add(event.uuid)
 
     Data is stored alongside the charm (in the charm container for Kubernetes
-    sidecar charms, and on the machine for machine charms), except for podspec
-    charms and charms explicitly passing `True` for `use_juju_for_storage` when
-    running :meth:`ops.main` (in those cases, the data is stored in Juju).
+    sidecar charms, and on the machine for machine charms). The exceptions are
+    two deprecated cases: Kubernetes podspec charms, and charms explicitly
+    passing `True` for `use_juju_for_storage` when running :meth:`ops.main`.
 
     For machine charms, charms are upgraded in-place on the machine, so the data
     is preserved. For Kubernetes sidecar charms, when the charm is upgraded, the

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -1254,7 +1254,7 @@ class StoredDict(typing.MutableMapping[Hashable, Any]):
 
     Charms are not expected to use this class directly. Adding a
     :class:`StoredState` attribute to a charm class will automatically use this
-    class to store dictionary-like data.
+    class to store dictionaries.
     """
 
     def __init__(self, stored_data: StoredStateData, under: Dict[Hashable, Any]):
@@ -1294,7 +1294,7 @@ class StoredList(typing.MutableSequence[Any]):
 
     Charms are not expected to use this class directly. Adding a
     :class:`StoredState` attribute to a charm class will automatically use this
-    class to store list-like data.
+    class to store lists.
     """
 
     def __init__(self, stored_data: StoredStateData, under: List[Any]):
@@ -1373,7 +1373,7 @@ class StoredSet(typing.MutableSet[Any]):
 
     Charms are not expected to use this class directly. Adding a
     :class:`StoredState` attribute to a charm class will automatically use this
-    class to store set-like data.
+    class to store sets.
     """
 
     def __init__(self, stored_data: StoredStateData, under: Set[Any]):


### PR DESCRIPTION
Adjustments to the `StoredState` documentation:

* For `StoredDict`, `StoredList`, and `StoredSet`, note that charms would not normally create these directly and would use `StoredState` instead.
* Explain where the data is stored (there is one case that it doesn't mention, where there is already a unit-state DB locally, but I think that complicates things too much to specify here).
* Explain what happens when the charm is upgraded and recommend using a peer relation over stored state for K8s charms that want data preserved across upgrades.

As a related drive-by: remove the `jujuremoved` tag for `use_juju_for_storage`, since this won't actually be going away with Juju 4.0.

Fixes #1270