### PR TITLE
feat: multiple possible implementations of assignment feature

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1760,6 +1760,7 @@ class RelationData(Mapping[Union['Unit', 'Application'], 'RelationDataContent'])
 
     def __init__(self, relation: Relation, our_unit: Unit, backend: '_ModelBackend'):
         self.relation = weakref.proxy(relation)
+        self._backend = backend  # for __setitem__ v0
         self._data: Dict[Union[Unit, Application], RelationDataContent] = {
             our_unit: RelationDataContent(self.relation, our_unit, backend),
             our_unit.app: RelationDataContent(self.relation, our_unit.app, backend),
@@ -1784,6 +1785,19 @@ class RelationData(Mapping[Union['Unit', 'Application'], 'RelationDataContent'])
 
     def __getitem__(self, key: Union['Unit', 'Application']) -> 'RelationDataContent':
         return self._data[key]
+
+    def __setitem__(self, key: Union['Unit', 'Application'], value: Dict[str, str]) -> None:
+        # v0 -- make a new RelationDataContent on assignment
+        content = RelationDataContent(relation=self.relation, entity=key, backend=self._backend)
+        content.update(value)
+        self._data[key] = content
+        return
+        # v1 -- replace contents of existing RelationDataContent object
+        if key not in self._data:
+            raise KeyError(key, 'Assignment only supported for known keys.')
+        content = self._data[key]
+        content.clear()
+        content.update(value)
 
     def __repr__(self):
         return repr(self._data)
@@ -1942,6 +1956,19 @@ class RelationDataContent(LazyMapping, MutableMapping[str, str]):
         except RelationDataAccessError:
             return '<n/a>'
         return super().__repr__()
+
+    # v2 -- just provide replace convenience method
+    def replace(self, items: Dict[str, str]) -> None:
+        """Convenience method that calls self.clear() then self.update(items).
+
+        Use like this:
+        ```
+        relation = self.model.relations[relation_name]
+        relation.data[app_or_unit].replace({...})
+        ```
+        """
+        self.clear()
+        self.update(items)
 
 
 class ConfigData(_GenericLazyMapping[Union[bool, int, float, str]]):


### PR DESCRIPTION
This draft PR sketches 3 approaches to resolving [#817](https://github.com/canonical/operator/issues/817).

v0: Keep a reference to the `backend` in `RelationData`. Use it in `__setitem__` to construct a new `RelationDataContent` object, and add this to `RelationData` with the provided `key`. But do we want to support adding new entries like this?

v1: In `__setitem__`, raise a `KeyError` if `key` isn't already stored. Get the current `RelationDataContent` for `key`, call `RelationDataContent.clear()` (already provided by inheritance from `MutableMapping` -- the provided implementation will call `RelationDataContent`'s custom `__delitem__`), and then call `RelationDataContent.update(...)`.

v2: Just add the convenience method `RelationDataContent.replace`, which just calls `clear` and `update`. `relation_data['foo'] = {...}` not supported, instead call `relation_data['foo'].replace({...})`. Same semantics as v1, but no surprising than `KeyError` on `__setitem__`.

What would be the best way to test this, btw? Just unit tests (using scenario)?