### PR TITLE
ci: fix broken GitHub variable expansion

### DIFF
--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -76,7 +76,7 @@ jobs:
             sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" requirements.txt
             echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
           elif [ -e "poetry.lock" ]; then
-            poetry add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@GITHUB_SHA --lock
+            poetry add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA --lock
           else
             echo "Error: No requirements.txt or poetry.lock file found"
             exit 1


### PR DESCRIPTION
1ebec7b2e4a1413765ecc07f81c3d7df2b61bb8d was missing a `$`, so "GITHUB_SHA" ended up in the dependency, rather than the actual SHA :blush:.