### PR TITLE
ci: update list of charms and handle increasing uv usage

### DIFF
--- a/.github/update-published-charms-tests-workflow.py
+++ b/.github/update-published-charms-tests-workflow.py
@@ -58,6 +58,8 @@ SKIP = {
     'charm-prometheus-libvirt-exporter',
     'juju-dashboard',
     'charm-openstack-service-checks',
+    # Maintenance mode / archived.
+    'charm-sysconfig',
 }
 
 

--- a/.github/update-published-charms-tests-workflow.py
+++ b/.github/update-published-charms-tests-workflow.py
@@ -54,6 +54,7 @@ SKIP = {
     'jimm',
     'notebook-operators',
     'argo-operators',
+    'k8s-operator',
     # Not ops.
     'charm-prometheus-libvirt-exporter',
     'juju-dashboard',

--- a/.github/update-published-charms-tests-workflow.py
+++ b/.github/update-published-charms-tests-workflow.py
@@ -53,6 +53,7 @@ SKIP = {
     # The charms are in a subfolder, which this can't handle yet.
     'jimm',
     'notebook-operators',
+    'argo-operators',
     # Not ops.
     'charm-prometheus-libvirt-exporter',
     'juju-dashboard',

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   o11y-charm-tests:

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -28,13 +28,20 @@ jobs:
           repository: ${{ matrix.charm-repo }}
           ref: ${{ matrix.commit }}
 
+      - name: Install dependencies
+        run: pip install tox~=4.2 uv~=0.6
+
       - name: Update 'ops' dependency in test charm to latest
         run: |
-          sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" requirements.txt
-          echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
-
-      - name: Install dependencies
-        run: pip install tox~=4.2
+          if [ -e "requirements.txt" ]; then
+            sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" requirements.txt
+            echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
+          elif [ -e "uv.lock" ]; then
+            uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA --raw-sources
+          else
+            echo "Error: no requirements.txt or uv.lock file found"
+            exit 1
+          fi
 
       - name: Run the charm's unit tests
         if: ${{ !(matrix.disabled) }}

--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -60,7 +60,7 @@ jobs:
           repository: ${{ matrix.charm-repo }}
 
       - name: Install patch dependencies
-        run: pip install poetry~=2.0 uv~=0.5
+        run: pip install poetry~=2.0 uv~=0.6 tox-uv~=1.2
 
       - name: Update 'ops' dependency in test charm to latest
         run: |

--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -15,20 +15,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - charm-repo: canonical/airbyte-k8s-operator
+          - charm-repo: canonical/airbyte-ui-k8s-operator
+          - charm-repo: canonical/argo-operators
+          - charm-repo: canonical/charm-sysconfig
+          - charm-repo: canonical/charm-ubuntu
           - charm-repo: canonical/content-cache-k8s-operator
-          - charm-repo: canonical/data-platform-libs
           - charm-repo: canonical/dex-auth-operator
+          - charm-repo: canonical/digest-squid-auth-helper
           - charm-repo: canonical/discourse-k8s-operator
           - charm-repo: canonical/grafana-agent-k8s-operator
           - charm-repo: canonical/hardware-observer-operator
+          - charm-repo: canonical/hydra-operator
           - charm-repo: canonical/identity-platform-login-ui-operator
           - charm-repo: canonical/indico-operator
           - charm-repo: canonical/jenkins-agent-k8s-operator
           - charm-repo: canonical/jenkins-agent-operator
+          - charm-repo: canonical/k8s-operator
           - charm-repo: canonical/kafka-operator
+          - charm-repo: canonical/kratos-operator
+          - charm-repo: canonical/kubeflow-profiles-operator
           - charm-repo: canonical/livepatch-k8s-operator
           - charm-repo: canonical/loki-k8s-operator
           - charm-repo: canonical/manual-tls-certificates-operator
+          - charm-repo: canonical/mongodb-k8s-operator
           - charm-repo: canonical/mongodb-operator
           - charm-repo: canonical/mysql-router-k8s-operator
           - charm-repo: canonical/namecheap-lego-k8s-operator
@@ -36,6 +46,7 @@ jobs:
           - charm-repo: canonical/oathkeeper-operator
           - charm-repo: canonical/oauth2-proxy-k8s-operator
           - charm-repo: canonical/openfga-operator
+          - charm-repo: canonical/openstack-exporter-operator
           - charm-repo: canonical/pgbouncer-k8s-operator
           - charm-repo: canonical/ranger-k8s-operator
           - charm-repo: canonical/route53-lego-k8s-operator
@@ -51,6 +62,7 @@ jobs:
           - charm-repo: canonical/temporal-worker-k8s-operator
           - charm-repo: canonical/traefik-k8s-operator
           - charm-repo: canonical/trino-k8s-operator
+          - charm-repo: canonical/vault-k8s-operator
           - charm-repo: canonical/wordpress-k8s-operator
           - charm-repo: canonical/zookeeper-operator
     steps:

--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -17,7 +17,6 @@ jobs:
         include:
           - charm-repo: canonical/airbyte-k8s-operator
           - charm-repo: canonical/airbyte-ui-k8s-operator
-          - charm-repo: canonical/argo-operators
           - charm-repo: canonical/charm-sysconfig
           - charm-repo: canonical/charm-ubuntu
           - charm-repo: canonical/content-cache-k8s-operator

--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -17,7 +17,6 @@ jobs:
         include:
           - charm-repo: canonical/airbyte-k8s-operator
           - charm-repo: canonical/airbyte-ui-k8s-operator
-          - charm-repo: canonical/charm-sysconfig
           - charm-repo: canonical/charm-ubuntu
           - charm-repo: canonical/content-cache-k8s-operator
           - charm-repo: canonical/dex-auth-operator

--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -88,6 +88,7 @@ jobs:
             poetry add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA --lock
           elif [ -e "uv.lock" ]; then
             uv add --frozen --raw-sources git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA
+            uv lock
           else
             echo "Error: No requirements.txt or poetry.lock or uv.lock file found"
             exit 1

--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -29,7 +29,6 @@ jobs:
           - charm-repo: canonical/indico-operator
           - charm-repo: canonical/jenkins-agent-k8s-operator
           - charm-repo: canonical/jenkins-agent-operator
-          - charm-repo: canonical/k8s-operator
           - charm-repo: canonical/kafka-operator
           - charm-repo: canonical/kratos-operator
           - charm-repo: canonical/kubeflow-profiles-operator


### PR DESCRIPTION
* Bumps the uv version to 0.6
* Installs tox-uv for the published charms tests (fix via @james-garner-canonical)
* Use `uv add` rather than patching requirements.txt for the observability charms (grafana-k8s has moved to this approach)
* Re-run the update script to get the latest list of published charms