### PR TITLE
chore: fix compatibility with ops-scenario 7.0.5

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -177,14 +177,18 @@ else:
         # monkeypatch it in, so that the ops.testing.ActionFailed object is the
         # one that we expect, even if people are mixing Harness and Scenario.
         # https://github.com/canonical/ops-scenario/issues/201
+        # This will be the case in the next version of ops-scenario, so this
+        # code can be removed as of the release of ops-scenario after 7.0.5.
+        # Remember to bump the required version of `ops-scenario` in pyproject.toml
+        # at that time as well.
         try:
             import scenario._runtime as _runtime
         except ImportError:
-            import scenario.runtime as _runtime
+            import scenario.runtime as _runtime  # type: ignore
         import scenario.context as _context
 
         _context.ActionFailed = ActionFailed  # type: ignore[reportPrivateImportUsage]
-        _runtime.ActionFailed = ActionFailed  # type: ignore[reportPrivateImportUsage]
+        _runtime.ActionFailed = ActionFailed
 
 # Names exposed for backwards compatibility
 _compatibility_names = [

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -177,7 +177,10 @@ else:
         # monkeypatch it in, so that the ops.testing.ActionFailed object is the
         # one that we expect, even if people are mixing Harness and Scenario.
         # https://github.com/canonical/ops-scenario/issues/201
-        import scenario._runtime as _runtime
+        try:
+            import scenario._runtime as _runtime
+        except ImportError:
+            import scenario.runtime as _runtime
         import scenario.context as _context
 
         _context.ActionFailed = ActionFailed  # type: ignore[reportPrivateImportUsage]


### PR DESCRIPTION
The next version of ops-scenario renames the `runtime` module to `_runtime`. The `main` branch of `ops` currently expects that rename to have happened, but doesn't require it in the `[testing]` dependency. This means that `main@HEAD` `ops` doesn't work unless you also use `main@HEAD` of `ops-scenario`, which isn't the case in our compatibility checks - or in any charm that ends up with that combination.

We could fix this by adjusting the `ops` dependencies to require the newer `ops-scenario`, but that would really require releasing a new version of `ops-scenario`, and we're unlikely to be doing that before we also release `ops`.

The relevant code is only required until we release the next version of `ops-scenario` so for now just handle 7.0.5 as well as the newer code.

This will fix several of the "broad compatibility" charm CI tests.