### PR TITLE
fix: remove ops.main.main deprecation warning, and avoid warnings in action output

### DIFF
--- a/ops/log.py
+++ b/ops/log.py
@@ -60,7 +60,6 @@ def setup_root_logging(
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
     logger.addHandler(JujuLogHandler(model_backend))
-    logging.captureWarnings(True)
 
     def custom_showwarning(
         message: typing.Union[str, Warning],
@@ -68,9 +67,10 @@ def setup_root_logging(
         filename: str,
         lineno: int,
         *_: typing.Any,
-    ) -> str:
-        """Like the default showwarning, but don't include the code."""
-        return f'{filename}:{lineno}: {category.__name__}: {message}'
+        **__: typing.Any,
+    ):
+        """Direct the warning to Juju's debug-log, and don't include the code."""
+        logger.warning('%s:%s: %s: %s', filename, lineno, category.__name__, message)
 
     warnings.showwarning = custom_showwarning
 

--- a/ops/log.py
+++ b/ops/log.py
@@ -23,7 +23,7 @@ from ops.model import _ModelBackend
 
 
 class JujuLogHandler(logging.Handler):
-    """A handler for sending logs and warnings to Juju via juju-log."""
+    """A handler for sending logs to Juju via juju-log."""
 
     def __init__(self, model_backend: _ModelBackend, level: int = logging.DEBUG):
         super().__init__(level)

--- a/ops/log.py
+++ b/ops/log.py
@@ -59,7 +59,6 @@ def setup_root_logging(
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
     logger.addHandler(JujuLogHandler(model_backend))
-
     if debug:
         handler = logging.StreamHandler()
         formatter = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')

--- a/ops/log.py
+++ b/ops/log.py
@@ -62,12 +62,12 @@ def setup_root_logging(
     logger.addHandler(JujuLogHandler(model_backend))
 
     def custom_showwarning(
-        message: typing.Union[str, Warning],
+        message: typing.Union[Warning, str],
         category: typing.Type[Warning],
         filename: str,
         lineno: int,
-        *_: typing.Any,
-        **__: typing.Any,
+        file: typing.Optional[typing.TextIO] = None,
+        line: typing.Optional[str] = None,
     ):
         """Direct the warning to Juju's debug-log, and don't include the code."""
         logger.warning('%s:%s: %s: %s', filename, lineno, category.__name__, message)

--- a/ops/log.py
+++ b/ops/log.py
@@ -23,11 +23,6 @@ import warnings
 from ops.model import _ModelBackend
 
 
-# We do this on module import because some warnings are issued before we set up
-# the framework, and we need to capture those as well.
-logging.captureWarnings(True)
-
-
 class JujuLogHandler(logging.Handler):
     """A handler for sending logs and warnings to Juju via juju-log."""
 
@@ -65,18 +60,19 @@ def setup_root_logging(
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
     logger.addHandler(JujuLogHandler(model_backend))
+    logging.captureWarnings(True)
 
-    def custom_warning_formatter(
+    def custom_showwarning(
         message: typing.Union[str, Warning],
         category: typing.Type[Warning],
         filename: str,
         lineno: int,
-        _: typing.Optional[str] = None,
+        *_: typing.Any,
     ) -> str:
-        """Like the default formatter, but don't include the code."""
+        """Like the default showwarning, but don't include the code."""
         return f'{filename}:{lineno}: {category.__name__}: {message}'
 
-    warnings.formatwarning = custom_warning_formatter
+    warnings.showwarning = custom_showwarning
 
     if debug:
         handler = logging.StreamHandler()

--- a/ops/log.py
+++ b/ops/log.py
@@ -18,14 +18,8 @@ import logging
 import sys
 import types
 import typing
-import warnings
 
 from ops.model import _ModelBackend
-
-
-# We do this on module import because some warnings are issued before we set up
-# the framework, and we need to capture those as well.
-logging.captureWarnings(True)
 
 
 class JujuLogHandler(logging.Handler):
@@ -65,18 +59,6 @@ def setup_root_logging(
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
     logger.addHandler(JujuLogHandler(model_backend))
-
-    def custom_warning_formatter(
-        message: typing.Union[str, Warning],
-        category: typing.Type[Warning],
-        filename: str,
-        lineno: int,
-        _: typing.Optional[str] = None,
-    ) -> str:
-        """Like the default formatter, but don't include the code."""
-        return f'{filename}:{lineno}: {category.__name__}: {message}'
-
-    warnings.formatwarning = custom_warning_formatter
 
     if debug:
         handler = logging.StreamHandler()

--- a/ops/log.py
+++ b/ops/log.py
@@ -48,8 +48,8 @@ def setup_root_logging(
 
       logging.getLogger().setLevel(logging.INFO)
 
-    Warnings issued by the warnings module are redirected to the logging system
-    and forwarded to juju-log, too.
+    Warnings issued by the warnings module will be captured via stderr and also
+    end up in juju-log.
 
     Args:
         model_backend: a ModelBackend to use for juju-log

--- a/ops/log.py
+++ b/ops/log.py
@@ -18,12 +18,18 @@ import logging
 import sys
 import types
 import typing
+import warnings
 
 from ops.model import _ModelBackend
 
 
+# We do this on module import because some warnings are issued before we set up
+# the framework, and we need to capture those as well.
+logging.captureWarnings(True)
+
+
 class JujuLogHandler(logging.Handler):
-    """A handler for sending logs to Juju via juju-log."""
+    """A handler for sending logs and warnings to Juju via juju-log."""
 
     def __init__(self, model_backend: _ModelBackend, level: int = logging.DEBUG):
         super().__init__(level)
@@ -48,8 +54,8 @@ def setup_root_logging(
 
       logging.getLogger().setLevel(logging.INFO)
 
-    Warnings issued by the warnings module will be captured via stderr and also
-    end up in juju-log.
+    Warnings issued by the warnings module are redirected to the logging system
+    and forwarded to juju-log, too.
 
     Args:
         model_backend: a ModelBackend to use for juju-log
@@ -59,6 +65,19 @@ def setup_root_logging(
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
     logger.addHandler(JujuLogHandler(model_backend))
+
+    def custom_warning_formatter(
+        message: typing.Union[str, Warning],
+        category: typing.Type[Warning],
+        filename: str,
+        lineno: int,
+        _: typing.Optional[str] = None,
+    ) -> str:
+        """Like the default formatter, but don't include the code."""
+        return f'{filename}:{lineno}: {category.__name__}: {message}'
+
+    warnings.formatwarning = custom_warning_formatter
+
     if debug:
         handler = logging.StreamHandler()
         formatter = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')

--- a/ops/main.py
+++ b/ops/main.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Support legacy ops.main.main() import."""
 
 import inspect
-import warnings
-from typing import Optional, Type
+import logging
+from typing import Any, Optional, Type
 
 import ops.charm
 
@@ -26,17 +27,17 @@ from ._main import (  # noqa: F401
     CHARM_STATE_FILE,  # type: ignore[reportUnusedImport]
     _Dispatcher,  # type: ignore[reportUnusedImport]
     _get_event_args,  # type: ignore[reportUnusedImport]
-    logger,  # type: ignore[reportUnusedImport]
 )
 
+logger = logging.getLogger(__name__)
 
-def _get_stack_level():
+
+def _top_frame():
     frame = inspect.currentframe()
-    stack_level = 0
     while frame:
-        stack_level += 1
+        if frame.f_back is None:
+            return frame
         frame = frame.f_back
-    return stack_level
 
 
 def main(charm_class: Type[ops.charm.CharmBase], use_juju_for_storage: Optional[bool] = None):
@@ -47,12 +48,37 @@ def main(charm_class: Type[ops.charm.CharmBase], use_juju_for_storage: Optional[
 
     See `ops.main() <#ops-main-entry-point>`_ for details.
     """
-    warnings.warn(
-        'Calling `ops.main.main()` is deprecated, call `ops.main()` instead',
-        DeprecationWarning,
-        # main(MyCharm) is a stack level of 2, but ops.main.main(MyCharm) is a
-        # stack level of 3. We know that this will be popping back to the top,
-        # in any reasonable usage, so just use the next-to-top level.
-        stacklevel=_get_stack_level() - 1,
+    # Normally, we would do warnings.warn() with a DeprecationWarning, but at
+    # this point in the charm execution, the framework has not been set up, so
+    # we haven't had a chance to direct warnings where we want them to go. That
+    # means that they'll end up going to stderr, and with actions that means
+    # they'll end up being displayed to the user.
+    # This means that we need to delay emitting the warning until the framework
+    # has been set up, so we wrap the charm and do it on instantiation. However,
+    # this means that a regular warning call won't provide the correct filename
+    # and line number - we could wrap this in a custom formatter, but it's
+    # simpler to just use a logging.warning() call instead.
+    # Note that unit tests almost never call main(), so wouldn't show this
+    # warning, so we're relying on integration tests, which aren't going to be
+    # treating warning calls in any special way. That means that we can just
+    # output the warning directly as a log message, and the effect will be the
+    # same.
+    # Note also that this will be logged with every event. Our assumption is
+    # that this will be noticeable enough during integration testing that it
+    # will get fixed before going into production.
+    frame = _top_frame()
+    assert frame is not None
+
+    class DeprecatedMainCharmBase(charm_class):
+        def __init__(self, *args: Any, **kwargs: Any):
+            super().__init__(*args, **kwargs)
+            logger.warning(
+                '%s:%s: DeprecationWarning: Calling `ops.main()` is deprecated, '
+                'call `ops.main()` instead',
+                frame.f_code.co_filename,
+                frame.f_lineno,
+            )
+
+    return _main.main(
+        charm_class=DeprecatedMainCharmBase, use_juju_for_storage=use_juju_for_storage
     )
-    return _main.main(charm_class=charm_class, use_juju_for_storage=use_juju_for_storage)

--- a/test/charms/test_main/actions.yaml
+++ b/test/charms/test_main/actions.yaml
@@ -43,5 +43,3 @@ log-info:
   description: log a message at Info level
 log-debug:
   description: log a message at Debug level
-warn:
-  description: generate a deprecation warning

--- a/test/charms/test_main/actions.yaml
+++ b/test/charms/test_main/actions.yaml
@@ -43,3 +43,5 @@ log-info:
   description: log a message at Info level
 log-debug:
   description: log a message at Debug level
+warn:
+  description: generate a deprecation warning

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -17,6 +17,7 @@ import logging
 import os
 import sys
 import typing
+import warnings
 
 import ops
 
@@ -65,6 +66,7 @@ class Charm(ops.CharmBase):
             on_log_warning_action=[],
             on_log_info_action=[],
             on_log_debug_action=[],
+            on_warn_action=[],
             on_secret_changed=[],
             on_secret_remove=[],
             on_secret_rotate=[],
@@ -113,6 +115,7 @@ class Charm(ops.CharmBase):
             self.framework.observe(self.on.log_warning_action, self._on_log_warning_action)
             self.framework.observe(self.on.log_info_action, self._on_log_info_action)
             self.framework.observe(self.on.log_debug_action, self._on_log_debug_action)
+            self.framework.observe(self.on.warn_action, self._on_warn_action)
 
         self.framework.observe(self.on.collect_metrics, self._on_collect_metrics)
         self.framework.observe(self.on.custom, self._on_custom)
@@ -303,6 +306,9 @@ class Charm(ops.CharmBase):
 
     def _on_log_debug_action(self, event: ops.ActionEvent):
         logger.debug('insightful debug')
+
+    def _on_warn_action(self, event: ops.ActionEvent):
+        warnings.warn('feature x is deprecated, use feature y instead', DeprecationWarning)
 
     def _on_get_model_name_action(self, event: ops.ActionEvent):
         self._stored._on_get_model_name_action.append(self.model.name)

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -17,7 +17,6 @@ import logging
 import os
 import sys
 import typing
-import warnings
 
 import ops
 
@@ -66,7 +65,6 @@ class Charm(ops.CharmBase):
             on_log_warning_action=[],
             on_log_info_action=[],
             on_log_debug_action=[],
-            on_warn_action=[],
             on_secret_changed=[],
             on_secret_remove=[],
             on_secret_rotate=[],
@@ -115,7 +113,6 @@ class Charm(ops.CharmBase):
             self.framework.observe(self.on.log_warning_action, self._on_log_warning_action)
             self.framework.observe(self.on.log_info_action, self._on_log_info_action)
             self.framework.observe(self.on.log_debug_action, self._on_log_debug_action)
-            self.framework.observe(self.on.warn_action, self._on_warn_action)
 
         self.framework.observe(self.on.collect_metrics, self._on_collect_metrics)
         self.framework.observe(self.on.custom, self._on_custom)
@@ -307,12 +304,9 @@ class Charm(ops.CharmBase):
     def _on_log_debug_action(self, event: ops.ActionEvent):
         logger.debug('insightful debug')
 
-    def _on_warn_action(self, event: ops.ActionEvent):
-        warnings.warn('feature x is deprecated, use feature y instead', DeprecationWarning)
-
     def _on_get_model_name_action(self, event: ops.ActionEvent):
         self._stored._on_get_model_name_action.append(self.model.name)
 
 
 if __name__ == '__main__':
-    ops.main(Charm)  # type: ignore
+    ops.main(Charm)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -895,30 +895,6 @@ class _TestMain(abc.ABC):
             self._simulate_event(fake_script, event_spec)
             assert calls in fake_script.calls(clear=True)
 
-        # Test warnings are captured and sent to the Juju debug-log,
-        event_spec = EventSpec(
-            ops.ActionEvent,
-            'warn_action',
-            env_var='JUJU_ACTION_NAME',
-            set_in_env={'JUJU_ACTION_UUID': '5'},
-        )
-        self._simulate_event(fake_script, event_spec)
-        calls = fake_script.calls(clear=True)
-
-        calls_without_message = [call[:-1] for call in calls]
-        expected_without_message = ['juju-log', '--log-level', 'WARNING', '--']
-        assert expected_without_message in calls_without_message
-
-        idx = calls_without_message.index(expected_without_message)
-        warning_message = calls[idx][-1]
-        pattern = (
-            r'^.*:(\d+):\s+DeprecationWarning:\s+'
-            + re.escape('feature x is deprecated, use feature y instead')
-            + '$'
-        )
-        if not re.match(pattern, warning_message):
-            pytest.fail(f'Warning was not sent to debug-log: {calls!r}')
-
     @pytest.mark.usefixtures('setup_charm')
     def test_excepthook(self, fake_script: FakeScript):
         with pytest.raises(subprocess.CalledProcessError):

--- a/test/test_main_invocation.py
+++ b/test/test_main_invocation.py
@@ -52,9 +52,6 @@ def test_top_level_import(charm_env: None):
 def test_top_level_import_legacy_call(charm_env: None):
     import ops
 
-    with pytest.deprecated_call():
-        ops.main.main(ops.CharmBase)
-
     with pytest.raises(TypeError):
         ops.main.main()  # type: ignore
 
@@ -70,9 +67,6 @@ def test_submodule_import(charm_env: None):
 
 def test_submodule_import_legacy_call(charm_env: None):
     import ops.main
-
-    with pytest.deprecated_call():
-        ops.main.main(ops.CharmBase)
 
     with pytest.raises(TypeError):
         ops.main.main()  # type: ignore
@@ -90,18 +84,12 @@ def test_import_from_top_level_module(charm_env: None):
 def test_import_from_top_level_module_legacy_call(charm_env: None):
     from ops import main
 
-    with pytest.deprecated_call():
-        main.main(ops.CharmBase)
-
     with pytest.raises(TypeError):
         main.main()  # type: ignore
 
 
 def test_legacy_import_from_submodule(charm_env: None):
     from ops.main import main
-
-    with pytest.deprecated_call():
-        main(ops.CharmBase)
 
     with pytest.raises(TypeError):
         main()  # type: ignore

--- a/test/test_main_invocation.py
+++ b/test/test_main_invocation.py
@@ -49,11 +49,11 @@ def test_top_level_import(charm_env: None):
         ops.main()  # type: ignore
 
 
-def test_top_level_import_legacy_call(charm_env: None, caplog: pytest.LogCaptureFixture):
+def test_top_level_import_legacy_call(charm_env: None):
     import ops
 
-    ops.main.main(ops.CharmBase)
-    assert 'DeprecationWarning: Calling `ops.main()` is deprecated' in caplog.records[0].message
+    with pytest.deprecated_call():
+        ops.main.main(ops.CharmBase)
 
     with pytest.raises(TypeError):
         ops.main.main()  # type: ignore
@@ -68,11 +68,11 @@ def test_submodule_import(charm_env: None):
         ops.main()  # type: ignore
 
 
-def test_submodule_import_legacy_call(charm_env: None, caplog: pytest.LogCaptureFixture):
+def test_submodule_import_legacy_call(charm_env: None):
     import ops.main
 
-    ops.main.main(ops.CharmBase)
-    assert 'DeprecationWarning: Calling `ops.main()` is deprecated' in caplog.records[0].message
+    with pytest.deprecated_call():
+        ops.main.main(ops.CharmBase)
 
     with pytest.raises(TypeError):
         ops.main.main()  # type: ignore
@@ -87,23 +87,21 @@ def test_import_from_top_level_module(charm_env: None):
         main()  # type: ignore
 
 
-def test_import_from_top_level_module_legacy_call(
-    charm_env: None, caplog: pytest.LogCaptureFixture
-):
+def test_import_from_top_level_module_legacy_call(charm_env: None):
     from ops import main
 
-    main.main(ops.CharmBase)
-    assert 'DeprecationWarning: Calling `ops.main()` is deprecated' in caplog.records[0].message
+    with pytest.deprecated_call():
+        main.main(ops.CharmBase)
 
     with pytest.raises(TypeError):
         main.main()  # type: ignore
 
 
-def test_legacy_import_from_submodule(charm_env: None, caplog: pytest.LogCaptureFixture):
+def test_legacy_import_from_submodule(charm_env: None):
     from ops.main import main
 
-    main(ops.CharmBase)
-    assert 'DeprecationWarning: Calling `ops.main()` is deprecated' in caplog.records[0].message
+    with pytest.deprecated_call():
+        main(ops.CharmBase)
 
     with pytest.raises(TypeError):
         main()  # type: ignore

--- a/test/test_main_invocation.py
+++ b/test/test_main_invocation.py
@@ -49,11 +49,11 @@ def test_top_level_import(charm_env: None):
         ops.main()  # type: ignore
 
 
-def test_top_level_import_legacy_call(charm_env: None):
+def test_top_level_import_legacy_call(charm_env: None, caplog: pytest.LogCaptureFixture):
     import ops
 
-    with pytest.deprecated_call():
-        ops.main.main(ops.CharmBase)
+    ops.main.main(ops.CharmBase)
+    assert 'DeprecationWarning: Calling `ops.main()` is deprecated' in caplog.records[0].message
 
     with pytest.raises(TypeError):
         ops.main.main()  # type: ignore
@@ -68,11 +68,11 @@ def test_submodule_import(charm_env: None):
         ops.main()  # type: ignore
 
 
-def test_submodule_import_legacy_call(charm_env: None):
+def test_submodule_import_legacy_call(charm_env: None, caplog: pytest.LogCaptureFixture):
     import ops.main
 
-    with pytest.deprecated_call():
-        ops.main.main(ops.CharmBase)
+    ops.main.main(ops.CharmBase)
+    assert 'DeprecationWarning: Calling `ops.main()` is deprecated' in caplog.records[0].message
 
     with pytest.raises(TypeError):
         ops.main.main()  # type: ignore
@@ -87,21 +87,23 @@ def test_import_from_top_level_module(charm_env: None):
         main()  # type: ignore
 
 
-def test_import_from_top_level_module_legacy_call(charm_env: None):
+def test_import_from_top_level_module_legacy_call(
+    charm_env: None, caplog: pytest.LogCaptureFixture
+):
     from ops import main
 
-    with pytest.deprecated_call():
-        main.main(ops.CharmBase)
+    main.main(ops.CharmBase)
+    assert 'DeprecationWarning: Calling `ops.main()` is deprecated' in caplog.records[0].message
 
     with pytest.raises(TypeError):
         main.main()  # type: ignore
 
 
-def test_legacy_import_from_submodule(charm_env: None):
+def test_legacy_import_from_submodule(charm_env: None, caplog: pytest.LogCaptureFixture):
     from ops.main import main
 
-    with pytest.deprecated_call():
-        main(ops.CharmBase)
+    main(ops.CharmBase)
+    assert 'DeprecationWarning: Calling `ops.main()` is deprecated' in caplog.records[0].message
 
     with pytest.raises(TypeError):
         main()  # type: ignore

--- a/test/test_main_invocation.py
+++ b/test/test_main_invocation.py
@@ -52,6 +52,8 @@ def test_top_level_import(charm_env: None):
 def test_top_level_import_legacy_call(charm_env: None):
     import ops
 
+    ops.main.main(ops.CharmBase)
+
     with pytest.raises(TypeError):
         ops.main.main()  # type: ignore
 
@@ -67,6 +69,8 @@ def test_submodule_import(charm_env: None):
 
 def test_submodule_import_legacy_call(charm_env: None):
     import ops.main
+
+    ops.main.main(ops.CharmBase)
 
     with pytest.raises(TypeError):
         ops.main.main()  # type: ignore
@@ -84,12 +88,16 @@ def test_import_from_top_level_module(charm_env: None):
 def test_import_from_top_level_module_legacy_call(charm_env: None):
     from ops import main
 
+    main.main(ops.CharmBase)
+
     with pytest.raises(TypeError):
         main.main()  # type: ignore
 
 
 def test_legacy_import_from_submodule(charm_env: None):
     from ops.main import main
+
+    main(ops.CharmBase)
 
     with pytest.raises(TypeError):
         main()  # type: ignore

--- a/testing/src/scenario/_ops_main_mock.py
+++ b/testing/src/scenario/_ops_main_mock.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import dataclasses
-import logging
 import marshal
 import re
 import sys
@@ -140,9 +139,6 @@ class Ops(_Manager):
         # Ops sets sys.excepthook to go to Juju's debug-log, but that's not
         # useful in a testing context, so we reset it here.
         super()._setup_root_logging()
-        # Ops also sets up logging to capture warnings, but we want the normal
-        # output.
-        logging.captureWarnings(False)
         sys.excepthook = sys.__excepthook__
 
     def _make_storage(self, _: _Dispatcher):

--- a/testing/src/scenario/_ops_main_mock.py
+++ b/testing/src/scenario/_ops_main_mock.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 
 import dataclasses
+import logging
 import marshal
 import re
 import sys
@@ -139,6 +140,9 @@ class Ops(_Manager):
         # Ops sets sys.excepthook to go to Juju's debug-log, but that's not
         # useful in a testing context, so we reset it here.
         super()._setup_root_logging()
+        # Ops also sets up logging to capture warnings, but we want the normal
+        # output.
+        logging.captureWarnings(False)
         sys.excepthook = sys.__excepthook__
 
     def _make_storage(self, _: _Dispatcher):

--- a/testing/src/scenario/_ops_main_mock.py
+++ b/testing/src/scenario/_ops_main_mock.py
@@ -7,6 +7,7 @@ import logging
 import marshal
 import re
 import sys
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, FrozenSet, List, Sequence, Set
 
 import ops
@@ -137,12 +138,17 @@ class Ops(_Manager):
         return ops.CharmMeta.from_yaml(metadata, actions_metadata)
 
     def _setup_root_logging(self):
-        # Ops sets sys.excepthook to go to Juju's debug-log, but that's not
-        # useful in a testing context, so we reset it here.
+        # The warnings module captures this in _showwarning_orig, but we
+        # shouldn't really be using a private method, so capture it ourselves as
+        # well.
+        original_showwarning = warnings.showwarning
         super()._setup_root_logging()
         # Ops also sets up logging to capture warnings, but we want the normal
         # output.
         logging.captureWarnings(False)
+        warnings.showwarning = original_showwarning
+        # Ops sets sys.excepthook to go to Juju's debug-log, but that's not
+        # useful in a testing context, so we reset it here.
         sys.excepthook = sys.__excepthook__
 
     def _make_storage(self, _: _Dispatcher):


### PR DESCRIPTION
Background:
* A `warnings.warn` call outputs to stderr by default.
* Juju captures stderr and when executing an action provides it to the user.
* We emit a DeprecationWarning when charms call `main()` other than `import ops ... ops.main()`
* DeprecationWarnings are ignored by default, *except* for issues in the `__main__` module.
* A warning like this is meant to be discovered during tests - but unit tests typically do not call `main()` or execute the `charm.py` file, so they will not trigger this warning. That means that we're relying on integration tests.

The above means that, currently, the deprecation warning is included in the action output - this warning is intended for the developer of the charm, not the user of the charm, so we want to change this.

Firstly, the `ops.main.main` deprecation warning is removed. It's too awkward to have a warning that gets emitted before the framework is set up. Instead, we'll rely on `charmcraft analyse` and static checks.

However, while that will solve the specific issue in #1460, we do also want to avoid any future leakage of warnings into action output if there are other warnings emitted that originate in the `__main__` model.

To that, rather than rely on Juju capturing the warning via stderr, we use the logging package to capture all warnings and redirect them to logging calls. These are then directed to Juju's debug-log via the existing mechanism. While we are doing this, we minimise the output to include references to the filename and line, but not the actual code itself (which may be sensitive).

When running (Scenario) tests, we ensure that the warning and logging systems use their default behaviour, so that pytest and other tools can work as expected.

Fixes #1460 