### PR TITLE
feat: add a docs link to the Harness deprecation warning

### DIFF
--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -316,7 +316,7 @@ class Harness(Generic[CharmType]):
         )
 
         warnings.warn(
-            'Harness is deprecated. See more: "
+            'Harness is deprecated. See more: '
             'https://ops.readthedocs.io/en/latest/howto/write-unit-tests-for-a-charm.html',
             PendingDeprecationWarning,
             stacklevel=2,

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -316,7 +316,7 @@ class Harness(Generic[CharmType]):
         )
 
         warnings.warn(
-            'Harness is deprecated. See more: '
+            'Harness is deprecated. For the recommended approach, see: '
             'https://ops.readthedocs.io/en/latest/howto/write-unit-tests-for-a-charm.html',
             PendingDeprecationWarning,
             stacklevel=2,

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -316,8 +316,7 @@ class Harness(Generic[CharmType]):
         )
 
         warnings.warn(
-            'Harness is deprecated; we recommend state transition testing '
-            "(previously known as 'Scenario') for charm unit tests instead. See more: "
+            'Harness is deprecated. See more: "
             'https://ops.readthedocs.io/en/latest/howto/write-unit-tests-for-a-charm.html',
             PendingDeprecationWarning,
             stacklevel=2,

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -316,8 +316,9 @@ class Harness(Generic[CharmType]):
         )
 
         warnings.warn(
-            'Harness is deprecated; we recommend using state transition testing '
-            "(previously known as 'Scenario') instead",
+            'Harness is deprecated; we recommend state transition testing '
+            "(previously known as 'Scenario') for charm unit tests instead. See more: "
+            'https://ops.readthedocs.io/en/latest/howto/write-unit-tests-for-a-charm.html',
             PendingDeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
Links to the documentation in the Harness pending deprecation warning, so that charmers know how to proceed, if they have no idea what "state transition testing" is (and don't go searching for "Scenario").

Fixes #1503