### PR TITLE
docs: fix some links and page titles

### DIFF
--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -4,9 +4,9 @@
 ```{toctree}
 :maxdepth: 2
 
-Manage logs <manage-logs>
 Run workloads with a machine charm <run-workloads-with-a-charm-machines>
 Run workloads with a Kubernetes charm <run-workloads-with-a-charm-kubernetes>
+Manage logs <manage-logs>
 Manage storage <manage-storage>
 Manage resources <manage-resources>
 Manage actions <manage-actions>

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -5,8 +5,8 @@
 :maxdepth: 2
 
 Manage logs <manage-logs>
-Run workloads with a charm machines <run-workloads-with-a-charm-machines>
-Run workloads with a charm Kubernetes <run-workloads-with-a-charm-kubernetes>
+Run workloads with a machine charm <run-workloads-with-a-charm-machines>
+Run workloads with a Kubernetes charm <run-workloads-with-a-charm-kubernetes>
 Manage storage <manage-storage>
 Manage resources <manage-resources>
 Manage actions <manage-actions>

--- a/docs/howto/run-workloads-with-a-charm-kubernetes.md
+++ b/docs/howto/run-workloads-with-a-charm-kubernetes.md
@@ -1,5 +1,5 @@
 (run-workloads-with-a-charm-kubernetes)=
-# How to run workloads with a charm - Kubernetes
+# How to run workloads with a Kubernetes charm
 
 The recommended way to create charms for Kubernetes is using the sidecar pattern with the workload container running Pebble.
 

--- a/docs/howto/run-workloads-with-a-charm-kubernetes.md
+++ b/docs/howto/run-workloads-with-a-charm-kubernetes.md
@@ -206,7 +206,7 @@ See the [layer specification](https://canonical-pebble.readthedocs-hosted.com/en
 
 To add a configuration layer, call [`Container.add_layer`](ops.Container.add_layer) with a label for the layer, and the layer's contents as a YAML string, Python dict, or [`pebble.Layer`](#ops.pebble.Layer) object.
 
-You can see an example of `add_layer` under the ["Replan" heading](#replan). The `combine=True` argument tells Pebble to combine the named layer into an existing layer of that name (or add a layer if none by that name exists). Using `combine=True` is common when dynamically adding layers.
+You can see an example of `add_layer` in [](#run-workloads-with-a-charm-kubernetes-replan). The `combine=True` argument tells Pebble to combine the named layer into an existing layer of that name (or add a layer if none by that name exists). Using `combine=True` is common when dynamically adding layers.
 
 Because `combine=True` combines the layer with an existing layer of the same name, it's normally used with `override: replace` in the YAML service configuration. This means replacing the entire service configuration with the fields in the new layer.
 
@@ -239,9 +239,10 @@ The main purpose of Pebble is to control and monitor services, which are usually
 
 In the context of Juju sidecar charms, Pebble is run with the `--hold` argument, which prevents it from automatically starting the services marked with `startup: enabled`. This is to give the charm full control over when the services in Pebble's configuration are actually started.
 
+(run-workloads-with-a-charm-kubernetes-replan)=
 ### Replan
 
-After adding a configuration layer to the plan (details below), you need to call `replan` to make any changes to `services` take effect. When you execute replan, Pebble will automatically restart any services that have changed, respecting dependency order. If the services are already running, it will stop them first using the normal [stop sequence](#start-and-stop).
+After adding a configuration layer to the plan (details below), you need to call `replan` to make any changes to `services` take effect. When you execute replan, Pebble will automatically restart any services that have changed, respecting dependency order. If the services are already running, it will stop them first using the normal [stop sequence](#run-workloads-with-a-charm-kubernetes-start-and-stop).
 
 The reason for replan is so that you as a user have control over when the (potentially high-impact) action of stopping and restarting your services takes place.
 
@@ -276,6 +277,7 @@ class SnappassTestCharm(ops.CharmBase):
 
 > See more: [](ops.Container)
 
+(run-workloads-with-a-charm-kubernetes-start-and-stop)=
 ### Start and stop
 
 To start (or stop) one or more services by name, use the [`start`](ops.Container.start) and [`stop`](ops.Container.stop) methods. Here's an example of how you might stop and start a database service during a backup action:

--- a/docs/howto/run-workloads-with-a-charm-machines.md
+++ b/docs/howto/run-workloads-with-a-charm-machines.md
@@ -1,5 +1,5 @@
 (run-workloads-with-a-charm-machines)=
-# How to run workloads with a charm - machines
+# How to run workloads with a machine charm
 
 There are several ways your charm might start a workload, depending on the type of charm you’re authoring. 
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -111,13 +111,9 @@ Follow the steps below to make your charm capable of integrating with the existi
 
 ### Fetch the Loki interface libraries
 
-<!--
-According to the documentation of the Loki charm, we require the {ref}``loki_push_api` <7814md>` library.
--->
-
 Ensure you're in your Multipass Ubuntu VM, in your charm folder. 
 
-Then, satisfy the interface library requirements of the Loki charm by fetching the {ref}``loki_push_api` <7814md>` library:
+Then, satisfy the interface library requirements of the Loki charm by fetching the [loki_push_api](https://charmhub.io/loki-k8s/libraries/loki_push_api) library:
 
 ```text
 ubuntu@charm-dev:~/fastapi-demo$ charmcraft fetch-lib charms.loki_k8s.v0.loki_push_api

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/write-scenario-tests-for-your-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/write-scenario-tests-for-your-charm.md
@@ -22,7 +22,7 @@ In the previous chapter we checked the basic functionality of our charm by writi
 
 However, there is one more type of test to cover, namely: state transition tests. 
 
-In the charming world the current recommendation is to write state transition tests with the 'scenario' model popularised by the {ref}``ops-scenario` <scenario>` library.
+In the charming world the current recommendation is to write state transition tests with the 'scenario' model popularised by the `ops-scenario` library.
 
 ```{note}
  Scenario is a state-transition testing SDK for operator framework charms. 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/write-scenario-tests-for-your-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/write-scenario-tests-for-your-charm.md
@@ -22,7 +22,7 @@ In the previous chapter we checked the basic functionality of our charm by writi
 
 However, there is one more type of test to cover, namely: state transition tests. 
 
-In the charming world the current recommendation is to write state transition tests with the 'scenario' model popularised by the `ops-scenario` library.
+In the charming world the current recommendation is to write state transition tests using [`ops[testing]`](ops_testing), which was previously known as 'Scenario'.
 
 ```{note}
  Scenario is a state-transition testing SDK for operator framework charms. 


### PR DESCRIPTION
This PR fixes some broken links (see my comments for details) and also the page titles of:

- https://ops.readthedocs.io/en/latest/howto/run-workloads-with-a-charm-machines.html
- https://ops.readthedocs.io/en/latest/howto/run-workloads-with-a-charm-kubernetes.html

I've changed the titles per our discussion in https://github.com/canonical/operator/issues/1581#issuecomment-2658234737.

I've also moved these two pages to the top of the How-to guides nav tree (per comments below).

**[Preview build](https://ops--1614.org.readthedocs.build/en/1614/)**