### PR TITLE
ci: bump versions to 2.19.2 and 7.19.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2.19.2 - 10 Mar 2025
+
+There are no differences from 2.19.1 -- this is purely a bump for CI.
+
 # 2.19.1 - 5 Mar 2025
 
 ## Fixes

--- a/ops/version.py
+++ b/ops/version.py
@@ -17,4 +17,4 @@
 This module is NOT to be used when developing charms using ops.
 """
 
-version: str = '2.19.1'
+version: str = '2.19.2'

--- a/testing/CHANGES.md
+++ b/testing/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.19.2 - 10 Mar 2025
+
+There are no differences from 7.19.1 -- this is a bump purely for CI purposes.
+
 # 7.19.1 - 5 Mar 2025
 
 **Note that there are no versions 7.3 through 7.18.** The minor version number

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "7.19.1"
+version = "7.19.2"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops==2.19.1",
+    "ops==2.19.2",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"


### PR DESCRIPTION
The CI failed releasing 2.19.1 and 7.19.1, so this just bumps the version numbers to have another go, now that the observability tests are disabled in this maintenance branch.