### PR TITLE
ci: bump poetry to 2.0 to match downstream

### DIFF
--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -35,7 +35,7 @@ jobs:
           path: myops
 
       - name: Install patch dependencies
-        run: pip install poetry~=1.6
+        run: pip install poetry~=2.0
 
       - name: Update 'ops' dependency in test charm to latest
         run: |
@@ -44,7 +44,7 @@ jobs:
             echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
           else
             sed -i -e "s/^ops[ ><=].*/ops = {path = \"myops\"}/" pyproject.toml
-            poetry lock --no-update
+            poetry lock
           fi
 
       - name: Install dependencies

--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -60,7 +60,7 @@ jobs:
           repository: ${{ matrix.charm-repo }}
 
       - name: Install patch dependencies
-        run: pip install poetry~=1.6 uv~=0.5
+        run: pip install poetry~=2.0 uv~=0.5
 
       - name: Update 'ops' dependency in test charm to latest
         run: |


### PR DESCRIPTION
The charms have moved to Poetry 2.0, so we need to as well to remain compatible with the new options (and `--no-update` is no longer a flag, as it's the default behaviour).