### PR TITLE
test: sort pytest params to guarantee identical ordering across workers

### DIFF
--- a/testing/tests/test_consistency_checker.py
+++ b/testing/tests/test_consistency_checker.py
@@ -180,8 +180,8 @@ def test_evt_bad_container_name():
     )
 
 
-@pytest.mark.parametrize("suffix", _RELATION_EVENTS_SUFFIX)
-def test_evt_bad_relation_name(suffix):
+@pytest.mark.parametrize("suffix", sorted(_RELATION_EVENTS_SUFFIX))
+def test_evt_bad_relation_name(suffix: str):
     assert_inconsistent(
         State(),
         _Event(f"foo{suffix}", relation=Relation("bar")),
@@ -195,8 +195,8 @@ def test_evt_bad_relation_name(suffix):
     )
 
 
-@pytest.mark.parametrize("suffix", _RELATION_EVENTS_SUFFIX)
-def test_evt_no_relation(suffix):
+@pytest.mark.parametrize("suffix", sorted(_RELATION_EVENTS_SUFFIX))
+def test_evt_no_relation(suffix: str):
     assert_inconsistent(State(), _Event(f"foo{suffix}"), _CharmSpec(MyCharm, {}))
     relation = Relation("bar")
     assert_consistent(


### PR DESCRIPTION
This PR updates the `scenario` tests to sort any `set` parameters so that the ordering is guaranteed to be the same every time. This is necessary because `pytest-xdist` will error if workers have different (or differently ordered) tests, because it [refers to tests by index](https://github.com/pytest-dev/pytest-xdist/issues/432#issuecomment-506535968).

> each worker performs a standard collection, and sends the collected test ids (in order) back to the master node. The master node ensures every worker collected the same number of tests and in the same order, because the scheduler will from that point on send just the test indexes (not the entire node id) to each worker to tell them which test to execute. That's why the collection must be the same across all workers.

This resolves failures like [this one](https://github.com/james-garner-canonical/operator/actions/runs/13620751544/job/38069841078).

```
_____________________________ ERROR collecting gw1 _____________________________
Different tests were collected between gw0 and gw1. The difference is:
--- gw0

+++ gw1

@@ -1246,13 +1246,13 @@

 testing/tests/test_consistency_checker.py::test_container_in_state_but_no_container_in_meta
 testing/tests/test_consistency_checker.py::test_container_not_in_state
 testing/tests/test_consistency_checker.py::test_evt_bad_container_name
+testing/tests/test_consistency_checker.py::test_evt_bad_relation_name[_relation_joined]
 testing/tests/test_consistency_checker.py::test_evt_bad_relation_name[_relation_changed]
-testing/tests/test_consistency_checker.py::test_evt_bad_relation_name[_relation_joined]
 testing/tests/test_consistency_checker.py::test_evt_bad_relation_name[_relation_created]
 testing/tests/test_consistency_checker.py::test_evt_bad_relation_name[_relation_departed]
 testing/tests/test_consistency_checker.py::test_evt_bad_relation_name[_relation_broken]
+testing/tests/test_consistency_checker.py::test_evt_no_relation[_relation_joined]
 testing/tests/test_consistency_checker.py::test_evt_no_relation[_relation_changed]
-testing/tests/test_consistency_checker.py::test_evt_no_relation[_relation_joined]
 testing/tests/test_consistency_checker.py::test_evt_no_relation[_relation_created]
 testing/tests/test_consistency_checker.py::test_evt_no_relation[_relation_departed]
 testing/tests/test_consistency_checker.py::test_evt_no_relation[_relation_broken]
To see why this happens see Known limitations in documentation
```