### PR TITLE
ci: coverage report generation should also include testing/src/scenario

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -19,10 +19,6 @@ jobs:
       - name: Generate coverage report
         run: |
           tox -e coverage
-          # Annoyingly, the coverage.xml file needs to be in a .coverage folder.
-          rm .coverage
-          mkdir .coverage
-          mv coverage.xml .coverage/
 
       - name: TICS GitHub Action
         uses: tiobe/tics-github-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ venv
 .vscode
 .coverage
 coverage.xml
+.coverage.data
 /.tox
 .*.swp
 

--- a/tox.ini
+++ b/tox.ini
@@ -107,6 +107,7 @@ commands =
 
 [testenv:coverage]
 description = Run unit tests with coverage
+allowlist_externals = mkdir
 passenv =
     RUN_REAL_PEBBLE_TESTS
     PEBBLE
@@ -120,10 +121,12 @@ deps =
     -e .
     -e testing
 commands =
-    coverage run --source={[vars]src_path} \
+    mkdir -p .coverage
+    coverage run --source={[vars]src_path},testing/src/scenario \
+             --data-file=.coverage.data \
              -m pytest --ignore={[vars]tst_path}smoke -v --tb native {posargs}
-    coverage xml
-    coverage report
+    coverage xml --data-file=.coverage.data -o .coverage/coverage.xml
+    coverage report --data-file=.coverage.data
 
 [testenv:pebble]
 description = Run real pebble tests


### PR DESCRIPTION
Include `testing/src/scenario/` in the coverage analysis.

Additionally, move the (TIOBE required) repositioning of the coverage XML file into the tox command, since it's only used for TIOBE now, and this slightly simplifies the work (since we can use the `--data-file` and `-o` options for coverage).