### PR TITLE
chore: fix skipping disabled observability charms

### DIFF
--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -38,7 +38,7 @@ jobs:
         run: pip install tox~=4.2
 
       - name: Run the charm's unit tests
-        if: !(matrix.disabled)
+        if: ${{ !(matrix.disabled) }}
         run: tox -vve unit
 
       - name: Run the charm's static analysis checks

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -38,9 +38,9 @@ jobs:
         run: pip install tox~=4.2
 
       - name: Run the charm's unit tests
-        if: ${{ !matrix.disabled }}
+        if: ${{ not (matrix.disabled) }}
         run: tox -vve unit
 
       - name: Run the charm's static analysis checks
-        if: ${{ !matrix.disabled }}
+        if: ${{ !(matrix.disabled) }}
         run: tox -vve static-charm

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -38,9 +38,9 @@ jobs:
         run: pip install tox~=4.2
 
       - name: Run the charm's unit tests
-        if: !matrix.disabled
+        if: ${{ not matrix.disabled }}
         run: tox -vve unit
 
       - name: Run the charm's static analysis checks
-        if: !matrix.disabled
+        if: ${{ not matrix.disabled }}
         run: tox -vve static-charm

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -38,9 +38,9 @@ jobs:
         run: pip install tox~=4.2
 
       - name: Run the charm's unit tests
-        if: ${{ not matrix.disabled }}
+        if: ${{ !matrix.disabled }}
         run: tox -vve unit
 
       - name: Run the charm's static analysis checks
-        if: ${{ not matrix.disabled }}
+        if: ${{ !matrix.disabled }}
         run: tox -vve static-charm

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -38,7 +38,7 @@ jobs:
         run: pip install tox~=4.2
 
       - name: Run the charm's unit tests
-        if: ${{ not (matrix.disabled) }}
+        if: !(matrix.disabled)
         run: tox -vve unit
 
       - name: Run the charm's static analysis checks


### PR DESCRIPTION
Took 5 attempts, but I got the syntax right after all.