### PR TITLE
ci: smoke test against k8s as well as microk8s

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -17,6 +17,11 @@ jobs:
         preset: ['machine', 'microk8s', 'k8s']
 
     steps:
+      - name: Temporary Docker workaround
+        run: |
+          sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
+          sudo rm -rf /run/containerd
+
       - name: Install concierge
         run: sudo snap install --classic concierge
 

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -14,7 +14,7 @@ jobs:
         # pylibjuju does not currently support Juju 4.x
         juju-channel: ['2.9/stable', '3/stable']
         charmcraft-channel: ['2.x/stable', '3.x/stable']
-        preset: ['machine', 'microk8s']
+        preset: ['machine', 'microk8s', 'k8s']
 
     steps:
       - name: Install concierge


### PR DESCRIPTION
The Concierge `dev` preset uses K8s rather than Microk8s, and in general we're moving towards K8s over Microk8s, so it's probably best to test against it.

It seems extraordinarily unlikely that anything in ops would work on K8s and not on Microk8s or vice-versa, so we could instead *swap* from `microk8s` to `k8s`. Given that we're in a transition period at the moment, and these tests only run monthly, it seems reasonable to have both for now.