### PR TITLE
ci: a better way than commenting out external repos

### DIFF
--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -17,10 +17,9 @@ jobs:
         include:
           - charm-repo: canonical/alertmanager-k8s-operator
             commit: fe233592f9324a6cf4aa9dbc71577ee170cf9eb3  # rev138 2024-10-18T12:11:02Z
-          # Waiting for an upstream PR:
-          # https://github.com/canonical/prometheus-k8s-operator/pull/639
-          #- charm-repo: canonical/prometheus-k8s-operator
-          #  commit: 7518ec8343941ca91248614fd8f2d50fdd9e068c  # rev135 2024-09-06T12:10:02Z
+          - charm-repo: canonical/prometheus-k8s-operator
+            commit: 7518ec8343941ca91248614fd8f2d50fdd9e068c  # rev135 2024-09-06T12:10:02Z
+            disabled: true # Waiting for an upstream PR: https://github.com/canonical/prometheus-k8s-operator/pull/639
           - charm-repo: canonical/grafana-k8s-operator
             commit: 07a52a65f272e115ab786f30cdb3b53be6b34bb7
     steps:
@@ -39,7 +38,9 @@ jobs:
         run: pip install tox~=4.2
 
       - name: Run the charm's unit tests
+        if: !matrix.disabled
         run: tox -vve unit
 
       - name: Run the charm's static analysis checks
+        if: !matrix.disabled
         run: tox -vve static-charm


### PR DESCRIPTION
Proposing a fix to https://github.com/canonical/operator/pull/1461 deleting commented out repos