### PR TITLE
fix: require today's ops for today's ops-scenario

### DIFF
--- a/testing/CHANGES.md
+++ b/testing/CHANGES.md
@@ -1,3 +1,9 @@
+# 7.1.1 - 30 Jan 2025
+
+## Fixes
+
+* require ops 2.18.0 or better as a hot-fix against accidentally introduced incompatibility (#1551)
+
 # 7.1.0 - 30 Jan 2025
 
 ## Features

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "7.2.0.dev0"
+version = "7.1.1"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops~=2.17",
+    "ops~=2.18",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"


### PR DESCRIPTION
and prep for release

the idea is that we'd:
- release this as `ops-scenario=7.1.1`
- yank `ops-scenario=7.1.0`

the users can then either stay on old ops and old ops-scenario, or upgrade both
the automatic version resolution should work, I think :)