### PR TITLE
docs: update Pebble docs links to documentation.ubuntu.com/pebble

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -300,6 +300,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'juju': ('https://canonical-juju.readthedocs-hosted.com/en/latest', None),
     'charmcraft': ('https://canonical-charmcraft.readthedocs-hosted.com/en/latest', None),
+    'pebble': ('https://documentation.ubuntu.com/pebble', None),
 }
 
 # -- General configuration ---------------------------------------------------

--- a/docs/howto/run-workloads-with-a-charm-kubernetes.md
+++ b/docs/howto/run-workloads-with-a-charm-kubernetes.md
@@ -23,7 +23,7 @@ The [`Container.pebble`](ops.Container.pebble) property returns the [`pebble.Cli
 
 <!--Juju already sets it up when it provisions the container-->
 
-The preferred way to run workloads on Kubernetes with charms is to start your workload with [Pebble](https://canonical-pebble.readthedocs-hosted.com/). You do not need to modify upstream container images to make use of Pebble for managing your workload. The Juju controller automatically injects Pebble into workload containers using an [Init Container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) and [Volume Mount](https://kubernetes.io/docs/concepts/storage/volumes/). The entrypoint of the container is overridden so that Pebble starts first and is able to manage running services. Charms communicate with the Pebble API using a UNIX socket, which is mounted into both the charm and workload containers.
+The preferred way to run workloads on Kubernetes with charms is to start your workload with [Pebble](https://documentation.ubuntu.com/pebble/). You do not need to modify upstream container images to make use of Pebble for managing your workload. The Juju controller automatically injects Pebble into workload containers using an [Init Container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) and [Volume Mount](https://kubernetes.io/docs/concepts/storage/volumes/). The entrypoint of the container is overridden so that Pebble starts first and is able to manage running services. Charms communicate with the Pebble API using a UNIX socket, which is mounted into both the charm and workload containers.
 
 ```{note}
 
@@ -194,13 +194,13 @@ In this example, each time a `config-changed` event is fired, a new overlay laye
 
 ### Configure a Pebble layer
 
-Pebble services are [configured by means of layers](https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/layer-specification/), with higher layers adding to or overriding lower layers, forming the effective Pebble configuration, or "plan".
+Pebble services are [configured by means of layers](https://documentation.ubuntu.com/pebble/how-to/use-layers/), with higher layers adding to or overriding lower layers, forming the effective Pebble configuration, or "plan".
 
 When a workload container is created and Pebble starts up, it looks in `/var/lib/pebble/default/layers` (if that exists) for configuration layers already present in the container image, such as `001-layer.yaml`. If there are existing layers there, that becomes the starting configuration, otherwise Pebble is happy to start with an empty configuration, meaning no services.
 
 In the latter case, Pebble is configured dynamically via the API by adding layers at runtime.
 
-See the [layer specification](https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/layer-specification/) for more details.
+See the [layer specification](https://documentation.ubuntu.com/pebble/reference/layer-specification/) for more details.
 
 #### Add a configuration layer
 
@@ -210,7 +210,7 @@ You can see an example of `add_layer` under the ["Replan" heading](#replan). The
 
 Because `combine=True` combines the layer with an existing layer of the same name, it's normally used with `override: replace` in the YAML service configuration. This means replacing the entire service configuration with the fields in the new layer.
 
-If you're adding a single layer with `combine=False` (default option) on top of an existing base layer, you may want to use `override: merge` in the service configuration. This will merge the fields specified with the service by that name in the base layer. [See an example of overriding a layer.](https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/layers/#layer-override)
+If you're adding a single layer with `combine=False` (default option) on top of an existing base layer, you may want to use `override: merge` in the service configuration. This will merge the fields specified with the service by that name in the base layer. [See an example of overriding a layer.](https://documentation.ubuntu.com/pebble/how-to/use-layers/#layer-override)
 
 #### Fetch the effective plan
 
@@ -421,7 +421,7 @@ Each check is performed with the specified `period` (the default is 10 seconds a
 
 A check is considered healthy until it's had `threshold` errors in a row (the default is 3). At that point, the `on-check-failure` action will be triggered, and the health endpoint will return an error response (both are discussed below). When the check succeeds again, the failure count is reset.
 
-See the [layer specification](https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/layer-specification/) for more details about the fields and options for different types of checks.
+See the [layer specification](https://documentation.ubuntu.com/pebble/reference/layer-specification/) for more details about the fields and options for different types of checks.
 
 ### Respond to a check failing or recovering
 
@@ -839,7 +839,7 @@ The first argument to `pebble notify` is the key, which must be in the format `<
 
 The `pebble notify` command has an optional `--repeat-after` flag, which tells Pebble to only allow the notice to repeat after the specified duration (the default is to repeat for every occurrence). If the caller says `--repeat-after=1h`, Pebble will prevent the notice with the same type and key from repeating within an hour -- useful to avoid the charm waking up too often when a notice occurs frequently.
 
-> See more: [GitHub | Pebble > Notices > `pebble notify`](https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/cli-commands/#reference-pebble-notify-command)
+> See more: [GitHub | Pebble > Notices > `pebble notify`](https://documentation.ubuntu.com/pebble/reference/cli-commands/#reference-pebble-notify-command)
 
 ### Respond to a notice
 

--- a/docs/howto/run-workloads-with-a-charm-kubernetes.md
+++ b/docs/howto/run-workloads-with-a-charm-kubernetes.md
@@ -23,7 +23,7 @@ The [`Container.pebble`](ops.Container.pebble) property returns the [`pebble.Cli
 
 <!--Juju already sets it up when it provisions the container-->
 
-The preferred way to run workloads on Kubernetes with charms is to start your workload with [Pebble](https://documentation.ubuntu.com/pebble/). You do not need to modify upstream container images to make use of Pebble for managing your workload. The Juju controller automatically injects Pebble into workload containers using an [Init Container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) and [Volume Mount](https://kubernetes.io/docs/concepts/storage/volumes/). The entrypoint of the container is overridden so that Pebble starts first and is able to manage running services. Charms communicate with the Pebble API using a UNIX socket, which is mounted into both the charm and workload containers.
+The preferred way to run workloads on Kubernetes with charms is to start your workload with {external+pebble:doc}`Pebble <index>`. You do not need to modify upstream container images to make use of Pebble for managing your workload. The Juju controller automatically injects Pebble into workload containers using an [Init Container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) and [Volume Mount](https://kubernetes.io/docs/concepts/storage/volumes/). The entrypoint of the container is overridden so that Pebble starts first and is able to manage running services. Charms communicate with the Pebble API using a UNIX socket, which is mounted into both the charm and workload containers.
 
 ```{note}
 
@@ -83,7 +83,7 @@ resources:
 # ...
 ```
 
-Once the containers are initialised, the charm needs to tell Pebble how to start the workload. Pebble uses a series of "layers" for its configuration. Layers contain a description of the processes to run, along with the path and arguments to the executable, any environment variables to be specified for the running process and any relevant process ordering (more information available in the [Pebble documentation](https://canonical-pebble.readthedocs-hosted.com)).
+Once the containers are initialised, the charm needs to tell Pebble how to start the workload. Pebble uses a series of "layers" for its configuration. Layers contain a description of the processes to run, along with the path and arguments to the executable, any environment variables to be specified for the running process and any relevant process ordering (more information available in the {external+pebble:doc}`Pebble documentation<index>`).
 
 ```{note}
 
@@ -194,13 +194,13 @@ In this example, each time a `config-changed` event is fired, a new overlay laye
 
 ### Configure a Pebble layer
 
-Pebble services are [configured by means of layers](https://documentation.ubuntu.com/pebble/how-to/use-layers/), with higher layers adding to or overriding lower layers, forming the effective Pebble configuration, or "plan".
+Pebble services are {external+pebble:ref}`configured by means of layers <how-to-use-layers>`, with higher layers adding to or overriding lower layers, forming the effective Pebble configuration, or "plan".
 
 When a workload container is created and Pebble starts up, it looks in `/var/lib/pebble/default/layers` (if that exists) for configuration layers already present in the container image, such as `001-layer.yaml`. If there are existing layers there, that becomes the starting configuration, otherwise Pebble is happy to start with an empty configuration, meaning no services.
 
 In the latter case, Pebble is configured dynamically via the API by adding layers at runtime.
 
-See the [layer specification](https://documentation.ubuntu.com/pebble/reference/layer-specification/) for more details.
+See the {external+pebble:ref}`layer specification <layer-specification>` for more details.
 
 #### Add a configuration layer
 
@@ -210,7 +210,7 @@ You can see an example of `add_layer` under the ["Replan" heading](#replan). The
 
 Because `combine=True` combines the layer with an existing layer of the same name, it's normally used with `override: replace` in the YAML service configuration. This means replacing the entire service configuration with the fields in the new layer.
 
-If you're adding a single layer with `combine=False` (default option) on top of an existing base layer, you may want to use `override: merge` in the service configuration. This will merge the fields specified with the service by that name in the base layer. [See an example of overriding a layer.](https://documentation.ubuntu.com/pebble/how-to/use-layers/#layer-override)
+If you're adding a single layer with `combine=False` (default option) on top of an existing base layer, you may want to use `override: merge` in the service configuration. This will merge the fields specified with the service by that name in the base layer. See {external+pebble:ref}`an example of overriding a layer <use_layers_layer_override)>`.
 
 #### Fetch the effective plan
 
@@ -421,7 +421,7 @@ Each check is performed with the specified `period` (the default is 10 seconds a
 
 A check is considered healthy until it's had `threshold` errors in a row (the default is 3). At that point, the `on-check-failure` action will be triggered, and the health endpoint will return an error response (both are discussed below). When the check succeeds again, the failure count is reset.
 
-See the [layer specification](https://documentation.ubuntu.com/pebble/reference/layer-specification/) for more details about the fields and options for different types of checks.
+See the {external+pebble:ref}`layer specification <layer-specification>` for more details about the fields and options for different types of checks.
 
 ### Respond to a check failing or recovering
 
@@ -839,7 +839,7 @@ The first argument to `pebble notify` is the key, which must be in the format `<
 
 The `pebble notify` command has an optional `--repeat-after` flag, which tells Pebble to only allow the notice to repeat after the specified duration (the default is to repeat for every occurrence). If the caller says `--repeat-after=1h`, Pebble will prevent the notice with the same type and key from repeating within an hour -- useful to avoid the charm waking up too often when a notice occurs frequently.
 
-> See more: [GitHub | Pebble > Notices > `pebble notify`](https://documentation.ubuntu.com/pebble/reference/cli-commands/#reference-pebble-notify-command)
+> See more: [Pebble | `pebble notify`](inv:pebble:std:label#reference_pebble_notify_command)
 
 ### Respond to a notice
 

--- a/docs/howto/run-workloads-with-a-charm-kubernetes.md
+++ b/docs/howto/run-workloads-with-a-charm-kubernetes.md
@@ -210,7 +210,7 @@ You can see an example of `add_layer` under the ["Replan" heading](#replan). The
 
 Because `combine=True` combines the layer with an existing layer of the same name, it's normally used with `override: replace` in the YAML service configuration. This means replacing the entire service configuration with the fields in the new layer.
 
-If you're adding a single layer with `combine=False` (default option) on top of an existing base layer, you may want to use `override: merge` in the service configuration. This will merge the fields specified with the service by that name in the base layer. See {external+pebble:ref}`an example of overriding a layer <use_layers_layer_override)>`.
+If you're adding a single layer with `combine=False` (default option) on top of an existing base layer, you may want to use `override: merge` in the service configuration. This will merge the fields specified with the service by that name in the base layer. See {external+pebble:ref}`an example of overriding a layer <use_layers_layer_override>`.
 
 #### Fetch the effective plan
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -200,7 +200,7 @@ def _on_demo_server_pebble_ready(self, event: ops.PebbleReadyEvent)  -> None:
 
     Learn more about interacting with Pebble at at https://juju.is/docs/sdk/pebble
     Learn more about Pebble layers at
-        https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/layers
+        https://documentation.ubuntu.com/pebble/how-to/use-layers/
     """
     # Get a reference the container attribute on the PebbleReadyEvent
     container = event.workload

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -102,7 +102,7 @@ def _update_layer_and_restart(self) -> None:
     standard entrypoint of an existing container using docker inspect
     Learn more about interacting with Pebble at https://juju.is/docs/sdk/pebble
     Learn more about Pebble layers at
-        https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/layers
+        https://documentation.ubuntu.com/pebble/how-to/use-layers/
     """
 
   # Learn more about statuses in the SDK docs:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -26,7 +26,7 @@ This module provides a way to interact with Pebble, including:
 
 For a command-line interface for local testing, see ``test/pebble_cli.py``.
 
-  See more: `Pebble documentation <https://canonical-pebble.readthedocs-hosted.com/>`_
+  See more: `Pebble documentation <https://documentation.ubuntu.com/pebble/>`_
 """
 
 from __future__ import annotations
@@ -812,7 +812,7 @@ class Plan:
 
     A plan is the combined layer configuration. The layer configuration is
     documented at
-    https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/layer-specification/
+    https://documentation.ubuntu.com/pebble/reference/layer-specification/
     """
 
     def __init__(self, raw: Optional[Union[str, PlanDict]] = None):
@@ -888,7 +888,7 @@ class Layer:
     """Represents a Pebble configuration layer.
 
     The format of this is documented at
-    https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/layer-specification/
+    https://documentation.ubuntu.com/pebble/reference/layer-specification/
     """
 
     #: Summary of the purpose of this layer.
@@ -1611,7 +1611,7 @@ class Notice:
     last_repeated: datetime.datetime
     """The time this notice was last repeated.
 
-    See Pebble's `Notices documentation <https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/notices/>`_
+    See Pebble's `Notices documentation <https://documentation.ubuntu.com/pebble/reference/notices/>`_
     for an explanation of what "repeated" means.
     """
 

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -823,7 +823,7 @@ class Notice(_max_posargs(1)):
     last_repeated: datetime.datetime = dataclasses.field(default_factory=_now_utc)
     """The time this notice was last repeated.
 
-    See Pebble's `Notices documentation <https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/notices/>`_
+    See Pebble's `Notices documentation <https://documentation.ubuntu.com/pebble/reference/notices/>`_
     for an explanation of what "repeated" means.
     """
 


### PR DESCRIPTION
Just update the hard-coded docs links from https://canonical-pebble.readthedocs-hosted.com/ to https://documentation.ubuntu.com/pebble/