### PR TITLE
ci: add support for injecting the latest ops when uv is used

### DIFF
--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -60,7 +60,7 @@ jobs:
           repository: ${{ matrix.charm-repo }}
 
       - name: Install patch dependencies
-        run: pip install poetry~=1.6
+        run: pip install poetry~=1.6 uv~=0.5
 
       - name: Update 'ops' dependency in test charm to latest
         run: |
@@ -77,8 +77,10 @@ jobs:
             echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
           elif [ -e "poetry.lock" ]; then
             poetry add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA --lock
+          elif [ -e "uv.lock" ]; then
+            uv add --frozen --raw-sources git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA
           else
-            echo "Error: No requirements.txt or poetry.lock file found"
+            echo "Error: No requirements.txt or poetry.lock or uv.lock file found"
             exit 1
           fi
 


### PR DESCRIPTION
When `uv` is used (as with self-signed-certificates-operator), the published-charms-tests workflow doesn't know how to inject the latest version of ops (there's no requirements.txt file).

This PR updates the workflow to look for `uv.lock` and if it exists then it uses `uv` to change the `ops` source in `pyproject.toml`.

self-signed-certificates-operator doesn't use `uv` to do the install in `tox` so we have to modify the raw sources list rather than have it be uv-specific. However, this should work even for projects that do, since the raw list is the originator of the dependencies - we might need to re-lock if other projects handle this differently, but we don't for now, so I've avoided that.

I've tested this manually, and have it manually against the branch (where it did install ops from my branch).