### PR TITLE
fix: ensure that the event snapshot is available when one observer defers and the other does not

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -892,10 +892,8 @@ class Framework(Object):
                     observer_path,
                     method_name,
                 )
-                # We don't need to save a new notice and snapshot, but we do
-                # want the event to run, because it has been saved previously
-                # and not completed.
-                saved = True
+                # Note that there may be other (event+observer) pairs that are
+                # not in the queue, and so may need to save the snapshot.
                 continue
             if not saved:
                 # Save the event for all known observers before the first notification


### PR DESCRIPTION
If an event has multiple observers, then if *any* of the (event+observer) pairs do not defer, then we need to save the snapshot so that it's available to process that (event+observer).

#1372 introduced a bug where if *any* of the (event+observer) pairs was skipped because an exact match was already in the deferral queue, we would skip saving the snapshot. This is ok if there's only a single observer, or if an (event+observer) that did not defer was processed before any that did defer, but not otherwise.

Fixes #1561