### PR TITLE
docs: remove the publish badge from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # The `ops` library
 
 ![CI Status](https://github.com/canonical/operator/actions/workflows/framework-tests.yaml/badge.svg)
-![Publish](https://github.com/canonical/operator/actions/workflows/publish.yml/badge.svg)
 
 The `ops` library is a Python framework for developing and testing Kubernetes and machine [charms](https://juju.is/docs/sdk/charmed-operators). While charms can be written in any language, `ops` defines the latest standard, and charmers are encouraged to use Python with `ops` for all charms. The library is an official component of the Charm SDK, itself a part of [the Juju universe](https://juju.is/).
 


### PR DESCRIPTION
This is currently broken (because the workflow was renamed), but rather than fix it, we've decided that it doesn't really add any value to have this badge, so we'll remove it instead.