### PR TITLE
chore: prepare 2.19.1 and 7.19.1 releases

### DIFF
--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -36,9 +36,9 @@ jobs:
         run: |
           if [ -e "requirements.txt" ]; then
             sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" requirements.txt
-            echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
+            echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@2.19-maintenance#egg=ops" >> requirements.txt
           elif [ -e "uv.lock" ]; then
-            uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA --raw-sources
+            uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@2.19-maintenance --raw-sources
           else
             echo "Error: no requirements.txt or uv.lock file found"
             exit 1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,25 +1,31 @@
+# 2.19.1 - 5 Mar 2025
+
+## Fixes
+
+* Install `ops-scenario` 7.19.1 for `ops[testing]`
+
 # 2.19.0 - 27 Feb 2025
 
 ## Features
 
-* Expose the Juju version via Model objects in (#1563)
-* Support starting and stopping Pebble checks, and the checks enabled field in (#1560)
+* Expose the Juju version via Model objects (#1563)
+* Support starting and stopping Pebble checks, and the checks enabled field (#1560)
 
 ## Documentation
 
-* Update logo and readme by @tmihoc in (#1571)
-* Fill out remaining external link placeholders in (#1564)
-* Use noun relation and verb integrate in (#1574)
-* Update ref to charmcraft.yaml reference by @medubelko in (#1580)
-* Add a how-to for setting open ports in (#1579)
-* Fix links that pointed to earlier Juju docs in (#1575)
-* Update links to Charmcraft docs in (#1582)
-* Small updates to machine charm tutorial in (#1583)
+* Update logo and readme by @tmihoc (#1571)
+* Fill out remaining external link placeholders (#1564)
+* Use noun relation and verb integrate (#1574)
+* Update ref to charmcraft.yaml reference by @medubelko (#1580)
+* Add a how-to for setting open ports (#1579)
+* Fix links that pointed to earlier Juju docs (#1575)
+* Update links to Charmcraft docs (#1582)
+* Small updates to machine charm tutorial (#1583)
 
 ## CI
 
-* Update list of charms and handle increasing uv usage in (#1588)
-* Handle presence/absence of "static" and "static-charm" envs in (#1590)
+* Update list of charms and handle increasing uv usage (#1588)
+* Handle presence/absence of "static" and "static-charm" envs (#1590)
 
 # 2.18.1 - 5 Feb 2025
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -371,13 +371,16 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
 10. Run `uvx -p 3.11 tox -e docs-deps` to recompile the `requirements.txt` file
    used for docs (in case dependencies have been updated in `pyproject.toml`)
    using the same Python version as specified in the `.readthedocs.yaml` file.
-11. Add, commit, and push, and open a PR to get the `CHANGES.md` updates, version bumps,
+11. Run `sed -i -e "s/\$GITHUB_SHA/main/g" .github/workflows/observability-charm-tests.yaml` and
+    replace `./testing/` in `docs/requirements.txt` with `ops-scenario==x`, where `x` is the
+    latest release (before the one you are preparing) of `ops-scenario`.
+12. Add, commit, and push, and open a PR to get the `CHANGES.md` updates, version bumps,
    and doc requirement bumps into main (and get it merged).
-12. Push a new tag in the form `scenario-<major>.<minor>.<patch>`. This is done by
+13. Push a new tag in the form `scenario-<major>.<minor>.<patch>`. This is done by
    executing `git tag scenario-x.y.z`, then `git push upstream tag scenario-x.y.z` locally
    (assuming you have configured `canonical/operator` as a remote named
    `upstream`).
-13. When you are ready, click "Publish". GitHub will create the ops tag.
+14. When you are ready, click "Publish". GitHub will create the ops tag.
 
     Pushing the tags will trigger automatic builds for the Python packages and
     publish them to PyPI ([ops](https://pypi.org/project/ops/) and
@@ -391,11 +394,14 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
 
     You can troubleshoot errors on the [Actions Tab](https://github.com/canonical/operator/actions).
 
-14. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com).
+15. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com).
 
-15. Open a PR to change the version strings to the expected
+16. Run `sed -i -e "s/main/\$GITHUB_SHA/g" .github/workflows/observability-charm-tests.yaml`
+    and `uvx --python=3.11 tox -e docs-deps`
+17. Open a PR to change the version strings to the expected
    next version, with ".dev0" appended (for example, if 3.14.1 is the next
-   expected version, use `'3.14.1.dev0'`).
+   expected version, use `'3.14.1.dev0'`), as well as the changes from the
+   previous step.
 
 ## Release Documentation
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -349,39 +349,35 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
    charms and ops get tested.
 2. Visit the [releases page on GitHub](https://github.com/canonical/operator/releases).
 3. Click "Draft a new release"
-4. The "Release Title" is the full version numbers of ops and/or ops-scenario,
+4. The "Release Title" is the full version numbers of ops and ops-scenario,
    in the form `ops <major>.<minor>.<patch> and ops-scenario <major>.<minor>.<patch>`
    and a brief summary of the main changes in the release.
-   For example: `2.3.12 Bug fixes for the Juju foobar feature when using Python 3.12`
+   For example: `ops 2.3.12 and ops-scenario 7.3.12 Bug fixes for the Juju foobar feature when using Python 3.12`
 5. Have the release create a new tag, in the form `<major>.<minor>.<patch>` for
-   `ops` and `scenario-<major>.<minor>.<patch>` for `ops-scenario`. If releasing
-   both packages, use the ops tag.
-6. If the last release was for both `ops` and `ops-scenario`, leave the previous
-   tag choice on `auto`. If the last release was for only one package, change
-   the previous tag to be the last time the same package(s) were being released.
-7. Use the "Generate Release Notes" button to get a copy of the changes into the
+   `ops`. Leave the previous tag choice on `auto`.
+6. Use the "Generate Release Notes" button to get a copy of the changes into the
    notes field.
-8. Format the auto-generated release notes according to the 'Release Documentation'
+7. Format the auto-generated release notes according to the 'Release Documentation'
    section below, save the release notes as a draft, and have someone else in the
    Charm-Tech team proofread it.
-9. Format the auto-generated release notes according to the `CHANGES.md` section below,
-   and add it to `CHANGES.md`.
-10. For `ops`, change [version.py](ops/version.py)'s `version` to the
+8. Format the auto-generated release notes according to the `CHANGES.md` section below,
+   and add it to `CHANGES.md` and `testing/CHANGES.md`.
+9. For `ops`, change [version.py](ops/version.py)'s `version` to the
    appropriate string. For `ops-scenario`, change the version in
    [testing/pyproject.toml](testing/pyproject.toml). Both packages use
-   [semantic versioning](https://semver.org/), and adjust independently
-   (that is: ops 2.18 doesn't imply ops-scenario 2.18, or any other number).
-11. Run `uvx -p 3.11 tox -e docs-deps` to recompile the `requirements.txt` file
+   [semantic versioning](https://semver.org/), and adjust together, so that
+   the minor and bugfix version are the same; for example, ops 2.19.1 and
+   ops-scenario 7.19.1. 
+10. Run `uvx -p 3.11 tox -e docs-deps` to recompile the `requirements.txt` file
    used for docs (in case dependencies have been updated in `pyproject.toml`)
    using the same Python version as specified in the `.readthedocs.yaml` file.
-12. Add, commit, and push, and open a PR to get the `CHANGES.md` update, version bumps,
+11. Add, commit, and push, and open a PR to get the `CHANGES.md` updates, version bumps,
    and doc requirement bumps into main (and get it merged).
-13. If the release includes both `ops` and `ops-scenario` packages, then push a
-   new tag in the form `scenario-<major>.<minor>.<patch>`. This is done by
+12. Push a new tag in the form `scenario-<major>.<minor>.<patch>`. This is done by
    executing `git tag scenario-x.y.z`, then `git push upstream tag scenario-x.y.z` locally
    (assuming you have configured `canonical/operator` as a remote named
    `upstream`).
-14. When you are ready, click "Publish". GitHub will create the additional tag.
+13. When you are ready, click "Publish". GitHub will create the ops tag.
 
     Pushing the tags will trigger automatic builds for the Python packages and
     publish them to PyPI ([ops](https://pypi.org/project/ops/) and
@@ -395,9 +391,9 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
 
     You can troubleshoot errors on the [Actions Tab](https://github.com/canonical/operator/actions).
 
-15. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com).
+14. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com).
 
-16. Open a PR to change the version strings to the expected
+15. Open a PR to change the version strings to the expected
    next version, with ".dev0" appended (for example, if 3.14.1 is the next
    expected version, use `'3.14.1.dev0'`).
 
@@ -452,7 +448,8 @@ CHANGES.md files.
   word.
 * Strip the username (who did each commit) if the author is a member of the
   Charm Tech team.
-* Replace the link to the pull request with the PR number in parentheses.
+* Replace the link to the pull request with the PR number in parentheses, including
+  removing the word "in".
 * Where appropriate, collapse multiple tightly related bullet points into a
   single point that refers to multiple commits.
 * Where appropriate, add backticks for code formatting.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -165,4 +165,4 @@ websocket-client==1.8.0
     # via ops (pyproject.toml)
 websockets==14.1
     # via sphinx-autobuild
-./testing/
+ops-scenario==7.2.0

--- a/ops/version.py
+++ b/ops/version.py
@@ -17,4 +17,4 @@
 This module is NOT to be used when developing charms using ops.
 """
 
-version: str = '2.19.0'
+version: str = '2.19.1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario>=7.0.5,<8",
+    "ops-scenario==7.19.1",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/testing/CHANGES.md
+++ b/testing/CHANGES.md
@@ -1,3 +1,18 @@
+# 7.19.1 - 5 Mar 2025
+
+**Note that there are no versions 7.3 through 7.18.** The minor version number
+was increased to align with the matching `ops` release.
+
+## Fixes
+
+* Require `ops` 2.19.1, to ensure that the Pebble checks startup field is available
+
+# 7.2.0 - 27 Feb 2025
+
+## Features
+
+* Support starting and stopping Pebble checks, and the checks enabled field (#1560)
+
 # 7.1.3 - 13 Feb 2025
 
 ## Fixes

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "7.2.0"
+version = "7.19.1"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops~=2.18",
+    "ops==2.19.1",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"


### PR DESCRIPTION
* Bump ops version to 2.19.1
* Bump ops-scenario version all the way to 7.19.1
* `ops[testing]` will only install `ops-scenario` version 7.19.1
* `ops-scenario` requires exactly `ops` 2.19.1
* Add CHANGES for 2.19.1 and 7.19.1
* Add missing CHANGES for 7.2.0
* Clean up the CHANGES from 2.19.0 (extraneous "in")
* Tweak the observability compatibility CI to use the latest merged versions rather than the ones from the PR branch (only for release)
* Tweak the docs build to use the latest published `ops-scenario` (only for release)
* Adjust the release instructions in HACKING.md to cover this process, all manual steps for now (we'll automate later on)