### PR TITLE
ci: run tox static environment for charms that have it

### DIFF
--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -39,7 +39,6 @@ jobs:
           - charm-repo: canonical/mongodb-operator
           - charm-repo: canonical/mysql-router-k8s-operator
           - charm-repo: canonical/namecheap-lego-k8s-operator
-            run-static: true
           - charm-repo: canonical/nginx-ingress-integrator-operator
           - charm-repo: canonical/oathkeeper-operator
           - charm-repo: canonical/oauth2-proxy-k8s-operator
@@ -48,12 +47,10 @@ jobs:
           - charm-repo: canonical/pgbouncer-k8s-operator
           - charm-repo: canonical/ranger-k8s-operator
           - charm-repo: canonical/route53-lego-k8s-operator
-            run-static: true
           - charm-repo: canonical/s3-integrator
           - charm-repo: canonical/saml-integrator-operator
           - charm-repo: canonical/seldon-core-operator
           - charm-repo: canonical/self-signed-certificates-operator
-            run-static: true
           - charm-repo: canonical/smtp-integrator-operator
           - charm-repo: canonical/superset-k8s-operator
           - charm-repo: canonical/temporal-admin-k8s-operator
@@ -98,14 +95,26 @@ jobs:
           fi
 
       - name: Install dependencies
+        id: deps
         run: pip install tox~=4.2
 
+        # the following test steps will only run if the last setup step (deps) succeeded
+
       - name: Run the charm's unit tests
-        id: unit
+        if: ${{ !cancelled() && steps.deps.outcome == 'success' }}
         run: tox -vve unit
 
+      - name: Check for tox static environment
+        if: ${{ !cancelled() && steps.deps.outcome == 'success' }}
+        run: |
+          if tox list --no-desc | grep '^static$'; then
+            echo 'HAS_STATIC=true' >> $GITHUB_ENV
+          else
+            echo 'HAS_STATIC=false' >> $GITHUB_ENV
+          fi
+
       - name: Run the charm's static tests
-        if: ${{ !cancelled() && matrix.run-static && steps.unit.outcome != 'skipped' }}
+        if: ${{ !cancelled() && steps.deps.outcome == 'success' && env.HAS_STATIC == 'true' }}
         run: tox -vve static
 
 

--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -98,7 +98,7 @@ jobs:
         id: deps
         run: pip install tox~=4.2
 
-        # the following test steps will only run if the last setup step (deps) succeeded
+        # The following test steps will only run if the last setup step (deps) succeeded.
 
       - name: Run the charm's unit tests
         if: ${{ !cancelled() && steps.deps.outcome == 'success' }}  # default behaviour if 1st step

--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -101,20 +101,21 @@ jobs:
         # the following test steps will only run if the last setup step (deps) succeeded
 
       - name: Run the charm's unit tests
-        if: ${{ !cancelled() && steps.deps.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.deps.outcome == 'success' }}  # default behaviour if 1st step
         run: tox -vve unit
 
       - name: Check for tox static environment
+        id: has-static
         if: ${{ !cancelled() && steps.deps.outcome == 'success' }}
         run: |
           if tox list --no-desc | grep '^static$'; then
-            echo 'HAS_STATIC=true' >> $GITHUB_ENV
+            echo 'static=true' >> "$GITHUB_OUTPUT"
           else
-            echo 'HAS_STATIC=false' >> $GITHUB_ENV
+            echo 'static=false' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run the charm's static tests
-        if: ${{ !cancelled() && steps.deps.outcome == 'success' && env.HAS_STATIC == 'true' }}
+        if: ${{ !cancelled() && steps.deps.outcome == 'success' && steps.has-static.outputs.static == 'true' }}
         run: tox -vve static
 
 

--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -39,6 +39,7 @@ jobs:
           - charm-repo: canonical/mongodb-operator
           - charm-repo: canonical/mysql-router-k8s-operator
           - charm-repo: canonical/namecheap-lego-k8s-operator
+            run-static: true
           - charm-repo: canonical/nginx-ingress-integrator-operator
           - charm-repo: canonical/oathkeeper-operator
           - charm-repo: canonical/oauth2-proxy-k8s-operator
@@ -47,10 +48,12 @@ jobs:
           - charm-repo: canonical/pgbouncer-k8s-operator
           - charm-repo: canonical/ranger-k8s-operator
           - charm-repo: canonical/route53-lego-k8s-operator
+            run-static: true
           - charm-repo: canonical/s3-integrator
           - charm-repo: canonical/saml-integrator-operator
           - charm-repo: canonical/seldon-core-operator
           - charm-repo: canonical/self-signed-certificates-operator
+            run-static: true
           - charm-repo: canonical/smtp-integrator-operator
           - charm-repo: canonical/superset-k8s-operator
           - charm-repo: canonical/temporal-admin-k8s-operator
@@ -98,7 +101,13 @@ jobs:
         run: pip install tox~=4.2
 
       - name: Run the charm's unit tests
+        id: unit
         run: tox -vve unit
+
+      - name: Run the charm's static tests
+        if: ${{ !cancelled() && matrix.run-static && steps.unit.outcome != 'skipped' }}
+        run: tox -vve static
+
 
   charmcraft-profile-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a steps to the `charm-tests` job defined in the `published-charm-tests` workflow to run the charm's `static` `tox` environment. The first step checks if the `static` environment exists, and the second step runs it if it does exist. Additionally, output and step ids are added to allow these steps to runeven if the unit test step fails, but not if there was a failure in an earlier step (installing dependencies, etc.) and not if the job was cancelled. Therefore a given job may be marked as a failure overall if both or either of the `static` and `unit` tests fail (if both fail, two failures will be listed for the job on the summary page for the workflow).