### PR TITLE
ci: move the XML coverage report to .report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -121,12 +121,11 @@ deps =
     -e .
     -e testing
 commands =
-    mkdir -p .coverage
+    mkdir -p .report
     coverage run --source={[vars]src_path},testing/src/scenario \
-             --data-file=.coverage.data \
              -m pytest --ignore={[vars]tst_path}smoke -v --tb native {posargs}
-    coverage xml --data-file=.coverage.data -o .coverage/coverage.xml
-    coverage report --data-file=.coverage.data
+    coverage xml -o .report/coverage.xml
+    coverage report
 
 [testenv:pebble]
 description = Run real pebble tests


### PR DESCRIPTION
Miguel, our TIOBE contact, has asked that we move the XML coverage file that gets loaded, to `.report/coverage.xml`. This also means we can avoid using a custom data file name, which is nice.