### PR TITLE
chore: update documentation dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@
 #
 alabaster==1.0.0
     # via sphinx
-anyio==4.4.0
+anyio==4.8.0
     # via
     #   starlette
     #   watchfiles
@@ -17,15 +17,15 @@ beautifulsoup4==4.12.3
     #   canonical-sphinx-extensions
     #   furo
     #   pyspelling
-bracex==2.5
+bracex==2.5.post1
     # via wcmatch
 canonical-sphinx-extensions==0.0.23
     # via ops (pyproject.toml)
-certifi==2024.7.4
+certifi==2024.12.14
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via requests
-click==8.1.7
+click==8.1.8
     # via uvicorn
 colorama==0.4.6
     # via sphinx-autobuild
@@ -37,21 +37,21 @@ docutils==0.21.2
     #   sphinx-tabs
 furo==2024.8.6
     # via ops (pyproject.toml)
-gitdb==4.0.11
+gitdb==4.0.12
     # via gitpython
-gitpython==3.1.43
+gitpython==3.1.44
     # via canonical-sphinx-extensions
 h11==0.14.0
     # via uvicorn
 html5lib==1.1
     # via pyspelling
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   myst-parser
     #   sphinx
@@ -65,17 +65,17 @@ markdown-it-py==3.0.0
     # via
     #   mdit-py-plugins
     #   myst-parser
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via jinja2
-mdit-py-plugins==0.4.1
+mdit-py-plugins==0.4.2
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
 myst-parser==4.0.0
     # via ops (pyproject.toml)
-packaging==24.1
+packaging==24.2
     # via sphinx
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   furo
     #   sphinx
@@ -91,9 +91,9 @@ requests==2.32.3
     # via
     #   canonical-sphinx-extensions
     #   sphinx
-six==1.16.0
+six==1.17.0
     # via html5lib
-smmap==5.0.1
+smmap==5.0.2
     # via gitdb
 sniffio==1.3.1
     # via anyio
@@ -117,7 +117,7 @@ sphinx==8.0.2
     #   sphinx-tabs
     #   sphinxcontrib-jquery
     #   sphinxext-opengraph
-sphinx-autobuild==2024.9.3
+sphinx-autobuild==2024.10.3
     # via ops (pyproject.toml)
 sphinx-basic-ng==1.0.0b2
     # via furo
@@ -127,7 +127,7 @@ sphinx-design==0.6.1
     # via ops (pyproject.toml)
 sphinx-notfound-page==1.0.4
     # via ops (pyproject.toml)
-sphinx-tabs==3.4.5
+sphinx-tabs==3.4.7
     # via ops (pyproject.toml)
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -145,22 +145,24 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sphinxext-opengraph==0.9.1
     # via ops (pyproject.toml)
-starlette==0.40.0
+starlette==0.45.2
     # via sphinx-autobuild
+typing-extensions==4.12.2
+    # via anyio
 uc-micro-py==1.0.3
     # via linkify-it-py
-urllib3==2.2.2
+urllib3==2.3.0
     # via requests
-uvicorn==0.30.6
+uvicorn==0.34.0
     # via sphinx-autobuild
-watchfiles==0.23.0
+watchfiles==1.0.4
     # via sphinx-autobuild
-wcmatch==9.0
+wcmatch==10.0
     # via pyspelling
 webencodings==0.5.1
     # via html5lib
 websocket-client==1.8.0
     # via ops (pyproject.toml)
-websockets==12.0
+websockets==14.1
     # via sphinx-autobuild
 ./testing/


### PR DESCRIPTION
There's a security release for Jinja (not one that impacts our use from what I can tell, but nice to just move to the updated version anyway). While bumping that, bump all the other dependencies as well.

This is just the result of removing the requirements file and regenerating it with `tox -e docs-deps`.