### PR TITLE
docs: update boilerplate links

### DIFF
--- a/docs/.sphinx/_templates/footer.html
+++ b/docs/.sphinx/_templates/footer.html
@@ -96,7 +96,7 @@
 
     {% if github_issues %}
     <div class="issue-github">
-      <a class="muted-link" href="{{ github_url }}/issues/new?title=doc%3A+ADD+A+TITLE&body=DESCRIBE+THE+ISSUE%0A%0A---%0ADocument: {{ pagename }}{{ page_source_suffix }}">Open a GitHub issue for this page</a>
+      <a class="muted-link" href="{{ github_url }}/issues/new?title=docs%3A+ADD+A+TITLE&body=DESCRIBE+THE+ISSUE%0A%0A---%0ADocument: {{ pagename }}{{ page_source_suffix }}">Open a GitHub issue for this page</a>
     </div>
     {% endif %}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,7 +86,7 @@ Discourse is the go-to forum for all questions Ops.
 * **[Join our online chat](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)**:
 Meet us in the #charmhub-charmdev channel on Matrix.
 
-* **[Report bugs](https://github.com/canonical/operator/)**:
+* **[Report bugs](https://github.com/canonical/operator/issues)**:
 We want to know about the problems so we can fix them.
 
 * **[Contribute docs](https://github.com/canonical/operator/tree/main/docs)**:

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@ As a community we adhere to the Ubuntu code of conduct.
 * **[Get support](https://discourse.charmhub.io/)**:
 Discourse is the go-to forum for all questions Ops.
 
-* **[Join our online chat](https://matrix.to/#/#charmhub-ops:ubuntu.com)**:
+* **[Join our online chat](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)**:
 Meet us in the #charmhub-charmdev channel on Matrix.
 
 * **[Report bugs](https://github.com/canonical/operator/)**:


### PR DESCRIPTION
Updates to some of the boilerplate links in the docs:

- "Join our online chat" now goes to Charm Development instead of Ops Library Development
- "Report bugs" now goes to GitHub issues instead of the repo home
- Adjusted "doc" to "docs" in the title of the issue that's started if you click "Open a GitHub issue for this page"

**[Preview build](https://ops--1515.org.readthedocs.build/en/1515/)**