### PR TITLE
ci: correctly point PyPI publishing to the ops-scenario packages

### DIFF
--- a/.github/workflows/publish-ops-scenario.yaml
+++ b/.github/workflows/publish-ops-scenario.yaml
@@ -29,10 +29,10 @@ jobs:
         run: python -m build
         working-directory: ./testing
       - name: Attest build provenance
-        working-directory: ./testing
         uses: actions/attest-build-provenance@v1.4.3
         with:
           subject-path: 'testing/dist/*'
       - name: Publish
-        working-directory: ./testing
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+            packages-dir: ./testing/dist/

--- a/.github/workflows/test-publish-ops-scenario.yaml
+++ b/.github/workflows/test-publish-ops-scenario.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           subject-path: 'testing/dist/*'
       - name: Publish to test.pypi.org
-        working-directory: ./testing
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          packages-dir: ./testing/dist/


### PR DESCRIPTION
`working-directory` is specifically for `run` steps. For the `gh-action-pypi-publish` action, `with: packages-dir` should be used.