### PR TITLE
feat: use :memory: as the unit state storage location for ops.testing

### DIFF
--- a/testing/src/scenario/_ops_main_mock.py
+++ b/testing/src/scenario/_ops_main_mock.py
@@ -143,9 +143,7 @@ class Ops(_Manager):
 
     def _make_storage(self, _: _Dispatcher):
         # TODO: add use_juju_for_storage support
-        # TODO: Pass a charm_state_path that is ':memory:' when appropriate.
-        charm_state_path = self._charm_root / self._charm_state_path
-        storage = ops.storage.SQLiteStorage(charm_state_path)
+        storage = ops.storage.SQLiteStorage(":memory:")
         logger.info("Copying input state to storage.")
         self.store = UnitStateDB(storage)
         self.store.apply_state(self.state)


### PR DESCRIPTION
This PR changes Scenario to always use `:memory:` as the location for the unit state database, to speed up running tests.

In most cases, the charm root location is a `TemporaryDirectory`, so the unit state database only exists during the event emission anyway. The database could be accessed if a specific root directory was provided (or inside the context manager context) but the correct way to interact with the database is through the State API (deferred events, saved state objects) so we don't want to leave that open for users.

Timing (best of 3):

|Suite|main|branch|
|-|-|-|
|operator unit tests (no concurrency)|4m11.923s|3m41.354s|
|traefik scenario tests|3m49.479s|1m56.795s|
|kafka-k8s-operator scenario tests|0m13.463s|0m13.236s|

Note that this [is already the case for Harness](https://github.com/canonical/operator/blob/0ad731a6a9118dfac240e84681f5c41810c4f3f2/ops/_private/harness.py#L309).

Refs #1434