### PR TITLE
docs: add doc style tips to HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -262,7 +262,7 @@ before generating docs to recompile the `requirements.txt` file used for docs:
 tox -e docs-deps
 ```
 
-## How to write a great doc
+## How to write great documentation
 
 - Use short sentences, ideally with one or two clauses.
 - Use headings to split the doc into sections. Make sure that the purpose of each section is clear from its heading.

--- a/HACKING.md
+++ b/HACKING.md
@@ -262,6 +262,18 @@ before generating docs to recompile the `requirements.txt` file used for docs:
 tox -e docs-deps
 ```
 
+## How to write a great doc
+
+- Use short sentences, ideally with one or two clauses.
+- Use headings to split the doc into sections. Make sure that the purpose of each section is clear from its heading.
+- Avoid a long introduction. Assume that the reader is only going to scan the first paragraph and the headings.
+- Avoid background context unless it's essential for the reader to understand.
+
+Recommended tone:
+- Use a casual tone, but avoid idioms. Common contractions such as "it's" and "doesn't" are great.
+- Use "we" to include the reader in what you're explaining.
+- Avoid passive descriptions. If you expect the reader to do something, give a direct instruction.
+
 ## How to Pull in Style Changes
 
 The documentation uses Canonical styling which is customised on top of the [Furo Sphinx theme](https://github.com/pradyunsg/furo). The easiest way to pull in Canonical style changes is by using the Canonical documentation starter pack, see [docs](https://canonical-starter-pack.readthedocs-hosted.com/) and [repository](https://github.com/canonical/sphinx-docs-starter-pack).


### PR DESCRIPTION
This PR adds a few style tips to the Documentation section of HACKING.md (the same ones we added to Pebble in https://github.com/canonical/pebble/pull/556).