### PR TITLE
fix: maintain transaction integrity on first run

### DIFF
--- a/ops/storage.py
+++ b/ops/storage.py
@@ -102,7 +102,6 @@ class SQLiteStorage:
                   observer_path TEXT,
                   method_name TEXT)
                 """)
-            self._db.commit()
 
     def close(self) -> None:
         """Part of the Storage API, close the storage backend."""


### PR DESCRIPTION
Fixing the db transaction when the db is being created in this dispatch call.

We commit the whole unit state on_commit()

If the DDL is committed early, then the rest of the operations are performed in the autocommit mode, potentially breaking the transactional guarantees the rest of the code assumes.

Meanwhile it is safe (and normal) to modify DDL within a transaction in sqlite.

Additionally, I feel that the transaction code was added to make doubly sure that two hooks cannot be run concurrently... Doesn't Juju guarantee that for us anyway?

