### PR TITLE
feat: expose the Juju version via Model objects

### DIFF
--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -16,6 +16,7 @@
 
 import os
 import re
+import warnings
 from functools import total_ordering
 from typing import Union
 
@@ -100,7 +101,15 @@ class JujuVersion:
 
     @classmethod
     def from_environ(cls) -> 'JujuVersion':
-        """Build a version from the ``JUJU_VERSION`` environment variable."""
+        """Build a version from the ``JUJU_VERSION`` environment variable.
+
+        .. deprecated:: 2.19.0 Use self.model.juju_version instead.
+        """
+        warnings.warn(
+            'JujuVersion.from_environ() is deprecated, use self.model.juju_version instead',
+            DeprecationWarning,
+            stacklevel=2,
+        )
         v = os.environ.get('JUJU_VERSION')
         if v is None:
             v = '0.0.0'

--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -103,7 +103,7 @@ class JujuVersion:
     def from_environ(cls) -> 'JujuVersion':
         """Build a version from the ``JUJU_VERSION`` environment variable.
 
-        .. deprecated:: 2.19.0 Use self.model.juju_version instead.
+        .. deprecated:: 2.19.0 Use :meth:`Model.juju_version` instead.
         """
         warnings.warn(
             'JujuVersion.from_environ() is deprecated, use self.model.juju_version instead',

--- a/ops/model.py
+++ b/ops/model.py
@@ -218,6 +218,11 @@ class Model:
         """
         return self._backend.model_uuid
 
+    @property
+    def juju_version(self) -> 'ops.JujuVersion':
+        """Return the version of Juju that is running the model."""
+        return self._backend._juju_context.version
+
     def get_unit(self, unit_name: str) -> 'Unit':
         """Get an arbitrary unit by name.
 

--- a/test/test_jujuversion.py
+++ b/test/test_jujuversion.py
@@ -46,15 +46,18 @@ def test_parsing(vs: str, major: int, minor: int, tag: str, patch: int, build: i
 @unittest.mock.patch('os.environ', new={})
 def test_from_environ():
     # JUJU_VERSION is not set
-    v = ops.JujuVersion.from_environ()
+    with pytest.deprecated_call():
+        v = ops.JujuVersion.from_environ()
     assert v == ops.JujuVersion('0.0.0')
 
     os.environ['JUJU_VERSION'] = 'no'
     with pytest.raises(RuntimeError, match='not a valid Juju version'):
-        ops.JujuVersion.from_environ()
+        with pytest.deprecated_call():
+            ops.JujuVersion.from_environ()
 
     os.environ['JUJU_VERSION'] = '2.8.0'
-    v = ops.JujuVersion.from_environ()
+    with pytest.deprecated_call():
+        v = ops.JujuVersion.from_environ()
     assert v == ops.JujuVersion('2.8.0')
 
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1146,6 +1146,16 @@ class TestModel:
             container.push_path(push_path, '/')
         assert container.exists('/src.txt'), 'push_path failed: file "src.txt" missing'
 
+    def test_juju_version_from_model(self):
+        version = '3.6.2'
+        context = _JujuContext.from_dict({'JUJU_VERSION': version})
+        backend = _ModelBackend('myapp/0', juju_context=context)
+        model = ops.Model(ops.CharmMeta(), backend)
+        assert model.juju_version == version
+        assert isinstance(model.juju_version, ops.JujuVersion)
+        # Make sure it's not being loaded from the environment.
+        assert JujuVersion.from_environ() == '0.0.0'
+
 
 class PushPullCase:
     """Test case for table-driven tests."""


### PR DESCRIPTION
Charm code currently needs to do `JujuVersion.from_environ()` to get the Juju version. This isn't very 'ops-y' - we expose all the other Juju state through the `Model` object, and it also means that charms instantiate `JujuVersion` objects multiple times - even though the framework has actually done this already when parsing the Juju environment variables.

This PR exposes the Juju version via `Model.juju_version`, and deprecates the `JujuVersion.from_environ()` method (actual removal will presumably be in 3.0, a long time off).

This also centralises all the Juju environment variable processing in the `JujuContext` object.