### PR TITLE
docs: add Juju version markers for start/stop checks

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -2506,6 +2506,8 @@ class Container:
     def start_checks(self, *check_names: str) -> List[str]:
         """Start given check(s) by name.
 
+        .. jujuadded:: 3.6.4
+
         Returns:
             A list of check names that were started. Checks that were already
             running will not be included.
@@ -2517,6 +2519,8 @@ class Container:
 
     def stop_checks(self, *check_names: str) -> List[str]:
         """Stop given check(s) by name.
+
+        .. jujuadded:: 3.6.4
 
         Returns:
             A list of check names that were stopped. Checks that were already

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -3101,6 +3101,8 @@ class Client:
     def start_checks(self, checks: Iterable[str]) -> List[str]:
         """Start checks by name.
 
+        .. jujuadded:: 3.6.4
+
         Args:
             checks: Non-empty list of checks to start.
 
@@ -3112,6 +3114,8 @@ class Client:
 
     def stop_checks(self, checks: Iterable[str]) -> List[str]:
         """Stop checks by name.
+
+        .. jujuadded:: 3.6.4
 
         Args:
             checks: Non-empty list of checks to stop.


### PR DESCRIPTION
The version of Pebble that includes the start/stop check functionality has been [merged into Juju](https://github.com/juju/juju/pull/19037), so should be in the next Juju release. 3.6.3 is in candidate and 3.6.4 is edge, so I think that means it'll be in 3.6.4, so set that as the marker.

[Preview](https://ops--1592.org.readthedocs.build/en/1592/reference/ops.html#ops.Container.start_checks)