### PR TITLE
feat: add a remove_revision() method to SecretRemoveEvent and SecretExpiredEvent

### DIFF
--- a/docs/howto/manage-secrets.md
+++ b/docs/howto/manage-secrets.md
@@ -177,7 +177,7 @@ class MyDatabaseCharm(ops.CharmBase):
 
     def _on_secret_remove(self, event: ops.SecretRemoveEvent):
         # All observers are done with this revision, remove it:
-        event.secret.remove_revision(event.revision)
+        event.remove_revision()
 ```
 
 ### Revoke a secret

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1012,7 +1012,7 @@ class SecretRemoveEvent(SecretEvent):
     inform the secret owner that the old revision can be removed.
 
     After any required cleanup, the charm should call
-    :meth:`event.secret.remove_revision() <ops.Secret.remove_revision>` to
+    :meth:`event.remove_revision() <ops.SecretRemoveEvent.remove_revision>` to
     remove the now-unused revision. If the charm does not, then the event will
     be emitted again, when further revisions are ready for removal.
 
@@ -1027,6 +1027,14 @@ class SecretRemoveEvent(SecretEvent):
     def revision(self) -> int:
         """The secret revision this event refers to."""
         return self._revision
+
+    def remove_revision(self):
+        """Remove the revision this event refers to.
+
+        Call this method after any required cleanup to inform Juju that the
+        secret revision can be removed.
+        """
+        self.secret.remove_revision(self._revision)
 
     def snapshot(self) -> Dict[str, Any]:
         """Used by the framework to serialize the event to disk.
@@ -1051,7 +1059,7 @@ class SecretExpiredEvent(SecretEvent):
 
     This event is fired on the secret owner to inform it that the secret revision
     must be removed. The event will keep firing until the owner removes the
-    revision by calling :meth:`event.secret.remove_revision() <ops.Secret.remove_revision>`.
+    revision by calling :meth:`event.remove_revision() <ops.SecretExpired.remove_revision>`.
 
     .. jujuadded:: 3.0
     """
@@ -1064,6 +1072,14 @@ class SecretExpiredEvent(SecretEvent):
     def revision(self) -> int:
         """The secret revision this event refers to."""
         return self._revision
+
+    def remove_revision(self):
+        """Remove the revision this event refers to.
+
+        Call this method after any required cleanup to inform Juju that the
+        secret revision can be removed.
+        """
+        self.secret.remove_revision(self._revision)
 
     def snapshot(self) -> Dict[str, Any]:
         """Used by the framework to serialize the event to disk.


### PR DESCRIPTION
In general, charms should treat secret revisions as an internal Juju detail - they only need to work with the tracked and latest versions, and don't need to know what numbers those happen to be.

To encourage this behaviour, this PR adds a `remove_revision` method to the secret-remove and secret-expired events, where charms are expected to call `secret-remove`. The method needs no arguments because the event already has the secret and revision in question.

Fixes #1309