### PR TITLE
docs: fix broken links and use cross references instead of absolute links

### DIFF
--- a/docs/explanation/holistic-vs-delta-charms.md
+++ b/docs/explanation/holistic-vs-delta-charms.md
@@ -59,7 +59,7 @@ Many existing charms use holistic event handling. A few examples are:
 
 Only some events make sense to handle holistically. For example, `remove` is triggered when a unit is about to be terminated, so it doesn't make sense to handle it holistically.
 
-Similarly, events like `secret-expired` and `secret-rotate` don't make sense to handle holistically, because the charm must do something specific in response to the event. For example, Juju will keep triggering `secret-expired` until the charm creates a new secret revision by calling [`event.secret.set_content()`](https://ops.readthedocs.io/en/latest/#ops.Secret.set_content).
+Similarly, events like `secret-expired` and `secret-rotate` don't make sense to handle holistically, because the charm must do something specific in response to the event. For example, Juju will keep triggering `secret-expired` until the charm creates a new secret revision by calling [`event.secret.set_content()`](ops.Secret.set_content).
 
 This is very closely related to [which events can be `defer`red](https://juju.is/docs/sdk/how-and-when-to-defer-events). A good rule of thumb is this: if an event can be deferred, it may make sense to handle it holistically.
 

--- a/docs/explanation/testing.md
+++ b/docs/explanation/testing.md
@@ -31,7 +31,7 @@ Unit tests are intended to be isolating and fast to complete. These are the test
 **Tools.** Unit testing a charm can be done using:
 
 - [`pytest`](https://pytest.org/) and/or [`unittest`](https://docs.python.org/3/library/unittest.html) and
-- [state transition testing](https://ops.readthedocs.io/en/latest/reference/ops-testing.html), using the `ops` unit testing framework
+- [state transition testing](ops_testing), using the `ops` unit testing framework
 
 **Examples.**
 

--- a/docs/howto/get-started-with-charm-testing.md
+++ b/docs/howto/get-started-with-charm-testing.md
@@ -95,7 +95,7 @@ You will notice that the starting point is typically always an event. A charm do
 
 In the charming world, unit testing means state-transition testing.
 
-> See more [`ops.testing`](https://ops.readthedocs.io/en/latest/reference/ops-testing.html)
+> See more [`ops.testing`](ops_testing)
 
 `State` is the 'mocker' for most inputs and outputs you will need. Where a live charm would gather its input through context variables and calls to the Juju API (by running the hook tools), a charm under unit test will gather data using a mocked backend managed by the testing framework. Where a live charm would produce output by writing files to a filesystem, `Context` and `Container` expose a mock filesystem the charm will be able to interact with without knowing the difference. More specific outputs, however, will need to be mocked individually.
 

--- a/docs/howto/manage-actions.md
+++ b/docs/howto/manage-actions.md
@@ -172,7 +172,7 @@ def test_backup_action():
     assert 'snapshot-size' in ctx.action_results
 ```
 
-> See more: [`Context.action_logs`](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.Context.action_logs), [`Context.action_results`](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.Context.action_results), [`ActionFailed`](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.ActionFailed)
+> See more: [](ops.testing.Context.action_logs), [](ops.testing.Context.action_results), [](ops.testing.ActionFailed)
 
 
 ### Write integration tests

--- a/docs/howto/manage-actions.md
+++ b/docs/howto/manage-actions.md
@@ -85,7 +85,7 @@ def _on_snapshot(self, event: ops.ActionEvent):
     ...
 ```
 
-> See more: [`ops.ActionEvent.params`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.ActionEvent.params)
+> See more: [](ops.ActionEvent.params)
 
 #### Report that an action has failed
 
@@ -105,7 +105,7 @@ def _on_snapshot(self, event: ops.ActionEvent):
    ...
 ```
 
-> See more: [`ops.ActionEvent.fail`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.ActionEvent.fail)
+> See more: [](ops.ActionEvent.fail)
 
 #### Return the results of an action
 
@@ -117,7 +117,7 @@ def _on_snapshot(self, event: ops.ActionEvent):
     event.set_results({'snapshot-size': size})
 ```
 
-> See more: [`ops.ActionEvent.set_results`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.ActionEvent.set_results)
+> See more: [](ops.ActionEvent.set_results)
 
 #### Log the progress of an action
 
@@ -133,7 +133,7 @@ def _on_snapshot(self, event: ops.ActionEvent):
     self.snapshot_table3()
 ```
 
-> See more: [`ops.ActionEvent.log`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.ActionEvent.log))
+> See more: [](ops.ActionEvent.log)
 
 #### Record the ID of an action task
 
@@ -146,7 +146,7 @@ def _on_snapshot(self, event: ops.ActionEvent):
     self.create_backup(temp_filename)
     ... 
 ```
-> See more: [`ops.ActionEvent.id`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.ActionEvent.id)
+> See more: [](ops.ActionEvent.id)
 
 ## Test the feature
 

--- a/docs/howto/manage-configurations.md
+++ b/docs/howto/manage-configurations.md
@@ -47,7 +47,7 @@ def _on_config_changed(self, event):
     self._update_layer_and_restart(None)
 ```
 
-> See more: [`ops.CharmBase.config`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.CharmBase.config)
+> See more: [](ops.CharmBase.config)
 
 ```{caution}
 

--- a/docs/howto/manage-leadership-changes.md
+++ b/docs/howto/manage-leadership-changes.md
@@ -15,7 +15,7 @@ In the `src/charm.py` file, in the `__init__` function of your charm, set up an 
 self.framework.observe(self.on.leader_elected, self._on_leader_elected)
 ```
 
-> See more: [`ops.LeaderElectedEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.LeaderElectedEvent)
+> See more: [](ops.LeaderElectedEvent)
 
 Now, in the body of the charm definition, define the event handler. For example, the handler below will update a configuration file:
 

--- a/docs/howto/manage-relations.md
+++ b/docs/howto/manage-relations.md
@@ -126,7 +126,7 @@ To use data received through the relation, have your charm observe the `relation
 framework.observe(self.on.replicas_relation_changed, self._update_configuration)
 ```
 
-> See more: [](ops.RelationChangedevent), [`juju` | Relation (integration)](https://juju.is/docs/juju/relation#heading--permissions-around-relation-databags)
+> See more: [](ops.RelationChangedEvent), [`juju` | Relation (integration)](https://juju.is/docs/juju/relation#heading--permissions-around-relation-databags)
 
 Most of the time, you should use the same holistic handler as when receiving other data, such as `secret-changed` and `config-changed`. To access the relation(s) in your holistic handler, use the [](ops.Model.get_relation) method or [](ops.Model.relations) attribute.
 

--- a/docs/howto/manage-relations.md
+++ b/docs/howto/manage-relations.md
@@ -24,7 +24,7 @@ Make sure to consult [the `charm-relations-interfaces` repository](https://githu
 Make sure to add your interface to [the `charm-relations-interfaces` repository](https://github.com/canonical/charm-relation-interfaces).
 ```
 
-To exchange data with other units of the same charm, define one or more `peers` endpoints including an interface name for each. Each peer relation must have an endpoint, which your charm will use to refer to the relation (as [`ops.Relation.name`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Relation.name)).
+To exchange data with other units of the same charm, define one or more `peers` endpoints including an interface name for each. Each peer relation must have an endpoint, which your charm will use to refer to the relation (as [](ops.Relation.name)).
 
 ```yaml
 peers:
@@ -32,7 +32,7 @@ peers:
     interface: charm_gossip
 ```
 
-To exchange data with another charm, define a `provides` or `requires` endpoint including an interface name. By convention, the interface name should be unique in the ecosystem. Each relation must have an endpoint, which your charm will use to refer to the relation (as [`ops.Relation.name`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Relation.name)).
+To exchange data with another charm, define a `provides` or `requires` endpoint including an interface name. By convention, the interface name should be unique in the ecosystem. Each relation must have an endpoint, which your charm will use to refer to the relation (as [](ops.Relation.name)).
 
 ```yaml
 provides:
@@ -98,9 +98,9 @@ def _on_db_relation_created(self, event: ops.RelationCreatedEvent):
     event.relation.data[event.app].update(credentials)
 ```
 
-The event object that is passed to the handler has a `relation` property, which contains an [`ops.Relation`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Relation) object. Your charm uses this object to find out about the relation (such as which units are included, in the [`.units` attribute](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Relation.units), or whether the relation is broken, in the [`.active` attribute](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Relation.active)) and to get and set data in the relation databag.
+The event object that is passed to the handler has a `relation` property, which contains an [](ops.Relation) object. Your charm uses this object to find out about the relation (such as which units are included, in the [`.units` attribute](ops.Relation.units), or whether the relation is broken, in the [`.active` attribute](ops.Relation.active)) and to get and set data in the relation databag.
 
-> See more: [`ops.RelationCreatedEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.RelationCreatedEvent)
+> See more: [](ops.RelationCreatedEvent)
 
 To do additional setup work when each unit joins the relation (both when the charms are first integrated and when additional units are added to the charm), your charm will need to observe the `relation-joined` event. In the `src/charm.py` file, in the `__init__` function of your charm, set up `relation-joined` event observers for the relevant relations and pair those with an event handler. For example:
 
@@ -116,7 +116,7 @@ def _on_smtp_relation_joined(self, event: ops.RelationJoinedEvent):
     event.relation.data[event.unit]["smtp_credentials"] = smtp_credentials_secret_id
 ```
 
-> See more: [`ops.RelationJoinedEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.RelationJoinedEvent)
+> See more: [](ops.RelationJoinedEvent)
 
 ##### Exchange data with other units
 
@@ -126,9 +126,9 @@ To use data received through the relation, have your charm observe the `relation
 framework.observe(self.on.replicas_relation_changed, self._update_configuration)
 ```
 
-> See more: [`ops.RelationChangedEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.RelationChangedevent), [`juju` | Relation (integration)](https://juju.is/docs/juju/relation#heading--permissions-around-relation-databags)
+> See more: [](ops.RelationChangedevent), [`juju` | Relation (integration)](https://juju.is/docs/juju/relation#heading--permissions-around-relation-databags)
 
-Most of the time, you should use the same holistic handler as when receiving other data, such as `secret-changed` and `config-changed`. To access the relation(s) in your holistic handler, use the [`ops.Model.get_relation`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Model.get_relation) method or [`ops.Model.relations`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Model.relations) attribute.
+Most of the time, you should use the same holistic handler as when receiving other data, such as `secret-changed` and `config-changed`. To access the relation(s) in your holistic handler, use the [](ops.Model.get_relation) method or [](ops.Model.relations) attribute.
 
 > See also: {ref}`holistic-vs-delta-charms`
 
@@ -171,7 +171,7 @@ def _update_configuration(self, _: ops.Eventbase):
 
 ##### Exchange data across the various relations
 
-To add data to the relation databag, use the [`.data` attribute](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Relation.data) much as you would a dictionary, after selecting whether to write to the app databag (leaders only) or unit databag. For example, to copy a value from the charm config to the relation data:
+To add data to the relation databag, use the [`.data` attribute](ops.Relation.data) much as you would a dictionary, after selecting whether to write to the app databag (leaders only) or unit databag. For example, to copy a value from the charm config to the relation data:
 
 ```python
 def _on_config_changed(self, event: ops.ConfigChangedEvent):
@@ -238,7 +238,7 @@ def _on_smtp_relation_departed(self, event: ops.RelationDepartedEvent):
         self.remove_smtp_user(event.unit.name)
 ```
 
-> See more: [ops.RelationDepartedEvent](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.RelationDepartedEvent)
+> See more: [](ops.RelationDepartedEvent)
 
 To clean up after a relation is entirely removed, have your charm observe the `relation-broken` event. In the `src/charm.py` file, in the `__init__` function of your charm, set up `relation-broken` events for the relevant relations and pair those with an event handler. For example:
 
@@ -255,7 +255,7 @@ def _on_db_relation_broken(self, event: ops.RelationBrokenEvent):
     self.drop_database(event.app.name)
 ```
 
-> See more: [ops.RelationBrokenEvent](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.RelationBrokenEvent)
+> See more: [](ops.RelationBrokenEvent)
 
 ## Test the feature
 

--- a/docs/howto/manage-relations.md
+++ b/docs/howto/manage-relations.md
@@ -273,7 +273,7 @@ state_out = ctx.run(ctx.on.relation_joined(relation, remote_unit_id=1), state=st
 assert 'smtp_credentials' in state_out.get_relation(relation.id).remote_units_data[1]
 ```
 
-> See more: [Scenario Relations](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.RelationBase)
+> See more: [Scenario Relations](ops.testing.RelationBase)
 
 ### Write integration tests
 

--- a/docs/howto/manage-resources.md
+++ b/docs/howto/manage-resources.md
@@ -23,7 +23,7 @@ resources:
     description: test resource
 ```
 
-In your charm's `src/charm.py` you can now use [`Model.resources.fetch(<resource_name>)`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Resources.fetch) to get the path to the resource, then manipulate it as needed. For example:
+In your charm's `src/charm.py` you can now use [`Model.resources.fetch(<resource_name>)`](ops.Resources.fetch) to get the path to the resource, then manipulate it as needed. For example:
 
 ```python
 # ...
@@ -59,7 +59,7 @@ def _on_config_changed(self, event):
     # do something
 ```
 
-The [`fetch()`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Resources.fetch) method will raise a [`NameError`](https://docs.python.org/3/library/exceptions.html#NameError) if the resource does not exist, and returns a Python [`Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) object to the resource if it does.
+The [`fetch()`](ops.Resources.fetch) method will raise a [`NameError`](https://docs.python.org/3/library/exceptions.html#NameError) if the resource does not exist, and returns a Python [`Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) object to the resource if it does.
 
 Note: During development, it may be useful to specify the resource at deploy time to facilitate faster testing without the need to publish a new charm/resource in between minor fixes. In the below snippet, we create a simple file with some text content, and pass it to the Juju controller to use in place of any published `my-resource` resource:
 

--- a/docs/howto/manage-secrets.md
+++ b/docs/howto/manage-secrets.md
@@ -57,7 +57,7 @@ Note that:
 - The only data shared in plain text is the secret ID (a locator URI). The secret ID can be publicly shared. Juju will ensure that only remote apps/units to which the secret has explicitly been granted by the owner will be able to fetch the actual secret payload from that ID.
 - The secret needs to be granted to a remote entity (app or unit), and that always goes via a relation instance. By passing a relation to `grant` (in this case the event's relation), we are explicitly declaring the scope of the secret -- its lifetime will be bound to that of this relation instance.
 
-> See more: [`ops.Application.add_secret()`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Application.add_secret)
+> See more: [](ops.Application.add_secret)
 
 ### Create a new secret revision
 
@@ -249,7 +249,7 @@ Note that:
 - The observer charm gets a secret via the model (not its app/unit). Because it's the owner who decides who the secret is granted to, the ownership of a secret is not an observer concern. The observer code can rightfully assume that, so long as a secret ID is  shared with it, the owner has taken care to grant and scope the secret in such a way that the observer has the rights to inspect its contents.
 - The charm first gets the secret object from the model, then gets the secret's content (a dict) and accesses individual attributes via the dict's items.
 
-> See more: [`ops.Secret.get_content()`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Secret.get_content)
+> See more: [](ops.Secret.get_content)
 
 ### Label the secrets you're observing
 
@@ -310,7 +310,7 @@ So, having labelled the secret on creation, the database charm could add a new r
         secret.set_content(...)  # pass a new revision payload, as before
 ```
 
-> See more: [`ops.Model.get_secret()`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Model.get_secret)
+> See more: [](ops.Model.get_secret)
 
 #### When to use labels
 
@@ -318,9 +318,9 @@ When should you use labels? A label is basically the secret's *name* (local to t
 
 Most charms that use secrets have a fixed number of secrets each with a specific meaning, so the charm author should give them meaningful labels like `database-credential`, `tls-cert`, and so on. Think of these as "pets" with names.
 
-In rare cases, however, a charm will have a set of secrets all with the same meaning: for example, a set of TLS certificates that are all equally valid. In this case it doesn't make sense to label them -- think of them as "cattle". To distinguish between secrets of this kind, you can use the [`Secret.unique_identifier`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Secret.unique_identifier) property.
+In rare cases, however, a charm will have a set of secrets all with the same meaning: for example, a set of TLS certificates that are all equally valid. In this case it doesn't make sense to label them -- think of them as "cattle". To distinguish between secrets of this kind, you can use the [`Secret.unique_identifier`](ops.Secret.unique_identifier) property.
 
-Note that [`Secret.id`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Secret.id), despite the name, is not really a unique ID, but a locator URI. We call this the "secret ID" throughout Juju and in the original secrets specification -- it probably should have been called "uri", but the name stuck.
+Note that [`Secret.id`](ops.Secret.id), despite the name, is not really a unique ID, but a locator URI. We call this the "secret ID" throughout Juju and in the original secrets specification -- it probably should have been called "uri", but the name stuck.
 
 ### Peek at a new secret revision
 
@@ -336,7 +336,7 @@ Sometimes, before reconfiguring to use a new credential revision, the observer c
         ...
 ```
 
-> See more: [`ops.Secret.peek_content()`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Secret.peek_content)
+> See more: [](ops.Secret.peek_content)
 
 ### Start tracking a different secret revision
 
@@ -356,7 +356,7 @@ class MyWebserverCharm(ops.CharmBase):
         self._configure_db_credentials(content['username'], content['password'])
 ```
 
-> See more: [`ops.Secret.get_content()`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Secret.get_content)
+> See more: [](ops.Secret.get_content)
 
 <br>
 

--- a/docs/howto/manage-storage.md
+++ b/docs/howto/manage-storage.md
@@ -51,7 +51,7 @@ In the `src/charm.py` file, in the `__init__` function of your charm, set up an 
 self.framework.observe(self.on.cache_storage_attached, self._update_configuration)
 ```
 
-> See more: [`ops.StorageAttachedEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.StorageAttachedEvent), [Juju SDK | Holistic vs delta charms](https://juju.is/docs/sdk/holistic-vs-delta-charms)
+> See more: [](ops.StorageAttachedEvent), [Juju SDK | Holistic vs delta charms](https://juju.is/docs/sdk/holistic-vs-delta-charms)
 
 Storage volumes will be automatically mounted into the charm container at either the path specified in the `location` field in the metadata, or the default location `/var/lib/juju/storage/<storage-name>`. However, your charm code should not hard-code the location, and should instead use the `.location` property of the storage object.
 
@@ -83,7 +83,7 @@ In the `src/charm.py` file, in the `__init__` function of your charm, set up an 
 self.framework.observe(self.on.cache_storage_detaching, self._on_storage_detaching)
 ```
 
-> See more: [`ops.StorageDetachingEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.StorageDetachingEvent)
+> See more: [](ops.StorageDetachingEvent)
 
 Now, in the body of the charm definition, define the event handler, or adjust an existing holistic one. For example, to warn users that data won't be cached:
 

--- a/docs/howto/manage-storage.md
+++ b/docs/howto/manage-storage.md
@@ -191,7 +191,7 @@ foo_1 = testing.Storage('foo')
 ctx.run(ctx.on.storage_attached(foo_1), testing.State(storages={foo_0, foo_1}))
 ```
 
-> See more: [`ops.testing.Storage`](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.Storage)
+> See more: [](ops.testing.Storage)
 
 ### Write integration tests
 

--- a/docs/howto/manage-the-workload-version.md
+++ b/docs/howto/manage-the-workload-version.md
@@ -33,7 +33,7 @@ observer for the `start` event and pair that with an event handler. For example:
 self.framework.observe(self.on.start, self._on_start)
 ```
 
-> See more: [`ops.StartEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.StartEvent)
+> See more: [](ops.StartEvent)
 
 Now, in the body of the charm definition, define the event handler. Typically,
 the workload version is retrieved from the workload itself, with a subprocess
@@ -47,7 +47,7 @@ def _on_start(self, event: ops.StartEvent):
     self.unit.set_workload_version(version)
 ```
 
-> See more: [`ops.Unit.set_workload_version`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Unit.set_workload_version)
+> See more: [](ops.Unit.set_workload_version)
 
 > Examples: [`jenkins-k8s` sets the workload version after getting it from the Jenkins package](https://github.com/canonical/jenkins-k8s-operator/blob/29e9b652714bd8314198965c41a60f5755dd381c/src/charm.py#L115), [`discourse-k8s` sets the workload version after getting it via an exec call](https://github.com/canonical/discourse-k8s-operator/blob/f523b29f909c69da7b9510b581dfcc2309698222/src/charm.py#L581), [`synapse` sets the workload version after getting it via an API call](https://github.com/canonical/synapse-operator/blob/778bcd414644c922373d542a304be14866835516/src/charm.py#L265)
 

--- a/docs/howto/run-workloads-with-a-charm-kubernetes.md
+++ b/docs/howto/run-workloads-with-a-charm-kubernetes.md
@@ -306,7 +306,7 @@ To stop a service, Pebble first sends `SIGTERM` to the service's process group t
 
 ### Fetch service status
 
-You can use the [`get_service`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_service) and [`get_services`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_services) methods to fetch the current status of one service or multiple services, respectively. The returned [`ServiceInfo`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.ServiceInfo) objects provide a `status` attribute with various states, or you can use the [`ServiceInfo.is_running`](https://ops.readthedocs.io/en/latest/#ops.pebble.ServiceInfo.is_running) method.
+You can use the [`get_service`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_service) and [`get_services`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_services) methods to fetch the current status of one service or multiple services, respectively. The returned [`ServiceInfo`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.ServiceInfo) objects provide a `status` attribute with various states, or you can use the [`ServiceInfo.is_running`](ops.pebble.ServiceInfo.is_running) method.
 
 Here is a modification to the start/stop example that checks whether the service is running before stopping it:
 

--- a/docs/howto/run-workloads-with-a-charm-kubernetes.md
+++ b/docs/howto/run-workloads-with-a-charm-kubernetes.md
@@ -636,7 +636,7 @@ container.remove_path('/tmp/mysubdir', recursive=True)
 
 ### Check file and directory existence
 
-To check if a paths exists you can use [`Container.exists`](ops.Container.exists) for directories or files and [`Container.isdir`](ops.Container.is_dir) for directories.  These functions are analogous to python's `os.path.isdir` and `os.path.exists` functions.  For example:
+To check if a paths exists you can use [`Container.exists`](ops.Container.exists) for directories or files and [`Container.isdir`](ops.Container.isdir) for directories.  These functions are analogous to python's `os.path.isdir` and `os.path.exists` functions.  For example:
 
 ```python
 # if /tmp/myfile exists

--- a/docs/howto/run-workloads-with-a-charm-kubernetes.md
+++ b/docs/howto/run-workloads-with-a-charm-kubernetes.md
@@ -5,16 +5,16 @@ The recommended way to create charms for Kubernetes is using the sidecar pattern
 
 Pebble is a lightweight, API-driven process supervisor designed for use with charms. If you specify the `containers` field in a charm's `charmcraft.yaml`, Juju will deploy the charm code in a sidecar container, with Pebble running as the workload container's `ENTRYPOINT`.
 
-When the workload container starts up, Juju fires a [`PebbleReadyEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.PebbleReadyEvent), which can be handled using [`Framework.observe`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Framework.observe). This gives the charm author access to `event.workload`, a [`Container`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container) instance.
+When the workload container starts up, Juju fires a [`PebbleReadyEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.PebbleReadyEvent), which can be handled using [`Framework.observe`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Framework.observe). This gives the charm author access to `event.workload`, a [`Container`](ops.Container) instance.
 
 The `Container` class has methods to modify the Pebble configuration "plan", start and stop services, read and write files, and run commands. These methods use the Pebble API, which communicates from the charm container to the workload container using HTTP over a Unix domain socket.
 
-The rest of this document provides details of how a charm interacts with the workload container via Pebble, using `ops` [`Container`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container) methods.
+The rest of this document provides details of how a charm interacts with the workload container via Pebble, using `ops` [`Container`](ops.Container) methods.
 
 
 ```{note}
 
-The [`Container.pebble`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.pebble) property returns the [`pebble.Client`](ops.pebble.Client) instance for the given container.
+The [`Container.pebble`](ops.Container.pebble) property returns the [`pebble.Client`](ops.pebble.Client) instance for the given container.
 ```
 
 ## Set up the workload container
@@ -204,7 +204,7 @@ See the [layer specification](https://canonical-pebble.readthedocs-hosted.com/en
 
 #### Add a configuration layer
 
-To add a configuration layer, call [`Container.add_layer`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.add_layer) with a label for the layer, and the layer's contents as a YAML string, Python dict, or [`pebble.Layer`](#ops.pebble.Layer) object.
+To add a configuration layer, call [`Container.add_layer`](ops.Container.add_layer) with a label for the layer, and the layer's contents as a YAML string, Python dict, or [`pebble.Layer`](#ops.pebble.Layer) object.
 
 You can see an example of `add_layer` under the ["Replan" heading](#replan). The `combine=True` argument tells Pebble to combine the named layer into an existing layer of that name (or add a layer if none by that name exists). Using `combine=True` is common when dynamically adding layers.
 
@@ -214,9 +214,9 @@ If you're adding a single layer with `combine=False` (default option) on top of 
 
 #### Fetch the effective plan
 
-Charm authors can also introspect the current plan using [`Container.get_plan`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_plan). It returns a [`pebble.Plan`](ops.pebble.Plan) object whose `services` attribute maps service names to [`pebble.Service`](ops.pebble.Service) instances.
+Charm authors can also introspect the current plan using [`Container.get_plan`](ops.Container.get_plan). It returns a [`pebble.Plan`](ops.pebble.Plan) object whose `services` attribute maps service names to [`pebble.Service`](ops.pebble.Service) instances.
 
-It is not necessary to use `get_plan` to determine whether the plan has changed and start services accordingly. If you call [`replan`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.replan), then Pebble will take care of this for you.
+It is not necessary to use `get_plan` to determine whether the plan has changed and start services accordingly. If you call [`replan`](ops.Container.replan), then Pebble will take care of this for you.
 
 Below is an example of how you might use `get_plan` to introspect the current configuration, and log the active services:
 
@@ -247,7 +247,7 @@ The reason for replan is so that you as a user have control over when the (poten
 
 Replan also starts the services that are marked as `startup: enabled` in the configuration plan, if they're not running already.
 
-Call [`Container.replan`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.replan) to execute the replan procedure. For example:
+Call [`Container.replan`](ops.Container.replan) to execute the replan procedure. For example:
 
 ```python
 class SnappassTestCharm(ops.CharmBase):
@@ -274,11 +274,11 @@ class SnappassTestCharm(ops.CharmBase):
 
 `ops` provides a way to ensure that your container is healthy. In the `Container` class, `Container.can_connect()` can be used if you only need to know that Pebble is responding at a specific point in time - for example to update a status message. This should *not* be used to guard against later Pebble operations, because that introduces a race condition where Pebble might be responsive when `can_connect()` is called, but is not when the later operation is executed. Instead, charms should always include `try`/`except` statements around Pebble operations, to avoid the unit going into error state.
 
-> See more: [`ops.Container`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container)
+> See more: [](ops.Container)
 
 ### Start and stop
 
-To start (or stop) one or more services by name, use the [`start`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.start) and [`stop`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.stop) methods. Here's an example of how you might stop and start a database service during a backup action:
+To start (or stop) one or more services by name, use the [`start`](ops.Container.start) and [`stop`](ops.Container.stop) methods. Here's an example of how you might stop and start a database service during a backup action:
 
 ```python
 class MyCharm(ops.CharmBase):
@@ -306,7 +306,7 @@ To stop a service, Pebble first sends `SIGTERM` to the service's process group t
 
 ### Fetch service status
 
-You can use the [`get_service`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_service) and [`get_services`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_services) methods to fetch the current status of one service or multiple services, respectively. The returned [`ServiceInfo`](ops.pebble.ServiceInfo) objects provide a `status` attribute with various states, or you can use the [`ServiceInfo.is_running`](ops.pebble.ServiceInfo.is_running) method.
+You can use the [`get_service`](ops.Container.get_service) and [`get_services`](ops.Container.get_services) methods to fetch the current status of one service or multiple services, respectively. The returned [`ServiceInfo`](ops.pebble.ServiceInfo) objects provide a `status` attribute with various states, or you can use the [`ServiceInfo.is_running`](ops.pebble.ServiceInfo.is_running) method.
 
 Here is a modification to the start/stop example that checks whether the service is running before stopping it:
 
@@ -326,7 +326,7 @@ class MyCharm(ops.CharmBase):
 
 ### Send signals to services
 
-You can use the [`Container.send_signal`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.send_signal) method to send a signal to one or more services. For example, to send `SIGHUP` to the hypothetical "nginx" and "redis" services:
+You can use the [`Container.send_signal`](ops.Container.send_signal) method to send a signal to one or more services. For example, to send `SIGHUP` to the hypothetical "nginx" and "redis" services:
 
 ```python
 container.send_signal('SIGHUP', 'nginx', 'redis')
@@ -476,7 +476,7 @@ class PostgresCharm(ops.CharmBase):
 
 ### Fetch check status
 
-You can use the [`get_check`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_check) and [`get_checks`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_checks) methods to fetch the current status of one check or multiple checks, respectively. The returned [`CheckInfo`](ops.pebble.CheckInfo) objects provide various attributes, most importantly a `status` attribute which will be either `UP` or `DOWN`.
+You can use the [`get_check`](ops.Container.get_check) and [`get_checks`](ops.Container.get_checks) methods to fetch the current status of one check or multiple checks, respectively. The returned [`CheckInfo`](ops.pebble.CheckInfo) objects provide various attributes, most importantly a `status` attribute which will be either `UP` or `DOWN`.
 
 Here is a code example that checks whether the `uptime` check is healthy, and writes an error log if not:
 
@@ -540,7 +540,7 @@ Pebble's files API allows charm authors to read and write files on the workload 
 
 ### Push
 
-Probably the most useful operation is [`Container.push`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.push), which allows you to write a file to the workload, for example, a PostgreSQL configuration file. You can use `push` as follows (note that this code would be inside a charm event handler):
+Probably the most useful operation is [`Container.push`](ops.Container.push), which allows you to write a file to the workload, for example, a PostgreSQL configuration file. You can use `push` as follows (note that this code would be inside a charm event handler):
 
 ```python
 config = """
@@ -552,11 +552,11 @@ container.push('/etc/pg/postgresql.conf', config, make_dirs=True)
 
 The `make_dirs=True` flag tells `push` to create the intermediate directories if they don't already exist (`/etc/pg` in this case).
 
-There are many additional features, including the ability to send raw bytes (by providing a Python `bytes` object as the second argument) and write data from a file-like object. You can also specify permissions and the user and group for the file. See the [API documentation](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.push) for details.
+There are many additional features, including the ability to send raw bytes (by providing a Python `bytes` object as the second argument) and write data from a file-like object. You can also specify permissions and the user and group for the file. See the [API documentation](ops.Container.push) for details.
 
 ### Pull
 
-To read a file from the workload, use [`Container.pull`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.pull), which returns a file-like object that you can `read()`.
+To read a file from the workload, use [`Container.pull`](ops.Container.pull), which returns a file-like object that you can `read()`.
 
 The files API doesn't currently support update, so to update a file you can use `pull` to perform a read-modify-write operation, for example:
 
@@ -573,7 +573,7 @@ If you specify the keyword argument `encoding=None` on the `pull()` call, reads 
 
 ### Push recursive
 
-To copy several files to the workload, use [`Container.push_path`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.push_path), which copies files recursively into a specified destination directory.  The API docs contain detailed examples of source and destination semantics and path handling.
+To copy several files to the workload, use [`Container.push_path`](ops.Container.push_path), which copies files recursively into a specified destination directory.  The API docs contain detailed examples of source and destination semantics and path handling.
 
 ```python
 # copy "/source/dir/[files]" into "/destination/dir/[files]"
@@ -587,7 +587,7 @@ A trailing "/*" on the source directory is the only supported globbing/matching.
 
 ### Pull recursive
 
-To copy several files to the workload, use [`Container.pull_path`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.pull_path), which copies files recursively into a specified destination directory.  The API docs contain detailed examples of source and destination semantics and path handling.
+To copy several files to the workload, use [`Container.pull_path`](ops.Container.pull_path), which copies files recursively into a specified destination directory.  The API docs contain detailed examples of source and destination semantics and path handling.
 
 ```python
 # copy "/source/dir/[files]" into "/destination/dir/[files]"
@@ -601,7 +601,7 @@ A trailing "/*" on the source directory is the only supported globbing/matching.
 
 ### List files
 
-To list the contents of a directory or return stat-like information about one or more files, use [`Container.list_files`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.list_files). It returns a list of [`pebble.FileInfo`](ops.pebble.FileInfo) objects for each entry (file or directory) in the given path, optionally filtered by a glob pattern. For example:
+To list the contents of a directory or return stat-like information about one or more files, use [`Container.list_files`](ops.Container.list_files). It returns a list of [`pebble.FileInfo`](ops.pebble.FileInfo) objects for each entry (file or directory) in the given path, optionally filtered by a glob pattern. For example:
 
 ```python
 infos = container.list_files('/etc', pattern='*.conf')
@@ -616,7 +616,7 @@ If you want information about the directory itself (instead of its contents), ca
 
 ### Create directory
 
-To create a directory, use [`Container.make_dir`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.make_dir). It takes an optional `make_parents=True` argument (like `mkdir -p`), as well as optional permissions and user/group arguments. Some examples:
+To create a directory, use [`Container.make_dir`](ops.Container.make_dir). It takes an optional `make_parents=True` argument (like `mkdir -p`), as well as optional permissions and user/group arguments. Some examples:
 
 ```python
 container.make_dir('/etc/pg', user='postgres', group='postgres')
@@ -625,7 +625,7 @@ container.make_dir('/some/other/nested/dir', make_parents=True)
 
 ### Remove path
 
-To delete a file or directory, use [`Container.remove_path`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.remove_path). If a directory is specified, it must be empty unless `recursive=True` is specified, in which case the entire directory tree is deleted, recursively (like `rm -r`). For example:
+To delete a file or directory, use [`Container.remove_path`](ops.Container.remove_path). If a directory is specified, it must be empty unless `recursive=True` is specified, in which case the entire directory tree is deleted, recursively (like `rm -r`). For example:
 
 ```python
 # Delete Apache access log
@@ -636,7 +636,7 @@ container.remove_path('/tmp/mysubdir', recursive=True)
 
 ### Check file and directory existence
 
-To check if a paths exists you can use [`Container.exists`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.exists) for directories or files and [`Container.isdir`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.is_dir) for directories.  These functions are analogous to python's `os.path.isdir` and `os.path.exists` functions.  For example:
+To check if a paths exists you can use [`Container.exists`](ops.Container.exists) for directories or files and [`Container.isdir`](ops.Container.is_dir) for directories.  These functions are analogous to python's `os.path.isdir` and `os.path.exists` functions.  For example:
 
 ```python
 # if /tmp/myfile exists
@@ -650,7 +650,7 @@ container.isdir('/tmp/mydir') # True
 
 ## Run commands on the workload container
 
-Pebble includes an API for executing arbitrary commands on the workload container: the [`Container.exec`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.exec) method. It supports sending stdin to the process and receiving stdout and stderr, as well as more advanced options.
+Pebble includes an API for executing arbitrary commands on the workload container: the [`Container.exec`](ops.Container.exec) method. It supports sending stdin to the process and receiving stdout and stderr, as well as more advanced options.
 
 To run simple commands and receive their output, call `Container.exec` to start the command, and then use the returned [`Process`](ops.pebble.ExecProcess) object's [`wait_output`](ops.pebble.ExecProcess.wait_output) method to wait for it to finish and collect its output.
 
@@ -868,8 +868,8 @@ All notice events have a [`notice`](https://ops.readthedocs.io/en/latest/referen
 
 A charm can also query for notices using the following two `Container` methods:
 
-* [`get_notice`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_notice), which gets a single notice by unique ID (the value of `notice.id`).
-* [`get_notices`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_notices), which returns all notices by default, and allows filtering notices by specific attributes such as `key`.
+* [`get_notice`](ops.Container.get_notice), which gets a single notice by unique ID (the value of `notice.id`).
+* [`get_notices`](ops.Container.get_notices), which returns all notices by default, and allows filtering notices by specific attributes such as `key`.
 
 ### Test notices
 
@@ -906,7 +906,7 @@ def test_backup_done(upload_fileobj):
 <!--
  <a href="#heading--access-the-pebble-client-directly"><h2 id="heading--access-the-pebble-client-directly">Access the Pebble client directly</h2></a>
 
-Occasionally charm code may want to access the lower-level Pebble API directly: the [`Container.pebble`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.pebble) property returns the [`pebble.Client`](ops.pebble.Client) instance for the given container.
+Occasionally charm code may want to access the lower-level Pebble API directly: the [`Container.pebble`](ops.Container.pebble) property returns the [`pebble.Client`](ops.pebble.Client) instance for the given container.
 
 Below is a (contrived) example of an action that uses the Pebble client directly to call [`pebble.Client.get_changes`](ops.pebble.Client.get_changes):
 

--- a/docs/howto/run-workloads-with-a-charm-kubernetes.md
+++ b/docs/howto/run-workloads-with-a-charm-kubernetes.md
@@ -873,7 +873,7 @@ A charm can also query for notices using the following two `Container` methods:
 
 ### Test notices
 
-To test charms that use Pebble Notices, use the [`pebble_custom_notice`](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.CharmEvents.pebble_custom_notice) method to simulate recording a notice with the given details. For example, to simulate the "backup-done" notice handled above, the charm tests could do the following:
+To test charms that use Pebble Notices, use the [`pebble_custom_notice`](ops.testing.CharmEvents.pebble_custom_notice) method to simulate recording a notice with the given details. For example, to simulate the "backup-done" notice handled above, the charm tests could do the following:
 
 ```python
 from ops import testing

--- a/docs/howto/run-workloads-with-a-charm-kubernetes.md
+++ b/docs/howto/run-workloads-with-a-charm-kubernetes.md
@@ -14,7 +14,7 @@ The rest of this document provides details of how a charm interacts with the wor
 
 ```{note}
 
-The [`Container.pebble`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.pebble) property returns the [`pebble.Client`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.Client) instance for the given container.
+The [`Container.pebble`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.pebble) property returns the [`pebble.Client`](ops.pebble.Client) instance for the given container.
 ```
 
 ## Set up the workload container
@@ -204,7 +204,7 @@ See the [layer specification](https://canonical-pebble.readthedocs-hosted.com/en
 
 #### Add a configuration layer
 
-To add a configuration layer, call [`Container.add_layer`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.add_layer) with a label for the layer, and the layer's contents as a YAML string, Python dict, or [`pebble.Layer`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.Layer) object.
+To add a configuration layer, call [`Container.add_layer`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.add_layer) with a label for the layer, and the layer's contents as a YAML string, Python dict, or [`pebble.Layer`](#ops.pebble.Layer) object.
 
 You can see an example of `add_layer` under the ["Replan" heading](#replan). The `combine=True` argument tells Pebble to combine the named layer into an existing layer of that name (or add a layer if none by that name exists). Using `combine=True` is common when dynamically adding layers.
 
@@ -214,7 +214,7 @@ If you're adding a single layer with `combine=False` (default option) on top of 
 
 #### Fetch the effective plan
 
-Charm authors can also introspect the current plan using [`Container.get_plan`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_plan). It returns a [`pebble.Plan`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.Plan) object whose `services` attribute maps service names to [`pebble.Service`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.Service) instances.
+Charm authors can also introspect the current plan using [`Container.get_plan`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_plan). It returns a [`pebble.Plan`](ops.pebble.Plan) object whose `services` attribute maps service names to [`pebble.Service`](ops.pebble.Service) instances.
 
 It is not necessary to use `get_plan` to determine whether the plan has changed and start services accordingly. If you call [`replan`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.replan), then Pebble will take care of this for you.
 
@@ -306,7 +306,7 @@ To stop a service, Pebble first sends `SIGTERM` to the service's process group t
 
 ### Fetch service status
 
-You can use the [`get_service`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_service) and [`get_services`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_services) methods to fetch the current status of one service or multiple services, respectively. The returned [`ServiceInfo`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.ServiceInfo) objects provide a `status` attribute with various states, or you can use the [`ServiceInfo.is_running`](ops.pebble.ServiceInfo.is_running) method.
+You can use the [`get_service`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_service) and [`get_services`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_services) methods to fetch the current status of one service or multiple services, respectively. The returned [`ServiceInfo`](ops.pebble.ServiceInfo) objects provide a `status` attribute with various states, or you can use the [`ServiceInfo.is_running`](ops.pebble.ServiceInfo.is_running) method.
 
 Here is a modification to the start/stop example that checks whether the service is running before stopping it:
 
@@ -476,7 +476,7 @@ class PostgresCharm(ops.CharmBase):
 
 ### Fetch check status
 
-You can use the [`get_check`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_check) and [`get_checks`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_checks) methods to fetch the current status of one check or multiple checks, respectively. The returned [`CheckInfo`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.CheckInfo) objects provide various attributes, most importantly a `status` attribute which will be either `UP` or `DOWN`.
+You can use the [`get_check`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_check) and [`get_checks`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.get_checks) methods to fetch the current status of one check or multiple checks, respectively. The returned [`CheckInfo`](ops.pebble.CheckInfo) objects provide various attributes, most importantly a `status` attribute which will be either `UP` or `DOWN`.
 
 Here is a code example that checks whether the `uptime` check is healthy, and writes an error log if not:
 
@@ -601,7 +601,7 @@ A trailing "/*" on the source directory is the only supported globbing/matching.
 
 ### List files
 
-To list the contents of a directory or return stat-like information about one or more files, use [`Container.list_files`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.list_files). It returns a list of [`pebble.FileInfo`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.FileInfo) objects for each entry (file or directory) in the given path, optionally filtered by a glob pattern. For example:
+To list the contents of a directory or return stat-like information about one or more files, use [`Container.list_files`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.list_files). It returns a list of [`pebble.FileInfo`](ops.pebble.FileInfo) objects for each entry (file or directory) in the given path, optionally filtered by a glob pattern. For example:
 
 ```python
 infos = container.list_files('/etc', pattern='*.conf')
@@ -652,7 +652,7 @@ container.isdir('/tmp/mydir') # True
 
 Pebble includes an API for executing arbitrary commands on the workload container: the [`Container.exec`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.exec) method. It supports sending stdin to the process and receiving stdout and stderr, as well as more advanced options.
 
-To run simple commands and receive their output, call `Container.exec` to start the command, and then use the returned [`Process`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.ExecProcess) object's [`wait_output`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.ExecProcess.wait_output) method to wait for it to finish and collect its output.
+To run simple commands and receive their output, call `Container.exec` to start the command, and then use the returned [`Process`](ops.pebble.ExecProcess) object's [`wait_output`](ops.pebble.ExecProcess.wait_output) method to wait for it to finish and collect its output.
 
 For example, to back up a PostgreSQL database, you might use `pg_dump`:
 
@@ -667,9 +667,9 @@ if warnings:
 
 ### Handle errors
 
-The `exec` method raises a [`pebble.APIError`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.APIError) if basic checks fail and the command can't be executed at all, for example, if the executable is not found.
+The `exec` method raises a [`pebble.APIError`](ops.pebble.APIError) if basic checks fail and the command can't be executed at all, for example, if the executable is not found.
 
-The [`ExecProcess.wait`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.ExecProcess.wait) and [`ExecProcess.wait_output`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.ExecProcess.wait_output) methods raise [`pebble.ChangeError`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.ChangeError) if there was an error starting or running the process, and [`pebble.ExecError`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.ExecError) if the process exits with a non-zero exit code.
+The [`ExecProcess.wait`](ops.pebble.ExecProcess.wait) and [`ExecProcess.wait_output`](ops.pebble.ExecProcess.wait_output) methods raise [`pebble.ChangeError`](ops.pebble.ChangeError) if there was an error starting or running the process, and [`pebble.ExecError`](ops.pebble.ExecError) if the process exits with a non-zero exit code.
 
 In the case where the process exits via a signal (such as SIGTERM or SIGKILL), the exit code will be 128 plus the signal number. SIGTERM's signal number is 15, so a process terminated via SIGTERM would give exit code 143 (128+15).
 
@@ -696,7 +696,7 @@ Exited with code 1. Stderr:
 
 ### Use command options
 
-The `Container.exec` method has various options (see [full API documentation](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.Client.exec)), including:
+The `Container.exec` method has various options (see [full API documentation](ops.pebble.Client.exec)), including:
 
 * `environment`: a dict of environment variables to pass to the process
 * `working_dir`: working directory to run the command in
@@ -733,7 +733,7 @@ process.wait_output()
 
 ### Use input/output options
 
-The simplest way of receiving standard output and standard error is by using the [`ExecProcess.wait_output`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.ExecProcess.wait_output) method as shown below. The simplest way of sending standard input to the program is as a string, using the `stdin` parameter to `exec`. For example:
+The simplest way of receiving standard output and standard error is by using the [`ExecProcess.wait_output`](ops.pebble.ExecProcess.wait_output) method as shown below. The simplest way of sending standard input to the program is as a string, using the `stdin` parameter to `exec`. For example:
 
 ```python
 process = container.exec(['tr', 'a-z', 'A-Z'],
@@ -806,7 +806,7 @@ Caution: it's easy to get threading wrong and cause deadlocks, so it's best to u
 
 ### Send signals to a running command
 
-To send a signal to the running process, use [`ExecProcess.send_signal`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.ExecProcess.send_signal) with a signal number or name. For example, the following will terminate the "sleep 10" process after one second:
+To send a signal to the running process, use [`ExecProcess.send_signal`](ops.pebble.ExecProcess.send_signal) with a signal number or name. For example, the following will terminate the "sleep 10" process after one second:
 
 ```python
 process = container.exec(['sleep', '10'])
@@ -906,9 +906,9 @@ def test_backup_done(upload_fileobj):
 <!--
  <a href="#heading--access-the-pebble-client-directly"><h2 id="heading--access-the-pebble-client-directly">Access the Pebble client directly</h2></a>
 
-Occasionally charm code may want to access the lower-level Pebble API directly: the [`Container.pebble`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.pebble) property returns the [`pebble.Client`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.Client) instance for the given container.
+Occasionally charm code may want to access the lower-level Pebble API directly: the [`Container.pebble`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.pebble) property returns the [`pebble.Client`](ops.pebble.Client) instance for the given container.
 
-Below is a (contrived) example of an action that uses the Pebble client directly to call [`pebble.Client.get_changes`](https://ops.readthedocs.io/en/latest/reference/pebble.html#ops.pebble.Client.get_changes):
+Below is a (contrived) example of an action that uses the Pebble client directly to call [`pebble.Client.get_changes`](ops.pebble.Client.get_changes):
 
 ```python
 import ops

--- a/docs/howto/run-workloads-with-a-charm-kubernetes.md
+++ b/docs/howto/run-workloads-with-a-charm-kubernetes.md
@@ -5,7 +5,7 @@ The recommended way to create charms for Kubernetes is using the sidecar pattern
 
 Pebble is a lightweight, API-driven process supervisor designed for use with charms. If you specify the `containers` field in a charm's `charmcraft.yaml`, Juju will deploy the charm code in a sidecar container, with Pebble running as the workload container's `ENTRYPOINT`.
 
-When the workload container starts up, Juju fires a [`PebbleReadyEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.PebbleReadyEvent), which can be handled using [`Framework.observe`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Framework.observe). This gives the charm author access to `event.workload`, a [`Container`](ops.Container) instance.
+When the workload container starts up, Juju fires a [`PebbleReadyEvent`](ops.PebbleReadyEvent), which can be handled using [`Framework.observe`](ops.Framework.observe). This gives the charm author access to `event.workload`, a [`Container`](ops.Container) instance.
 
 The `Container` class has methods to modify the Pebble configuration "plan", start and stop services, read and write files, and run commands. These methods use the Pebble API, which communicates from the charm container to the workload container using HTTP over a Unix domain socket.
 
@@ -63,7 +63,7 @@ If multiple containers are specified in `charmcraft.yaml` (as above), each Pod w
 - a container running the `redis-image`
 - a container running the charm code
 
-The Juju controller emits [`PebbleReadyEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.PebbleReadyEvent)s to charms when Pebble has initialised its API in a container. These events are named `<container_name>_pebble_ready`. Using the example above, the charm would receive two Pebble related events (assuming the Pebble API starts correctly in each workload):
+The Juju controller emits [`PebbleReadyEvent`](ops.PebbleReadyEvent)s to charms when Pebble has initialised its API in a container. These events are named `<container_name>_pebble_ready`. Using the example above, the charm would receive two Pebble related events (assuming the Pebble API starts correctly in each workload):
 
 - `myapp_pebble_ready`
 - `redis_pebble_ready`.
@@ -93,7 +93,7 @@ In many cases, using the container's specified entrypoint may be desired. You ca
 `$ docker inspect <image>`
 ```
 
-When using an OCI-image that is not built specifically for use with Pebble, layers are defined at runtime using Pebble’s API. Recall that when Pebble has initialised in a container (and the API is ready), the Juju controller emits a [`PebbleReadyEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.PebbleReadyEvent) event to the charm. Often it is in the callback bound to this event that layers are defined, and services started:
+When using an OCI-image that is not built specifically for use with Pebble, layers are defined at runtime using Pebble’s API. Recall that when Pebble has initialised in a container (and the API is ready), the Juju controller emits a [`PebbleReadyEvent`](ops.PebbleReadyEvent) event to the charm. Often it is in the callback bound to this event that layers are defined, and services started:
 
 ```python
 # ...
@@ -862,7 +862,7 @@ class PostgresCharm(ops.CharmBase):
             logger.info("Handling other thing")
 ```
 
-All notice events have a [`notice`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.PebbleNoticeEvent.notice) property with the details of the notice recorded. That is used in the example above to switch on the notice `key` and look at its `last_data` (to determine the backup's path).
+All notice events have a [`notice`](ops.PebbleNoticeEvent.notice) property with the details of the notice recorded. That is used in the example above to switch on the notice `key` and look at its `last_data` (to determine the backup's path).
 
 ### Fetch notices
 

--- a/docs/howto/write-scenario-tests-for-a-charm.md
+++ b/docs/howto/write-scenario-tests-for-a-charm.md
@@ -60,8 +60,8 @@ def test_charm_runs():
 ```
 
 > See more: 
->  - [State](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.State)
->  - [Context](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops.testing.Context)
+>  - [`State`](ops.testing.State)
+>  - [`Context`](ops.testing.Context)
 
 ```{note}
 

--- a/docs/howto/write-unit-tests-for-a-charm.md
+++ b/docs/howto/write-unit-tests-for-a-charm.md
@@ -42,7 +42,7 @@ def test_config_changed(harness: ops.testing.Harness[TestCharmCharm]):
 
 ```
 
-We use [`pytest` unit testing framework](https://docs.pytest.org) (Python’s standard [unit testing framework](https://docs.python.org/3/library/unittest.html) is a valid alternative), augmenting it with [`Harness`](https://ops.readthedocs.io/en/latest/#ops.testing.Harness), the Ops library's testing harness. [`Harness`](https://ops.readthedocs.io/en/latest/#ops.testing.Harness) provides some convenient mechanisms for mocking charm events and processes.
+We use [`pytest` unit testing framework](https://docs.pytest.org) (Python’s standard [unit testing framework](https://docs.python.org/3/library/unittest.html) is a valid alternative), augmenting it with [](ops_testing_harness). `Harness` provides some convenient mechanisms for mocking charm events and processes.
 
 A common pattern is to specify some minimal `metadata.yaml` content for testing like this:
 
@@ -98,7 +98,7 @@ harness.charm.unit.status = BlockedStatus("Testing")
 
 Any of your charm’s properties and methods (including event callbacks) can be accessed using
 `harness.charm`.  You can check out the [harness API
-docs](https://ops.readthedocs.io/en/latest/index.html#ops.testing.Harness) for more ways to use the
+docs](ops_testing_harness) for more ways to use the
 harness to trigger other events and to test your charm (e.g. triggering leadership-related events,
 testing pebble events and sidecar container interactions, etc.).
 
@@ -138,9 +138,9 @@ In `ops` 1.4, functionality was added to the Harness to more accurately track co
 Containers normally start in a disconnected state, and any interaction with the remote container (push, pull, add_layer, and so on) will raise an `ops.pebble.ConnectionError`. 
 
 To mark a container as connected,
-you can either call [`harness.set_can_connect(container, True)`](https://ops.readthedocs.io/en/latest/#ops.testing.Harness.set_can_connect), or you can call [`harness.container_pebble_ready(container)`](https://ops.readthedocs.io/en/latest/#ops.testing.Harness.container_pebble_ready) if you want to mark the container as connected *and* trigger its pebble-ready event.
+you can either call [`harness.set_can_connect(container, True)`](ops.testing.Harness.set_can_connect), or you can call [`harness.container_pebble_ready(container)`](ops.testing.Harness.container_pebble_ready) if you want to mark the container as connected *and* trigger its pebble-ready event.
 
-However, if you're using [`harness.begin_with_initial_hooks()`](https://ops.readthedocs.io/en/latest/#ops.testing.Harness.begin_with_initial_hooks) in your tests, that will automatically call `container_pebble_ready()` for all containers in the charm's metadata, so you don't have to do it manually.
+However, if you're using [`harness.begin_with_initial_hooks()`](ops.testing.Harness.begin_with_initial_hooks) in your tests, that will automatically call `container_pebble_ready()` for all containers in the charm's metadata, so you don't have to do it manually.
 
 If you have a hook that pushes a file to the container, like this:
 

--- a/docs/howto/write-unit-tests-for-a-charm.md
+++ b/docs/howto/write-unit-tests-for-a-charm.md
@@ -173,7 +173,7 @@ def test_something(harness):
     harness.update_config(key_values={'the-answer': 42})
 ```
 
-Which suggests that your `_config_changed` hook should probably use [`Container.can_connect()`](https://ops.readthedocs.io/en/latest/#ops.Container.can_connect):
+Which suggests that your `_config_changed` hook should probably use [`Container.can_connect()`](ops.Container.can_connect):
 
 ```python
 def _config_changed(event):

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/open-a-kubernetes-port-in-your-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/open-a-kubernetes-port-in-your-charm.md
@@ -49,7 +49,7 @@ def _handle_ports(self) -> None:
     self.unit.set_ports(port)
 ```
 
-> See more: [`ops.Unit.set_ports`](https://ops.readthedocs.io/en/latest/#ops.Unit.set_ports)
+> See more: [](ops.Unit.set_ports)
 
 
 ## Test the new feature

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/preserve-your-charms-data.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/preserve-your-charms-data.md
@@ -28,7 +28,7 @@ There are a  few strategies you can adopt here:
 
 First, you can use an Ops construct called `Stored State`. With this strategy you can store data on the local unit (at least, so long as your `main` function doesn't set `use_juju_for_storage` to `True`). However, if your Kubernetes pod dies, your unit also dies, and thus also the data. For this reason this strategy is generally not recommended.
 
-> Read more: [`ops.StoredState`](https://ops.readthedocs.io/en/latest/#ops.StoredState), {ref}`StoredState: Uses, Limitations <storedstate-uses-limitations>`
+> Read more: [](ops.StoredState), {ref}`StoredState: Uses, Limitations <storedstate-uses-limitations>`
 
 Second, you can make use of the Juju notion of 'peer relations'  and 'data bags'  and set up a peer relation data bag. This will help you store the information in the Juju's database backend. 
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/write-unit-tests-for-your-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/write-unit-tests-for-your-charm.md
@@ -22,7 +22,7 @@ When you're writing a charm, you will want to ensure that it will behave reliabl
 
 For example, that the various components -- relation data, pebble services, or configuration files -- all behave as expected in response to an event.
 
-You can ensure all this by writing a rich battery of units tests. In the context of a charm we recommended using [`pytest`](https://pytest.org/) (but [`unittest`](https://docs.python.org/3/library/unittest.html) can also be used) and especially the operator framework's built-in testing library --  [`ops.testing.Harness`](https://ops.readthedocs.io/en/latest/harness.html#module-ops.testing). We will be using the Python testing tool [`tox`](https://tox.wiki/en/4.14.2/index.html) to automate our testing and set up our testing environment.
+You can ensure all this by writing a rich battery of units tests. In the context of a charm we recommended using [`pytest`](https://pytest.org/) (but [`unittest`](https://docs.python.org/3/library/unittest.html) can also be used) and especially the operator framework's built-in testing library --  [](ops_testing_harness). We will be using the Python testing tool [`tox`](https://tox.wiki/en/4.14.2/index.html) to automate our testing and set up our testing environment.
 
 In this chapter you will write a simple unit test to check that your workload container is initialised correctly.
 
@@ -146,7 +146,7 @@ def test_pebble_layer(
 ```
 
 
-> Read more: [`ops.testing`](https://ops.readthedocs.io/en/latest/harness.html#module-ops.testing)
+> Read more: [](ops_testing_harness)
 
 ## Run the test
 


### PR DESCRIPTION
This PR addresses #1506

### Changes that affect the published docs

- Fixed links that broke after the library docs were moved under [Reference](https://ops.readthedocs.io/en/latest/reference/index.html). See 8d62861 (for Harness-related links) and 1d8374e (for other links). For some of the Harness-related links, I set the links to use the full doc title "ops.testing.Harness (legacy unit testing)" to help emphasise that Harness is legacy.

- In [How to run workloads with a charm - Kubernetes](https://ops.readthedocs.io/en/latest/howto/run-workloads-with-a-charm-kubernetes.html), fixed a link to `ops.Container.isdir`. See b5d5528

- In [Manage relations](https://ops.readthedocs.io/en/latest/howto/manage-relations.html), fixed a link to `ops.RelationChangedEvent`. See a2e84e9

### Changes that affect the doc source only

- Replaced absolute links to `ops.testing` by a cross reference to the [ops.testing](http://127.0.0.1:8000/reference/ops-testing.html) page. See a375749. The .rst source for this page defines a reference called `ops_testing`, so I've used this format for links from .md pages:

    ```
    [Link title](ops_testing)
    ````

- Replaced links to classes, methods, etc by cross references. See:

    - c34ae8e for links to `ops.testing`
    - 3612f02 for links to `ops.pebble`
    - 42f3f36 for links to `ops.Container`
    - 31f8261 for other links

    References like `ops.foo.bar` are generated by `automodule`/`autoclass` directives in the .rst source files. If a link doesn't need custom link text, we automatically get code font when doing `[](ops.foo.bar)` in .md files.