### PR TITLE
chore: bump version number for next ops release

### DIFF
--- a/ops/version.py
+++ b/ops/version.py
@@ -17,4 +17,4 @@
 This module is NOT to be used when developing charms using ops.
 """
 
-version: str = '2.17.1'
+version: str = '2.18.0.dev0'


### PR DESCRIPTION
Bumping ops version to 2.18.0.dev0 after the 2.17.1 release