### PR TITLE
fix: expose the mocked Juju environment variables via os.environ again

### DIFF
--- a/testing/src/scenario/_runtime.py
+++ b/testing/src/scenario/_runtime.py
@@ -352,14 +352,10 @@ class Runtime:
                 ) from e
 
             finally:
-                for key, value in os.environ.copy().items():
-                    if key in previous_env:
-                        os.environ[key] = value
-                    else:
+                for key in tuple(os.environ):
+                    if key not in previous_env:
                         del os.environ[key]
-                for key, value in previous_env.items():
-                    if key not in os.environ:
-                        os.environ[key] = value
+                os.environ.update(previous_env)
                 logger.info(" - exited ops.main")
 
         context.emitted_events.extend(captured)

--- a/testing/src/scenario/_runtime.py
+++ b/testing/src/scenario/_runtime.py
@@ -322,10 +322,10 @@ class Runtime:
             juju_context = _JujuContext.from_dict(env)
             # We need to set JUJU_VERSION in os.environ, because charms may use
             # `JujuVersion.from_environ()` to get the (simulated) Juju version.
-            # All of the other environment variables are exposed to the charm
-            # through the framework machinery, so don't require this.
-            previous_juju_version = os.environ.get("JUJU_VERSION")
-            os.environ["JUJU_VERSION"] = env["JUJU_VERSION"]
+            # For consistency, we put all the other ones there too, although we'd
+            # like to change this in the future.
+            previous_env = os.environ.copy()
+            os.environ.update(env)
 
             logger.info(" - entering ops.main (mocked)")
             from ._ops_main_mock import Ops  # noqa: F811
@@ -352,10 +352,14 @@ class Runtime:
                 ) from e
 
             finally:
-                if previous_juju_version is None:
-                    del os.environ["JUJU_VERSION"]
-                else:
-                    os.environ["JUJU_VERSION"] = previous_juju_version
+                for key, value in os.environ.copy().items():
+                    if key in previous_env:
+                        os.environ[key] = value
+                    else:
+                        del os.environ[key]
+                for key, value in previous_env.items():
+                    if key not in os.environ:
+                        os.environ[key] = value
                 logger.info(" - exited ops.main")
 
         context.emitted_events.extend(captured)

--- a/testing/tests/test_runtime.py
+++ b/testing/tests/test_runtime.py
@@ -110,7 +110,7 @@ def test_env_clean_on_charm_error():
             context=Context(my_charm_type, meta=meta),
         ) as manager:
             assert manager._juju_context.remote_app_name == remote_name
-            assert "JUJU_REMOTE_APP" not in os.environ
+            assert "JUJU_REMOTE_APP" in os.environ
             _ = 1 / 0  # raise some error
     # Ensure that some other error didn't occur (like AssertionError!).
     assert "ZeroDivisionError" in str(exc.value)


### PR DESCRIPTION
Rather than only put `JUJU_VERSION` into `os.environ`, copy the entire contents of the mock Juju environment variables (and after the run, put the environment dictionary back to the same state it was originally).

In general, we feel that charms should be using ops to access this information, rather than going directly to the raw environment variable, but this was too large a change to make in a refactoring bugfix release, and should wait for an 8.x release (and also ensuring that there are reasonable ways to get everything from ops - for example, the event name is perhaps too tricky to get globally right now).

Fixes #1572