### PR TITLE
docs: update links to Charmcraft docs

### DIFF
--- a/docs/howto/get-started-with-charm-testing.md
+++ b/docs/howto/get-started-with-charm-testing.md
@@ -50,7 +50,9 @@ This will provide the following files that you'll use when writing your tests (a
 
 There are also profiles for `kubernetes` and for building charms for apps developed with popular frameworks such as Django and Flask.
 
-> See more: [ Write your first Kubernetes charm for a Flask app](https://juju.is/docs/sdk/write-your-first-kubernetes-charm-for-a-flask-app)
+> See more:
+> - {external+charmcraft:ref}`Charmcraft | Write your first Kubernetes charm for a Django app <write-your-first-kubernetes-charm-for-a-django-app>`
+> - {external+charmcraft:ref}`Charmcraft | Write your first Kubernetes charm for a Flask app <write-your-first-kubernetes-charm-for-a-flask-app>`
 
 ## Unit testing
 

--- a/docs/howto/get-started-with-charm-testing.md
+++ b/docs/howto/get-started-with-charm-testing.md
@@ -48,11 +48,9 @@ This will provide the following files that you'll use when writing your tests (a
 └── tox.ini
 ```
 
-There are also profiles for `kubernetes` and for building charms for apps developed with popular frameworks such as Django and Flask.
+Charmcraft has a similar profile called `kubernetes`. There are also profiles for building apps developed with Django, Flask, Go, and more.
 
-> See more:
-> - {external+charmcraft:ref}`Charmcraft | Write your first Kubernetes charm for a Django app <write-your-first-kubernetes-charm-for-a-django-app>`
-> - {external+charmcraft:ref}`Charmcraft | Write your first Kubernetes charm for a Flask app <write-your-first-kubernetes-charm-for-a-flask-app>`
+> See more: {external+charmcraft:ref}`Charmcraft | Tutorial <tutorial>`
 
 ## Unit testing
 

--- a/docs/howto/get-started-with-charm-testing.md
+++ b/docs/howto/get-started-with-charm-testing.md
@@ -48,7 +48,7 @@ This will provide the following files that you'll use when writing your tests (a
 └── tox.ini
 ```
 
-Charmcraft has a similar profile called `kubernetes`. There are also profiles for building apps developed with Django, Flask, Go, and more.
+Charmcraft has a similar profile called `kubernetes`. There are also profiles for building charms for apps developed with Django, Flask, Go, and more.
 
 > See more: {external+charmcraft:ref}`Charmcraft | Tutorial <tutorial>`
 

--- a/docs/tutorial/write-your-first-machine-charm.md
+++ b/docs/tutorial/write-your-first-machine-charm.md
@@ -1,7 +1,7 @@
 (write-your-first-machine-charm)=
 # Write your first machine charm
 
-In this tutorial you will write a machine charm for Juju using ([Charmcraft](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/) and) Ops.
+In this tutorial you will write a machine charm for Juju using {external+charmcraft:doc}`Charmcraft <index>` and Ops.
 
 <!-- TODO (tam)
 Add this link above:


### PR DESCRIPTION
This PR updates [Get started with charm testing](https://ops.readthedocs.io/en/latest/howto/get-started-with-charm-testing.html):
- Added a link to [Write your first Kubernetes charm for a Django app](https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/write-your-first-kubernetes-charm-for-a-django-app/) in Charmcraft
- Converted the existing link to [Write your first Kubernetes charm for a Flask app](https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/write-your-first-kubernetes-charm-for-a-flask-app/) into an intersphinx link

**[Preview link](https://ops--1582.org.readthedocs.build/en/1582/howto/get-started-with-charm-testing.html)**

This PR also fixes unwanted brackets in [Write your first machine charm](https://ops.readthedocs.io/en/latest/tutorial/write-your-first-machine-charm.html) and converts the Charmcraft link into an intersphinx link:

> In this tutorial you will write a machine charm for Juju using ([Charmcraft](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/) and) Ops.

**[Preview link](https://ops--1582.org.readthedocs.build/en/1582/tutorial/write-your-first-machine-charm.html)**