### PR TITLE
ci: all the ops-scenario publish actions need to be done in testing/

### DIFF
--- a/.github/workflows/publish-ops-scenario.yaml
+++ b/.github/workflows/publish-ops-scenario.yaml
@@ -29,8 +29,10 @@ jobs:
         run: python -m build
         working-directory: ./testing
       - name: Attest build provenance
+        working-directory: ./testing
         uses: actions/attest-build-provenance@v1.4.3
         with:
           subject-path: 'testing/dist/*'
       - name: Publish
+        working-directory: ./testing
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test-publish-ops-scenario.yaml
+++ b/.github/workflows/test-publish-ops-scenario.yaml
@@ -30,6 +30,7 @@ jobs:
         with:
           subject-path: 'testing/dist/*'
       - name: Publish to test.pypi.org
+        working-directory: ./testing
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
The build step is already done in `./testing/`, but the publish and attestation steps are not, which mean they fail because they cannot find the `dists` folder.