### PR TITLE
ci: enable the prometheus-k8s revision updates again

### DIFF
--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -19,7 +19,6 @@ jobs:
             commit: 083c0a2ab2a14e9c9aa4fd95f1d8ad51eb0abb13  # rev144 2024-12-20T12:11:09Z
           - charm-repo: canonical/prometheus-k8s-operator
             commit: 62cd2d9b8c3a528910ce12c553209817e1b7a889 # rev226 2024-12-19T16:01:25Z
-            disabled: true # Waiting for an upstream PR: https://github.com/canonical/prometheus-k8s-operator/pull/639
           - charm-repo: canonical/grafana-k8s-operator
             commit: 802a566dd0c801ffa6703ea2c350491bd09d94d8
     steps:


### PR DESCRIPTION
The [upstream PR](https://github.com/canonical/prometheus-k8s-operator/pull/639) has been merged, so it should be fine for us to resume tracking the latest revision in our compatibility tests.