### PR TITLE
refactor: don't use the max-positional-args parent class for JujuLogLine

### DIFF
--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -181,7 +181,7 @@ def _max_posargs(n: int):
 
 
 @dataclasses.dataclass(frozen=True)
-class JujuLogLine(_max_posargs(2)):
+class JujuLogLine:
     """An entry in the Juju debug-log."""
 
     level: str


### PR DESCRIPTION
The Scenario code that limits the number of positional arguments (needed in Python 3.8 since the dataclasses there do not have `KW_ONLY`) is quite expensive. For the case of `JujuLogLine`, it's not actually providing any value, because both of the arguments can be positional. `JujuLogLine` objects are created frequently (one per logging call), so the cost of creation matters a lot for the test performance.

This PR changes `JujuLogLine` to be a regular frozen dataclass. There are other performance improvements possible in the max-positional-args code (most significant of which would be only using it for Python 3.8 and 3.9) but this one-line change provides most of the benefits, so seems worth doing before any more significant work.

Timing (best of 3):

|Suite|main|branch|
|-|-|-|
|operator unit tests (no concurrency)|4m11.923s|3m20.175s|
|traefik scenario tests|3m49.479s|2m18.024s|
|kafka-k8s-operator scenario tests|0m13.463s|0m9.973s|

Refs #1434