### PR TITLE
[POC] any-event

### DIFF
--- a/ops/_main.py
+++ b/ops/_main.py
@@ -488,6 +488,9 @@ class _Manager:
 
     def _emit(self):
         """Emit the event on the charm."""
+        # emit the 'any' event onto the charm
+        self._emit_charm_event("any")
+
         # TODO: Remove the collect_metrics check below as soon as the relevant
         #       Juju changes are made. Also adjust the docstring on
         #       EventBase.defer().

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -92,6 +92,21 @@ class _ContainerBaseDict(TypedDict):
 logger = logging.getLogger(__name__)
 
 
+class AnyEvent(EventBase):
+    """Event always emitted on the charm."""
+
+    def defer(self) -> NoReturn:
+        """The `any` event is not deferrable.
+
+        This is because these events are run alongside each event invocation,
+        so deferring would always end up simply doubling the work.
+
+        Raises:
+            RuntimeError: always.
+        """
+        raise RuntimeError('cannot defer `any` event')
+
+
 class HookEvent(EventBase):
     """Events raised by Juju to progress a charm's lifecycle.
 
@@ -1197,6 +1212,9 @@ class CharmEvents(ObjectEvents):
 
     # NOTE: The one-line docstrings below are copied from the first line of
     #       each event class's docstring. Please keep in sync.
+
+    any = EventSource(AnyEvent)
+    """Always triggered on the charm, regardless of the juju event being processed (see :class:`~ops.AnyEvent`)."""
 
     install = EventSource(InstallEvent)
     """Triggered when a charm is installed (see :class:`~ops.InstallEvent`)."""


### PR DESCRIPTION
brainstorming proof of concept API for introducing an 'any' event in ops

### Issue 1:
```
class MyCharm(ops.CharmBase):
    def __init__...
        ...
        self.reconcile()
    def reconcile(self):
        # holistic charm state reconciler
```
examples: 
- [parca-k8s-operator](https://github.com/canonical/parca-k8s-operator/blob/main/src/charm.py#L182) 
- 
### Issue 2:
```
class MyCharm(ops.CharmBase):
    def __init__...
        ...
        for event in [list of all possible events]:
            self.framework.observe(event, self._on_any)

    def _on_any(self, _event):
        # holistic charm state reconciler
```

### Proposed solution:
```
class MyCharm(ops.CharmBase):
    def __init__...
        ...
        self.framework.observe(self.on.any, self._on_any)

    def _on_any(self, _event):
        # holistic charm state reconciler
```
