### PR TITLE
test: allow check to fail an additional time when running the test

### DIFF
--- a/test/test_real_pebble.py
+++ b/test/test_real_pebble.py
@@ -129,7 +129,7 @@ class TestRealPebble:
             time.sleep(0.06)
         else:
             assert False, 'timed out waiting for "bad" check to go down'
-        assert bad_check.failures == 2
+        assert bad_check.failures >= 2
         assert bad_check.threshold == 2
         good_check = next(c for c in checks if c.name == 'good')
         assert good_check.status == pebble.CheckStatus.UP


### PR DESCRIPTION
When running the real Pebble, it's possible that the tests fail more than twice when the test code is running. For the purposes of the test, we only care that it's at least twice (more than the threshold).

Fixes #1524