### PR TITLE
chore: upgrade ruff to v0.7.0

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -716,7 +716,7 @@ class Framework(Object):
             parent_path = parent.path
 
         kind_: str = kind or cls.handle_kind
-        self._type_registry[(parent_path, kind_)] = cls
+        self._type_registry[parent_path, kind_] = cls
         self._type_known.add(cls)
 
     def save_snapshot(self, value: Union['StoredStateData', 'EventBase']):

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -3216,8 +3216,6 @@ class _FilesParser:
         self._parser.feed(data)
 
     def _prepare_tempfile(self, filename: str):
-        # TODO: Remove noqa SIM115 when the following issue is fixed.
-        # https://github.com/astral-sh/ruff/issues/7313
         tf = tempfile.NamedTemporaryFile(delete=False)  # noqa: SIM115
         self._files[filename] = tf  # type: ignore # we have a custom protocol for it
         self.current_filename = filename

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -3216,7 +3216,9 @@ class _FilesParser:
         self._parser.feed(data)
 
     def _prepare_tempfile(self, filename: str):
-        tf = tempfile.NamedTemporaryFile(delete=False)
+        # TODO: Remove noqa SIM115 when the following issue is fixed.
+        # https://github.com/astral-sh/ruff/issues/7313
+        tf = tempfile.NamedTemporaryFile(delete=False)  # noqa: SIM115
         self._files[filename] = tf  # type: ignore # we have a custom protocol for it
         self.current_filename = filename
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,10 +171,10 @@ ignore = [
     "RUF015",
     # Mutable class attributes should be annotated with `typing.ClassVar`
     "RUF012",
-    # Unnecessary dict comprehension for iterable; use `dict.fromkeys` instead
-    "C420",
     # Unnecessary `tuple` call (rewrite as a literal)
     "C408",
+    # Unnecessary dict comprehension for iterable; use `dict.fromkeys` instead
+    "C420",
 ]
 
 [tool.ruff.lint.pyupgrade]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,7 @@ ignore = [
     # Mutable class attributes should be annotated with `typing.ClassVar`
     "RUF012",
     # Unnecessary dict comprehension for iterable; use `dict.fromkeys` instead
-    "RUF025",
+    "C420",
     # Unnecessary `tuple` call (rewrite as a literal)
     "C408",
 ]

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1231,8 +1231,6 @@ class _TestMainWithDispatch(_TestMain):
         request: pytest.FixtureRequest,
         fake_script: FakeScript,
     ):
-        # TODO: Remove noqa SIM115 when the following issue is fixed.
-        # https://github.com/astral-sh/ruff/issues/7313
         self.stdout = self.stderr = tempfile.TemporaryFile()  # noqa: SIM115
         request.addfinalizer(self.stdout.close)
 
@@ -1385,8 +1383,6 @@ class TestMainWithDispatch(_TestMainWithDispatch):
     @pytest.mark.usefixtures('setup_charm')
     def test_crash_action(self, request: pytest.FixtureRequest, fake_script: FakeScript):
         self._prepare_actions()
-        # TODO: Remove noqa SIM115 when the following issue is fixed.
-        # https://github.com/astral-sh/ruff/issues/7313
         self.stderr = tempfile.TemporaryFile('w+t')  # noqa: SIM115
         request.addfinalizer(self.stderr.close)
         fake_script.write('action-get', "echo '{}'")

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1231,7 +1231,9 @@ class _TestMainWithDispatch(_TestMain):
         request: pytest.FixtureRequest,
         fake_script: FakeScript,
     ):
-        self.stdout = self.stderr = tempfile.TemporaryFile()
+        # TODO: Remove noqa SIM115 when the following issue is fixed.
+        # https://github.com/astral-sh/ruff/issues/7313
+        self.stdout = self.stderr = tempfile.TemporaryFile()  # noqa: SIM115
         request.addfinalizer(self.stdout.close)
 
         fake_script_hooks = FakeScript(request, self.hooks_dir)
@@ -1383,7 +1385,9 @@ class TestMainWithDispatch(_TestMainWithDispatch):
     @pytest.mark.usefixtures('setup_charm')
     def test_crash_action(self, request: pytest.FixtureRequest, fake_script: FakeScript):
         self._prepare_actions()
-        self.stderr = tempfile.TemporaryFile('w+t')
+        # TODO: Remove noqa SIM115 when the following issue is fixed.
+        # https://github.com/astral-sh/ruff/issues/7313
+        self.stderr = tempfile.TemporaryFile('w+t')  # noqa: SIM115
         request.addfinalizer(self.stderr.close)
         fake_script.write('action-get', "echo '{}'")
         with pytest.raises(subprocess.CalledProcessError):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -2808,7 +2808,9 @@ class TestModelBackend:
         version: str,
     ):
         # on 2.7.0+, things proceed as expected
-        t = tempfile.NamedTemporaryFile()
+        # TODO: Remove noqa SIM115 when the following issue is fixed.
+        # https://github.com/astral-sh/ruff/issues/7313
+        t = tempfile.NamedTemporaryFile()  # noqa: SIM115
         try:
             fake_script.write(
                 'relation-set',

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -2808,8 +2808,6 @@ class TestModelBackend:
         version: str,
     ):
         # on 2.7.0+, things proceed as expected
-        # TODO: Remove noqa SIM115 when the following issue is fixed.
-        # https://github.com/astral-sh/ruff/issues/7313
         t = tempfile.NamedTemporaryFile()  # noqa: SIM115
         try:
             fake_script.write(

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -3691,9 +3691,11 @@ class TestExec:
         assert io_ws.sends == []
 
     def test_wait_file_io(self, client: MockClient):
-        fin = tempfile.TemporaryFile(mode='w+', encoding='utf-8')
-        out = tempfile.TemporaryFile(mode='w+', encoding='utf-8')
-        err = tempfile.TemporaryFile(mode='w+', encoding='utf-8')
+        # TODO: Remove noqa SIM115 when the following issue is fixed.
+        # https://github.com/astral-sh/ruff/issues/7313
+        fin = tempfile.TemporaryFile(mode='w+', encoding='utf-8')  # noqa: SIM115
+        out = tempfile.TemporaryFile(mode='w+', encoding='utf-8')  # noqa: SIM115
+        err = tempfile.TemporaryFile(mode='w+', encoding='utf-8')  # noqa: SIM115
         try:
             fin.write('foo\n')
             fin.seek(0)

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -3691,8 +3691,6 @@ class TestExec:
         assert io_ws.sends == []
 
     def test_wait_file_io(self, client: MockClient):
-        # TODO: Remove noqa SIM115 when the following issue is fixed.
-        # https://github.com/astral-sh/ruff/issues/7313
         fin = tempfile.TemporaryFile(mode='w+', encoding='utf-8')  # noqa: SIM115
         out = tempfile.TemporaryFile(mode='w+', encoding='utf-8')  # noqa: SIM115
         err = tempfile.TemporaryFile(mode='w+', encoding='utf-8')  # noqa: SIM115

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -441,8 +441,6 @@ class TestJujuStateBackend:
         assert fake_script.calls(clear=True) == []
 
     def test_set_encodes_args(self, fake_script: FakeScript):
-        # TODO: Remove noqa SIM115 when the following issue is fixed.
-        # https://github.com/astral-sh/ruff/issues/7313
         t = tempfile.NamedTemporaryFile()  # noqa: SIM115
         try:
             fake_script.write(
@@ -480,8 +478,6 @@ class TestJujuStateBackend:
         ]
 
     def test_set_and_get_complex_value(self, fake_script: FakeScript):
-        # TODO: Remove noqa SIM115 when the following issue is fixed.
-        # https://github.com/astral-sh/ruff/issues/7313
         t = tempfile.NamedTemporaryFile()  # noqa: SIM115
         try:
             fake_script.write(

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -441,7 +441,9 @@ class TestJujuStateBackend:
         assert fake_script.calls(clear=True) == []
 
     def test_set_encodes_args(self, fake_script: FakeScript):
-        t = tempfile.NamedTemporaryFile()
+        # TODO: Remove noqa SIM115 when the following issue is fixed.
+        # https://github.com/astral-sh/ruff/issues/7313
+        t = tempfile.NamedTemporaryFile()  # noqa: SIM115
         try:
             fake_script.write(
                 'state-set',
@@ -478,7 +480,9 @@ class TestJujuStateBackend:
         ]
 
     def test_set_and_get_complex_value(self, fake_script: FakeScript):
-        t = tempfile.NamedTemporaryFile()
+        # TODO: Remove noqa SIM115 when the following issue is fixed.
+        # https://github.com/astral-sh/ruff/issues/7313
+        t = tempfile.NamedTemporaryFile()  # noqa: SIM115
         try:
             fake_script.write(
                 'state-set',

--- a/tox.ini
+++ b/tox.ini
@@ -60,14 +60,14 @@ commands =
 [testenv:fmt]
 description = Apply coding style standards to code
 deps =
-    ruff==0.4.5
+    ruff==0.7.0
 commands =
     ruff format --preview
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    ruff==0.4.5
+    ruff==0.7.0
     codespell==2.3.0
 commands =
     ruff check --preview


### PR DESCRIPTION
Currently, we are using ruff 0.4.5 but recently 0.7.0 was released, this PR upgrades ruff to 0.7.0 for both formatting and linting.

Closes https://github.com/canonical/operator/issues/1335.