### PR TITLE
refactor: use _JujuContext in Scenario

### DIFF
--- a/testing/src/scenario/mocking.py
+++ b/testing/src/scenario/mocking.py
@@ -33,6 +33,7 @@ from ops import (
     ModelError,
 )
 from ops._private.harness import ExecArgs, _TestingPebbleClient
+from ops.jujucontext import _JujuContext
 from ops.model import CloudSpec as CloudSpec_Ops
 from ops.model import Port as Port_Ops
 from ops.model import Secret as Secret_Ops  # lol
@@ -130,8 +131,9 @@ class _MockModelBackend(_ModelBackend):  # type: ignore
         event: "_Event",
         charm_spec: "_CharmSpec[CharmType]",
         context: "Context",
+        juju_context: "_JujuContext",
     ):
-        super().__init__()
+        super().__init__(juju_context=juju_context)
         self._state = state
         self._event = event
         self._context = context

--- a/testing/src/scenario/ops_main_mock.py
+++ b/testing/src/scenario/ops_main_mock.py
@@ -195,11 +195,9 @@ class Ops:
         self.event = event
         self.context = context
         self.charm_spec = charm_spec
-        self.juju_context = (
-            ops.jujucontext._JujuContext.from_dict(os.environ)
-            if juju_context is None
-            else juju_context
-        )
+        if juju_context is None:
+            juju_context = ops.jujucontext._JujuContext.from_dict(os.environ)
+        self.juju_context = juju_context
 
         # set by setup()
         self.dispatcher: Optional[_Dispatcher] = None


### PR DESCRIPTION
Properly use the `ops.jujucontext._JujuContext` class in Scenario.

When `_JujuContext` was introduced in ops, we added some quick compatibility code to Scenario that made use of it, but it was basically just recreating the context object from the environment everywhere.

This PR tidies things up in two main ways:
* Create a single `_JujuContext` object and pass it around where it's required. This also sets the stage for using the ops `_Manager` class in a later PR.
* Rather than updating and then later (imprecisely) reverting `os.environ`, just pass the mock environment directly when creating the `_JujuContext` object.

Note that to maintain backwards compatibility of public methods the argument is optional in some places and will fall back to the environment - this won't be exactly the same, since we aren't manipulating the environment any more, but the signatures are the same. I don't think it's worth jumping through the hoops to have it entirely the same behaviour (by having the fallback do environment patching). It seems unlikely anyone is actually using these, even though they are public (the only candidate I can think of is Catan, but that's pinned to 6.x). Perhaps, given that the *behaviour* ends up potentially changing (depending on how the caller is using things), it's not worth keeping the signatures the same? I'm interested in reviewer's opinions on this.