### PR TITLE
fix: make push_path open in binary mode so it works on non-text files

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -2662,7 +2662,7 @@ class Container:
                     if info.type is pebble.FileType.DIRECTORY:
                         self.make_dir(dstpath, make_parents=True)
                         continue
-                    with open(info.path) as src:
+                    with open(info.path, 'rb') as src:
                         self.push(
                             dstpath,
                             src,

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1369,8 +1369,8 @@ def test_recursive_push_and_pull(case: PushPullCase):
     for file in case.files:
         fpath = os.path.join(push_src.name, file[1:])
         os.makedirs(os.path.dirname(fpath), exist_ok=True)
-        with open(fpath, 'w') as f:
-            f.write('hello')
+        with open(fpath, 'wb') as f:
+            f.write(b'push \xc3\x28')  # invalid UTF-8 to ensure binary works
     if case.dirs:
         for directory in case.dirs:
             fpath = os.path.join(push_src.name, directory[1:])
@@ -1402,6 +1402,8 @@ def test_recursive_push_and_pull(case: PushPullCase):
     ), f'push_path gave wrong expected errors: want {case.errors}, got {errors}'
     for fpath in case.want:
         assert c.exists(fpath), f'push_path failed: file {fpath} missing at destination'
+        content = c.pull(fpath, encoding=None).read()
+        assert content == b'push \xc3\x28'
     for fdir in case.want_dirs:
         assert c.isdir(fdir), f'push_path failed: dir {fdir} missing at destination'
 


### PR DESCRIPTION
There was a bug in `push_path` where it called `open` with the default (text) mode on the local files, causing it to not work on binary files (more specifically, if they weren't valid UTF-8). This is the fix for that -- `push_path` should treat the files as raw bytes, so read in binary mode.

Also change the test to ensure binary / non-UTF-8 files work as expected.

Fixes #1455.