### PR TITLE
chore: fix ci warnings

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -30,6 +30,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Python 3
         uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Install tox
         run: pip install tox~=4.2
@@ -79,6 +81,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
+          # To suppress the "Restore cache failed" error, since there is no go.sum file here.
+          cache: false
 
       - name: Install tox
         run: pip install tox~=4.2


### PR DESCRIPTION
Fix Python version warnings and go cache warnings in github actions.

Closes https://github.com/canonical/operator/issues/1346.

On the go cache warning: By default [the cache is enabled](https://github.com/actions/setup-go/blob/main/action.yml#L15), but in our case, since we only need go to install Pebble and there is no `go.sum` file, there is no need for the cache, see the logic [in the code here](https://github.com/actions/setup-go/blob/main/src/main.ts#L67-L79). So I am disabling the cache explicitly, which should not make the actions run slower but should suppress the warnings.

See a successful run [here](https://github.com/canonical/operator/actions/runs/11402361559) and there is no more warnings.