### PR TITLE
ci: bump versions to 2.19.3 and 7.19.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2.19.3 - 10 Mar 2025
+
+There are no differences from 2.19.2 -- this is purely a bump for CI.
+
 # 2.19.2 - 10 Mar 2025
 
 There are no differences from 2.19.1 -- this is purely a bump for CI.

--- a/ops/version.py
+++ b/ops/version.py
@@ -17,4 +17,4 @@
 This module is NOT to be used when developing charms using ops.
 """
 
-version: str = '2.19.2'
+version: str = '2.19.3'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario==7.19.1",
+    "ops-scenario==7.19.3",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/testing/CHANGES.md
+++ b/testing/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.19.3 - 10 Mar 2025
+
+There are no differences from 7.19.2 -- this is a bump purely for CI purposes.
+
 # 7.19.2 - 10 Mar 2025
 
 There are no differences from 7.19.1 -- this is a bump purely for CI purposes.

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "7.19.2"
+version = "7.19.3"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops==2.19.2",
+    "ops==2.19.3",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"


### PR DESCRIPTION
Just like the previous bump but onto the 3rd attempt. Somehow the last release pushed 2.20.dev0 - I assume I must have selected the branch incorrectly in the releases page :disappointed: 