### PR TITLE
ci: include Juju 2.9 in the smoke tests

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         # pylibjuju does not currently support Juju 4.x
         # The smoke tests do not yet work on Juju 2.9.
-        juju-channel: ['3/stable']
+        juju-channel: ['2/stable', '3/stable']
         charmcraft-channel: ['2.x/stable', '3.x/stable']
         preset: ['machine', 'microk8s']
 

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         # pylibjuju does not currently support Juju 4.x
-        # The smoke tests do not yet work on Juju 2.9.
         juju-channel: ['2.9/stable', '3/stable']
         charmcraft-channel: ['2.x/stable', '3.x/stable']
         preset: ['machine', 'microk8s']

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         # pylibjuju does not currently support Juju 4.x
         # The smoke tests do not yet work on Juju 2.9.
-        juju-channel: ['2/stable', '3/stable']
+        juju-channel: ['2.9/stable', '3/stable']
         charmcraft-channel: ['2.x/stable', '3.x/stable']
         preset: ['machine', 'microk8s']
 

--- a/tox.ini
+++ b/tox.ini
@@ -174,7 +174,6 @@ description = Run a smoke test against a Juju controller.
 allowlist_externals = juju
                       charmcraft
                       bash
-passenv = JUJU_VERSION
 deps =
     build
     coverage[toml]~=7.0
@@ -186,8 +185,8 @@ commands =
     python -m build --sdist --outdir={toxinidir}/test/charms/test_smoke/
     # Inject the tarball into the smoke test charm's requirements.
     bash -c 'echo "./$(ls -1 ./test/charms/test_smoke/ | grep tar.gz)" > ./test/charms/test_smoke/requirements.txt'
-    # If a specific Juju version is set, then make sure we are using that version of pylibjuju.
-    bash -c 'if [ -n "$JUJU_VERSION" ]; then pip install "juju ~= $JUJU_VERSION"; fi'
+    # Make sure we are using the appropriate version of pylibjuju.
+    bash -c 'JUJU_VERSION=$(juju --version | awk -F. "{print \$1 \".\" \$2}"); if [ -n "$JUJU_VERSION" ]; then pip install "juju ~= $JUJU_VERSION"; fi'
 
     # Run our smoke tests (this will build the charm, then run the tests).
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {toxinidir}/test/smoke/


### PR DESCRIPTION
Now that we're using Concierge running against Juju 2.9 works trivially, so we might as well include it for now, to avoid any breakage.

This also fixes the python-libjuju installation that broke in the last change (but still worked because the default is 3.x, which is what Juju 3.x needs).