### PR TITLE
chore: enable the scheduled TIOBE reporting again

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -2,10 +2,8 @@ name: TIOBE Quality Checks
 
 on:
   workflow_dispatch:
-# Disabled for upgrade, see:
-# https://discourse.canonical.com/t/end-of-the-year-update-for-tiobe-tics-required-action-to-disable-tics-cicd-pipelines/4890
-#  schedule:
-#    - cron:  '0 7 1 * *'
+  schedule:
+    - cron:  '0 7 1 * *'
 
 jobs:
   TICS:


### PR DESCRIPTION
[Internal post saying it can be enabled again](https://discourse.canonical.com/t/end-of-the-year-update-for-tiobe-tics-disable-tics-cicd-pipelines-if-needed-service-will-be-shutdown/4890/6?u=tony-meyer).