### PR TITLE
docs: fix link to Juju docs in Kubernetes charm tutorial

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/set-up-your-development-environment.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/set-up-your-development-environment.md
@@ -11,7 +11,7 @@ You will need a charm directory, the various tools in the charm SDK, Juju, and a
 
 You can get all of this by following our generic development setup guide, with some annotations. 
 
-> See [`juju` | Set up your environment automatically](https://juju.is/docs/juju/set-up--tear-down-your-test-environment#tear-down-automatically, with the following changes:
+> See [Set up / tear down automatically](https://juju.is/docs/juju/set-up--tear-down-your-test-environment#set-up-tear-down-automatically, with the following changes:
 > - At the directory step, call your directory `fastapi-demo`. 
 > - At the VM setup step, call your VM `charm-dev` and also set up Docker: 
 >     1. `sudo addgroup --system docker`

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/set-up-your-development-environment.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/set-up-your-development-environment.md
@@ -11,7 +11,7 @@ You will need a charm directory, the various tools in the charm SDK, Juju, and a
 
 You can get all of this by following our generic development setup guide, with some annotations. 
 
-> See [Set up / tear down automatically](https://juju.is/docs/juju/set-up--tear-down-your-test-environment#set-up-tear-down-automatically, with the following changes:
+> See [Set up / tear down automatically](https://juju.is/docs/juju/set-up--tear-down-your-test-environment#set-up-tear-down-automatically), with the following changes:
 > - At the directory step, call your directory `fastapi-demo`. 
 > - At the VM setup step, call your VM `charm-dev` and also set up Docker: 
 >     1. `sudo addgroup --system docker`


### PR DESCRIPTION
This PR fixes the link to Juju on this page: https://ops.readthedocs.io/en/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/set-up-your-development-environment.html

Fixed issues:

- The link points to "Tear down automatically" in the Juju instructions. It should point to the full instructions for setting up automatically.
- The link doesn't render properly because of a missing `)` at the end.