### PR TITLE
ci: fix PR title ci job concurrency

### DIFF
--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
https://matrix.to/#/!eNCNzcteYUDDYpStsu:ubuntu.com/$PjGy1bizJkNGgu-A629wckDFKPzEQ5BKXIkmlE8sUyg?via=ubuntu.com&via=matrix.org

> Huh, looks like we have a small bug in the CI:
>
> > Canceling since a higher priority waiting request for 'Validate PR Title-refs/heads/main' exists
> 
> which happened for this PR: https://github.com/canonical/operator/pull/1447
> 
> surely the concurrency group should not be set to "main" for a new PR, should it?