### PR TITLE
fix: raise ModelError on unknown/error status set in Scenario

### DIFF
--- a/testing/src/mocking.py
+++ b/testing/src/mocking.py
@@ -368,15 +368,15 @@ class _MockModelBackend(_ModelBackend):  # type: ignore
 
     def status_set(
         self,
-        status: _RawStatusLiteral,
+        status: _SettableStatusName,
         message: str = "",
         *,
         is_app: bool = False,
     ):
-        if status not in get_args(_SettableStatusName):
+        valid_names = get_args(_SettableStatusName)
+        if status not in valid_names:
             raise ModelError(
-                f'ERROR invalid status "{status}", expected one of '
-                f"[maintenance blocked waiting active]"
+                f'ERROR invalid status "{status}", expected one of [{", ".join(valid_names)}]',
             )
         self._context._record_status(self._state, is_app)
         status_obj = _EntityStatus.from_status_name(status, message)

--- a/testing/src/mocking.py
+++ b/testing/src/mocking.py
@@ -62,7 +62,6 @@ from scenario.state import (
     _EntityStatus,
     _port_cls_by_protocol,
     _RawPortProtocolLiteral,
-    _RawStatusLiteral,
 )
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/testing/src/mocking.py
+++ b/testing/src/mocking.py
@@ -376,7 +376,7 @@ class _MockModelBackend(_ModelBackend):  # type: ignore
         if status not in get_args(_SettableStatusName):
             raise ModelError(
                 f'ERROR invalid status "{status}", expected one of '
-                f'[maintenance blocked waiting active]'
+                f"[maintenance blocked waiting active]"
             )
         self._context._record_status(self._state, is_app)
         status_obj = _EntityStatus.from_status_name(status, message)

--- a/testing/src/mocking.py
+++ b/testing/src/mocking.py
@@ -20,6 +20,7 @@ from typing import (
     Tuple,
     Union,
     cast,
+    get_args,
 )
 
 from ops import JujuVersion, pebble
@@ -42,6 +43,7 @@ from ops.model import (
     SecretRotate,
     _format_action_result_dict,
     _ModelBackend,
+    _SettableStatusName,
 )
 from ops.pebble import Client, ExecError
 
@@ -371,6 +373,11 @@ class _MockModelBackend(_ModelBackend):  # type: ignore
         *,
         is_app: bool = False,
     ):
+        if status not in get_args(_SettableStatusName):
+            raise ModelError(
+                f'ERROR invalid status "{status}", expected one of '
+                f'[maintenance blocked waiting active]'
+            )
         self._context._record_status(self._state, is_app)
         status_obj = _EntityStatus.from_status_name(status, message)
         self._state._update_status(status_obj, is_app)

--- a/testing/tests/test_e2e/test_status.py
+++ b/testing/tests/test_e2e/test_status.py
@@ -13,6 +13,7 @@ from scenario.state import (
     UnknownStatus,
     WaitingStatus,
 )
+from scenario.errors import UncaughtCharmError
 from ..helpers import trigger
 
 
@@ -169,3 +170,48 @@ def test_status_comparison(status):
     assert isinstance(status, type(ops_status))
     # The repr of the scenario and ops classes should be identical.
     assert repr(status) == repr(ops_status)
+
+
+@pytest.mark.parametrize(
+    "status",
+    (
+        ActiveStatus("foo"),
+        WaitingStatus("bar"),
+        BlockedStatus("baz"),
+        MaintenanceStatus("qux"),
+    ),
+)
+def set_status_success(status: ops.StatusBase):
+    class MyCharm(CharmBase):
+        def __init__(self, framework: Framework):
+            super().__init__(framework)
+            framework.observe(self.on.update_status, self._on_update_status)
+
+        def _on_update_status(self, _):
+            self.unit.status = status
+
+    ctx = Context(MyCharm, meta={"name": "foo"})
+    ctx.run(ctx.on.update_status(), State())
+
+
+@pytest.mark.parametrize(
+    "status",
+    (
+        ErrorStatus("fiz"),
+        UnknownStatus(),
+    ),
+)
+def test_status_error(status: ops.StatusBase):
+    class MyCharm(CharmBase):
+        def __init__(self, framework: Framework):
+            super().__init__(framework)
+            framework.observe(self.on.update_status, self._on_update_status)
+
+        def _on_update_status(self, _):
+            self.unit.status = status
+
+    ctx = Context(MyCharm, meta={"name": "foo"})
+    with pytest.raises(UncaughtCharmError) as excinfo:
+        ctx.run(ctx.on.update_status(), State())
+    assert isinstance(excinfo.value.__cause__, ops.ModelError)
+    assert f'invalid status "{status.name}"' in str(excinfo.value.__cause__)

--- a/testing/tests/test_e2e/test_status.py
+++ b/testing/tests/test_e2e/test_status.py
@@ -181,7 +181,7 @@ def test_status_comparison(status):
         MaintenanceStatus("qux"),
     ),
 )
-def set_status_success(status: ops.StatusBase):
+def test_status_success(status: ops.StatusBase):
     class MyCharm(CharmBase):
         def __init__(self, framework: Framework):
             super().__init__(framework)


### PR DESCRIPTION
This copies across the fix from Harness to also be present in Scenario: if `status_set` is passed anything other than the valid statuses, then `ModelError` is raised (to better mimic what the Juju hook would actually do).

Closes https://github.com/canonical/ops-scenario/issues/202 (rather than copying it over to this repo).