### PR TITLE
ci: handle presence/absence of "static" and "static-charm" envs

### DIFF
--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -57,9 +57,11 @@ jobs:
             echo "::set-output name=exists::false"
           fi
 
-      - name: Run the charm's scenario unit tests
-        if: ${{ steps.check-tox-env-scenario.outputs.exists == 'true' && !(matrix.disabled) }}
-        run: tox -vve scenario
+      # alertmanager-k8s has old Scenario tests, so we can't do this until those
+      # are updated.
+#      - name: Run the charm's scenario unit tests
+#        if: ${{ steps.check-tox-env-scenario.outputs.exists == 'true' && !(matrix.disabled) }}
+#        run: tox -vve scenario
 
       - name: Check if 'static' tox environment exists
         id: check-tox-env-static

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -52,9 +52,9 @@ jobs:
         id: check-tox-env-scenario
         run: |
           if tox --listenvs | grep -q "^scenario$"; then
-            echo "::set-output name=exists::true"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=exists::false"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       # alertmanager-k8s has old Scenario tests, so we can't do this until those
@@ -67,9 +67,9 @@ jobs:
         id: check-tox-env-static
         run: |
           if tox --listenvs | grep -q "^static$"; then
-            echo "::set-output name=exists::true"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=exists::false"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run the charm's static analysis checks
@@ -80,9 +80,9 @@ jobs:
         id: check-tox-env-static-charm
         run: |
           if tox --listenvs | grep -q "^static-charm$"; then
-            echo "::set-output name=exists::true"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=exists::false"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run the charm's static (charm) analysis checks

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -51,6 +51,7 @@ jobs:
       - name: Check if 'scenario' tox environment exists
         id: check-tox-env-scenario
         run: |
+          tox --listenvs
           if tox --listenvs | grep -q "^scenario$"; then
             echo "exists=true" >> $GITHUB_ENV
           else

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -51,39 +51,38 @@ jobs:
       - name: Check if 'scenario' tox environment exists
         id: check-tox-env-scenario
         run: |
-          tox --listenvs
           if tox --listenvs | grep -q "^scenario$"; then
-            echo "exists=true" >> $GITHUB_ENV
+            echo "scenario_exists=true" >> $GITHUB_ENV
           else
-            echo "exists=false" >> $GITHUB_ENV
+            echo "scenario_exists=false" >> $GITHUB_ENV
           fi
 
       - name: Run the charm's scenario unit tests
-        if: ${{ steps.check-tox-env-scenario.outputs.exists == 'true' && !(matrix.disabled) }}
+        if: ${{ steps.check-tox-env-scenario.outputs.scenario_exists == 'true' && !(matrix.disabled) }}
         run: tox -vve scenario
 
       - name: Check if 'static' tox environment exists
         id: check-tox-env-static
         run: |
           if tox --listenvs | grep -q "^static$"; then
-            echo "exists=true" >> $GITHUB_ENV
+            echo "static_exists=true" >> $GITHUB_ENV
           else
-            echo "exists=false" >> $GITHUB_ENV
+            echo "static_exists=false" >> $GITHUB_ENV
           fi
 
       - name: Run the charm's static analysis checks
-        if: ${{ steps.check-tox-env-static.outputs.exists == 'true' && !(matrix.disabled) }}
+        if: ${{ steps.check-tox-env-static.outputs.static_exists == 'true' && !(matrix.disabled) }}
         run: tox -vve static
 
       - name: Check if 'static-charm' tox environment exists
         id: check-tox-env-static-charm
         run: |
           if tox --listenvs | grep -q "^static-charm$"; then
-            echo "exists=true" >> $GITHUB_ENV
+            echo "static_charm_exists=true" >> $GITHUB_ENV
           else
-            echo "exists=false" >> $GITHUB_ENV
+            echo "static_charm_exists=false" >> $GITHUB_ENV
           fi
 
       - name: Run the charm's static (charm) analysis checks
-        if: ${{ steps.check-tox-env-static-charm.outputs.exists == 'true' && !(matrix.disabled) }}
+        if: ${{ steps.check-tox-env-static-charm.outputs.static_charm_exists == 'true' && !(matrix.disabled) }}
         run: tox -vve static-charm

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -48,6 +48,38 @@ jobs:
         if: ${{ !(matrix.disabled) }}
         run: tox -vve unit
 
+      - name: Check if 'scenario' tox environment exists
+        id: check-tox-env-scenario
+        run: |
+          if tox --listenvs | grep -q "^scenario$"; then
+            echo "exists=true" >> $GITHUB_ENV
+          else
+            echo "exists=false" >> $GITHUB_ENV
+
+      - name: Run the charm's scenario unit tests
+        if: ${{ steps.check-tox-env-scenario.outputs.exists == 'true' && !(matrix.disabled) }}
+        run: tox -vve scenario
+
+      - name: Check if 'static' tox environment exists
+        id: check-tox-env-static
+        run: |
+          if tox --listenvs | grep -q "^static$"; then
+            echo "exists=true" >> $GITHUB_ENV
+          else
+            echo "exists=false" >> $GITHUB_ENV
+
       - name: Run the charm's static analysis checks
-        if: ${{ !(matrix.disabled) }}
+        if: ${{ steps.check-tox-env-static.outputs.exists == 'true' && !(matrix.disabled) }}
+        run: tox -vve static
+
+      - name: Check if 'static-charm' tox environment exists
+        id: check-tox-env-static-charm
+        run: |
+          if tox --listenvs | grep -q "^static-charm$"; then
+            echo "exists=true" >> $GITHUB_ENV
+          else
+            echo "exists=false" >> $GITHUB_ENV
+
+      - name: Run the charm's static (charm) analysis checks
+        if: ${{ steps.check-tox-env-static-charm.outputs.exists == 'true' && !(matrix.disabled) }}
         run: tox -vve static-charm

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -52,37 +52,37 @@ jobs:
         id: check-tox-env-scenario
         run: |
           if tox --listenvs | grep -q "^scenario$"; then
-            echo "scenario_exists=true" >> $GITHUB_ENV
+            echo "::set-output name=exists::true"
           else
-            echo "scenario_exists=false" >> $GITHUB_ENV
+            echo "::set-output name=exists::false"
           fi
 
       - name: Run the charm's scenario unit tests
-        if: ${{ steps.check-tox-env-scenario.outputs.scenario_exists == 'true' && !(matrix.disabled) }}
+        if: ${{ steps.check-tox-env-scenario.outputs.exists == 'true' && !(matrix.disabled) }}
         run: tox -vve scenario
 
       - name: Check if 'static' tox environment exists
         id: check-tox-env-static
         run: |
           if tox --listenvs | grep -q "^static$"; then
-            echo "static_exists=true" >> $GITHUB_ENV
+            echo "::set-output name=exists::true"
           else
-            echo "static_exists=false" >> $GITHUB_ENV
+            echo "::set-output name=exists::false"
           fi
 
       - name: Run the charm's static analysis checks
-        if: ${{ steps.check-tox-env-static.outputs.static_exists == 'true' && !(matrix.disabled) }}
+        if: ${{ steps.check-tox-env-static.outputs.exists == 'true' && !(matrix.disabled) }}
         run: tox -vve static
 
       - name: Check if 'static-charm' tox environment exists
         id: check-tox-env-static-charm
         run: |
           if tox --listenvs | grep -q "^static-charm$"; then
-            echo "static_charm_exists=true" >> $GITHUB_ENV
+            echo "::set-output name=exists::true"
           else
-            echo "static_charm_exists=false" >> $GITHUB_ENV
+            echo "::set-output name=exists::false"
           fi
 
       - name: Run the charm's static (charm) analysis checks
-        if: ${{ steps.check-tox-env-static-charm.outputs.static_charm_exists == 'true' && !(matrix.disabled) }}
+        if: ${{ steps.check-tox-env-static-charm.outputs.exists == 'true' && !(matrix.disabled) }}
         run: tox -vve static-charm

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -55,6 +55,7 @@ jobs:
             echo "exists=true" >> $GITHUB_ENV
           else
             echo "exists=false" >> $GITHUB_ENV
+          fi
 
       - name: Run the charm's scenario unit tests
         if: ${{ steps.check-tox-env-scenario.outputs.exists == 'true' && !(matrix.disabled) }}
@@ -67,6 +68,7 @@ jobs:
             echo "exists=true" >> $GITHUB_ENV
           else
             echo "exists=false" >> $GITHUB_ENV
+          fi
 
       - name: Run the charm's static analysis checks
         if: ${{ steps.check-tox-env-static.outputs.exists == 'true' && !(matrix.disabled) }}
@@ -79,6 +81,7 @@ jobs:
             echo "exists=true" >> $GITHUB_ENV
           else
             echo "exists=false" >> $GITHUB_ENV
+          fi
 
       - name: Run the charm's static (charm) analysis checks
         if: ${{ steps.check-tox-env-static-charm.outputs.exists == 'true' && !(matrix.disabled) }}


### PR DESCRIPTION
The observability charms we test against now have a mixture of environment names, so check whether each is present before trying to run them.