### PR TITLE
ci: use more descriptive names for the publish workflows

### DIFF
--- a/.github/workflows/publish-ops-scenario.yaml
+++ b/.github/workflows/publish-ops-scenario.yaml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish (ops-scenario)
 on:
   push:
     tags:

--- a/.github/workflows/publish-ops.yaml
+++ b/.github/workflows/publish-ops.yaml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish (ops)
 on:
   push:
     tags:
@@ -7,7 +7,7 @@ on:
       # will likely be publishing at least three packages: ops, ops-scenario,
       # and ops-harness.
       - '2.*'
-  
+
 jobs:
   framework-tests:
     uses: ./.github/workflows/framework-tests.yaml

--- a/.github/workflows/test-publish-ops-scenario.yaml
+++ b/.github/workflows/test-publish-ops-scenario.yaml
@@ -1,4 +1,4 @@
-name: Test Publish
+name: Test Publish (ops-scenario)
 on: [workflow_dispatch, workflow_call]
 
 jobs:

--- a/.github/workflows/test-publish-ops.yaml
+++ b/.github/workflows/test-publish-ops.yaml
@@ -1,4 +1,4 @@
-name: Test Publish
+name: Test Publish (ops)
 on: [workflow_dispatch, workflow_call]
 
 jobs:


### PR DESCRIPTION
Include the name of the package being published in the workflow title, so that there aren't two called "Publish" etc.