### PR TITLE
refactor: when testing deferral, don't observe life cycle events

### DIFF
--- a/testing/tests/test_e2e/test_deferred.py
+++ b/testing/tests/test_e2e/test_deferred.py
@@ -61,12 +61,11 @@ def test_deferred_evt_emitted(mycharm):
     )
 
     # we deferred the first 2 events we saw: update-status, start.
-    assert len(out.deferred) == 2
-    assert out.deferred[0].name == "start"
-    assert out.deferred[1].name == "update_status"
+    start, update_status = out.deferred
+    assert start.name == "start"
+    assert update_status.name == "update_status"
 
     # we saw start and update-status.
-    assert len(mycharm.captured) == 2
     upstat, start = mycharm.captured
     assert isinstance(upstat, UpdateStatusEvent)
     assert isinstance(start, StartEvent)
@@ -92,12 +91,11 @@ def test_deferred_relation_event(mycharm):
     )
 
     # we deferred the first 2 events we saw: relation-changed, start.
-    assert len(out.deferred) == 2
-    assert out.deferred[0].name == "foo_relation_changed"
-    assert out.deferred[1].name == "start"
+    relation_changed, start = out.deferred
+    assert relation_changed.name == "foo_relation_changed"
+    assert start.name == "start"
 
     # we saw start and relation-changed.
-    assert len(mycharm.captured) == 2
     upstat, start = mycharm.captured
     assert isinstance(upstat, RelationChangedEvent)
     assert isinstance(start, StartEvent)
@@ -122,18 +120,17 @@ def test_deferred_relation_event_from_relation(mycharm):
     )
 
     # we deferred the first 2 events we saw: foo_relation_changed, start.
-    assert len(out.deferred) == 2
-    assert out.deferred[0].name == "foo_relation_changed"
-    assert out.deferred[0].snapshot_data == {
+    relation_changed, start = out.deferred
+    assert relation_changed.name == "foo_relation_changed"
+    assert relation_changed.snapshot_data == {
         "relation_name": rel.endpoint,
         "relation_id": rel.id,
         "app_name": "remote",
         "unit_name": "remote/1",
     }
-    assert out.deferred[1].name == "start"
+    assert start.name == "start"
 
     # we saw start and foo_relation_changed.
-    assert len(mycharm.captured) == 2
     upstat, start = mycharm.captured
     assert isinstance(upstat, RelationChangedEvent)
     assert isinstance(start, StartEvent)
@@ -159,12 +156,11 @@ def test_deferred_workload_event(mycharm):
     )
 
     # we deferred the first 2 events we saw: foo_pebble_ready, start.
-    assert len(out.deferred) == 2
-    assert out.deferred[0].name == "foo_pebble_ready"
-    assert out.deferred[1].name == "start"
+    pebble_ready, start = out.deferred
+    assert pebble_ready.name == "foo_pebble_ready"
+    assert start.name == "start"
 
     # we saw start and foo_pebble_ready.
-    assert len(mycharm.captured) == 2
     upstat, start = mycharm.captured
     assert isinstance(upstat, WorkloadEvent)
     assert isinstance(start, StartEvent)


### PR DESCRIPTION
Pulled out from the OTEL branch.
Since life cycle events can't be deferred anyway, let's not observe them in these tests.
I hope this makes the tests more focused, and perhaps easier to maintain.

Inspired by #1589