### PR TITLE
chore: bump doc dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,9 +10,9 @@ anyio==4.8.0
     # via
     #   starlette
     #   watchfiles
-babel==2.16.0
+babel==2.17.0
     # via sphinx
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.3
     # via
     #   canonical-sphinx-extensions
     #   furo
@@ -21,7 +21,7 @@ bracex==2.5.post1
     # via wcmatch
 canonical-sphinx-extensions==0.0.23
     # via ops (pyproject.toml)
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 charset-normalizer==3.4.1
     # via requests
@@ -51,13 +51,13 @@ idna==3.10
     #   requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   myst-parser
     #   sphinx
 linkify-it-py==2.0.3
     # via ops (pyproject.toml)
-lxml==5.3.0
+lxml==5.3.1
     # via pyspelling
 markdown==3.7
     # via pyspelling
@@ -71,7 +71,7 @@ mdit-py-plugins==0.4.2
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-myst-parser==4.0.0
+myst-parser==4.0.1
     # via ops (pyproject.toml)
 packaging==24.2
     # via sphinx
@@ -125,7 +125,7 @@ sphinx-copybutton==0.5.2
     # via ops (pyproject.toml)
 sphinx-design==0.6.1
     # via ops (pyproject.toml)
-sphinx-notfound-page==1.0.4
+sphinx-notfound-page==1.1.0
     # via ops (pyproject.toml)
 sphinx-tabs==3.4.7
     # via ops (pyproject.toml)
@@ -145,10 +145,12 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sphinxext-opengraph==0.9.1
     # via ops (pyproject.toml)
-starlette==0.45.2
+starlette==0.46.1
     # via sphinx-autobuild
 typing-extensions==4.12.2
-    # via anyio
+    # via
+    #   anyio
+    #   beautifulsoup4
 uc-micro-py==1.0.3
     # via linkify-it-py
 urllib3==2.3.0
@@ -163,6 +165,6 @@ webencodings==0.5.1
     # via html5lib
 websocket-client==1.8.0
     # via ops (pyproject.toml)
-websockets==14.1
+websockets==15.0.1
     # via sphinx-autobuild
 ./testing/


### PR DESCRIPTION
There's a security alert for Jinja 3.1.5. As far as I can tell, it's not relevant to our use (which is only in doc generation anyway), but it's nice to move to the fixed version even if just to silence the warning systems.

While we're doing this, bump the other doc dependencies (this is just generating a fresh `requirements.txt` via `uvx --python=3.11 tox -e docs-deps`).

I haven't read through all of the changes in each of the bumps, but for the ones that aren't micro bumps, certifi seems safe (and that's calendar versioning, not semver), sphinx-notfound-page seems safe, the starlette changes don't seem relevant, and the websockets changes don't seem relevant to docs (it's less clear for ops itself).