### PR TITLE
ci: add compatibility testing for ops and ops-scenario versions

### DIFF
--- a/.github/workflows/ops-scenario-matrix.yaml
+++ b/.github/workflows/ops-scenario-matrix.yaml
@@ -1,0 +1,60 @@
+name: ops/ops-scenario compatibility
+
+on:
+  workflow_dispatch:
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ops: ["main", "2.17.1", "2.18.0", "2.18.1", "2.19.0"]
+        scenario: ["7.1.1", "7.1.2", "7.1.3", "7.2.0"]
+        exclude:
+        - {ops: "2.17.1", scenario: "7.1.1"} # ops-scenario 7.1.1 explicitly depends on ops 2.18
+        - {ops: "2.17.1", scenario: "7.1.2"} # ops-scenario 7.1.2 explicitly depends on ops 2.18
+        - {ops: "2.17.1", scenario: "7.1.3"} # ops-scenario 7.1.2 explicitly depends on ops 2.18
+        - {ops: "2.17.1", scenario: "7.2.0"} # Missed requiring ops 2.19.0 for CheckStartup
+        - {ops: "2.18.0", scenario: "7.2.0"} # Missed requiring ops 2.19.0 for CheckStartup
+        - {ops: "2.18.1", scenario: "7.2.0"} # Missed requiring ops 2.19.0 for CheckStartup
+
+    steps:
+      - name: Expand ref
+        id: set-ref
+        run: |
+          if [ "${{ matrix.ops }}" == "main" ]; then
+            echo "refs=refs/heads/main" >> "$GITHUB_OUTPUT"
+          else
+            echo "refs=refs/tags/${{ matrix.ops }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout ops
+        uses: actions/checkout@v4
+        with:
+          repository: canonical/operator
+          ref: ${{ steps.set-ref.outputs.refs }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+
+      - name: Install tox
+        run: pip install tox~=4.24
+
+      - name: Checkout ops-scenario
+        uses: actions/checkout@v4
+        with:
+          repository: canonical/operator
+          ref: refs/tags/scenario-${{ matrix.scenario }}
+          path: temp_scenario
+          sparse-checkout: |
+            testing
+
+      - name: Inject scenario
+        run: |
+          rm -rf $GITHUB_WORKSPACE/testing
+          mv temp_scenario/testing $GITHUB_WORKSPACE/testing
+
+      - name: Run unit tests
+        run: tox -e unit

--- a/.github/workflows/ops-scenario-matrix.yaml
+++ b/.github/workflows/ops-scenario-matrix.yaml
@@ -1,6 +1,8 @@
 name: ops/ops-scenario compatibility
 
 on:
+  schedule:
+    - cron: '0 3 25 * *'
   workflow_dispatch:
 
 jobs:

--- a/HACKING.md
+++ b/HACKING.md
@@ -374,14 +374,16 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
 11. Run `uvx -p 3.11 tox -e docs-deps` to recompile the `requirements.txt` file
    used for docs (in case dependencies have been updated in `pyproject.toml`)
    using the same Python version as specified in the `.readthedocs.yaml` file.
-12. Add, commit, and push, and open a PR to get the `CHANGES.md` update, version bumps,
+12. Add the new version(s) of `ops` and `ops-scenario` to the
+   `.github/workflows/ops-scenario-matrix.yaml` matrix.
+13. Add, commit, and push, and open a PR to get the `CHANGES.md` update, version bumps,
    and doc requirement bumps into main (and get it merged).
-13. If the release includes both `ops` and `ops-scenario` packages, then push a
+14. If the release includes both `ops` and `ops-scenario` packages, then push a
    new tag in the form `scenario-<major>.<minor>.<patch>`. This is done by
    executing `git tag scenario-x.y.z`, then `git push upstream tag scenario-x.y.z` locally
    (assuming you have configured `canonical/operator` as a remote named
    `upstream`).
-14. When you are ready, click "Publish". GitHub will create the additional tag.
+15. When you are ready, click "Publish". GitHub will create the additional tag.
 
     Pushing the tags will trigger automatic builds for the Python packages and
     publish them to PyPI ([ops](https://pypi.org/project/ops/) and
@@ -395,9 +397,9 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
 
     You can troubleshoot errors on the [Actions Tab](https://github.com/canonical/operator/actions).
 
-15. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com).
+16. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com).
 
-16. Open a PR to change the version strings to the expected
+17. Open a PR to change the version strings to the expected
    next version, with ".dev0" appended (for example, if 3.14.1 is the next
    expected version, use `'3.14.1.dev0'`).
 

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops~=2.18",
+    "ops~=2.19",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"


### PR DESCRIPTION
It's important that we know which versions of `ops` work with which versions of `ops-scenario`, so that we can set the version in the `ops[testing]` optional dependency and the dependencies of `ops-scenario` correctly.

For example, `ops-scenario` 7.2.0 broke compatibility with earlier versions of ops (which don't have the Pebble check startup support) but we missed bumping the required version, which means that you can install a broken combination, like `ops==2.18.1` and `ops-scenario==7.2.0`.

We also want to know when the main version of `ops` is going to break compatibility with older versions of `ops-scenario`, as with the changes from https://github.com/canonical/operator/pull/1586, so we can make sure we set the version correctly before releasing.

Issues with `main` of `ops` and `main` of `ops-scenario` should be covered by the regular test runs.

This PR runs the unit tests (of both `ops` and `ops-scenario`) for all the combinations of versions:
* That aren't explicitly prohibited by the dependency specifications in the projects
* That are after the merge into one repository (mostly just to keep this simple)
* That aren't ops 2.17.0, which doesn't use the local code for `tox -e unit`
* That aren't known failures (Scenario 7.2.0 and older ops)

The workflow is set to run once a month around release time, like the other compatibility checks, and can be manually run.

The workflow clones and checks out the specified ops branch/tag, and then clones the repo a second time, only including the top-level `testing` folder, checked out to the specified ops-scenario tag, and then replaces the top-level `testing` folder with that one. This means that we have both the branch Scenario code and the branch Scenario tests.

[Example run in my fork](https://github.com/tonyandrewmeyer/operator/actions/runs/13647822571).