### PR TITLE
ci: disable the observability tests requirement in publishing for the 19.1 branch

### DIFF
--- a/.github/workflows/publish-ops-scenario.yaml
+++ b/.github/workflows/publish-ops-scenario.yaml
@@ -7,8 +7,8 @@ on:
 jobs:
   framework-tests:
     uses: ./.github/workflows/framework-tests.yaml
-  observability-charm-tests:
-    uses: ./.github/workflows/observability-charm-tests.yaml
+#  observability-charm-tests:
+#    uses: ./.github/workflows/observability-charm-tests.yaml
   hello-charm-tests:
     uses: ./.github/workflows/hello-charm-tests.yaml
   build-n-publish:

--- a/.github/workflows/publish-ops.yaml
+++ b/.github/workflows/publish-ops.yaml
@@ -11,8 +11,8 @@ on:
 jobs:
   framework-tests:
     uses: ./.github/workflows/framework-tests.yaml
-  observability-charm-tests:
-    uses: ./.github/workflows/observability-charm-tests.yaml
+#  observability-charm-tests:
+#    uses: ./.github/workflows/observability-charm-tests.yaml
   hello-charm-tests:
     uses: ./.github/workflows/hello-charm-tests.yaml
   build-n-publish:


### PR DESCRIPTION
The observability tests need to install ops and ops-scenario, and they can't do that with the requirements in the branch, because they aren't available yet.

As a workaround for now, disable the requirement for these tests to pass in the maintenance branch. This should allow publishing both versions.

For the next release, we'll need to either do this again or implement the wheel solution or something similar.