### PR TITLE
chore: prepare for 2.19.4 and 7.19.4

### DIFF
--- a/.github/workflows/publish-ops-scenario.yaml
+++ b/.github/workflows/publish-ops-scenario.yaml
@@ -7,8 +7,6 @@ on:
 jobs:
   framework-tests:
     uses: ./.github/workflows/framework-tests.yaml
-#  observability-charm-tests:
-#    uses: ./.github/workflows/observability-charm-tests.yaml
   hello-charm-tests:
     uses: ./.github/workflows/hello-charm-tests.yaml
   build-n-publish:
@@ -18,7 +16,7 @@ jobs:
       id-token: write
       attestations: write
       contents: read
-    needs: [framework-tests, observability-charm-tests, hello-charm-tests]
+    needs: [framework-tests, hello-charm-tests]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/publish-ops.yaml
+++ b/.github/workflows/publish-ops.yaml
@@ -11,8 +11,6 @@ on:
 jobs:
   framework-tests:
     uses: ./.github/workflows/framework-tests.yaml
-#  observability-charm-tests:
-#    uses: ./.github/workflows/observability-charm-tests.yaml
   hello-charm-tests:
     uses: ./.github/workflows/hello-charm-tests.yaml
   build-n-publish:
@@ -22,7 +20,7 @@ jobs:
       id-token: write
       attestations: write
       contents: read
-    needs: [framework-tests, observability-charm-tests, hello-charm-tests]
+    needs: [framework-tests, hello-charm-tests]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2.19.4 - 11 Mar 2025
+
+There are no differences from 2.19.3 -- this is purely a bump for CI.
+
 # 2.19.3 - 10 Mar 2025
 
 There are no differences from 2.19.2 -- this is purely a bump for CI.

--- a/ops/version.py
+++ b/ops/version.py
@@ -17,4 +17,4 @@
 This module is NOT to be used when developing charms using ops.
 """
 
-version: str = '2.19.3'
+version: str = '2.19.4'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario==7.19.3",
+    "ops-scenario==7.19.4",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/testing/CHANGES.md
+++ b/testing/CHANGES.md
@@ -1,3 +1,7 @@
+# 7.19.4 - 11 Mar 2025
+
+There are no differences from 7.19.3 -- this is a bump purely for CI purposes.
+
 # 7.19.3 - 10 Mar 2025
 
 There are no differences from 7.19.2 -- this is a bump purely for CI purposes.

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "7.19.3"
+version = "7.19.4"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops==2.19.3",
+    "ops==2.19.4",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"


### PR DESCRIPTION
* Disable the requirement for the observability checks for publishing.
* Bump versions to 19.4
* Bump [testing] to 7.19.4
* Bump ops-scenario requirement to 2.19.4
* Embarrassing changelog entries