### PR TITLE
docs: use explicit framework param instead of *args

### DIFF
--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -20,8 +20,8 @@ This API provides core features to your charm, including:
   the base class for charm libraries.
 - :class:`~ops.framework.EventBase` class and individual event types, like
   the :class:`~ops.ActionEvent` class.
-- :class:`~ops.Framework` class, accessible as ``self.framework`` in a charm,
-  the main interface for the charm to `ops` library infrastructure, including:
+- :class:`~ops.Framework` class, the main interface for the charm to `ops` library
+  infrastructure, including:
 
   - :attr:`~ops.Framework.on` shorthand property used to
     :meth:`~ops.Framework.observe` and react to Juju events.

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -1915,10 +1915,9 @@ class Harness(Generic[CharmType]):
 
             # charm.py
             class ExampleCharm(ops.CharmBase):
-                def __init__(self, *args):
-                    super().__init__(*args)
-                    self.framework.observe(self.on["mycontainer"].pebble_ready,
-                                           self._on_pebble_ready)
+                def __init__(self, framework: ops.Framework):
+                    super().__init__(framework)
+                    framework.observe(self.on["mycontainer"].pebble_ready, self._on_pebble_ready)
 
                 def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
                     self.hostname = event.workload.pull("/etc/hostname").read()

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1137,8 +1137,8 @@ class CollectStatusEvent(LifecycleEvent):
     requires a "port" config option set before it can proceed::
 
         class MyCharm(ops.CharmBase):
-            def __init__(self, *args):
-                super().__init__(*args)
+            def __init__(self, framework: ops.Framework):
+                super().__init__(framework)
                 self.webapp = Webapp(self)
                 # initialize other components
 
@@ -1182,7 +1182,7 @@ class CharmEvents(ObjectEvents):
     By default, the events listed as attributes of this class will be
     provided via the :attr:`CharmBase.on` attribute. For example::
 
-        self.framework.observe(self.on.config_changed, self._on_config_changed)
+        framework.observe(self.on.config_changed, self._on_config_changed)
 
     In addition to the events listed as attributes of this class,
     dynamically-named events will also be defined based on the charm's
@@ -1191,8 +1191,8 @@ class CharmEvents(ObjectEvents):
     ``self.on[<name>].<event>`` or using a prefix like
     ``self.on.<name>_<event>``, for example::
 
-        self.framework.observe(self.on["db"].relation_created, self._on_db_relation_created)
-        self.framework.observe(self.on.workload_pebble_ready, self._on_workload_pebble_ready)
+        framework.observe(self.on["db"].relation_created, self._on_db_relation_created)
+        framework.observe(self.on.workload_pebble_ready, self._on_workload_pebble_ready)
     """
 
     # NOTE: The one-line docstrings below are copied from the first line of
@@ -1302,10 +1302,10 @@ class CharmBase(Object):
         import ops
 
         class MyCharm(ops.CharmBase):
-            def __init__(self, *args):
-                super().__init__(*args)
-                self.framework.observe(self.on.config_changed, self._on_config_changed)
-                self.framework.observe(self.on.stop, self._on_stop)
+            def __init__(self, framework: ops.Framework):
+                super().__init__(framework)
+                framework.observe(self.on.config_changed, self._on_config_changed)
+                framework.observe(self.on.stop, self._on_stop)
                 # ...
 
         if __name__ == "__main__":


### PR DESCRIPTION
A while back we decided to recommend using an explicit `framework` parameter instead `*args` to a charm's `__init__`. We've updated `charmcraft init` templates, but we forgot a few places in our docs. Update them to match here.

[Preview](https://ops--1523.org.readthedocs.build/en/1523/reference/ops.html#ops.CharmBase)