### PR TITLE
feat: expose charm-user in CharmMeta

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1451,6 +1451,17 @@ class CharmMeta:
     assumes: 'JujuAssumes'
     """Juju features this charm requires."""
 
+    charm_user: Literal['root', 'sudoer', 'non-root']
+    """Type of user used to run the charm hook code.
+
+    The value of ``root`` ensures the charm runs as root. The value of
+    ``sudoer`` runs the charm as a user other than root with access to sudo to
+    elevate its privileges. ``non-root`` ensures the charm does not run as root
+    and also does not have ``sudo`` privileges.
+
+    .. jujuadded 3.6.0
+    """
+
     containers: Dict[str, 'ContainerMeta']
     """Container metadata for each defined container."""
 
@@ -1524,6 +1535,7 @@ class CharmMeta:
         # Note that metadata v2 does not define min-juju-version ('assumes'
         # should be used instead).
         self.min_juju_version = raw_.get('min-juju-version')
+        self.charm_user = raw_.get('charm-user', 'root')
         self.requires = {
             name: RelationMeta(RelationRole.requires, name, rel)
             for name, rel in raw_.get('requires', {}).items()

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -1129,3 +1129,19 @@ assumes:
             ops.JujuAssumesCondition.ANY,
         ),
     ]
+
+
+@pytest.mark.parametrize('user', ['root', 'sudoer', 'non-root'])
+def test_meta_charm_user(user: str):
+    meta = ops.CharmMeta.from_yaml(f"""
+name: my-charm
+charm-user: {user}
+""")
+    assert meta.charm_user == user
+
+
+def test_meta_charm_user_default():
+    meta = ops.CharmMeta.from_yaml("""
+name: my-charm
+""")
+    assert meta.charm_user == 'root'


### PR DESCRIPTION
Exposes the `charm-user` field in `CharmMeta`.

The field is added as a string (with type annotations providing the three possible values) rather than an enum. We have a mixture in the other meta fields - `RelationRole` is an enum, but `ResourceMeta.type` is a string and `StorageMeta.type` is a string. It seems like `charm-user` can go with the simpler form - and it's also easier to add an enum later than it is to remove one.

Like most of the rest of the meta loading, there's also no validation (that it's one of the three possible values) - it seems reasonable to assume that if there's some other value in a production environment that's a `charmcraft` bug (or there's a new type we don't handle yet) and in development `charmcraft` will raise the problem when packing.

See also the [charmcraft docs](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/metadata-yaml-file/#charm-user) (and a [PR to fix it being missing from charmcraft.yaml reference](https://github.com/canonical/charmcraft/pull/2195)).

Fixes #1396