### PR TITLE
docs: clearly deprecate Harness in the testing how-tos

### DIFF
--- a/docs/explanation/testing.md
+++ b/docs/explanation/testing.md
@@ -31,13 +31,7 @@ Unit tests are intended to be isolating and fast to complete. These are the test
 **Tools.** Unit testing a charm can be done using:
 
 - [`pytest`](https://pytest.org/) and/or [`unittest`](https://docs.python.org/3/library/unittest.html) and
-- the {ref}`write-scenario-tests-for-a-charm`, the `ops` unit testing framework
-
-<!--
-Unit tests are written using the `unittest` library shipped with Python or [pytest](https://pypi.org/project/pytest/). To facilitate unit testing of charms, use the [testing harness](https://juju.is/docs/sdk/testing) specifically designed for charmed operators which is available in the [Charmed Operator SDK](https://operator-framework.readthedocs.io/en/latest/#module-ops.testing). 
--->
-
-
+- [state transition testing](https://ops.readthedocs.io/en/latest/reference/ops-testing.html), using the `ops` unit testing framework
 
 **Examples.**
 

--- a/docs/explanation/testing.md
+++ b/docs/explanation/testing.md
@@ -31,7 +31,7 @@ Unit tests are intended to be isolating and fast to complete. These are the test
 **Tools.** Unit testing a charm can be done using:
 
 - [`pytest`](https://pytest.org/) and/or [`unittest`](https://docs.python.org/3/library/unittest.html) and
-- [`ops.testing.Harness`](https://operator-framework.readthedocs.io/en/latest/#module-ops.testing) and/or {ref}``ops-scenario` <scenario>`
+- the {ref}`write-scenario-tests-for-a-charm`, the `ops` unit testing framework
 
 <!--
 Unit tests are written using the `unittest` library shipped with Python or [pytest](https://pypi.org/project/pytest/). To facilitate unit testing of charms, use the [testing harness](https://juju.is/docs/sdk/testing) specifically designed for charmed operators which is available in the [Charmed Operator SDK](https://operator-framework.readthedocs.io/en/latest/#module-ops.testing). 

--- a/docs/howto/get-started-with-charm-testing.md
+++ b/docs/howto/get-started-with-charm-testing.md
@@ -91,7 +91,7 @@ A 'live', deployed Juju application will have access to all the inputs we discus
  
 You will notice that the starting point is typically always an event. A charm doesn't do anything unless it's being run, and it is only run when an event occurs. So there is *always* an event context to be mocked. This has important consequences for the unit-testing framework, as we will see below.
 
-### The framework
+### The testing framework
 
 In the charming world, unit testing means state-transition testing.
 
@@ -112,7 +112,7 @@ A typical test will look like this:
 
 > Obviously, other flows are possible; for example, where you unit test individual charm methods without going through the whole event context setup, but this is the characteristic one.
 
-### Understanding the test framework
+### Understanding the testing framework
 
 When you instantiate `Context` and `State` objects, the charm instance does not exist yet. Just like in a live charm, it is possible that when the charm is executed for the first time, the Juju model already has given it storage, relations, some config, or leadership. This delay is meant to give us a chance to simulate this in our test setup. You create a `State` object, then you prepare the 'initial state' of the model mock, then you finally initialise the charm and simulate one or more events.
 

--- a/docs/howto/get-started-with-charm-testing.md
+++ b/docs/howto/get-started-with-charm-testing.md
@@ -106,7 +106,7 @@ A typical test will look like this:
   - set up the context
   - mock any 'output' callable that you know would misfire or break (for example, a system call -- you don't want a unit test to reboot your laptop)
   - set up the Juju state in which the event will fire, including config and relation data
- - **mock an event**
+ - **simulate an event via `Context.run`**
  - get the output
  - run assertions on the output
 
@@ -144,20 +144,19 @@ from ops import testing
 def test_pebble_ready_writes_config_file():
     """Test that on pebble-ready, a config file is written"""
     ctx = testing.Context(MyCharm)
-    # If you want to mock charm config:
-    config = {'foo': 'bar'}
-    # If you want to mock charm leadership:
-    leader = True
 
-    # If you want to mock relation data:
     relation = testing.Relation(
         'relation-name',
         remote_app_name='remote-app-name',
         remote_units_data={1: {'baz': 'qux'}},
     )
     
-    # We are done setting up the inputs.
-    state_in = testing.State(config=config, leader=leader, relations={relation})
+    # We are done setting up the inputs:
+    state_in = testing.State(
+      config={'foo': 'bar'},  # Mock the current charm config.
+      leader=True,  # Mock the charm leadership.
+      relations={relation},  # Mock relation data.
+    )
 
     # This will fire a `<container-name>-pebble-ready` event.
     state_out = ctx.run(ctx.on.pebble_ready(container), state_in)

--- a/docs/howto/get-started-with-charm-testing.md
+++ b/docs/howto/get-started-with-charm-testing.md
@@ -97,14 +97,14 @@ In the charming world, unit testing means state-transition testing.
 
 > See more [`ops.testing`](https://ops.readthedocs.io/en/latest/reference/ops-testing.html)
 
-`State` is the 'mocker' for most inputs and outputs you will need. Where a live charm would gather its input through context variables and calls to the Juju api (by running the hook tools), a charm under unit test will gather data via a mocked backend managed by the testing framework. Where a live charm would produce output by writing files to a filesystem, `Context` and `Container` expose a mock filesystem the charm will be able to interact with without knowing the difference. More specific outputs, however, will need to be mocked individually.
+`State` is the 'mocker' for most inputs and outputs you will need. Where a live charm would gather its input through context variables and calls to the Juju API (by running the hook tools), a charm under unit test will gather data using a mocked backend managed by the testing framework. Where a live charm would produce output by writing files to a filesystem, `Context` and `Container` expose a mock filesystem the charm will be able to interact with without knowing the difference. More specific outputs, however, will need to be mocked individually.
 
 A typical test will look like this:
  
 - set things up:
   - set up the charm and its metadata
   - set up the context
-  - mock any 'output' callable that you know would misfire or break (e.g. a system call -- you don't want a unit test to reboot your laptop)
+  - mock any 'output' callable that you know would misfire or break (for example, a system call -- you don't want a unit test to reboot your laptop)
   - set up the Juju state in which the event will fire, including config and relation data
  - **mock an event**
  - get the output

--- a/docs/howto/get-started-with-charm-testing.md
+++ b/docs/howto/get-started-with-charm-testing.md
@@ -91,7 +91,7 @@ A 'live', deployed Juju application will have access to all the inputs we discus
  
 You will notice that the starting point is typically always an event. A charm doesn't do anything unless it's being run, and it is only run when an event occurs. So there is *always* an event context to be mocked. This has important consequences for the unit-testing framework, as we will see below.
 
-### The harness
+### The framework
 
 In the charming world, unit testing means state-transition testing.
 

--- a/docs/howto/write-scenario-tests-for-a-charm.md
+++ b/docs/howto/write-scenario-tests-for-a-charm.md
@@ -1,9 +1,9 @@
 (write-scenario-tests-for-a-charm)=
 # How to write unit tests for a charm
 
-First of all, install the testing framework. To do this in a virtual environment
-while you are developing, you can do this with `pip` or any other package
-manager; for example:
+First of all, install the Ops testing framework. To do this in a virtual environment
+while you are developing, use `pip` or another package
+manager. For example:
 
 ```
 pip install ops[testing]

--- a/docs/howto/write-scenario-tests-for-a-charm.md
+++ b/docs/howto/write-scenario-tests-for-a-charm.md
@@ -48,7 +48,7 @@ def test_charm_runs():
     #  Create a Context to specify what code we will be running,
     ctx = testing.Context(MyCharm)
     #  and create a State to specify what simulated data the charm being run will access.
-    state_in = testing.State()
+    state_in = testing.State(leader=True)
 
     # Act:
     #  Ask the context to run an event, e.g. 'start', with the state we have previously created.

--- a/docs/howto/write-scenario-tests-for-a-charm.md
+++ b/docs/howto/write-scenario-tests-for-a-charm.md
@@ -1,45 +1,67 @@
 (write-scenario-tests-for-a-charm)=
-# How to write scenario tests for a charm
+# How to write unit tests for a charm
 
-First of all, install scenario:
+First of all, install the testing framework. To do this in a virtual environment
+while you are developing, you can do this with `pip` or any other package
+manager; for example:
 
-`pip install ops-scenario`
+```
+pip install ops[testing]
+```
+
+Normally, you'll include this in the dependency group for your unit tests, for
+example in a test-requirements.txt file:
+
+```text
+ops[testing] ~= 2.17
+```
+
+Or in `pyproject.toml`:
+
+```toml
+[dependency-groups]
+test = [
+  "ops[testing] ~= 2.17",
+]
+```
 
 Then, open a new `test_foo.py` file where you will put the test code.
 
 ```python
-# import the necessary objects from scenario and ops
-from scenario import State, Context
 import ops
+from ops import testing
 ```
-
 
 Then declare a new charm type:
 ```python
 class MyCharm(ops.CharmBase):
     pass        
 ```
-And finally we can write a test function. The test code should use a Context object to encapsulate the charm type being tested (`MyCharm`) and any necessary metadata, then declare the initial `State` the charm will be presented when run, and `run` the context with an `event` and that initial state as parameters. 
+
+And finally we can write a test function. The test code should use a `Context` object to encapsulate the charm type being tested (`MyCharm`) and any necessary metadata, then declare the initial `State` the charm will be presented when run, and `run` the context with an `event` and that initial state as parameters. 
+
 In code:
 
 ```python
 def test_charm_runs():
-    # arrange: 
-    #  create a Context to specify what code we will be running
-    ctx = Context(MyCharm, meta={'name': 'my-charm'})
-    #  and create a State to specify what simulated data the charm being run will access
-    state_in = State()
-    # act:
-    #  ask the context to run an event, e.g. 'start', with the state we have previously created
+    # Arrange: 
+    #  Create a Context to specify what code we will be running,
+    ctx = testing.Context(MyCharm)
+    #  and create a State to specify what simulated data the charm being run will access.
+    state_in = testing.State()
+
+    # Act:
+    #  Ask the context to run an event, e.g. 'start', with the state we have previously created.
     state_out = ctx.run(ctx.on.start(), state_in)
-    # assert:
-    #  verify that the output state looks like you expect it to
+
+    # Assert:
+    #  Verify that the output state looks like you expect it to.
     assert state_out.status.unit.name == 'unknown' 
 ```
 
 > See more: 
->  - [State](https://ops.readthedocs.io/en/latest/state-transition-testing.html#ops.testing.State)
->  - [Context](https://ops.readthedocs.io/en/latest/state-transition-testing.html#ops.testing.Context)
+>  - [State](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.State)
+>  - [Context](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.Context)
 
 ```{note}
 
@@ -48,8 +70,8 @@ If you like using unittest, you should rewrite this as a method of some TestCase
 
 ## Mocking beyond the State
 
-If you wish to use Scenario to test an existing charm type, you will probably need to mock out certain calls that are not covered by the `State` data structure.
-In that case, you will have to manually mock, patch or otherwise simulate those calls on top of what Scenario does for you.
+If you wish to use the framework to test an existing charm type, you will probably need to mock out certain calls that are not covered by the `State` data structure.
+In that case, you will have to manually mock, patch or otherwise simulate those calls on top of what the framework does for you.
 
 For example, suppose that the charm we're testing uses the `KubernetesServicePatch`. To update the test above to mock that object, modify the test file to contain:
 
@@ -63,17 +85,17 @@ def my_charm():
         yield MyCharm
 ```
 
-Then you should rewrite the test to pass the patched charm type to the Context, instead of the unpatched one. In code:
+Then you should rewrite the test to pass the patched charm type to the `Context`, instead of the unpatched one. In code:
+
 ```python
 def test_charm_runs(my_charm):
-    # arrange: 
-    #  create a Context to specify what code we will be running
-    ctx = Context(my_charm, meta={'name': 'my-charm'})
+    # Arrange: 
+    #  Create a Context to specify what code we will be running
+    ctx = Context(my_charm)
     # ...
 ```
 
 ```{note}
 
-If you use pytest, you should put the `my_charm` fixture in a toplevel `conftest.py`, as it will likely be shared between all your scenario tests.
-
+If you use pytest, you should put the `my_charm` fixture in a top level `conftest.py`, as it will likely be shared between all your unit tests.
 ```

--- a/docs/howto/write-unit-tests-for-a-charm.md
+++ b/docs/howto/write-unit-tests-for-a-charm.md
@@ -1,17 +1,18 @@
 (write-unit-tests-for-a-charm)=
-# How to write unit tests for a charm
+# How to write legacy unit tests for a charm
 
-The Ops library provides a testing harness, so you can check your charm does the right thing in different scenarios without having to create a full deployment. When you run `charmcraft init`, the template charm it creates includes some sample tests, along with a `tox.ini` file; use `tox` to run the tests and to get a short report of unit test coverage.
+`ops` provides a legacy testing harness that was previously used to check your charm does the right thing in different scenarios without having to create a full deployment.
 
 ## Testing basics
 
 Here’s a minimal example, taken from the `charmcraft init` template with some additional comments:
 
 ```python
-# Import Ops library's testing harness
+# Import Ops library's legacy testing harness
 import ops
 import ops.testing
 import pytest
+
 # Import your charm class
 from charm import TestCharmCharm
 
@@ -192,4 +193,3 @@ harness.update_config(key_values={'the-answer': 42}) # can_connect is False
 harness.container_pebble_ready('foo') # set can_connect to True
 assert 42 == harness.charm.config_value
 ```
-


### PR DESCRIPTION
Small adjustments to the how-to guides on testing to make it clear that Harness is deprecated:

* Tweak the general guide so that it's still basically saying the same thing, but refers to Scenario rather than Harness.
* Adjust example tests to use ops.testing Scenario classes rather than Harness.
* Make sure it's clear that `ops[testing]` should be installed to write unit tests.
* Use Scenario from `ops.testing` rather than from `scenario`.

Note that this does not substantially change the testing documentation: there's a roadmap item to do that later in 25.04.

[Live preview](https://ops--1508.org.readthedocs.build/en/1508/)