### PR TITLE
docs: update how-to guides to use the new unit testing framework

### DIFF
--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -19,9 +19,9 @@ Manage secrets <manage-secrets>
 Manage the charm version <manage-the-charm-version>
 Manage the workload version <manage-the-workload-version>
 Get started with charm testing <get-started-with-charm-testing>
-Write unit tests for a charm <write-unit-tests-for-a-charm>
-Write scenario tests for a charm <write-scenario-tests-for-a-charm>
+Write unit tests for a charm <write-scenario-tests-for-a-charm>
 Write integration tests for a charm <write-integration-tests-for-a-charm>
+Write legacy unit tests for a charm <write-unit-tests-for-a-charm>
 Turn a hooks-based charm into an ops charm <turn-a-hooks-based-charm-into-an-ops-charm>
 
 ```

--- a/docs/howto/manage-actions.md
+++ b/docs/howto/manage-actions.md
@@ -11,6 +11,7 @@
 
 To tell users what actions can be performed on the charm, define an `actions` section in `charmcraft.yaml` that lists the actions and information about each action. The actions should include a short description that explains what running the action will do. Normally, all parameters that can be passed to the action are also included here, including the type of parameter and any default value. You can also specify that some parameters are required when the action is run.
 For example:
+
 ```yaml
 actions:
   snapshot:
@@ -41,8 +42,6 @@ actions:
     additionalProperties: false
 ```
 
-
-
 ### Observe the action event and define an event handler
 
 In the `src/charm.py` file, in the `__init__` function of your charm, set up an observer for the action event associated with your action and pair that with an event handler. For example:
@@ -51,10 +50,9 @@ In the `src/charm.py` file, in the `__init__` function of your charm, set up an 
 self.framework.observe(self.on.grant_admin_role_action, self._on_grant_admin_role_action)
 ```
 
-
 Now, in the body of the charm definition, define the action event handler. For example:
 
-```
+```python
 def _on_grant_admin_role_action(self, event):
     """Handle the grant-admin-role action."""
     # Fetch the user parameter from the ActionEvent params dict
@@ -77,7 +75,6 @@ def _on_grant_admin_role_action(self, event):
 
 More detail below:
 
-
 #### Use action params
 
 To make use of action parameters, either ones that the user has explicitly passed, or default values, use the `params` attribute of the event object that is passed to the handler. This is a dictionary of parameter name (string) to parameter value. For example:
@@ -87,8 +84,8 @@ def _on_snapshot(self, event: ops.ActionEvent):
     filename = event.params["filename"]
     ...
 ```
-> See more: [`ops.ActionEvent.params`](https://ops.readthedocs.io/en/latest/#ops.ActionEvent.params)
 
+> See more: [`ops.ActionEvent.params`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.ActionEvent.params)
 
 #### Report that an action has failed
 
@@ -108,22 +105,24 @@ def _on_snapshot(self, event: ops.ActionEvent):
    ...
 ```
 
-> See more: [`ops.ActionEvent.fail`](https://ops.readthedocs.io/en/latest/#ops.ActionEvent.fail)
+> See more: [`ops.ActionEvent.fail`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.ActionEvent.fail)
 
 #### Return the results of an action
 
 To pass back the results of an action to the user, use the `set_results` method of the action event. These will be displayed in the `juju run` output. For example:
+
 ```python
 def _on_snapshot(self, event: ops.ActionEvent):
     size = self.do_snapshot(event.params['filename'])
     event.set_results({'snapshot-size': size})
 ```
-> See more: [`ops.ActionEvent.set_results`](https://ops.readthedocs.io/en/latest/#ops.ActionEvent.set_results)
 
+> See more: [`ops.ActionEvent.set_results`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.ActionEvent.set_results)
 
 #### Log the progress of an action
 
 In a long-running action, to give the user updates on progress, use the `.log()` method of the action event. This is sent back to the user, via Juju, in real-time, and appears in the output of the `juju run` command. For example:
+
 ```python
 def _on_snapshot(self, event: ops.ActionEvent):
     event.log('Starting snapshot')
@@ -133,12 +132,13 @@ def _on_snapshot(self, event: ops.ActionEvent):
     event.log('Table2 complete')
     self.snapshot_table3()
 ```
-> See more: [`ops.ActionEvent.log`](https://ops.readthedocs.io/en/latest/#ops.ActionEvent.log)
 
+> See more: [`ops.ActionEvent.log`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.ActionEvent.log))
 
 #### Record the ID of an action task
 
 When a unique ID is needed for the action task - for example, for logging or creating temporary files, use the `.id` attribute of the action event. For example:
+
 ```python
 def _on_snapshot(self, event: ops.ActionEvent):
     temp_filename = f'backup-{event.id}.tar.gz'
@@ -146,8 +146,7 @@ def _on_snapshot(self, event: ops.ActionEvent):
     self.create_backup(temp_filename)
     ... 
 ```
-> See more: [`ops.ActionEvent.id`](https://ops.readthedocs.io/en/latest/#ops.ActionEvent.id)
-
+> See more: [`ops.ActionEvent.id`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.ActionEvent.id)
 
 ## Test the feature
 
@@ -155,53 +154,29 @@ def _on_snapshot(self, event: ops.ActionEvent):
 
 What you need to do depends on what kind of tests you want to write.
 
-
 ### Write unit tests
 
-> See first: {ref}`write-unit-tests-for-a-charm`
-
-When using Harness for unit tests, use the `run_action` method to verify that charm actions have the expected behaviour. This method will either raise an `ActionFailed` exception (if the charm used the `event.fail()` method) or return an `ActionOutput` object. These can be used to verify the failure message, logs, and results of the action. For example:
-
-```python
-def test_backup_action():
-    harness = ops.testing.Harness()
-    harness.begin()
-    try:
-        out = harness.run_action('snapshot', {'filename': 'db-snapshot.tar.gz'})
-    except ops.testing.ActionFailed as e:
-        assert "Could not backup because" in e.message
-    else:
-        assert out.logs == ['Starting snapshot', 'Table1 complete', 'Table2 complete']
-        assert 'snapshot-size' in out.results
-    finally:
-        harness.cleanup()
-
-
-```
-
-> See more: [`ops.testing.Harness.run_action`](https://ops.readthedocs.io/en/latest/#ops.testing.Harness.run_action)
-
-
-### Write scenario tests
 > See first: {ref}`write-scenario-tests-for-a-charm`
 
-When using Scenario for unit tests, to verify that the charm state is as expected after executing an action, use the `run_action` method of the Scenario `Context` object. The method returns an `ActionOutput` object that contains any logs and results that the charm set.
+To verify that the charm state is as expected after executing an action, use the `run` method of the `Context` object, with `ctx.on.action`. The context contains any logs and results that the charm set.
+
 For example:
+
 ```python
+from ops import testing
+
 def test_backup_action():
-    action = scenario.Action('snapshot', params={'filename': 'db-snapshot.tar.gz'})
-    ctx = scenario.Context(MyCharm)
-    out = ctx.run_action(action, scenario.State())
-    assert out.logs == ['Starting snapshot', 'Table1 complete', 'Table2 complete']
-    if out.success:
-      assert 'snapshot-size' in out.results
-    else:
-      assert 'Failed to run' in out.failure
+    ctx = testing.Context(MyCharm)
+    ctx.run(ctx.on.action('snapshot', params={'filename': 'db-snapshot.tar.gz'}), testing.State())
+    assert ctx.action_logs == ['Starting snapshot', 'Table1 complete', 'Table2 complete']
+    assert 'snapshot-size' in ctx.action_results
 ```
-> See more: [Scenario action testing](https://github.com/canonical/ops-scenario?tab=readme-ov-file#actions)
+
+> See more: [`Context.action_logs`](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.Context.action_logs), [`Context.action_results`](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.Context.action_results), [`ActionFailed`](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.ActionFailed)
 
 
 ### Write integration tests
+
 > See first: {ref}`write-integration-tests-for-a-charm`
 
 To verify that an action works correctly against a real Juju instance, write an integration test with `pytest_operator`. For example:
@@ -215,4 +190,3 @@ async def test_logger(ops_test):
     assert action.status == 'completed'
     assert action.results['snapshot-size'].isdigit()
 ```
-

--- a/docs/howto/manage-configurations.md
+++ b/docs/howto/manage-configurations.md
@@ -25,7 +25,6 @@ config:
       type: string
 ```
 
-
 ### Observe the `config-changed` event and define the event handler
 
 In the `src/charm.py` file of the charm project, in the `__init__` function of the charm, set up an observer for the config changed event and pair that with an event handler:
@@ -47,14 +46,14 @@ def _on_config_changed(self, event):
     logger.debug("New application port is requested: %s", port)
     self._update_layer_and_restart(None)
 ```
-> See more: [`ops.CharmBase.config`](https://ops.readthedocs.io/en/latest/#ops.CharmBase.config)
+
+> See more: [`ops.CharmBase.config`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.CharmBase.config)
 
 ```{caution}
 
  - Multiple configuration values can be changed at one time through Juju, resulting in only one `config_changed` event. Thus, your charm code must be able to process more than one config value changing at a time.
 - If `juju config` is run with values the same as the current configuration, the  `config_changed` event will not run. Therefore, if you have a single config value, there is no point in tracking its previous value -- the event will only be triggered if the value changes.
 - Configuration cannot be changed from within the charm code. Charms, by design, aren't able to mutate their own configuration by themselves (e.g., in order to ignore an admin-provided configuration), or to configure other applications. In Ops, one typically interacts with config via a read-only facade.
-
 ```
 
 ### (If applicable) Update and restart the Pebble layer
@@ -69,56 +68,27 @@ https://github.com/canonical/juju-sdk-tutorial-k8s/compare/01_create_minimal_cha
 
 > See first: {ref}`get-started-with-charm-testing`
 
-You'll want to add two levels of tests: unit and scenario.
-
 ### Write unit tests
 
 > See first: {ref}`write-unit-tests-for-a-charm`
 
-To use a unit test to verify that the configuration change is handled correct, the test needs to trigger the `config-changed` event and then check that the update method was called. In your `tests/unit/test_charm.py` file, add the following test functions to the file:
+To verify that the `config-changed` event validates the port, pass the new config to the `State`, and, after running the event, check the unit status. For example, in your `tests/unit/test_charm.py` file, add the following test function:
 
 ```python
-def test_invalid_port_configuration():
-    harness = ops.testing.Harness()
-    harness.begin()
+from ops import testing
 
-    harness.update_config({"server-port": 22})
-    assert isinstance(harness.model.unit.status, ops.BlockedStatus)
-
-def test_port_configuration(monkeypatch):
-    update_called = False
-    def mock_update(*args):
-        update_called = True
-    monkeypatch.setattr(MyCharm, "_update_layer_and_restart", mock_update)
-
-    harness = ops.testing.Harness()
-    harness.begin()
-
-    harness.update_config({"server-port": 8080})
-
-    assert update_called
-```
-
-### Write scenario tests
-
-> See first: {ref}`write-scenario-tests-for-a-charm`
-
-To use a Scenario test to verify that the `config-changed` event validates the port, pass the new config to the `State`, and, after running the event, check the unit status. For example, in your `tests/scenario/test_charm.py` file, add the following test function:
-
-```python
 def test_open_port():
-    ctx = scenario.Context(MyCharm)
+    ctx = testing.Context(MyCharm)
 
-    state_out = ctx.run("config_changed", scenario.State(config={"server-port": 22}))
+    state_out = ctx.run(ctx.on.config_changed(), testing.State(config={"server-port": 22}))
 
-    assert isinstance(state_out.unit_status, ops.BlockedStatus)
+    assert isinstance(state_out.unit_status, testingZ.BlockedStatus)
 ```
 
-### Test-deploy
+### Manually test
 
 To verify that the configuration option works as intended, pack your charm, update it in the Juju model, and run `juju config` followed by the name of the application deployed by your charm and then your newly defined configuration option key set to some value. For example, given the `server-port` key defined above, you could try:
 
 ```text
 juju config <name of application deployed by your charm> server-port=4000
 ```
-

--- a/docs/howto/manage-leadership-changes.md
+++ b/docs/howto/manage-leadership-changes.md
@@ -15,7 +15,7 @@ In the `src/charm.py` file, in the `__init__` function of your charm, set up an 
 self.framework.observe(self.on.leader_elected, self._on_leader_elected)
 ```
 
-> See more: [`ops.LeaderElectedEvent`](https://ops.readthedocs.io/en/latest/#ops.LeaderElectedEvent)
+> See more: [`ops.LeaderElectedEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.LeaderElectedEvent)
 
 Now, in the body of the charm definition, define the event handler. For example, the handler below will update a configuration file:
 
@@ -52,48 +52,11 @@ event or an `is-leader` check. If the charm code may run longer, then extra
 
 > See first: {ref}`get-started-with-charm-testing`
 
-
 ### Write unit tests
-
-> See first: {ref}`write-unit-tests-for-a-charm`
-
-When using Harness for unit tests, use the `set_leader()` method to control whether the unit is the leader. For example, to verify that leadership change is handled correctly:
-
-```python
-@pytest.fixture()
-def harness():
-    yield ops.testing.Harness(MyCharm)
-    harness.cleanup()
-
-
-def test_new_leader(harness):
-    # Before the test, the unit is not leader.
-    harness.set_leader(False)
-    harness.begin()
-    # Simulate Juju electing the unit as leader.
-    harness.set_leader(True)
-    # Assert that it was handled correctly.
-    assert ...
-
-
-def test_leader_sets_secrets(harness):
-    # The unit is the leader throughout the test, and no leader-elected event
-    # is emitted.
-    harness.set_leader(True)
-    harness.begin()
-    secret_id = harness.add_model_secret(APP_NAME, content={"secret": "sssh"})
-    harness.update_config(secret_option=secret_id)
-    # Assert that the config-changed handler set additional secret metadata:
-    assert ...
-```
-
-> See more: [`ops.testing.Harness.set_leader`](https://ops.readthedocs.io/en/latest/harness.html#ops.testing.Harness.set_leader)
-
-## Write scenario tests
 
 > See first: {ref}`write-scenario-tests-for-a-charm`
 
-When using Scenario for unit tests, pass the leadership status to the `State`. For example:
+To verify behaviour when leadership has changed, pass the leadership status to the `State`. For example:
 
 ```python
 class MyCharm(ops.CharmBase):
@@ -110,11 +73,10 @@ class MyCharm(ops.CharmBase):
 
 @pytest.mark.parametrize('leader', (True, False))
 def test_status_leader(leader):
-    ctx = scenario.Context(MyCharm, meta={"name": "foo"})
-    out = ctx.run('start', scenario.State(leader=leader))
-    assert out.unit_status == ops.ActiveStatus('I rule' if leader else 'I am ruled')
+    ctx = testing.Context(MyCharm, meta={"name": "foo"})
+    out = ctx.run(ctx.on.start(), testing.State(leader=leader))
+    assert out.unit_status == testing.ActiveStatus('I rule' if leader else 'I am ruled')
 ```
-
 
 ## Write integration tests
 
@@ -146,5 +108,3 @@ async def get_leader_unit(ops_test, app, model=None):
 > Examples: [Zookeeper testing upgrades](https://github.com/canonical/zookeeper-operator/blob/106f9c2cd9408a172b0e93f741d8c9f860c4c38e/tests/integration/test_upgrade.py#L22), [postgresql testing password rotation action](https://github.com/canonical/postgresql-k8s-operator/blob/62645caa89fd499c8de9ac3e5e9598b2ed22d619/tests/integration/test_password_rotation.py#L38)
 
 > See more: [`juju.unit.Unit.is_leader_from_status`](https://pythonlibjuju.readthedocs.io/en/latest/api/juju.unit.html#juju.unit.Unit.is_leader_from_status)
-
- 

--- a/docs/howto/manage-libraries.md
+++ b/docs/howto/manage-libraries.md
@@ -159,10 +159,15 @@ def test_charm_runs_with_relations(context, endpoint, n_relations):
 def test_relation_changed_behaviour(context, endpoint, n_relations):
     """Verify that the charm lib does what it should on relation changed."""
     # Arrange:
-    relations = {Relation(
-        endpoint=endpoint, interface='my-interface', remote_app_name=f"remote_{n}",
-        remote_app_data={"foo": f"my-data-{n}"}
-    ) for n in range(n_relations)}
+    relations = {
+        Relation(
+            endpoint=endpoint,
+            interface='my-interface',
+            remote_app_name=f"remote_{n}",
+            remote_app_data={"foo": f"my-data-{n}"},
+        )
+        for n in range(n_relations)
+    }
     state_in = testing.State(relations=relations)
     # act
     state_out: testing.State = context.run(context.on.relation_changed(relations[0]), state_in)
@@ -188,10 +193,15 @@ from lib.charms.my_Charm.v0.my_lib import MyObject
 def test_my_object_data(context, endpoint, n_relations):
     """Verify that the charm lib does what it should on relation changed."""
     # Arrange:
-    relations = {Relation(
-        endpoint=endpoint, interface='my-interface', remote_app_name=f"remote_{n}",
-        remote_app_data={"foo": f"my-data-{n}"}
-    ) for n in range(n_relations)}
+    relations = {
+        Relation(
+            endpoint=endpoint,
+            interface='my-interface',
+            remote_app_name=f"remote_{n}",
+            remote_app_data={"foo": f"my-data-{n}"},
+        )
+        for n in range(n_relations)
+    }
     state_in = testing.State(relations=relations)
     
     with context(context.on.relation_changed(relations[0]), state_in) as mgr:

--- a/docs/howto/manage-logs.md
+++ b/docs/howto/manage-logs.md
@@ -13,7 +13,6 @@ The default logging level for a Juju model is `INFO`. To see, e.g., `DEBUG` leve
 
 To log a message in a charm, import Python's `logging` module, then use the `getLogger()` function with the desired level. For example:
 
-
 ```python
 import logging
 # ...
@@ -25,11 +24,10 @@ class HelloOperatorCharm(ops.CharmBase):
     def _on_config_changed(self, _):
         current = self.config["thing"]
         if current not in self._stored.things:
-            # Note the use of the logger here
+            # Note the use of the logger here:
             logger.debug("found a new thing: %r", current)
             self._stored.things.append(current)
 ```
-
 
 > See more: 
 > - [`logging`](https://docs.python.org/3/library/logging.html), [`logging.getLogger()`](https://docs.python.org/3/library/logging.html#logging.getLogger)

--- a/docs/howto/manage-relations.md
+++ b/docs/howto/manage-relations.md
@@ -15,7 +15,6 @@ To integrate with another charm, or with itself (to communicate with other units
 
 ```{caution}
 
-
 **If you're using an existing interface:**
 
 Make sure to consult [the `charm-relations-interfaces` repository](https://github.com/canonical/charm-relation-interfaces) for guidance about how to implement them correctly.
@@ -23,11 +22,9 @@ Make sure to consult [the `charm-relations-interfaces` repository](https://githu
 **If you're defining a new interface:**
 
 Make sure to add your interface to [the `charm-relations-interfaces` repository](https://github.com/canonical/charm-relation-interfaces).
-
-
 ```
 
-To exchange data with other units of the same charm, define one or more `peers` endpoints including an interface name for each. Each peer relation must have an endpoint, which your charm will use to refer to the relation (as [`ops.Relation.name`](https://ops.readthedocs.io/en/latest/#ops.Relation.name)).
+To exchange data with other units of the same charm, define one or more `peers` endpoints including an interface name for each. Each peer relation must have an endpoint, which your charm will use to refer to the relation (as [`ops.Relation.name`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Relation.name)).
 
 ```yaml
 peers:
@@ -35,7 +32,7 @@ peers:
     interface: charm_gossip
 ```
 
-To exchange data with another charm, define a `provides` or `requires` endpoint including an interface name. By convention, the interface name should be unique in the ecosystem. Each relation must have an endpoint, which your charm will use to refer to the relation (as [`ops.Relation.name`](https://ops.readthedocs.io/en/latest/#ops.Relation.name)).
+To exchange data with another charm, define a `provides` or `requires` endpoint including an interface name. By convention, the interface name should be unique in the ecosystem. Each relation must have an endpoint, which your charm will use to refer to the relation (as [`ops.Relation.name`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Relation.name)).
 
 ```yaml
 provides:
@@ -54,7 +51,6 @@ Note that implementing a cross-model relation is done in the same way as one bet
 
 Which side of the relation is the “provider” or the “requirer” is often arbitrary, but if one side has a workload that is a server and the other a client, then the server side should be the provider. This becomes important for how Juju sets up network permissions in cross-model relations.
 
-
 If the relation is with a subordinate charm, make sure to set the `scope` field to `container`.
 
 ```yaml
@@ -64,7 +60,7 @@ requires:
     scope: container
 ```
 
-Other than this, implement a subordinate relation in the same way as any other relation. Note however that subordinate units cannot see each other’s peer data.
+Other than this, implement a subordinate relation in the same way as any other relation. Note however that subordinate units cannot see each other's peer data.
 
 > See also: [Charm taxonomy](https://juju.is/docs/sdk/charm-taxonomy#heading--subordinate-charms)
 
@@ -102,9 +98,9 @@ def _on_db_relation_created(self, event: ops.RelationCreatedEvent):
     event.relation.data[event.app].update(credentials)
 ```
 
-The event object that is passed to the handler has a `relation` property, which contains an [`ops.Relation`](https://ops.readthedocs.io/en/latest/#ops.Relation) object. Your charm uses this object to find out about the relation (such as which units are included, in the [`.units` attribute](https://ops.readthedocs.io/en/latest/#ops.Relation.units), or whether the relation is broken, in the [`.active` attribute](https://ops.readthedocs.io/en/latest/#ops.Relation.active)) and to get and set data in the relation databag.
+The event object that is passed to the handler has a `relation` property, which contains an [`ops.Relation`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Relation) object. Your charm uses this object to find out about the relation (such as which units are included, in the [`.units` attribute](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Relation.units), or whether the relation is broken, in the [`.active` attribute](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Relation.active)) and to get and set data in the relation databag.
 
-> See more: [`ops.RelationCreatedEvent`](https://ops.readthedocs.io/en/latest/#ops.RelationCreatedEvent)
+> See more: [`ops.RelationCreatedEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.RelationCreatedEvent)
 
 To do additional setup work when each unit joins the relation (both when the charms are first integrated and when additional units are added to the charm), your charm will need to observe the `relation-joined` event. In the `src/charm.py` file, in the `__init__` function of your charm, set up `relation-joined` event observers for the relevant relations and pair those with an event handler. For example:
 
@@ -120,7 +116,7 @@ def _on_smtp_relation_joined(self, event: ops.RelationJoinedEvent):
     event.relation.data[event.unit]["smtp_credentials"] = smtp_credentials_secret_id
 ```
 
-> See more: [`ops.RelationJoinedEvent`](https://ops.readthedocs.io/en/latest/#ops.RelationJoinedEvent)
+> See more: [`ops.RelationJoinedEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.RelationJoinedEvent)
 
 ##### Exchange data with other units
 
@@ -130,9 +126,9 @@ To use data received through the relation, have your charm observe the `relation
 framework.observe(self.on.replicas_relation_changed, self._update_configuration)
 ```
 
-> See more: [[`ops.RelationChangedEvent`](https://ops.readthedocs.io/en/latest/#ops.RelationChangedEvent)](https://discourse.charmhub.io/t/relation-name-relation-changed-event/6475), [`juju` | Relation (integration)](https://juju.is/docs/juju/relation#heading--permissions-around-relation-databags)
+> See more: [`ops.RelationChangedEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.RelationChangedevent), [`juju` | Relation (integration)](https://juju.is/docs/juju/relation#heading--permissions-around-relation-databags)
 
-Most of the time, you should use the same holistic handler as when receiving other data, such as `secret-changed` and `config-changed`. To access the relation(s) in your holistic handler, use the [`ops.Model.get_relation`](https://ops.readthedocs.io/en/latest/#ops.Model.get_relation) method or [`ops.Model.relations`](https://ops.readthedocs.io/en/latest/#ops.Model.relations) attribute.
+Most of the time, you should use the same holistic handler as when receiving other data, such as `secret-changed` and `config-changed`. To access the relation(s) in your holistic handler, use the [`ops.Model.get_relation`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Model.get_relation) method or [`ops.Model.relations`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Model.relations) attribute.
 
 > See also: {ref}`holistic-vs-delta-charms`
 
@@ -175,7 +171,7 @@ def _update_configuration(self, _: ops.Eventbase):
 
 ##### Exchange data across the various relations
 
-To add data to the relation databag, use the [`.data` attribute](https://ops.readthedocs.io/en/latest/#ops.Relation.data) much as you would a dictionary, after selecting whether to write to the app databag (leaders only) or unit databag. For example, to copy a value from the charm config to the relation data:
+To add data to the relation databag, use the [`.data` attribute](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Relation.data) much as you would a dictionary, after selecting whether to write to the app databag (leaders only) or unit databag. For example, to copy a value from the charm config to the relation data:
 
 ```python
 def _on_config_changed(self, event: ops.ConfigChangedEvent):
@@ -242,7 +238,7 @@ def _on_smtp_relation_departed(self, event: ops.RelationDepartedEvent):
         self.remove_smtp_user(event.unit.name)
 ```
 
-> See more: [ops.RelationDepartedEvent](https://ops.readthedocs.io/en/latest/#ops.RelationDepartedEvent)
+> See more: [ops.RelationDepartedEvent](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.RelationDepartedEvent)
 
 To clean up after a relation is entirely removed, have your charm observe the `relation-broken` event. In the `src/charm.py` file, in the `__init__` function of your charm, set up `relation-broken` events for the relevant relations and pair those with an event handler. For example:
 
@@ -259,59 +255,25 @@ def _on_db_relation_broken(self, event: ops.RelationBrokenEvent):
     self.drop_database(event.app.name)
 ```
 
-> See more: [ops.RelationBrokenEvent](https://ops.readthedocs.io/en/latest/#ops.RelationBrokenEvent)
-
+> See more: [ops.RelationBrokenEvent](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.RelationBrokenEvent)
 
 ## Test the feature
 
 ### Write unit tests
 
-To write unit tests covering your charm’s behaviour when working with relations, in your `unit/test_charm.py` file, create a `Harness` object and use it to simulate adding and removing relations, or the remote app providing data. For example:
+For each relation event that your charm observes, write at least one test. Create a `Relation` object that defines the relation, include that in the input state, run the relation event, and assert that the output state is what you’d expect. For example:
 
 ```python
-@pytest.fixture()
-def harness():
-    harness = testing.Harness(MyCharm)
-    yield harness
-    harness.cleanup()
+from ops import testing
 
-def test_new_smtp_relation(harness):
-    # Before the test begins, we have integrated a remote app
-    # with this charm, so we call add_relation() before begin().
-    relation_id = harness.add_relation('smtp', 'consumer_app')
-    harness.begin()
-    # For the test, we simulate a unit joining the relation.
-    harness.add_relation_unit()
-    assert 'smtp_credentials’ in harness.get_relation_data(relation_id, 'consumer_app/0' )
-
-def test_db_relation_broken(harness):
-    relation_id = harness.add_relation('db', 'postgresql')
-    harness.begin()
-    harness.remove_relation(relation_id)
-    assert harness.charm.get_db() is None
-
-def test_receive_db_credentials(harness):
-    relation_id = harness.add_relation('db', 'postgresql')
-    harness.begin()
-    harness.update_relation_data(relation_id, harness.charm.app, {'credentials-id': 'secret:xxx'})
-    assert harness.charm.db_tables_created()
+ctx = testing.Context(MyCharm)
+relation = testing.Relation(endpoint='smtp', remote_units_data={1: {}})
+state_in = testing.State(relations=[relation])
+state_out = ctx.run(ctx.on.relation_joined(relation, remote_unit_id=1), state=state_in)
+assert 'smtp_credentials' in state_out.get_relation(relation.id).remote_units_data[1]
 ```
 
-> See more: [ops.testing.Harness](https://ops.readthedocs.io/en/latest/harness.html#ops.testing.Harness)
-
-### Write scenario tests
-
-For each relation event that your charm observes, write at least one Scenario test. Create a `Relation` object that defines the relation, include that in the input state, run the relation event, and assert that the output state is what you’d expect. For example:
-
-```python
-ctx = scenario.Context(MyCharm)
-relation = scenario.Relation(id=1, endpoint='smtp', remote_units_data={1: {}})
-state_in = scenario.State(relations=[relation])
-state_out = context.run(relation.joined_event(remote_unit_id=1), state=state_in)
-assert 'smtp_credentials' in state_out.relations[0].remote_units_data[1]
-```
-
-> See more: [Scenario Relations](https://github.com/canonical/ops-scenario/#relations)
+> See more: [Scenario Relations](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.RelationBase)
 
 ### Write integration tests
 
@@ -341,5 +303,3 @@ async def test_active_when_deploy_db_facade(ops_test: OpsTest):
 ```
 
 > See more: [`pytest-operator`](https://pypi.org/project/pytest-operator/)
-
-

--- a/docs/howto/manage-resources.md
+++ b/docs/howto/manage-resources.md
@@ -11,7 +11,7 @@
 Because resources are defined in a charm’s `charmcraft.yaml`, they are intrinsically linked to a charm. As such, there is no need to register them separately in Charmhub. Other charms may have resources with the same name, but this is not a problem; references to resources always contain the charm name and resource name.
 -->
 
-In your charm's `src/charm.py` file, use Ops to fetch the path to the resource and then manipulate it as needed.
+In your charm's `src/charm.py` file, use `ops` to fetch the path to the resource and then manipulate it as needed.
 
 For example, suppose your `charmcraft.yaml` file contains this simple resource definition:
 
@@ -23,7 +23,7 @@ resources:
     description: test resource
 ```
 
-In your charm's `src/charm.py` you can now use [`Model.resources.fetch(<resource_name>)`](https://ops.readthedocs.io/en/latest/#ops.Resources.fetch) to get the path to the resource, then manipulate it as needed. For example:
+In your charm's `src/charm.py` you can now use [`Model.resources.fetch(<resource_name>)`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Resources.fetch) to get the path to the resource, then manipulate it as needed. For example:
 
 ```python
 # ...
@@ -59,8 +59,7 @@ def _on_config_changed(self, event):
     # do something
 ```
 
-The [`fetch()`](https://ops.readthedocs.io/en/latest/#ops.Resources.fetch) method will raise a [`NameError`](https://docs.python.org/3/library/exceptions.html#NameError) if the resource does not exist, and returns a Python [`Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) object to the resource if it does.
-
+The [`fetch()`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Resources.fetch) method will raise a [`NameError`](https://docs.python.org/3/library/exceptions.html#NameError) if the resource does not exist, and returns a Python [`Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) object to the resource if it does.
 
 Note: During development, it may be useful to specify the resource at deploy time to facilitate faster testing without the need to publish a new charm/resource in between minor fixes. In the below snippet, we create a simple file with some text content, and pass it to the Juju controller to use in place of any published `my-resource` resource:
 
@@ -69,4 +68,3 @@ echo "TEST" > /tmp/somefile.txt
 charmcraft pack
 juju deploy ./my-charm.charm --resource my-resource=/tmp/somefile.txt
 ```
-

--- a/docs/howto/manage-secrets.md
+++ b/docs/howto/manage-secrets.md
@@ -5,7 +5,7 @@
 > See first: [`juju` | Secret](https://juju.is/docs/juju/secret), [`juju` | Manage secrets](https://juju.is/docs/juju/manage-secrets), [`charmcraft` | Manage secrets]()
 -->
 
-> Added in `ops 2.0.0`, `juju 3.0.2`
+> Added in `Juju 3.0.2`
 
 This document shows how to use secrets in a charm -- both when the charm is the secret owner as well as when it is merely an observer.
 
@@ -57,12 +57,9 @@ Note that:
 - The only data shared in plain text is the secret ID (a locator URI). The secret ID can be publicly shared. Juju will ensure that only remote apps/units to which the secret has explicitly been granted by the owner will be able to fetch the actual secret payload from that ID.
 - The secret needs to be granted to a remote entity (app or unit), and that always goes via a relation instance. By passing a relation to `grant` (in this case the event's relation), we are explicitly declaring the scope of the secret -- its lifetime will be bound to that of this relation instance.
 
-> See more: [`ops.Application.add_secret()`](https://ops.readthedocs.io/en/latest/#ops.Application.add_secret), 
-
-
+> See more: [`ops.Application.add_secret()`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Application.add_secret)
 
 ### Create a new secret revision
-
 
 To create a new secret revision, the owner charm must call `secret.set_content()` and pass in the new payload:
 
@@ -81,11 +78,13 @@ class MyDatabaseCharm(ops.CharmBase):
 
 This will inform Juju that a new revision is available, and Juju will inform all observers tracking older revisions that a new one is available, by means of a `secret-changed` hook.
 
+```{caution}
+If your charm creates new revisions, it **must** also add a handler for the `secret-remove` event, and call `remove_revision` in it. If not, old revisions will continually build up in the secret backend.
+```
 
 ### Change the rotation policy or the expiration date of a secret
 
 Typically you want to rotate a secret periodically to contain the damage from a leak, or to avoid giving hackers too much time to break the encryption.
-
 
 A charm can configure a secret, at creation time, to have one or both of:
 
@@ -144,11 +143,7 @@ class MyDatabaseCharm(ops.CharmBase):
             self._rotate_webserver_secret(event.secret)
 ```
 
-
-
-
 ### Remove a secret
-
 
 To remove a secret (effectively destroying it for good), the owner needs to call `secret.remove_all_revisions`. Regardless of the logic leading to the decision of when to remove a secret, the code will look like some variation of the following:
 
@@ -164,10 +159,9 @@ class MyDatabaseCharm(ops.CharmBase):
 
 After this is called, the observer charm will get a `ModelError` whenever it attempts to get the secret. In general, the presumption is that the observer charm will take the absence of the relation as indication that the secret is gone as well, and so will not attempt to get it.
 
-
 ### Remove a single secret revision
 
-Removing a single secret revision is a more common (and less drastic!) operation than removing all revisions.
+Removing a single secret revision is a more common (and less drastic!) operation than removing all revisions. If your charm creates new revisions of secrets, it **must** implement a `secret-remove` handler that calls `remove_revision`.
 
 Typically, the owner will remove a secret revision when it receives a `secret-remove` event -- that is, when that specific revision is no longer tracked by any observer. If a secret owner did remove a revision while it was still being tracked by observers, they would get a `ModelError` when they tried to get the secret.
 
@@ -184,16 +178,16 @@ class MyDatabaseCharm(ops.CharmBase):
                                self._on_secret_remove)
 
     def _on_secret_remove(self, event: ops.SecretRemoveEvent):
-        # all observers are done with this revision, remove it
+        # All observers are done with this revision, remove it:
         event.secret.remove_revision(event.revision)
 ```
-
 
 ### Revoke a secret
 
 For whatever reason, the owner of a secret can decide to revoke access to the secret to a remote entity. That is done by calling `secret.revoke`, and is the inverse of `secret.grant`.
 
 An example of usage might look like:
+
 ```python
 class MyDatabaseCharm(ops.CharmBase):
 
@@ -206,7 +200,6 @@ class MyDatabaseCharm(ops.CharmBase):
 ```
 
 Just like when the owner granted the secret, we need to pass a relation to the `revoke` call, making it clear what scope this action is to be applied to.
-
 
 ## Secret observer charm
 
@@ -255,11 +248,9 @@ Note that:
 - The observer charm gets a secret via the model (not its app/unit). Because it's the owner who decides who the secret is granted to, the ownership of a secret is not an observer concern. The observer code can rightfully assume that, so long as a secret ID is  shared with it, the owner has taken care to grant and scope the secret in such a way that the observer has the rights to inspect its contents.
 - The charm first gets the secret object from the model, then gets the secret's content (a dict) and accesses individual attributes via the dict's items.
 
-
-> See more: [`ops.Secret.get_content()`](https://ops.readthedocs.io/en/latest/#ops.Secret.get_content)
+> See more: [`ops.Secret.get_content()`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Secret.get_content)
 
 ### Label the secrets you're observing
-
 
 Sometimes a charm will observe multiple secrets. In the `secret-changed` event handler above, you might ask yourself: How do I know which secret has changed?
 The answer lies with **secret labels**: a label is a charm-local name that you can assign to a secret. Let's go through the following code:
@@ -318,7 +309,7 @@ So, having labelled the secret on creation, the database charm could add a new r
         secret.set_content(...)  # pass a new revision payload, as before
 ```
 
-> See more: [`ops.Model.get_secret()`](https://ops.readthedocs.io/en/latest/#ops.Model.get_secret)
+> See more: [`ops.Model.get_secret()`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Model.get_secret)
 
 #### When to use labels
 
@@ -326,12 +317,9 @@ When should you use labels? A label is basically the secret's *name* (local to t
 
 Most charms that use secrets have a fixed number of secrets each with a specific meaning, so the charm author should give them meaningful labels like `database-credential`, `tls-cert`, and so on. Think of these as "pets" with names.
 
-In rare cases, however, a charm will have a set of secrets all with the same meaning: for example, a set of TLS certificates that are all equally valid. In this case it doesn't make sense to label them -- think of them as "cattle". To distinguish between secrets of this kind, you can use the [`Secret.unique_identifier`](https://ops.readthedocs.io/en/latest/#ops.Secret.unique_identifier) property, added in ops 2.6.0.
+In rare cases, however, a charm will have a set of secrets all with the same meaning: for example, a set of TLS certificates that are all equally valid. In this case it doesn't make sense to label them -- think of them as "cattle". To distinguish between secrets of this kind, you can use the [`Secret.unique_identifier`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Secret.unique_identifier) property.
 
-Note that [`Secret.id`](https://ops.readthedocs.io/en/latest/#ops.Secret.id), despite the name, is not really a unique ID, but a locator URI. We call this the "secret ID" throughout Juju and in the original secrets specification -- it probably should have been called "uri", but the name stuck.
-
-
-
+Note that [`Secret.id`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Secret.id), despite the name, is not really a unique ID, but a locator URI. We call this the "secret ID" throughout Juju and in the original secrets specification -- it probably should have been called "uri", but the name stuck.
 
 ### Peek at a new secret revision
 
@@ -347,11 +335,9 @@ Sometimes, before reconfiguring to use a new credential revision, the observer c
         ...
 ```
 
-> See more: [`ops.Secret.peek_content()`](https://ops.readthedocs.io/en/latest/#ops.Secret.peek_content)
-
+> See more: [`ops.Secret.peek_content()`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Secret.peek_content)
 
 ### Start tracking a different secret revision
-
 
 To update to a new revision, the web server charm will typically subscribe to the `secret-changed` event and call `get_content` with the "refresh" argument set (refresh asks Juju to start tracking the latest revision for this observer).
 
@@ -369,10 +355,7 @@ class MyWebserverCharm(ops.CharmBase):
         self._configure_db_credentials(content['username'], content['password'])
 ```
 
-
-> See more: [`ops.Secret.get_content()`](https://ops.readthedocs.io/en/latest/#ops.Secret.get_content)
-
-
+> See more: [`ops.Secret.get_content()`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Secret.get_content)
 
 <br>
 

--- a/docs/howto/manage-secrets.md
+++ b/docs/howto/manage-secrets.md
@@ -79,7 +79,7 @@ class MyDatabaseCharm(ops.CharmBase):
 This will inform Juju that a new revision is available, and Juju will inform all observers tracking older revisions that a new one is available, by means of a `secret-changed` hook.
 
 ```{caution}
-If your charm creates new revisions, it **must** also add a handler for the `secret-remove` event, and call `remove_revision` in it. If not, old revisions will continually build up in the secret backend.
+If your charm creates new revisions, it **must** also add a handler for the `secret-remove` event, and call `remove_revision` in it. If not, old revisions will continually build up in the secret backend. See more: {ref}`howto-remove-a-secret`
 ```
 
 ### Change the rotation policy or the expiration date of a secret
@@ -143,6 +143,7 @@ class MyDatabaseCharm(ops.CharmBase):
             self._rotate_webserver_secret(event.secret)
 ```
 
+(howto-remove-a-secret)=
 ### Remove a secret
 
 To remove a secret (effectively destroying it for good), the owner needs to call `secret.remove_all_revisions`. Regardless of the logic leading to the decision of when to remove a secret, the code will look like some variation of the following:

--- a/docs/howto/manage-storage.md
+++ b/docs/howto/manage-storage.md
@@ -43,8 +43,6 @@ containers:
         location: /var/cache
 ```
 
-
-
 ### Observe the `storage-attached` event and define an event handler
 
 In the `src/charm.py` file, in the `__init__` function of your charm, set up an observer for the `storage-attached` event associated with your storage and pair that with an event handler, typically a holistic one. For example:
@@ -53,7 +51,7 @@ In the `src/charm.py` file, in the `__init__` function of your charm, set up an 
 self.framework.observe(self.on.cache_storage_attached, self._update_configuration)
 ```
 
-> See more: [`ops.StorageAttachedEvent`](https://ops.readthedocs.io/en/latest/#ops.StorageAttachedEvent), [Juju SDK | Holistic vs delta charms](https://juju.is/docs/sdk/holistic-vs-delta-charms)
+> See more: [`ops.StorageAttachedEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.StorageAttachedEvent), [Juju SDK | Holistic vs delta charms](https://juju.is/docs/sdk/holistic-vs-delta-charms)
 
 Storage volumes will be automatically mounted into the charm container at either the path specified in the `location` field in the metadata, or the default location `/var/lib/juju/storage/<storage-name>`. However, your charm code should not hard-code the location, and should instead use the `.location` property of the storage object.
 
@@ -85,7 +83,7 @@ In the `src/charm.py` file, in the `__init__` function of your charm, set up an 
 self.framework.observe(self.on.cache_storage_detaching, self._on_storage_detaching)
 ```
 
-> See more: [`ops.StorageDetachingEvent`](https://ops.readthedocs.io/en/latest/#ops.StorageDetachingEvent)
+> See more: [`ops.StorageDetachingEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.StorageDetachingEvent)
 
 Now, in the body of the charm definition, define the event handler, or adjust an existing holistic one. For example, to warn users that data won't be cached:
 
@@ -102,7 +100,6 @@ def _on_storage_detaching(self, event: ops.StorageDetachingEvent):
 ```{note}
 
 Juju only supports adding multiple instances of the same storage volume on machine charms. Kubernetes charms may only have a single instance of each volume.
-
 ```
 
 If the charm needs additional units of a storage, it can request that with the `storages.request`
@@ -131,59 +128,25 @@ has attached the new storage.
 
 > See first: {ref}`get-started-with-charm-testing`
 
-You'll want to add three levels of tests:
+You'll want to add unit and integration tests:
 
 ### Write unit tests
 
-> See first: {ref}`write-unit-tests-for-a-charm`
-
-When using Harness for unit tests, use the `add_storage()` method to simulate Juju adding storage to the charm. You can either have the method also simulate attaching the storage, or do that explicitly with the `attach_storage()` method. In this example, we verify that the charm responds as expected to storage attached and detaching events:
-
-```python
-@pytest.fixture()
-def harness():
-    yield ops.testing.Harness(MyCharm)
-    harness.cleanup()
-
-
-def test_storage_attached(harness):
-    # Add one instance of the expected storage to the charm. This is before `.begin()` is called,
-    # so will not trigger any events.
-    storage_id = harness.add_storage("cache", 1)
-    harness.begin()
-    # Simulate Juju attaching the storage, which will trigger a storage-attached event on the charm.
-    harness.attach_storage(storage_id)
-    # Assert that it was handled correctly.
-    assert ...
-
-
-def test_storage_detaching(harness):
-    storage_id = harness.add_storage("cache", 1, attach=True)
-    harness.begin()
-    # Simulate the harness being detached (.remove_storage() would simulate it being removed
-    # entirely).
-    harness.remove_storage(storage_id)
-    # Assert that it was handled correctly.
-    assert ...
-```
-
-> See more: [`ops.testing.Harness.add_storage`](https://ops.readthedocs.io/en/latest/harness.html#ops.testing.Harness.add_storage), [`ops.testing.Harness.attach_storage`](https://ops.readthedocs.io/en/latest/harness.html#ops.testing.Harness.attach_storage), [`ops.testing.Harness.detach_storage`](https://ops.readthedocs.io/en/latest/harness.html#ops.testing.Harness.detach_storage), [`ops.testing.harness.remove_storage`](https://ops.readthedocs.io/en/latest/harness.html#ops.testing.Harness.remove_storage) 
-
-### Write scenario tests
-
 > See first: {ref}`write-scenario-tests-for-a-charm`
 
-When using Scenario for unit tests, to verify that the charm state is as expected after storage changes, use the `run` method of the Scenario `Context` object. For example, to provide the charm with mock storage:
+To verify that the charm state is as expected after storage changes, use the `run` method of the `Context` object. For example, to provide the charm with mock storage:
 
 ```python
+from ops import testing
+
 # Some charm with a 'foo' filesystem-type storage defined in its metadata:
-ctx = scenario.Context(MyCharm)
-storage = scenario.Storage("foo")
+ctx = testing.Context(MyCharm)
+storage = testing.Storage("foo")
 
 # Set up storage with some content:
 (storage.get_filesystem(ctx) / "myfile.txt").write_text("helloworld")
 
-with ctx.manager("update-status", scenario.State(storage=[storage])) as mgr:
+with ctx(ctx.on.update_status(), testing.State(storages={storage})) as mgr:
     foo = mgr.charm.model.storages["foo"][0]
     loc = foo.location
     path = loc / "myfile.txt"
@@ -193,9 +156,11 @@ with ctx.manager("update-status", scenario.State(storage=[storage])) as mgr:
     myfile = loc / "path.py"
     myfile.write_text("helloworlds")
 
+    state_out = mgr.run()
+
 # Verify that the contents are as expected afterwards.
 assert (
-    storage.get_filesystem(ctx) / "path.py"
+    state_out.get_storage(storage.name).get_filesystem(ctx) / "path.py"
 ).read_text() == "helloworlds"
 ```
 
@@ -203,31 +168,30 @@ If a charm requests adding more storage instances while handling some event, you
 can inspect that from the `Context.requested_storage` API.
 
 ```python
-ctx = scenario.Context(MyCharm)
-ctx.run('some-event-that-will-request-more-storage', scenario.State())
+ctx = testing.Context(MyCharm)
+ctx.run(ctx.on.some_event_that_will_request_more_storage(), testing.State())
 
 # The charm has requested two 'foo' storage volumes to be provisioned:
 assert ctx.requested_storages['foo'] == 2
 ```
 
-Requesting storage volumes has no other consequence in Scenario. In real life,
+Requesting storage volumes has no other consequence in the unit test. In real life,
 this request will trigger Juju to provision the storage and execute the charm
-again with foo-storage-attached. So a natural follow-up Scenario test suite for
+again with foo-storage-attached. So a natural follow-up test suite for
 this case would be:
 
 ```
-ctx = scenario.Context(MyCharm)
-foo_0 = scenario.Storage('foo')
+ctx = testing.Context(MyCharm)
+foo_0 = testing.Storage('foo')
 # The charm is notified that one of the storage volumes it has requested is ready:
-ctx.run(foo_0.attached_event, State(storage=[foo_0]))
+ctx.run(ctx.on.storage_attached(foo_0), testing.State(storages={foo_0}))
 
-foo_1 = scenario.Storage('foo')
+foo_1 = testing.Storage('foo')
 # The charm is notified that the other storage is also ready:
-ctx.run(foo_1.attached_event, State(storage=[foo_0, foo_1]))
+ctx.run(ctx.on.storage_attached(foo_1), testing.State(storages={foo_0, foo_1}))
 ```
 
-> See more: [Scenario storage testing](https://github.com/canonical/ops-scenario/#storage)
-
+> See more: [`ops.testing.Storage`](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.Storage)
 
 ### Write integration tests
 

--- a/docs/howto/manage-the-charm-version.md
+++ b/docs/howto/manage-the-charm-version.md
@@ -39,7 +39,6 @@ there is no version, the key will not be present in the status output.
 Note that this is distinct from the charm **revision**, which is set when
 uploading a charm to CharmHub (or when deploying/refreshing for local charms).
 
-
 > Examples: [`container-log-archive-charm` sets `version` to a version control hash](https://git.launchpad.net/container-log-archive-charm/tree/)
 
 ## Test the feature

--- a/docs/howto/manage-the-workload-version.md
+++ b/docs/howto/manage-the-workload-version.md
@@ -16,7 +16,6 @@ If the charm has not set the workload version, then the field will not be
 present in JSON or YAML format, and if the version string is too long or
 contains particular characters then it will not be displayed in the tabular
 format.
-
 ```
 
 For Kubernetes charms, the workload is typically started in the
@@ -34,7 +33,7 @@ observer for the `start` event and pair that with an event handler. For example:
 self.framework.observe(self.on.start, self._on_start)
 ```
 
-> See more: [`ops.StartEvent`](https://ops.readthedocs.io/en/latest/#ops.StartEvent)
+> See more: [`ops.StartEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.StartEvent)
 
 Now, in the body of the charm definition, define the event handler. Typically,
 the workload version is retrieved from the workload itself, with a subprocess
@@ -48,7 +47,7 @@ def _on_start(self, event: ops.StartEvent):
     self.unit.set_workload_version(version)
 ```
 
-> See more: [`ops.Unit.set_workload_version`](https://ops.readthedocs.io/en/latest/#ops.Unit.set_workload_version)
+> See more: [`ops.Unit.set_workload_version`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Unit.set_workload_version)
 
 > Examples: [`jenkins-k8s` sets the workload version after getting it from the Jenkins package](https://github.com/canonical/jenkins-k8s-operator/blob/29e9b652714bd8314198965c41a60f5755dd381c/src/charm.py#L115), [`discourse-k8s` sets the workload version after getting it via an exec call](https://github.com/canonical/discourse-k8s-operator/blob/f523b29f909c69da7b9510b581dfcc2309698222/src/charm.py#L581), [`synapse` sets the workload version after getting it via an API call](https://github.com/canonical/synapse-operator/blob/778bcd414644c922373d542a304be14866835516/src/charm.py#L265)
 
@@ -56,58 +55,28 @@ def _on_start(self, event: ops.StartEvent):
 
 > See first: [Get started with charm testing](https://juju.is/docs/sdk/get-started-with-charm-testing)
 
-You'll want to add three levels of tests, unit, scenario, and integration.
-
+You'll want to add unit and integration tests.
 
 ### Write unit tests
 
-> See first: {ref}`write-unit-tests-for-a-charm`
-
-To verify the workload version is set in a unit test, use the
-`ops.testing.Harness.get_workload_version()` method to
-get the version that the charm set. In your `tests/unit/test_charm.py` file,
-add a new test to verify the workload version is set; for example:
-
-```python
-# You may already have this fixture to use in other tests.
-@pytest.fixture()
-def harness():
-    yield ops.testing.Harness(MyCharm)
-    harness.cleanup()
-
-def test_start(harness):
-    # Suppose that the charm gets the workload version by running the command
-    # `/bin/server --version` in the container. Firstly, we mock that out:
-    harness.handle_exec("webserver", ["/bin/server", "--version"], result="1.2\n")
-    # begin_with_initial_hooks will trigger the 'start' event, and we expect
-    # the charm's 'start' handler to set the workload version.
-    harness.begin_with_initial_hooks()
-    assert harness.get_workload_version() == "1.2"
-```
-
-> See more: [`ops.testing.Harness.get_workload_version`](https://ops.readthedocs.io/en/latest/harness.html#ops.testing.Harness.get_workload_version)
-
-> Examples: [grafana-k8s checking the workload version](https://github.com/canonical/grafana-k8s-operator/blob/1c80f746f8edeae6fd23ddf31eed45f5b88c06b4/tests/unit/test_charm.py#L283) (and the [earlier mocking](https://github.com/canonical/grafana-k8s-operator/blob/1c80f746f8edeae6fd23ddf31eed45f5b88c06b4/tests/unit/test_charm.py#L127)), [sdcore-webui checks both that the version is set when it is available, and not set when not](https://github.com/canonical/sdcore-webui-k8s-operator/blob/1a66ad3f623d665657d04ad556139439f4733a28/tests/unit/test_charm.py#L447)
-
-
-### Write scenario tests
-
 > See first: {ref}`write-scenario-tests-for-a-charm`
 
-To verify the workload version is set using Scenario, retrieve the workload
-version from the `State`. In your `tests/scenario/test_charm.py` file, add a
+To verify the workload version is set in a unit test, retrieve the workload
+version from the `State`. In your `tests/unit/test_charm.py` file, add a
 new test that verifies the workload version is set. For example:
 
 ```python
+from ops import testing
+
 def test_workload_version_is_set():
-    ctx = scenario.Context(MyCharm, meta={"name": "foo"})
+    ctx = testing.Context(MyCharm)
     # Suppose that the charm gets the workload version by running the command
     # `/bin/server --version` in the container. Firstly, we mock that out:
-    container = scenario.Container(
+    container = testing.Container(
         "webserver",
-        exec_mock={("/bin/server", "--version"): scenario.ExecOutput(stdout="1.2\n")},
+        execs={testing.Exec(["/bin/server", "--version"], stdout="1.2\n")},
     )
-    out = ctx.run('start', scenario.State(containers=[container]))
+    out = ctx.run(ctx.on.start(), testing.State(containers={container}))
     assert out.workload_version == "1.2"
 ```
 
@@ -151,4 +120,3 @@ No "see more" link: this is not currently documented in the pylibjuju docs.
 -->
 
 > Examples: [synapse checking that the unit's workload version matches the one reported by the server](https://github.com/canonical/synapse-operator/blob/778bcd414644c922373d542a304be14866835516/tests/integration/test_charm.py#L139)
-

--- a/docs/howto/run-workloads-with-a-charm-kubernetes.md
+++ b/docs/howto/run-workloads-with-a-charm-kubernetes.md
@@ -300,7 +300,7 @@ class MyCharm(ops.CharmBase):
 
 It's not an error to start a service that's already started, or stop one that's already stopped. These actions are *idempotent*, meaning they can safely be performed more than once, and the service will remain in the same state.
 
-When Pebble starts a service, Pebble waits one second to ensure the process doesn't exit too quickly -- if the process exits within one second, the start operation raises an error and the service remains stopped.
+When Pebble starts a service, it waits one second to ensure the process doesn't exit too quickly. In Juju 3.6.0 and earlier, if the process exits within one second, the start operation raises an error and the service remains stopped. In Juju 3.6.1 and later, the operation will still raise an error, but Pebble will continue to try starting the service.
 
 To stop a service, Pebble first sends `SIGTERM` to the service's process group to try to stop the service gracefully. If the process has not exited after 5 seconds, Pebble sends `SIGKILL` to the process group. If the process still doesn't exit after another 5 seconds, the stop operation raises an error. If the process exits any time before the 10 seconds have elapsed, the stop operation succeeds.
 


### PR DESCRIPTION
Adjustments to the how-to guides:
* Links to the API reference are updated to the new location. I assume that these can be references that will automatically resolve somehow, but I'm not sure how to do that, so I opened #1506 and just fixed them as full links for now (at least they'll work again).
* A few minor whitespace cleanups.
* Removed all the Harness sections, moving the Scenario sections up to be "unit tests"
* Updated the Scenario sections to use ops.testing and Scenario 7
* Updated the secrets how-to to be more explicit about needing to remove revisions if you create new ones.

[Live preview](https://ops--1507.org.readthedocs.build/en/1507/)