### PR TITLE
ci: use the actual poetry command, rather than manually tweaking the file

### DIFF
--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -59,17 +59,11 @@ jobs:
         with:
           repository: ${{ matrix.charm-repo }}
 
-      - name: Checkout the operator repository
-        uses: actions/checkout@v4
-        with:
-          path: myops
-
       - name: Install patch dependencies
         run: pip install poetry~=1.6
 
       - name: Update 'ops' dependency in test charm to latest
         run: |
-          rm -rf myops/test
           if [ -e "test-requirements.txt" ]; then
             sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" test-requirements.txt
             echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> test-requirements.txt
@@ -82,8 +76,7 @@ jobs:
             sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" requirements.txt
             echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
           elif [ -e "poetry.lock" ]; then
-            sed -i -e "s/^ops[ ><=].*/ops = {path = \"myops\"}/" pyproject.toml
-            poetry lock --no-update
+            poetry add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@GITHUB_SHA --lock
           else
             echo "Error: No requirements.txt or poetry.lock file found"
             exit 1
@@ -111,14 +104,8 @@ jobs:
       - name: Charmcraft init
         run: charmcraft init --profile=${{ matrix.profile }} --author=charm-tech
 
-      - name: Checkout the operator repository
-        uses: actions/checkout@v4
-        with:
-          path: myops
-
       - name: Update 'ops' dependency in test charm to latest
         run: |
-          rm -rf myops/test
           if [ -e "requirements.txt" ]; then
             sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" requirements.txt
             echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
@@ -129,3 +116,6 @@ jobs:
 
       - name: Run the charm's unit tests
         run: tox -vve unit
+
+      - name: Run the charm's static tests
+        run: tox -vve static


### PR DESCRIPTION
When handling charms that used poetry, the workflow would do a clone of the ops repo, tweak the poetry.lock file to include it and then re-lock. This leaves a copy of the ops repo around, and sometimes the ops tests get picked up by pytest, which is not what we want here.

The PR changes this to use the proper `poetry add` functionality to add the appropriate version of ops, in the same way that the requirements.txt files are updated.

Additional related fixes:
 * The test runs for the charmcraft profiles also had the operator clone but never used it, so remove that.
 * The charmcraft profile can safely run the static checks (since the charms are so minimal), and that would have caught an issue previously, so add that.