### PR TITLE
feat: support starting and stopping Pebble checks, and the checks enabled field

### DIFF
--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -3187,7 +3187,6 @@ class _TestingPebbleClient:
                         failures=0,
                         threshold=3 if check.threshold is None else check.threshold,
                         startup=check.startup,
-                        change_id=pebble.ChangeID(str(uuid.uuid4())),
                     )
                     self._check_infos[name] = info
                 if not info.change_id:
@@ -3389,6 +3388,7 @@ class _TestingPebbleClient:
                     failures=0,
                     change_id=pebble.ChangeID(''),
                 )
+                self._check_infos[name] = info
             info.level = check.level
             info.threshold = 3 if check.threshold is None else check.threshold
             info.startup = check.startup
@@ -3837,6 +3837,7 @@ class _TestingPebbleClient:
             if info.change_id:
                 change = self._changes[info.change_id]
                 change.status = pebble.ChangeStatus.ABORT.value
+                info.status = pebble.CheckStatus.INACTIVE
                 info.change_id = pebble.ChangeID('')
 
     def notify(

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -3400,7 +3400,6 @@ class _TestingPebbleClient:
             if info.startup != pebble.CheckStartup.DISABLED and not info.change_id:
                 self._new_perform_check(info)
 
-
     def _render_services(self) -> Dict[str, pebble.Service]:
         services: Dict[str, pebble.Service] = {}
         for key in sorted(self._layers.keys()):

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -3182,7 +3182,20 @@ class _TestingPebbleClient:
                 if not info.change_id:
                     info.status = pebble.CheckStatus.UP
                     info.failures = 0
-                    info.change_id = pebble.ChangeID("replanned")
+                    now = datetime.datetime.now()
+                    change = pebble.Change(
+                        pebble.ChangeID(str(uuid.uuid4())),
+                        pebble.ChangeKind.PERFORM_CHECK.value,
+                        summary=name,
+                        status=pebble.ChangeStatus.DOING.value,
+                        tasks=[],
+                        ready=False,
+                        err=None,
+                        spawn_time=now,
+                        ready_time=now,
+                    )
+                    self._changes[change.id] = change
+                    info.change_id = change.id
         return self.autostart_services(timeout, delay)
 
     def start_services(
@@ -3352,6 +3365,38 @@ class _TestingPebbleClient:
 
         else:
             self._layers[label] = layer_obj
+
+        # Checks are started when the layer is added, not (only) on replan.
+        for name, check in layer_obj.checks.items():
+            try:
+                info = self._check_infos[name]
+            except KeyError:
+                info = pebble.CheckInfo(
+                    name,
+                    level=check.level,
+                    status=pebble.CheckStatus.UP,
+                    failures=0,
+                    change_id=pebble.ChangeID(''),
+                )
+            info.level = check.level
+            info.threshold = 3 if check.threshold is None else check.threshold
+            info.startup = check.startup
+            if info.startup != pebble.CheckStartup.DISABLED and not info.change_id:
+                info.status = pebble.CheckStatus.UP
+                info.failures = 0
+                change = pebble.Change(
+                    pebble.ChangeID(str(uuid.uuid4())),
+                    pebble.ChangeKind.PERFORM_CHECK.value,
+                    summary=name,
+                    status=pebble.ChangeStatus.DOING.value,
+                    tasks=[],
+                    ready=False,
+                    err=None,
+                    spawn_time=datetime.datetime.now(),
+                    ready_time=None,
+                )
+                self._changes[change.id] = change
+                info.change_id = change.id
 
     def _render_services(self) -> Dict[str, pebble.Service]:
         services: Dict[str, pebble.Service] = {}
@@ -3759,7 +3804,19 @@ class _TestingPebbleClient:
             if not info.change_id:
                 info.status = pebble.CheckStatus.UP
                 info.failures = 0
-                info.change_id = pebble.ChangeID("started")
+                change = pebble.Change(
+                    pebble.ChangeID(str(uuid.uuid4())),
+                    pebble.ChangeKind.PERFORM_CHECK.value,
+                    summary=name,
+                    status=pebble.ChangeStatus.DOING.value,
+                    tasks=[],
+                    ready=False,
+                    err=None,
+                    spawn_time=datetime.datetime.now(),
+                    ready_time=None,
+                )
+                self._changes[change.id] = change
+                info.change_id = change.id
 
     def stop_checks(self, names: List[str]):
         self._check_connection()
@@ -3768,7 +3825,9 @@ class _TestingPebbleClient:
                 raise self._api_error(404, f'cannot find check with name "{name}"')
             info = self._check_infos[name]
             if info.change_id:
-                info.change_id = pebble.ChangeID("")
+                change = self._changes[info.change_id]
+                change.status = pebble.ChangeStatus.ABORT.value
+                info.change_id = pebble.ChangeID('')
 
     def notify(
         self,

--- a/ops/model.py
+++ b/ops/model.py
@@ -40,8 +40,8 @@ from typing import (
     BinaryIO,
     Callable,
     ClassVar,
+    Collection,
     Dict,
-    FrozenSet,
     Generator,
     Iterable,
     List,
@@ -2498,7 +2498,7 @@ class Container:
             raise RuntimeError(f'expected 1 check, got {len(checks)}')
         return checks[check_name]
 
-    def start_checks(self, *check_names: str) -> FrozenSet[str]:
+    def start_checks(self, *check_names: str) -> Collection[str]:
         """Start given check(s) by name.
 
         Returns:
@@ -2508,9 +2508,9 @@ class Container:
         if not check_names:
             raise TypeError('start-checks expected at least 1 argument, got 0')
 
-        return self._pebble.start_checks(check_names)
+        return frozenset(self._pebble.start_checks(check_names))
 
-    def stop_checks(self, *check_names: str) -> FrozenSet[str]:
+    def stop_checks(self, *check_names: str) -> Collection[str]:
         """Stop given check(s) by name.
 
         Returns:
@@ -2520,7 +2520,7 @@ class Container:
         if not check_names:
             raise TypeError('stop-checks expected at least 1 argument, got 0')
 
-        return self._pebble.stop_checks(check_names)
+        return frozenset(self._pebble.stop_checks(check_names))
 
     @typing.overload
     def pull(self, path: Union[str, PurePath], *, encoding: None) -> BinaryIO: ...

--- a/ops/model.py
+++ b/ops/model.py
@@ -2502,7 +2502,8 @@ class Container:
         """Start given check(s) by name.
 
         Returns:
-            A set of check names that were started.
+            A set of check names that were started. Checks that were already
+            running will not be included.
         """
         if not check_names:
             raise TypeError('start-checks expected at least 1 argument, got 0')
@@ -2513,7 +2514,8 @@ class Container:
         """Stop given check(s) by name.
 
         Returns:
-            A set of check names that were stopped.
+            A set of check names that were stopped. Checks that were already
+            inactive will not be included.
         """
         if not check_names:
             raise TypeError('stop-checks expected at least 1 argument, got 0')

--- a/ops/model.py
+++ b/ops/model.py
@@ -2497,6 +2497,20 @@ class Container:
             raise RuntimeError(f'expected 1 check, got {len(checks)}')
         return checks[check_name]
 
+    def start_checks(self, *check_names: str):
+        """Start given check(s) by name."""
+        if not check_names:
+            raise TypeError('start-checks expected at least 1 argument, got 0')
+
+        self._pebble.start_checks(check_names)
+
+    def stop(self, *check_names: str):
+        """Stop given check(s) by name."""
+        if not check_names:
+            raise TypeError('stop-checks expected at least 1 argument, got 0')
+
+        self._pebble.stop_checks(check_names)
+
     @typing.overload
     def pull(self, path: Union[str, PurePath], *, encoding: None) -> BinaryIO: ...
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -40,7 +40,6 @@ from typing import (
     BinaryIO,
     Callable,
     ClassVar,
-    Collection,
     Dict,
     Generator,
     Iterable,
@@ -2498,29 +2497,29 @@ class Container:
             raise RuntimeError(f'expected 1 check, got {len(checks)}')
         return checks[check_name]
 
-    def start_checks(self, *check_names: str) -> Collection[str]:
+    def start_checks(self, *check_names: str) -> List[str]:
         """Start given check(s) by name.
 
         Returns:
-            A set of check names that were started. Checks that were already
+            A list of check names that were started. Checks that were already
             running will not be included.
         """
         if not check_names:
             raise TypeError('start-checks expected at least 1 argument, got 0')
 
-        return frozenset(self._pebble.start_checks(check_names))
+        return self._pebble.start_checks(check_names)
 
-    def stop_checks(self, *check_names: str) -> Collection[str]:
+    def stop_checks(self, *check_names: str) -> List[str]:
         """Stop given check(s) by name.
 
         Returns:
-            A set of check names that were stopped. Checks that were already
+            A list of check names that were stopped. Checks that were already
             inactive will not be included.
         """
         if not check_names:
             raise TypeError('stop-checks expected at least 1 argument, got 0')
 
-        return frozenset(self._pebble.stop_checks(check_names))
+        return self._pebble.stop_checks(check_names)
 
     @typing.overload
     def pull(self, path: Union[str, PurePath], *, encoding: None) -> BinaryIO: ...

--- a/ops/model.py
+++ b/ops/model.py
@@ -41,6 +41,7 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
+    FrozenSet,
     Generator,
     Iterable,
     List,
@@ -2497,19 +2498,27 @@ class Container:
             raise RuntimeError(f'expected 1 check, got {len(checks)}')
         return checks[check_name]
 
-    def start_checks(self, *check_names: str):
-        """Start given check(s) by name."""
+    def start_checks(self, *check_names: str) -> FrozenSet[str]:
+        """Start given check(s) by name.
+
+        Returns:
+            A set of check names that were started.
+        """
         if not check_names:
             raise TypeError('start-checks expected at least 1 argument, got 0')
 
-        self._pebble.start_checks(check_names)
+        return self._pebble.start_checks(check_names)
 
-    def stop(self, *check_names: str):
-        """Stop given check(s) by name."""
+    def stop_checks(self, *check_names: str) -> FrozenSet[str]:
+        """Stop given check(s) by name.
+
+        Returns:
+            A set of check names that were stopped.
+        """
         if not check_names:
             raise TypeError('stop-checks expected at least 1 argument, got 0')
 
-        self._pebble.stop_checks(check_names)
+        return self._pebble.stop_checks(check_names)
 
     @typing.overload
     def pull(self, path: Union[str, PurePath], *, encoding: None) -> BinaryIO: ...

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -65,7 +65,6 @@ from typing import (
     BinaryIO,
     Callable,
     Dict,
-    FrozenSet,
     Generator,
     Generic,
     Iterable,
@@ -2370,7 +2369,7 @@ class Client:
 
         raise TimeoutError(f'timed out waiting for change {change_id} ({timeout} seconds)')
 
-    def _checks_action(self, action: str, checks: Iterable[str]) -> FrozenSet[str]:
+    def _checks_action(self, action: str, checks: Iterable[str]) -> List[str]:
         if isinstance(checks, (str, bytes)) or not hasattr(checks, '__iter__'):
             raise TypeError(f'checks must be of type Iterable[str], not {type(checks).__name__}')
 
@@ -2381,7 +2380,7 @@ class Client:
 
         body = {'action': action, 'checks': checks}
         resp = self._request('POST', '/v1/checks', body=body)
-        return frozenset(resp['result']['changed'])
+        return resp['result']['changed']
 
     def add_layer(self, label: str, layer: Union[str, LayerDict, Layer], *, combine: bool = False):
         """Dynamically add a new layer onto the Pebble configuration layers.
@@ -3100,7 +3099,7 @@ class Client:
         resp = self._request('GET', '/v1/checks', query)
         return [CheckInfo.from_dict(info) for info in resp['result']]
 
-    def start_checks(self, checks: Iterable[str]) -> FrozenSet[str]:
+    def start_checks(self, checks: Iterable[str]) -> List[str]:
         """Start checks by name.
 
         Args:
@@ -3112,7 +3111,7 @@ class Client:
         """
         return self._checks_action('start', checks)
 
-    def stop_checks(self, checks: Iterable[str]) -> FrozenSet[str]:
+    def stop_checks(self, checks: Iterable[str]) -> List[str]:
         """Stop checks by name.
 
         Args:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1478,10 +1478,14 @@ class CheckInfo:
         self.startup = startup
         if change_id:
             self.status = status
-        else:
-            # No change ID means the check is inactive, or that the user has an
-            # old version of Pebble. We assume the former.
+        elif startup:
+            # This is a version of Pebble that supports stopping checks, which
+            # means that the check is inactive if it has no change ID.
             self.status = CheckStatus.INACTIVE
+        else:
+            # This must be an older version of Pebble that does not use changes
+            # to drive checks, which means that we just use the status as-is.
+            self.status = status
         self.failures = failures
         self.threshold = threshold
         self.change_id = change_id
@@ -3116,7 +3120,8 @@ class Client:
             checks: Non-empty list of checks to start.
 
         Returns:
-            Set of check names that were started.
+            Set of check names that were started. Checks that were already
+            running will not be included.
         """
         return self._checks_action('start', checks)
 
@@ -3127,7 +3132,8 @@ class Client:
             checks: Non-empty list of checks to stop.
 
         Returns:
-            Set of check names that were stopped.
+            Set of check names that were stopped. Checks that were already
+            inactive will not be included.
         """
         return self._checks_action('stop', checks)
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1489,7 +1489,6 @@ class CheckInfo:
         if not change_id and 'startup' in d:
             # This is a version of Pebble that supports stopping checks, which
             # means that the check is inactive if it has no change ID.
-            logger.debug('Check %s has raw status %s, but is inactive.', d['name'], status)
             status = CheckStatus.INACTIVE
         return cls(
             name=d['name'],

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1429,7 +1429,7 @@ class CheckInfo:
 
     startup: Union[CheckStartup, str]
     """Startup mode.
-    
+
     :attr:`CheckStartup.ENABLED` means the check will be started when added, and
     in a replan. :attr:`CheckStartup.DISABLED` means the check must be manually
     started.
@@ -2168,8 +2168,9 @@ class Client:
         return self._services_action('autostart', [], timeout, delay)
 
     def replan_services(self, timeout: float = 30.0, delay: float = 0.1) -> ChangeID:
-        """Replan by (re)starting changed and startup-enabled services and checks and wait for them
-        to start.
+        """Replan by (re)starting changed and startup-enabled services and checks.
+
+        After requesting the replan, also wait for any impacted services to start.
 
         Args:
             timeout: Seconds before replan change is considered timed out (float). If

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -2370,7 +2370,7 @@ class Client:
         raise TimeoutError(f'timed out waiting for change {change_id} ({timeout} seconds)')
 
     def _checks_action(self, action: str, checks: Iterable[str]) -> List[str]:
-        if isinstance(checks, (str, bytes)) or not hasattr(checks, '__iter__'):
+        if isinstance(checks, str) or not hasattr(checks, '__iter__'):
             raise TypeError(f'checks must be of type Iterable[str], not {type(checks).__name__}')
 
         checks = tuple(checks)

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -135,7 +135,7 @@ CheckDict = typing.TypedDict(
     {
         'override': str,
         'level': Union['CheckLevel', str],
-        'startup': Literal['enabled', 'disabled'],
+        'startup': Literal['', 'enabled', 'disabled'],
         'period': Optional[str],
         'timeout': Optional[str],
         'http': Optional[HttpDict],
@@ -1106,9 +1106,9 @@ class Check:
             level = dct.get('level', '')
         self.level = level
         try:
-            startup: Union[CheckStartup, str] = CheckStartup(dct.get('startup', 'enabled'))
+            startup: Union[CheckStartup, str] = CheckStartup(dct.get('startup', ''))
         except ValueError:
-            startup = dct.get('startup', 'enabled')
+            startup = dct.get('startup', '')
         self.startup = startup
         self.period: Optional[str] = dct.get('period', '')
         self.timeout: Optional[str] = dct.get('timeout', '')

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -349,6 +349,7 @@ def test_workload_events(request: pytest.FixtureRequest, monkeypatch: pytest.Mon
                 'status': 'down',
                 'failures': 3,
                 'threshold': 3,
+                'change-id': '1',
             })
         ]
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1875,6 +1875,7 @@ containers:
                 'status': 'up',
                 'failures': 0,
                 'threshold': 3,
+                'change-id': '1',
             }),
             pebble.CheckInfo.from_dict({
                 'name': 'c2',
@@ -1882,6 +1883,7 @@ containers:
                 'status': 'down',
                 'failures': 2,
                 'threshold': 2,
+                'change-id': '2',
             }),
         ]
 
@@ -1921,6 +1923,7 @@ containers:
                 'status': 'up',
                 'failures': 0,
                 'threshold': 3,
+                'change-id': '1',
             })
         ])
         c = container.get_check('c1')
@@ -1944,6 +1947,7 @@ containers:
                 'status': 'up',
                 'failures': 0,
                 'threshold': 3,
+                'change-id': '1',
             }),
             pebble.CheckInfo.from_dict({
                 'name': 'c2',
@@ -1951,6 +1955,7 @@ containers:
                 'status': 'down',
                 'failures': 2,
                 'threshold': 2,
+                'change-id': '2',
             }),
         ])
         with pytest.raises(RuntimeError):

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -1288,7 +1288,7 @@ class TestCheckInfo:
         )
         assert check.name == 'chk1'
         assert check.level == pebble.CheckLevel.READY
-        assert check.status == pebble.CheckStatus.INACTIVE  # No change-id means inactive.
+        assert check.status == pebble.CheckStatus.UP
         assert check.failures == 0
         assert check.threshold == 3
         assert check.change_id is None
@@ -1296,13 +1296,14 @@ class TestCheckInfo:
         check = pebble.CheckInfo(
             name='chk1',
             level=pebble.CheckLevel.READY,
-            status=pebble.CheckStatus.UP,
+            startup=pebble.CheckStartup.ENABLED,
+            status=pebble.CheckStatus.INACTIVE,
             threshold=3,
             change_id=pebble.ChangeID(''),
         )
         assert check.name == 'chk1'
         assert check.level == pebble.CheckLevel.READY
-        assert check.status == pebble.CheckStatus.INACTIVE  # Empty change-id means inactive.
+        assert check.status == pebble.CheckStatus.INACTIVE
         assert check.failures == 0
         assert check.threshold == 3
         assert check.change_id == pebble.ChangeID('')
@@ -1310,6 +1311,7 @@ class TestCheckInfo:
         check = pebble.CheckInfo(
             name='chk2',
             level=pebble.CheckLevel.ALIVE,
+            startup=pebble.CheckStartup.DISABLED,
             status=pebble.CheckStatus.DOWN,
             failures=5,
             threshold=3,
@@ -1339,6 +1341,7 @@ class TestCheckInfo:
         check = pebble.CheckInfo.from_dict({
             'name': 'chk4',
             'status': 'down',
+            'startup': 'enabled',
             'failures': 3,
             'threshold': 3,
             'change-id': '42',
@@ -1349,6 +1352,21 @@ class TestCheckInfo:
         assert check.failures == 3
         assert check.threshold == 3
         assert check.change_id == pebble.ChangeID('42')
+
+        check = pebble.CheckInfo.from_dict({
+            'name': 'chk5',
+            'status': 'down',
+            'startup': 'enabled',
+            'failures': 3,
+            'threshold': 3,
+            'change-id': '',
+        })
+        assert check.name == 'chk5'
+        assert check.level == pebble.CheckLevel.UNSET
+        assert check.status == pebble.CheckStatus.INACTIVE  # Empty change-id means inactive.
+        assert check.failures == 3
+        assert check.threshold == 3
+        assert check.change_id == pebble.ChangeID('')
 
 
 _bytes_generator = typing.Generator[bytes, typing.Any, typing.Any]

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -2943,11 +2943,13 @@ bad path\r
         assert checks[0].status == pebble.CheckStatus.UP
         assert checks[0].failures == 0
         assert checks[0].threshold == 2
+        assert checks[0].change_id == pebble.ChangeID('1')
         assert checks[1].name == 'chk2'
         assert checks[1].level == pebble.CheckLevel.ALIVE
         assert checks[1].status == pebble.CheckStatus.DOWN
         assert checks[1].failures == 5
         assert checks[1].threshold == 3
+        assert checks[1].change_id == pebble.ChangeID('3')
 
         assert client.requests == [
             ('GET', '/v1/checks', {}, None),
@@ -2975,6 +2977,7 @@ bad path\r
         assert checks[0].status == pebble.CheckStatus.UP
         assert checks[0].failures == 0
         assert checks[0].threshold == 3
+        assert checks[0].change_id == pebble.ChangeID('1')
 
         assert client.requests == [
             ('GET', '/v1/checks', {'level': 'ready', 'names': ['chk2']}, None),

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -7077,19 +7077,19 @@ class TestChecks:
     def test_start_checks(self, request: pytest.FixtureRequest):
         container = self._container_with_layer(request)
         changed = container.start_checks('chk1', 'chk2', 'chk3')
-        assert changed == {'chk3'}
+        assert changed == ['chk3']
 
     def test_stop_checks(self, request: pytest.FixtureRequest):
         container = self._container_with_layer(request)
         changed = container.stop_checks('chk1', 'chk2', 'chk3')
-        assert changed == {'chk1', 'chk2'}
+        assert changed == ['chk1', 'chk2']
 
     def test_stop_then_start(self, request: pytest.FixtureRequest):
         container = self._container_with_layer(request)
         changed = container.stop_checks('chk1', 'chk2', 'chk3')
-        assert changed == {'chk1', 'chk2'}
+        assert changed == ['chk1', 'chk2']
         changed = container.start_checks('chk1', 'chk2', 'chk3')
-        assert changed == {'chk1', 'chk2', 'chk3'}
+        assert changed == ['chk1', 'chk2', 'chk3']
         for info in container.get_checks('chk1').values():
             assert info.status == pebble.CheckStatus.UP
             assert info.change_id, 'Change ID should not be None or the empty string'

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -7027,6 +7027,79 @@ class TestCloudSpec:
             harness.model.get_cloud_spec()
 
 
+class TestChecks:
+    def __init__(self):
+        self.layer = pebble.Layer({
+            'checks': {
+                'chk1': {
+                    'override': 'replace',
+                    'exec': {'command': 'foo'},
+                },
+                'chk2': {
+                    'override': 'replace',
+                    'startup': 'enabled',
+                    'exec': {'command': 'foo'},
+                },
+                'chk3': {
+                    'override': 'replace',
+                    'startup': 'disabled',
+                    'exec': {'command': 'foo'},
+                },
+            },
+        })
+
+    def test_add_layer_with_checks(self):
+        harness = ops.testing.Harness(ops.CharmBase)
+        harness.set_can_connect('mycontainer', True)
+        harness.begin()
+        container = harness.charm.unit.get_container('mycontainer')
+        container.add_layer('mylayer', self.layer)
+        chk1 = container.get_checks('chk1')['chk1']
+        assert chk1.startup == pebble.CheckStartup.ENABLED
+        assert chk1.failures == 0
+        assert chk1.status == pebble.CheckStatus.UP
+        chk2 = container.get_checks('chk2')['chk2']
+        assert chk2.startup == pebble.CheckStartup.ENABLED
+        assert chk2.failures == 0
+        assert chk2.status == pebble.CheckStatus.UP
+        chk3 = container.get_checks('chk3')['chk3']
+        assert chk3.startup == pebble.CheckStartup.DISABLED
+        assert chk3.failures == 0
+        assert chk3.status == pebble.CheckStatus.INACTIVE
+
+    def test_start_checks(self):
+        harness = ops.testing.Harness(ops.CharmBase)
+        harness.set_can_connect('mycontainer', True)
+        harness.begin()
+        container = harness.charm.unit.get_container('mycontainer')
+        container.add_layer('mylayer', self.layer)
+        changed = container.start_checks('chk1', 'chk2', 'chk3')
+        assert changed == {'chk3'}
+
+    def test_stop_checks(self):
+        harness = ops.testing.Harness(ops.CharmBase)
+        harness.set_can_connect('mycontainer', True)
+        harness.begin()
+        container = harness.charm.unit.get_container('mycontainer')
+        container.add_layer('mylayer', self.layer)
+        changed = container.stop_checks('chk1', 'chk2', 'chk3')
+        assert changed == {'chk1', 'chk2'}
+
+    def test_stop_then_start(self):
+        harness = ops.testing.Harness(ops.CharmBase)
+        harness.set_can_connect('mycontainer', True)
+        harness.begin()
+        container = harness.charm.unit.get_container('mycontainer')
+        container.add_layer('mylayer', self.layer)
+        changed = container.stop_checks('chk1', 'chk2', 'chk3')
+        assert changed == {'chk1', 'chk2'}
+        changed = container.start_checks('chk1', 'chk2', 'chk3')
+        assert changed == {'chk1', 'chk2', 'chk3'}
+        for info in container.get_checks('chk1').values():
+            assert info.status == pebble.CheckStatus.UP
+            assert info.change_id, 'Change ID should not be None or the empty string'
+
+
 @pytest.mark.skipif(
     not hasattr(ops.testing, 'Context'), reason='requires optional ops[testing] install'
 )

--- a/testing/src/scenario/mocking.py
+++ b/testing/src/scenario/mocking.py
@@ -774,7 +774,7 @@ class _MockPebbleClient(_TestingPebbleClient):
         self._last_notice_id = 0
         self._changes: Dict[str, pebble.Change] = {}
 
-        # load any existing notices and check-infos from the state
+        # load any existing notices and check information from the state
         self._notices: Dict[Tuple[str, str], pebble.Notice] = {}
         self._check_infos: Dict[str, pebble.CheckInfo] = {}
         try:

--- a/testing/src/scenario/mocking.py
+++ b/testing/src/scenario/mocking.py
@@ -11,6 +11,7 @@ to interact with the Juju controller and the Pebble service manager.
 import datetime
 import io
 import shutil
+import uuid
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -54,6 +55,7 @@ from .errors import ActionMissingFromContextError
 from .logger import logger as scenario_logger
 from .state import (
     CharmType,
+    CheckInfo,
     JujuLogLine,
     Mount,
     Network,
@@ -772,21 +774,84 @@ class _MockPebbleClient(_TestingPebbleClient):
         self._last_notice_id = 0
         self._changes: Dict[str, pebble.Change] = {}
 
-        # load any existing notices and check information from the state
+        # load any existing notices and check-infos from the state
         self._notices: Dict[Tuple[str, str], pebble.Notice] = {}
         self._check_infos: Dict[str, pebble.CheckInfo] = {}
-        for container in state.containers:
+        try:
+            container = state.get_container(self._container_name)
+        except KeyError:
+            # The container is in the metadata but not in the state - perhaps
+            # this is an install event, at which point the container doesn't
+            # exist yet. This means there will be no notices or check infos.
+            pass
+        else:
             for notice in container.notices:
                 if hasattr(notice.type, "value"):
                     notice_type = cast(pebble.NoticeType, notice.type).value
                 else:
                     notice_type = str(notice.type)
                 self._notices[notice_type, notice.key] = notice._to_ops()
+            now = datetime.datetime.now()
             for check in container.check_infos:
                 self._check_infos[check.name] = check._to_ops()
+                kind = (
+                    pebble.ChangeKind.PERFORM_CHECK.value
+                    if check.status == pebble.CheckStatus.UP
+                    else pebble.ChangeKind.RECOVER_CHECK.value
+                )
+                change = pebble.Change(
+                    pebble.ChangeID(str(uuid.uuid4())),
+                    kind,
+                    summary=check.name,
+                    status=pebble.ChangeStatus.DOING.value,
+                    tasks=[],
+                    ready=False,
+                    err=None,
+                    spawn_time=now,
+                    ready_time=now,
+                )
+                self._changes[check.change_id] = change
 
     def get_plan(self) -> pebble.Plan:
         return self._container.plan
+
+    def _update_state_check_infos(self):
+        """Copy any new or changed check infos into the state."""
+        infos = frozenset({
+            CheckInfo(
+                name=info.name,
+                level=info.level,
+                startup=info.startup,
+                status=info.status,
+                failures=info.failures,
+                threshold=info.threshold,
+                change_id=info.change_id,
+            )
+            for info in self._check_infos.values()
+        })
+        object.__setattr__(self._container, "check_infos", infos)
+
+    def replan_services(self, timeout: float = 30.0, delay: float = 0.1):
+        super().replan_services(timeout=timeout, delay=delay)
+        self._update_state_check_infos()
+
+    def add_layer(
+        self,
+        label: str,
+        layer: Union[str, "pebble.LayerDict", pebble.Layer],
+        *,
+        combine: bool = False,
+    ):
+        super().add_layer(label, layer, combine=combine)
+        self._update_state_check_infos()
+
+    def start_checks(self, names: List[str]):
+        super().start_checks(names)
+        self._update_state_check_infos()
+
+    def stop_checks(self, names: List[str]):
+        super().stop_checks(names)
+        self._update_state_check_infos()
 
     @property
     def _container(self) -> "ContainerSpec":

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -995,8 +995,6 @@ class Container(_max_posargs(1)):
     notices: list[Notice] = dataclasses.field(default_factory=list)
     """Any Pebble notices that already exist in the container."""
 
-    # NOTE: this probably should have been a dictionary (with the check name as
-    # the key) - we should look into changing that in version 8.
     check_infos: frozenset[CheckInfo] = frozenset()
     """All Pebble health checks that have been added to the container."""
 

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -865,6 +865,9 @@ class CheckInfo(_max_posargs(1)):
     level: pebble.CheckLevel | None = None
     """Level of the check."""
 
+    startup: pebble.CheckStartup = pebble.CheckStartup.ENABLED
+    """Startup mode of the check."""
+
     status: pebble.CheckStatus = pebble.CheckStatus.UP
     """Status of the check.
 
@@ -887,6 +890,7 @@ class CheckInfo(_max_posargs(1)):
         return pebble.CheckInfo(
             name=self.name,
             level=self.level,
+            startup=self.startup,
             status=self.status,
             failures=self.failures,
             threshold=self.threshold,

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -903,7 +903,7 @@ class CheckInfo(_max_posargs(1)):
             object.__setattr__(self, "change_id", change_id)
 
     def __hash__(self) -> int:
-        return hash(self.id)
+        return hash(self.name)
 
     def _to_ops(self) -> pebble.CheckInfo:
         return pebble.CheckInfo(

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -874,8 +874,8 @@ class CheckInfo(_max_posargs(1)):
     :attr:`ops.pebble.CheckStatus.UP` means the check is healthy (the number of
     failures is fewer than the threshold), :attr:`ops.pebble.CheckStatus.DOWN`
     means the check is unhealthy (the number of failures has reached the
-    threshold), and :attr:`ops.pebble.CheckStatus.INACTIVE` means the check is
-    not currently running.
+    threshold), and :attr:`ops.pebble.CheckStatus.INACTIVE` means the check has
+    been stopped, so is not currently running.
     """
 
     failures: int = 0

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -887,6 +887,18 @@ class CheckInfo(_max_posargs(1)):
     This is how many consecutive failures for the check to be considered 'down'.
     """
 
+    change_id: pebble.ChangeID | None = None
+    """The ID of the Pebble Change associated with this check.
+
+    Passing ``None`` will automatically assign a new Change ID.
+    """
+
+    def __post_init__(self):
+        if self.change_id is None:
+            object.__setattr__(
+                self, "change_id", pebble.ChangeID(_generate_new_change_id())
+            )
+
     def _to_ops(self) -> pebble.CheckInfo:
         return pebble.CheckInfo(
             name=self.name,
@@ -895,6 +907,7 @@ class CheckInfo(_max_posargs(1)):
             status=self.status,
             failures=self.failures,
             threshold=self.threshold,
+            change_id=self.change_id,
         )
 
 

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -902,6 +902,9 @@ class CheckInfo(_max_posargs(1)):
                 change_id = pebble.ChangeID(_generate_new_change_id())
             object.__setattr__(self, "change_id", change_id)
 
+    def __hash__(self) -> int:
+        return hash(self.id)
+
     def _to_ops(self) -> pebble.CheckInfo:
         return pebble.CheckInfo(
             name=self.name,

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -874,7 +874,8 @@ class CheckInfo(_max_posargs(1)):
     :attr:`ops.pebble.CheckStatus.UP` means the check is healthy (the number of
     failures is fewer than the threshold), :attr:`ops.pebble.CheckStatus.DOWN`
     means the check is unhealthy (the number of failures has reached the
-    threshold).
+    threshold), and :attr:`ops.pebble.CheckStatus.INACTIVE` means the check is
+    not currently running.
     """
 
     failures: int = 0

--- a/testing/tests/test_e2e/test_pebble.py
+++ b/testing/tests/test_e2e/test_pebble.py
@@ -546,3 +546,89 @@ def test_pebble_check_failed_two_containers():
     assert foo_infos[0].status == pebble.CheckStatus.DOWN
     assert foo_infos[0].failures == 7
     assert len(bar_infos) == 0
+
+
+def test_pebble_add_layer():
+    class MyCharm(CharmBase):
+        def __init__(self, framework: Framework):
+            super().__init__(framework)
+            framework.observe(self.on.foo_pebble_ready, self._on_foo_ready)
+
+        def _on_foo_ready(self, _):
+            self.unit.get_container("foo").add_layer(
+                "foo",
+                {"checks": {"chk1": {"override": "replace"}}},
+            )
+
+    ctx = Context(MyCharm, meta={"name": "foo", "containers": {"foo": {}}})
+    container = Container("foo", can_connect=True)
+    state_out = ctx.run(
+        ctx.on.pebble_ready(container), state=State(containers={container})
+    )
+    chk1_info = state_out.get_container("foo").get_check_info("chk1")
+    assert chk1_info.status == pebble.CheckStatus.UP
+
+
+def test_pebble_start_check():
+    class MyCharm(CharmBase):
+        def __init__(self, framework: Framework):
+            super().__init__(framework)
+            framework.observe(self.on.foo_pebble_ready, self._on_foo_ready)
+
+        def _on_foo_ready(self, _):
+            container = self.unit.get_container("foo")
+            container.add_layer(
+                "foo",
+                {"checks": {"chk1": {"override": "replace", "startup": "disabled"}}},
+            )
+            container.start_checks("chk1")
+
+    ctx = Context(MyCharm, meta={"name": "foo", "containers": {"foo": {}}})
+    container = Container("foo", can_connect=True)
+    state_out = ctx.run(
+        ctx.on.pebble_ready(container), state=State(containers={container})
+    )
+    chk1_info = state_out.get_container("foo").get_check_info("chk1")
+    assert chk1_info.status == pebble.CheckStatus.UP
+
+
+def test_pebble_stop_check():
+    class MyCharm(CharmBase):
+        def __init__(self, framework: Framework):
+            super().__init__(framework)
+            framework.observe(self.on.config_changed, self._on_config_changed)
+
+        def _on_config_changed(self, _):
+            container = self.unit.get_container("foo")
+            container.stop_checks("chk1")
+
+    ctx = Context(MyCharm, meta={"name": "foo", "containers": {"foo": {}}})
+    info_in = CheckInfo("chk1", status=pebble.CheckStatus.UP)
+    container = Container("foo", can_connect=True, check_infos=frozenset({info_in}))
+    state_out = ctx.run(ctx.on.config_changed(), state=State(containers={container}))
+    info_out = state_out.get_container("foo").get_check_info("chk1")
+    assert info_out.status == pebble.CheckStatus.INACTIVE
+
+
+def test_pebble_replan_checks():
+    class MyCharm(CharmBase):
+        def __init__(self, framework: Framework):
+            super().__init__(framework)
+            framework.observe(self.on.config_changed, self._on_config_changed)
+
+        def _on_config_changed(self, _):
+            container = self.unit.get_container("foo")
+            container.replan()
+
+    ctx = Context(MyCharm, meta={"name": "foo", "containers": {"foo": {}}})
+    info_in = CheckInfo("chk1", status=pebble.CheckStatus.INACTIVE)
+    layer = pebble.Layer({"checks": {"chk1": {"override": "replace"}}})
+    container = Container(
+        "foo",
+        can_connect=True,
+        check_infos=frozenset({info_in}),
+        layers={"layer1": layer},
+    )
+    state_out = ctx.run(ctx.on.config_changed(), state=State(containers={container}))
+    info_out = state_out.get_container("foo").get_check_info("chk1")
+    assert info_out.status == pebble.CheckStatus.UP

--- a/testing/tests/test_e2e/test_state.py
+++ b/testing/tests/test_e2e/test_state.py
@@ -1,7 +1,8 @@
 import copy
 from dataclasses import asdict, replace
-from typing import Type
+from typing import Optional, Type
 
+import ops
 import pytest
 from ops.charm import CharmBase, CharmEvents, CollectStatusEvent
 from ops.framework import EventBase, Framework
@@ -11,6 +12,7 @@ from scenario.state import (
     _DEFAULT_JUJU_DATABAG,
     Address,
     BindAddress,
+    CheckInfo,
     Container,
     Model,
     Network,
@@ -249,6 +251,17 @@ def test_relation_set(mycharm):
         "c": "d",
         **_DEFAULT_JUJU_DATABAG,
     }
+
+
+@pytest.mark.parametrize("id", ("", None, "28"))
+def test_checkinfo_changeid(id: Optional[str]):
+    info = CheckInfo("foo", change_id=ops.pebble.ChangeID(id))
+    if id is None:
+        assert info.change_id, "None should result in a random change_id"
+        info2 = CheckInfo("foo")
+        assert info.change_id != info2.change_id
+    else:
+        assert info.change_id == ops.pebble.ChangeID(id)
 
 
 @pytest.mark.parametrize(

--- a/testing/tests/test_e2e/test_state.py
+++ b/testing/tests/test_e2e/test_state.py
@@ -253,15 +253,17 @@ def test_relation_set(mycharm):
     }
 
 
-@pytest.mark.parametrize("id", ("", None, "28"))
+def test_checkinfo_changeid_none():
+    info = CheckInfo("foo", change_id=None)
+    assert info.change_id, "None should result in a random change_id"
+    info2 = CheckInfo("foo")  # None is also the default.
+    assert info.change_id != info2.change_id
+
+
+@pytest.mark.parametrize("id", ("", "28"))
 def test_checkinfo_changeid(id: Optional[str]):
     info = CheckInfo("foo", change_id=ops.pebble.ChangeID(id))
-    if id is None:
-        assert info.change_id, "None should result in a random change_id"
-        info2 = CheckInfo("foo")
-        assert info.change_id != info2.change_id
-    else:
-        assert info.change_id == ops.pebble.ChangeID(id)
+    assert info.change_id == ops.pebble.ChangeID(id)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add support for:

* The `startup` field in Pebble checks.
* The `start_checks` and `stop_checks` Pebble API calls.

Harness (and Scenario, mostly via re-using the Harness implementation) is adjusted to more closely simulate the Changes implementation of Pebble Checks, so that the 'if the change ID is the empty string, the check is inactive' behaviour can be simulated.

A subtle bug with notices and check-infos is also fixed: previously the mocked Pebble would gather all notices and check-infos from all containers in the state, instead of only those that are in the correct container.

[Pebble PR](https://github.com/canonical/pebble/pull/560)