### PR TITLE
feat: ops.testing.State components are less mutable

### DIFF
--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -241,7 +241,7 @@ class CloudCredential(_max_posargs(0)):
     auth_type: str
     """Authentication type."""
 
-    attributes: dict[str, str] = dataclasses.field(default_factory=dict)
+    attributes: Mapping[str, str] = dataclasses.field(default_factory=dict)
     """A dictionary containing cloud credentials.
 
     For example, for AWS, it contains `access-key` and `secret-key`;
@@ -352,7 +352,7 @@ class Secret(_max_posargs(1)):
     to this unit.
     """
 
-    remote_grants: dict[int, set[str]] = dataclasses.field(default_factory=dict)
+    remote_grants: Mapping[int, set[str]] = dataclasses.field(default_factory=dict)
     """Mapping from relation IDs to remote units and applications to which this
     secret has been granted."""
 
@@ -860,7 +860,7 @@ class Notice(_max_posargs(1)):
     occurrences: int = 1
     """The number of times one of these notices has occurred."""
 
-    last_data: dict[str, str] = dataclasses.field(default_factory=dict)
+    last_data: Mapping[str, str] = dataclasses.field(default_factory=dict)
     """Additional data captured from the last occurrence of one of these notices."""
 
     repeat_after: datetime.timedelta | None = None
@@ -963,13 +963,13 @@ class Container(_max_posargs(1)):
     # pebble or derive them from the resulting plan (which one CAN get from pebble).
     # So if we are instantiating Container by fetching info from a 'live' charm, the 'layers'
     # will be unknown. all that we can know is the resulting plan (the 'computed plan').
-    _base_plan: dict[str, Any] = dataclasses.field(default_factory=dict)
+    _base_plan: Mapping[str, Any] = dataclasses.field(default_factory=dict)
     # We expect most of the user-facing testing to be covered by this 'layers' attribute,
     # as it is all that will be known when unit-testing.
-    layers: dict[str, pebble.Layer] = dataclasses.field(default_factory=dict)
+    layers: Mapping[str, pebble.Layer] = dataclasses.field(default_factory=dict)
     """All :class:`ops.pebble.Layer` definitions that have already been added to the container."""
 
-    service_statuses: dict[str, pebble.ServiceStatus] = dataclasses.field(
+    service_statuses: Mapping[str, pebble.ServiceStatus] = dataclasses.field(
         default_factory=dict,
     )
     """The current status of each Pebble service running in the container."""
@@ -988,7 +988,7 @@ class Container(_max_posargs(1)):
     # when the charm runs `pebble.pull`, it will return .open() from one of those paths.
     # when the charm pushes, it will either overwrite one of those paths (careful!) or it will
     # create a tempfile and insert its path in the mock filesystem tree
-    mounts: dict[str, Mount] = dataclasses.field(default_factory=dict)
+    mounts: Mapping[str, Mount] = dataclasses.field(default_factory=dict)
     """Provides access to the contents of the simulated container filesystem.
 
     For example, suppose you want to express that your container has:
@@ -1257,7 +1257,7 @@ class StoredState(_max_posargs(1)):
     # However, it's complex to describe those types, since it's a recursive
     # definition - even in TypeShed the _Marshallable type includes containers
     # like list[Any], which seems to defeat the point.
-    content: dict[str, Any] = dataclasses.field(default_factory=dict)
+    content: Mapping[str, Any] = dataclasses.field(default_factory=dict)
     """The content of the :class:`ops.StoredState` instance."""
 
     _data_type_name: str = "StoredStateData"

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1562,6 +1562,7 @@ class State(_max_posargs(0)):
             value = getattr(self, attr)
             new_value = frozenset(copy.deepcopy(v, memo) for v in value)
             object.__setattr__(new_state, attr, new_value)
+        object.__setattr__(new_state, "deferred", self.deferred[:])
         return new_state
 
     def _update_workload_version(self, new_workload_version: str):

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1548,11 +1548,12 @@ class State(_max_posargs(0)):
         # reduce method as well.
         # TODO: When we require Python 3.10+ this method should be removed.
         new_state = copy.copy(self)
+        object.__setattr__(new_state, "config", self.config.copy())
         for attr in (
             "relations",
+            "networks",
             "containers",
             "storages",
-            "networks",
             "opened_ports",
             "secrets",
             "resources",
@@ -1561,7 +1562,6 @@ class State(_max_posargs(0)):
             value = getattr(self, attr)
             new_value = frozenset(copy.deepcopy(v, memo) for v in value)
             object.__setattr__(new_state, attr, new_value)
-        object.__setattr__(new_state, "config", self.config.copy())
         return new_state
 
     def _update_workload_version(self, new_workload_version: str):

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1581,11 +1581,11 @@ class State(_max_posargs(0)):
         storage: str,
         /,
         *,
-        index: int | None = 0,
+        index: int = 0,
     ) -> Storage:
         """Get storage from this State, based on the storage's name and index."""
         for state_storage in self.storages:
-            if state_storage.name == storage and storage.index == index:
+            if state_storage.name == storage and state_storage.index == index:
                 return state_storage
         raise ValueError(
             f"storage: name={storage}, index={index} not found in the State",


### PR DESCRIPTION
This PR has two changes to make the `testing.State` less mutable (or more immuntable as my Kiwi fingers keep typing).

* All of the components that have a dictionary or list attribute now deepcopy that attribute in `__postinit__`. The type annotations are also changed to `Mapping` and `Sequence` so static type checking should detect when charm tests try to alter these (the actual underlying types are still the ones passed, and default to dict and list).
* In `State.__deepcopy__` we deepcopy all of the items inside the collections (the relations, the containers, and so forth) - this means that all of these items are separate in the input and output states. This also includes the config.

This also fixes a small bug that was found by the new tests: `State.get_storage` was wrongly comparing the index of the storage object to the *`str.index` function* (so would never match) rather than to the index of the `Storage` object in the state. The `| None` type annotation is also removed, as the index is `int`, not `int | None`, so it doesn't make sense to pass `None` in as the index.

Fixes #1605