### PR TITLE
chore: use relative imports

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -54,7 +54,8 @@ counts: Optional[Tuple[str, int]]
 
 ### Use relative imports inside a package
 
-In code inside a package (directory), use relative `.` imports. For example, in the `ops` directory of the Ops codebase:
+When writing code inside a package (a directory containing an `__init__.py` file), use relative imports with a `.` instead of absolute imports.
+For example, within the `ops` package:
 
 **Don't:**
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -52,6 +52,27 @@ counts: Optional[Tuple[str, int]]
 ```
 
 
+### Use relative imports inside a package
+
+In code inside a package (directory), use relative `.` imports. For example, in the `ops` directory of the Ops codebase:
+
+**Don't:**
+
+```python
+from ops import charm
+```
+
+**Do:**
+
+```python
+from . import charm
+
+# Or, if you need to avoid adding the public name "charm" to the namespace:
+
+from . import charm as _charm
+```
+
+
 ### Avoid nested comprehensions and generator expressions
 
 "Flat is better than nested."

--- a/ops/_main.py
+++ b/ops/_main.py
@@ -23,13 +23,13 @@ import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
 
-import ops.charm
-import ops.framework
-import ops.model
-import ops.storage
-from ops.charm import CharmMeta
-from ops.jujucontext import _JujuContext
-from ops.log import setup_root_logging
+from . import charm as _charm
+from . import framework as _framework
+from . import model as _model
+from . import storage as _storage
+from . import version as _version
+from .jujucontext import _JujuContext
+from .log import setup_root_logging
 
 CHARM_STATE_FILE = '.unit-state.db'
 
@@ -49,8 +49,8 @@ def _exe_path(path: Path) -> Optional[Path]:
 
 
 def _create_event_link(
-    charm: 'ops.charm.CharmBase',
-    bound_event: 'ops.framework.BoundEvent',
+    charm: '_charm.CharmBase',
+    bound_event: '_framework.BoundEvent',
     link_to: Union[str, Path],
 ):
     """Create a symlink for a particular event.
@@ -63,10 +63,10 @@ def _create_event_link(
     # type guard
     assert bound_event.event_kind, f'unbound BoundEvent {bound_event}'
 
-    if issubclass(bound_event.event_type, ops.charm.HookEvent):
+    if issubclass(bound_event.event_type, _charm.HookEvent):
         event_dir = charm.framework.charm_dir / 'hooks'
         event_path = event_dir / bound_event.event_kind.replace('_', '-')
-    elif issubclass(bound_event.event_type, ops.charm.ActionEvent):
+    elif issubclass(bound_event.event_type, _charm.ActionEvent):
         if not bound_event.event_kind.endswith('_action'):
             raise RuntimeError(f'action event name {bound_event.event_kind} needs _action suffix')
         event_dir = charm.framework.charm_dir / 'actions'
@@ -89,7 +89,7 @@ def _create_event_link(
         event_path.symlink_to(target_path)
 
 
-def _setup_event_links(charm_dir: Path, charm: 'ops.charm.CharmBase', juju_context: _JujuContext):
+def _setup_event_links(charm_dir: Path, charm: '_charm.CharmBase', juju_context: _JujuContext):
     """Set up links for supported events that originate from Juju.
 
     Whether a charm can handle an event or not can be determined by
@@ -108,42 +108,42 @@ def _setup_event_links(charm_dir: Path, charm: 'ops.charm.CharmBase', juju_conte
     link_to = os.path.realpath(juju_context.dispatch_path or sys.argv[0])
     for bound_event in charm.on.events().values():
         # Only events that originate from Juju need symlinks.
-        if issubclass(bound_event.event_type, (ops.charm.HookEvent, ops.charm.ActionEvent)):
+        if issubclass(bound_event.event_type, (_charm.HookEvent, _charm.ActionEvent)):
             _create_event_link(charm, bound_event, link_to)
 
 
 def _get_event_args(
-    charm: 'ops.charm.CharmBase',
-    bound_event: 'ops.framework.BoundEvent',
+    charm: '_charm.CharmBase',
+    bound_event: '_framework.BoundEvent',
     juju_context: _JujuContext,
 ) -> Tuple[List[Any], Dict[str, Any]]:
     event_type = bound_event.event_type
     model = charm.framework.model
 
     relation = None
-    if issubclass(event_type, ops.charm.WorkloadEvent):
+    if issubclass(event_type, _charm.WorkloadEvent):
         workload_name = juju_context.workload_name
         assert workload_name is not None
         container = model.unit.get_container(workload_name)
         args: List[Any] = [container]
-        if issubclass(event_type, ops.charm.PebbleNoticeEvent):
+        if issubclass(event_type, _charm.PebbleNoticeEvent):
             notice_id = juju_context.notice_id
             notice_type = juju_context.notice_type
             notice_key = juju_context.notice_key
             args.extend([notice_id, notice_type, notice_key])
-        elif issubclass(event_type, ops.charm.PebbleCheckEvent):
+        elif issubclass(event_type, _charm.PebbleCheckEvent):
             check_name = juju_context.pebble_check_name
             args.append(check_name)
         return args, {}
-    elif issubclass(event_type, ops.charm.SecretEvent):
+    elif issubclass(event_type, _charm.SecretEvent):
         args: List[Any] = [
             juju_context.secret_id,
             juju_context.secret_label,
         ]
-        if issubclass(event_type, (ops.charm.SecretRemoveEvent, ops.charm.SecretExpiredEvent)):
+        if issubclass(event_type, (_charm.SecretRemoveEvent, _charm.SecretExpiredEvent)):
             args.append(juju_context.secret_revision)
         return args, {}
-    elif issubclass(event_type, ops.charm.StorageEvent):
+    elif issubclass(event_type, _charm.StorageEvent):
         # Before JUJU_STORAGE_ID exists, take the event name as
         # <storage_name>_storage_<attached|detached> and replace it with <storage_name>
         storage_name = juju_context.storage_name or '-'.join(
@@ -157,17 +157,17 @@ def _get_event_args(
         else:
             # If there's more than one value, pick the right one. We'll realize the key on lookup
             storage = next((s for s in storages if s.index == index), None)
-        storage = cast(Union[ops.storage.JujuStorage, ops.storage.SQLiteStorage], storage)
+        storage = cast(Union[_storage.JujuStorage, _storage.SQLiteStorage], storage)
         storage.location = storage_location  # type: ignore
         return [storage], {}
-    elif issubclass(event_type, ops.charm.ActionEvent):
+    elif issubclass(event_type, _charm.ActionEvent):
         args: List[Any] = [juju_context.action_uuid]
         return args, {}
-    elif issubclass(event_type, ops.charm.RelationEvent):
+    elif issubclass(event_type, _charm.RelationEvent):
         relation_name = juju_context.relation_name
         assert relation_name is not None
         relation_id = juju_context.relation_id
-        relation: Optional[ops.model.Relation] = model.get_relation(relation_name, relation_id)
+        relation: Optional[_model.Relation] = model.get_relation(relation_name, relation_id)
 
     remote_app_name = juju_context.remote_app_name
     remote_unit_name = juju_context.remote_unit_name
@@ -223,7 +223,7 @@ class _Dispatcher:
         else:
             self._init_legacy()
 
-    def ensure_event_links(self, charm: 'ops.charm.CharmBase'):
+    def ensure_event_links(self, charm: '_charm.CharmBase'):
         """Make sure necessary symlinks are present on disk."""
         if self.is_dispatch_aware:
             # links aren't needed
@@ -324,7 +324,7 @@ class _Dispatcher:
 
 
 def _should_use_controller_storage(
-    db_path: Path, meta: CharmMeta, juju_context: _JujuContext
+    db_path: Path, meta: _charm.CharmMeta, juju_context: _JujuContext
 ) -> bool:
     """Figure out whether we want to use controller storage or not."""
     # if local state has been used previously, carry on using that
@@ -375,8 +375,8 @@ class _Manager:
 
     def __init__(
         self,
-        charm_class: Type['ops.charm.CharmBase'],
-        model_backend: Optional[ops.model._ModelBackend] = None,
+        charm_class: Type['_charm.CharmBase'],
+        model_backend: Optional[_model._ModelBackend] = None,
         use_juju_for_storage: Optional[bool] = None,
         charm_state_path: str = CHARM_STATE_FILE,
         juju_context: Optional[_JujuContext] = None,
@@ -387,7 +387,7 @@ class _Manager:
         self._charm_state_path = charm_state_path
         self._charm_class = charm_class
         if model_backend is None:
-            model_backend = ops.model._ModelBackend(juju_context=self._juju_context)
+            model_backend = _model._ModelBackend(juju_context=self._juju_context)
         self._model_backend = model_backend
 
         # Do this as early as possible to be sure to catch the most logs.
@@ -405,9 +405,9 @@ class _Manager:
         self.charm = self._make_charm(self.framework, self.dispatcher)
 
     def _load_charm_meta(self):
-        return CharmMeta.from_charm_root(self._charm_root)
+        return _charm.CharmMeta.from_charm_root(self._charm_root)
 
-    def _make_charm(self, framework: 'ops.framework.Framework', dispatcher: _Dispatcher):
+    def _make_charm(self, framework: '_framework.Framework', dispatcher: _Dispatcher):
         charm = self._charm_class(framework)
         dispatcher.ensure_event_links(charm)
         return charm
@@ -421,13 +421,13 @@ class _Manager:
             self._model_backend, debug=self._juju_context.debug, exc_stderr=handling_action
         )
 
-        logger.debug('ops %s up and running.', ops.__version__)
+        logger.debug('ops %s up and running.', _version.version)
 
     def _make_storage(self, dispatcher: _Dispatcher):
         charm_state_path = self._charm_root / self._charm_state_path
 
         use_juju_for_storage = self._use_juju_for_storage
-        if use_juju_for_storage and not ops.storage.juju_backend_available():
+        if use_juju_for_storage and not _storage.juju_backend_available():
             # raise an exception; the charm is broken and needs fixing.
             msg = 'charm set use_juju_for_storage=True, but Juju version {} does not support it'
             raise RuntimeError(msg.format(self._juju_context.version))
@@ -457,9 +457,9 @@ class _Manager:
             raise _Abort(0)
 
         if self._use_juju_for_storage:
-            store = ops.storage.JujuStorage()
+            store = _storage.JujuStorage()
         else:
-            store = ops.storage.SQLiteStorage(charm_state_path)
+            store = _storage.SQLiteStorage(charm_state_path)
         return store
 
     def _make_framework(self, dispatcher: _Dispatcher):
@@ -471,11 +471,11 @@ class _Manager:
         else:
             broken_relation_id = None
 
-        model = ops.model.Model(
+        model = _model.Model(
             self._charm_meta, self._model_backend, broken_relation_id=broken_relation_id
         )
         store = self._make_storage(dispatcher)
-        framework = ops.framework.Framework(
+        framework = _framework.Framework(
             store,
             self._charm_root,
             self._charm_meta,
@@ -501,9 +501,9 @@ class _Manager:
         # Emit the Juju event.
         self._emit_charm_event(self.dispatcher.event_name)
         # Emit collect-status events.
-        ops.charm._evaluate_status(self.charm)
+        _charm._evaluate_status(self.charm)
 
-    def _get_event_to_emit(self, event_name: str) -> Optional[ops.framework.BoundEvent]:
+    def _get_event_to_emit(self, event_name: str) -> Optional[_framework.BoundEvent]:
         try:
             return getattr(self.charm.on, event_name)
         except AttributeError:
@@ -547,7 +547,7 @@ class _Manager:
             self.framework.close()
 
 
-def main(charm_class: Type[ops.charm.CharmBase], use_juju_for_storage: Optional[bool] = None):
+def main(charm_class: Type[_charm.CharmBase], use_juju_for_storage: Optional[bool] = None):
     """Set up the charm and dispatch the observed event.
 
     See `ops.main() <#ops-main-entry-point>`_ for details.

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -58,16 +58,16 @@ from typing import (
     cast,
 )
 
-from ops import charm, framework, model, pebble, storage
-from ops._private import yaml
-from ops.charm import CharmBase, CharmMeta, RelationRole
-from ops.jujucontext import _JujuContext
-from ops.model import Container, RelationNotFoundError, StatusName, _NetworkDict
-from ops.pebble import ExecProcess
+from .. import charm, framework, model, pebble, storage
+from ..charm import CharmBase, CharmMeta, RelationRole
+from ..jujucontext import _JujuContext
+from ..model import Container, RelationNotFoundError, StatusName, _NetworkDict
+from ..pebble import ExecProcess
+from . import yaml
 
 if typing.TYPE_CHECKING:
     try:
-        from ops.testing import State  # type: ignore
+        from ..testing import State  # type: ignore
     except ImportError:
         # This is used in the ActionFailed type annotations: it will never be
         # used in this case, because it's only relevant when ops.testing has

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -36,9 +36,9 @@ from typing import (
     cast,
 )
 
-from ops import model
-from ops._private import yaml
-from ops.framework import (
+from . import model
+from ._private import yaml
+from .framework import (
     EventBase,
     EventSource,
     Framework,

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -47,9 +47,9 @@ from typing import (
     Union,
 )
 
-from ops import charm
-from ops.model import Model, _ModelBackend
-from ops.storage import JujuStorage, NoSnapshotError, SQLiteStorage
+from . import charm
+from .model import Model, _ModelBackend
+from .storage import JujuStorage, NoSnapshotError, SQLiteStorage
 
 
 class Serializable(typing.Protocol):

--- a/ops/jujucontext.py
+++ b/ops/jujucontext.py
@@ -18,7 +18,7 @@ import dataclasses
 from pathlib import Path
 from typing import Any, Mapping, Optional, Set
 
-from ops.jujuversion import JujuVersion
+from .jujuversion import JujuVersion
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ops/log.py
+++ b/ops/log.py
@@ -20,7 +20,7 @@ import types
 import typing
 import warnings
 
-from ops.model import _ModelBackend
+from .model import _ModelBackend
 
 
 class JujuLogHandler(logging.Handler):

--- a/ops/main.py
+++ b/ops/main.py
@@ -16,9 +16,8 @@
 
 from typing import Optional, Type
 
-import ops.charm
-
 from . import _main
+from . import charm as _charm
 
 # Re-export specific set of symbols that Scenario 6 imports from ops.main
 from ._main import (  # noqa: F401
@@ -29,7 +28,7 @@ from ._main import (  # noqa: F401
 )
 
 
-def main(charm_class: Type[ops.charm.CharmBase], use_juju_for_storage: Optional[bool] = None):
+def main(charm_class: Type[_charm.CharmBase], use_juju_for_storage: Optional[bool] = None):
     """Legacy entrypoint to set up the charm and dispatch the observed event.
 
     .. deprecated:: 2.16.0

--- a/ops/model.py
+++ b/ops/model.py
@@ -57,13 +57,13 @@ from typing import (
     get_args,
 )
 
-import ops
-import ops.pebble as pebble
-from ops._private import timeconv, yaml
-from ops.jujucontext import _JujuContext
-from ops.jujuversion import JujuVersion
+from . import charm as _charm
+from . import pebble
+from ._private import timeconv, yaml
+from .jujucontext import _JujuContext
+from .jujuversion import JujuVersion
 
-# JujuVersion is not used in ops.model, but there are charms that are importing JujuVersion
+# JujuVersion is not used in this file, but there are charms that are importing JujuVersion
 # from ops.model, so we keep it here.
 _ = JujuVersion
 
@@ -82,7 +82,7 @@ _SETTABLE_STATUS_NAMES: Tuple[_SettableStatusName, ...] = get_args(_SettableStat
 # mapping from relation name to a list of relation objects
 _RelationMapping_Raw = Dict[str, Optional[List['Relation']]]
 # mapping from container name to container metadata
-_ContainerMeta_Raw = Dict[str, 'ops.charm.ContainerMeta']
+_ContainerMeta_Raw = Dict[str, '_charm.ContainerMeta']
 
 # relation data is a string key: string value mapping so far as the
 # controller is concerned
@@ -124,14 +124,14 @@ class Model:
 
     def __init__(
         self,
-        meta: 'ops.charm.CharmMeta',
+        meta: '_charm.CharmMeta',
         backend: '_ModelBackend',
         broken_relation_id: Optional[int] = None,
     ):
         self._cache = _ModelCache(meta, backend)
         self._backend = backend
         self._unit = self.get_unit(self._backend.unit_name)
-        relations: Dict[str, ops.RelationMeta] = meta.relations
+        relations: Dict[str, _charm.RelationMeta] = meta.relations
         self._relations = RelationMapping(
             relations, self.unit, self._backend, self._cache, broken_relation_id=broken_relation_id
         )
@@ -219,7 +219,7 @@ class Model:
         return self._backend.model_uuid
 
     @property
-    def juju_version(self) -> 'ops.JujuVersion':
+    def juju_version(self) -> JujuVersion:
         """Return the version of Juju that is running the model."""
         return self._backend._juju_context.version
 
@@ -343,7 +343,7 @@ if typing.TYPE_CHECKING:
 
 
 class _ModelCache:
-    def __init__(self, meta: 'ops.charm.CharmMeta', backend: '_ModelBackend'):
+    def __init__(self, meta: '_charm.CharmMeta', backend: '_ModelBackend'):
         self._meta = meta
         self._backend = backend
         self._secret_set_cache: collections.defaultdict[str, Dict[str, Any]] = (
@@ -383,7 +383,7 @@ class Application:
     """
 
     def __init__(
-        self, name: str, meta: 'ops.charm.CharmMeta', backend: '_ModelBackend', cache: _ModelCache
+        self, name: str, meta: '_charm.CharmMeta', backend: '_ModelBackend', cache: _ModelCache
     ):
         self.name = name
         self._backend = backend
@@ -559,7 +559,7 @@ class Unit:
     def __init__(
         self,
         name: str,
-        meta: 'ops.charm.CharmMeta',
+        meta: '_charm.CharmMeta',
         backend: '_ModelBackend',
         cache: '_ModelCache',
     ):
@@ -908,7 +908,7 @@ class RelationMapping(Mapping[str, List['Relation']]):
 
     def __init__(
         self,
-        relations_meta: Dict[str, 'ops.RelationMeta'],
+        relations_meta: Dict[str, '_charm.RelationMeta'],
         our_unit: 'Unit',
         backend: '_ModelBackend',
         cache: '_ModelCache',
@@ -1670,7 +1670,7 @@ class Relation:
 
     This class should not be instantiated directly, instead use :meth:`Model.get_relation`,
     :attr:`Model.relations`, or :attr:`ops.RelationEvent.relation`. This is principally used by
-    :class:`ops.RelationMeta` to represent the relationships between charms.
+    :class:`ops.charm.RelationMeta` to represent the relationships between charms.
     """
 
     name: str
@@ -3962,7 +3962,7 @@ class LazyNotice:
             self.type = type
         self.key = key
 
-        self._notice: Optional[ops.pebble.Notice] = None
+        self._notice: Optional[pebble.Notice] = None
 
     def __repr__(self):
         type_repr = self.type if isinstance(self.type, pebble.NoticeType) else repr(self.type)
@@ -3999,7 +3999,7 @@ class LazyCheckInfo:
     def __init__(self, container: Container, name: str):
         self._container = container
         self.name = name
-        self._info: Optional[ops.pebble.CheckInfo] = None
+        self._info: Optional[pebble.CheckInfo] = None
 
     def __repr__(self):
         return f'LazyCheckInfo(name={self.name!r})'

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -81,7 +81,7 @@ from typing import (
 
 import websocket
 
-from ops._private import timeconv, yaml
+from ._private import timeconv, yaml
 
 # Public as these are used in the Container.add_layer signature
 ServiceDict = typing.TypedDict(

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -37,29 +37,22 @@ The module includes:
 
 import importlib.metadata
 
+from . import charm, framework, model, pebble, storage
 from ._private.harness import (
     ActionFailed,
     ActionOutput,
     AppUnitOrName,
-    CharmBase,
-    CharmMeta,
     CharmType,
-    Container,
     ExecArgs,
     ExecHandler,
-    ExecProcess,
     ExecResult,
     Harness,
     ReadableBuffer,
-    RelationNotFoundError,
-    RelationRole,
     YAMLStringOrFile,
-    charm,
-    framework,
-    model,
-    pebble,
-    storage,
 )
+from .charm import CharmBase, CharmMeta, RelationRole
+from .model import Container, RelationNotFoundError
+from .pebble import ExecProcess
 
 # The Harness unit testing framework.
 __all__ = [


### PR DESCRIPTION
Per discussion at daily. I thought this would be a trivial job, but the Ops imports are a bit of a mess, so it was a bit more work than usual.

As Dima pointed out, we have to be careful in public modules (like `ops.charm`) not to remove existing names or introduce new names. I think I've done that right, but please review that carefully. The one exception is when in `model.py` or similar I've not worried about removing `ops`, because if you're writing `ops.charm.ops.foo` you deserve an `AttributeError`, at least. :-)