### PR TITLE
fix: put the Juju version in the environment as well as the JujuContext

### DIFF
--- a/testing/tests/test_runtime.py
+++ b/testing/tests/test_runtime.py
@@ -117,3 +117,19 @@ def test_env_clean_on_charm_error():
 
     # Ensure that the Juju environment didn't leak into the outside one.
     assert os.getenv("JUJU_REMOTE_APP", None) is None
+
+
+def test_juju_version_is_set_in_environ():
+    version = "2.9"
+
+    class MyCharm(ops.CharmBase):
+        def __init__(self, framework: ops.Framework):
+            super().__init__(framework)
+            framework.observe(self.on.start, self._on_start)
+
+        def _on_start(self, _: ops.StartEvent):
+            juju_version = ops.JujuVersion.from_environ()
+            assert juju_version == version
+
+    ctx = Context(MyCharm, meta={"name": "foo"}, juju_version=version)
+    ctx.run(ctx.on.start(), State())


### PR DESCRIPTION
Charms are expected to access the Juju environment variables via the mechanisms that ops provides. Generally, this is through the model and other attributes of the charm class. However, the Juju version is not available via the charm object, and instead is expected to be obtained by charms via `JujuVersion.from_environ()`.

Previously, we stopped Scenario from putting all the Juju environment variables in `os.environ`, and instead provided them directly to the `JujuContext` object. This works, except for the `JUJU_VERSION` case, as `from_environ` (as the name indicates) loads the version from `os.environ`, not from a `JujuContext` object.

This PR changes the behaviour so that `JUJU_VERSION` is set in both the context and the environment.

Fixes #1555.