### PR TITLE
docs: fix copy 'n' paste error in stop_services docstring

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -2173,7 +2173,7 @@ class Client:
         timeout: float = 30.0,
         delay: float = 0.1,
     ) -> ChangeID:
-        """Stop services by name and wait (poll) for them to be started.
+        """Stop services by name and wait (poll) for them to be stopped.
 
         Args:
             services: Non-empty list of services to stop.


### PR DESCRIPTION
This was just a copy-n-paste error, presumably from copying from the `start_services` docstring.