### PR TITLE
chore: make event_name mandatory in Framework

### DIFF
--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -312,6 +312,7 @@ class Harness(Generic[CharmType]):
             self._charm_dir,
             self._meta,
             self._model,
+            '',
             juju_debug_at=self._juju_context.debug_at,
             # Harness tests will often have defer() usage without 'purging' the
             # deferred handler with reemit(), but still expect the next emit()

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -606,7 +606,7 @@ class Framework(Object):
         charm_dir: Union[str, pathlib.Path],
         meta: 'charm.CharmMeta',
         model: 'Model',
-        event_name: Optional[str] = None,
+        event_name: str,
         juju_debug_at: Optional[Set[str]] = None,
         skip_duplicate_events: bool = True,
     ):

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -73,6 +73,7 @@ def create_framework(
         charm_dir,
         meta=model._cache._meta if model else ops.CharmMeta(),
         model=model,  # type: ignore
+        event_name='',
         juju_debug_at=_JujuContext.from_dict(os.environ).debug_at,
     )
     request.addfinalizer(framework.close)
@@ -94,6 +95,7 @@ class TestFramework:
                 None,  # type: ignore
                 None,  # type: ignore
                 None,  # type: ignore
+                '',
                 juju_debug_at=set(),
             )
         assert 'WARNING:ops.framework:deprecated: Framework now takes a Storage not a path' in [

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -112,6 +112,7 @@ def create_framework(
         tmpdir,
         meta,
         model,
+        'foo_event',
         juju_debug_at=_JujuContext.from_dict(os.environ).debug_at,
     )
 

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -54,6 +54,7 @@ class StoragePermutations(abc.ABC):
             None,  # type: ignore
             None,  # type: ignore
             None,  # type: ignore
+            '',
             juju_debug_at=set(),
         )
 


### PR DESCRIPTION
I'm sure that the event name is always set (except some units tests)
Meanwhile we've got this signature: `Framework.__init__(..., event_name: str|None, ...)`
And therefore `self._event_name` is optional too.

This PR makes this mandatory.

Open question remaining: whether ops-scenario / ops version needs to be bumped to keep the two in sync.
That would be necessary if ops-scenario ships with harness code and ops is not.
(I don't recall if ops / ops['testing'] has reached that stage)
