### PR TITLE
feat: Make Context and Manager variadic types

### DIFF
--- a/testing/src/scenario/context.py
+++ b/testing/src/scenario/context.py
@@ -14,7 +14,6 @@ from typing import (
     Any,
     Callable,
     Mapping,
-    cast,
 )
 
 import ops
@@ -79,7 +78,7 @@ class Manager(Generic[CharmType]):
 
         self._emitted: bool = False
 
-        self.ops: Ops | None = None
+        self.ops: Ops[CharmType] | None = None
 
     @property
     def charm(self) -> CharmType:
@@ -87,11 +86,11 @@ class Manager(Generic[CharmType]):
 
         The charm is only available during the context manager scope.
         """
-        if not self.ops:
+        if self.ops is None or self.ops.charm is None:
             raise RuntimeError(
                 "you should __enter__ this context manager before accessing this",
             )
-        return cast(CharmType, self.ops.charm)
+        return self.ops.charm
 
     @property
     def _runner(self):
@@ -565,7 +564,7 @@ class Context(Generic[CharmType]):
         else:
             self.unit_status_history.append(state.unit_status)
 
-    def __call__(self, event: _Event, state: State):
+    def __call__(self, event: _Event, state: State) -> Manager[CharmType]:
         """Context manager to introspect live charm object before and after the event is emitted.
 
         Usage::

--- a/testing/src/scenario/context.py
+++ b/testing/src/scenario/context.py
@@ -9,6 +9,7 @@ import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from typing import (
+    Generic,
     TYPE_CHECKING,
     Any,
     Callable,
@@ -43,7 +44,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from .ops_main_mock import Ops
     from .state import (
         AnyJson,
-        CharmType,
         JujuLogLine,
         RelationBase,
         State,
@@ -55,7 +55,7 @@ logger = scenario_logger.getChild("runtime")
 _DEFAULT_JUJU_VERSION = "3.5"
 
 
-class Manager:
+class Manager(Generic[CharmType]):
     """Context manager to offer test code some runtime charm object introspection.
 
     This class should not be instantiated directly: use a :class:`Context`
@@ -69,7 +69,7 @@ class Manager:
 
     def __init__(
         self,
-        ctx: Context,
+        ctx: Context[CharmType],
         arg: _Event,
         state_in: State,
     ):
@@ -82,7 +82,7 @@ class Manager:
         self.ops: Ops | None = None
 
     @property
-    def charm(self) -> ops.CharmBase:
+    def charm(self) -> CharmType:
         """The charm object instantiated by ops to handle the event.
 
         The charm is only available during the context manager scope.
@@ -91,7 +91,7 @@ class Manager:
             raise RuntimeError(
                 "you should __enter__ this context manager before accessing this",
             )
-        return cast(ops.CharmBase, self.ops.charm)
+        return cast(CharmType, self.ops.charm)
 
     @property
     def _runner(self):
@@ -355,7 +355,7 @@ class CharmEvents:
         return _Event(f"{name}_action", action=_Action(name, **kwargs))
 
 
-class Context:
+class Context(Generic[CharmType]):
     """Represents a simulated charm's execution context.
 
     The main entry point to running a test. It contains:

--- a/testing/src/scenario/ops_main_mock.py
+++ b/testing/src/scenario/ops_main_mock.py
@@ -6,7 +6,7 @@ import inspect
 import os
 import pathlib
 import sys
-from typing import TYPE_CHECKING, Any, Optional, Sequence, Type, cast
+from typing import TYPE_CHECKING, Any, Generic, Optional, Sequence, Type, cast
 
 import ops.charm
 import ops.framework
@@ -22,10 +22,11 @@ from ops.charm import CharmMeta
 from ops.log import setup_root_logging
 
 from .errors import BadOwnerPath, NoObserverError
+from .state import CharmType
 
 if TYPE_CHECKING:  # pragma: no cover
     from .context import Context
-    from .state import CharmType, State, _CharmSpec, _Event
+    from .state import State, _CharmSpec, _Event
 
 # pyright: reportPrivateUsage=false
 
@@ -95,7 +96,7 @@ def setup_framework(
     charm_dir: pathlib.Path,
     state: "State",
     event: "_Event",
-    context: "Context",
+    context: "Context[CharmType]",
     charm_spec: "_CharmSpec[CharmType]",
 ):
     from .mocking import _MockModelBackend
@@ -170,7 +171,7 @@ def setup_charm(
 def setup(
     state: "State",
     event: "_Event",
-    context: "Context",
+    context: "Context[CharmType]",
     charm_spec: "_CharmSpec[CharmType]",
 ):
     """Setup dispatcher, framework and charm objects."""
@@ -188,14 +189,14 @@ def setup(
     return dispatcher, framework, charm
 
 
-class Ops:
+class Ops(Generic[CharmType]):
     """Class to manage stepping through ops setup, event emission and framework commit."""
 
     def __init__(
         self,
         state: "State",
         event: "_Event",
-        context: "Context",
+        context: "Context[CharmType]",
         charm_spec: "_CharmSpec[CharmType]",
     ):
         self.state = state
@@ -206,7 +207,7 @@ class Ops:
         # set by setup()
         self.dispatcher: Optional[_Dispatcher] = None
         self.framework: Optional[ops.Framework] = None
-        self.charm: Optional[ops.CharmBase] = None
+        self.charm: Optional["CharmType"] = None
 
         self._has_setup = False
         self._has_emitted = False


### PR DESCRIPTION
Closes #1444.

This change enables passing the Charm type all the way from the Context to the charm attribute in the manager for better autocompletion and type checks.

You can give this a try with the following code snippet:

```python
from ops import CharmBase
from testing.src.scenario import Context, State


class MyCharm(CharmBase):
    some_attribute: str


def test_function():
    ctx = Context(MyCharm)
    state = State()

    with ctx(ctx.on.config_changed(), state) as manager:
        charm = manager.charm
        charm.some_attribute  # behold, autocompletion!
```

A word of caution, though, the testing module is not using the bundled scenario code base. It is still using `ops_scenario`. For users to benefit from this new feature, we would need to change the import machinery.
