### PR TITLE
chore: update docs-deps step in HACKING.md for the release

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -367,8 +367,9 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
    [testing/pyproject.toml](testing/pyproject.toml). Both packages use
    [semantic versioning](https://semver.org/), and adjust independently
    (that is: ops 2.18 doesn't imply ops-scenario 2.18, or any other number).
-9. Run `tox -e docs-deps` to recompile the `requirements.txt` file used for docs
-   (in case dependencies have been updated in `pyproject.toml`).
+9. Run `uvx -p 3.11 tox -e docs-deps` to recompile the `requirements.txt` file
+   used for docs (in case dependencies have been updated in `pyproject.toml`)
+   using the same Python version as specified in the `.readthedocs.yaml` file.
 10. Add, commit, and push, and open a PR to get the changelogs, version bumps,
    and doc requirement bumps into main (and get it merged).
 11. Save the release notes as a draft, and have someone else in the Charm-Tech


### PR DESCRIPTION
`tox -e docs-deps` produces subtly different result depending on which Python is used, as pip-compile uses that Python to resolve transient deps, so 3.10, 3.11, 3.12, 3.13 are all different.