### PR TITLE
fix: assorted fixes for Pebble layer merging in Harness and Scenario

### DIFF
--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -3319,7 +3319,7 @@ class _TestingPebbleClient:
         raise NotImplementedError(self.wait_change)
 
     def _update_check_infos_from_plan(self):
-        # In testing, the check info is has the level, threshold, and startup
+        # In testing, the check info has the level, threshold, and startup
         # from the check baked in, so we need to update the info when the plan
         # changes.
         for check in self.get_plan().checks.values():

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -3406,6 +3406,7 @@ class _TestingPebbleClient:
                 info = pebble.CheckInfo(
                     name,
                     level=check.level,
+                    startup=check.startup,
                     status=status,
                     threshold=3 if check.threshold is None else check.threshold,
                     failures=0,

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -41,6 +41,7 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
+    Final,
     Generic,
     Iterable,
     List,
@@ -3106,6 +3107,8 @@ class _TestingPebbleClient:
     as the only public methods of this type are for implementing Client.
     """
 
+    _DEFAULT_CHECK_THRESHOLD: Final[int] = 3
+
     def __init__(self, backend: _TestingModelBackend, container_root: pathlib.Path):
         self._backend = _TestingModelBackend
         self._layers: Dict[str, pebble.Layer] = {}
@@ -3200,12 +3203,15 @@ class _TestingPebbleClient:
                 continue
             info = self._check_infos.get(name)
             if info is None:
+                threshold = (
+                    self._DEFAULT_CHECK_THRESHOLD if check.threshold is None else check.threshold
+                )
                 info = pebble.CheckInfo(
                     name=name,
                     level=check.level,
                     status=pebble.CheckStatus.UP,
                     failures=0,
-                    threshold=3 if check.threshold is None else check.threshold,
+                    threshold=threshold,
                     startup=check.startup,
                 )
                 self._check_infos[name] = info
@@ -3327,7 +3333,9 @@ class _TestingPebbleClient:
             if not info:
                 continue
             info.level = check.level
-            info.threshold = 3 if check.threshold is None else check.threshold
+            info.threshold = (
+                self._DEFAULT_CHECK_THRESHOLD if check.threshold is None else check.threshold
+            )
             info.startup = check.startup
 
     def add_layer(
@@ -3430,12 +3438,15 @@ class _TestingPebbleClient:
                     if check.startup == pebble.CheckStartup.DISABLED
                     else pebble.CheckStatus.UP
                 )
+                threshold = (
+                    self._DEFAULT_CHECK_THRESHOLD if check.threshold is None else check.threshold
+                )
                 info = pebble.CheckInfo(
                     name,
                     level=check.level,
                     startup=check.startup,
                     status=status,
-                    threshold=3 if check.threshold is None else check.threshold,
+                    threshold=threshold,
                     failures=0,
                     change_id=pebble.ChangeID(''),
                 )

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -876,6 +876,9 @@ class Plan:
 
     __str__ = to_yaml
 
+    def __repr__(self):
+        return f'Plan({self.to_dict()!r})'
+
     def __eq__(self, other: Union[PlanDict, Plan]) -> bool:
         if isinstance(other, dict):
             return self.to_dict() == other
@@ -1106,8 +1109,8 @@ class Check:
             level = dct.get('level', '')
         self.level = level
         self.startup = CheckStartup(dct.get('startup', ''))
-        self.period: Optional[str] = dct.get('period', '')
-        self.timeout: Optional[str] = dct.get('timeout', '')
+        self.period: Optional[str] = dct.get('period')
+        self.timeout: Optional[str] = dct.get('timeout')
         self.threshold: Optional[int] = dct.get('threshold')
 
         http = dct.get('http')
@@ -1210,7 +1213,7 @@ class Check:
         attributes take precedence.
         """
         for name, value in other.__dict__.items():
-            if not value or name == 'name':
+            if value is None or name == 'name':
                 continue
             if name == 'http':
                 self._merge_http(value)
@@ -1218,6 +1221,10 @@ class Check:
                 self._merge_tcp(value)
             elif name == 'exec':
                 self._merge_exec(value)
+            elif name == 'startup' and value == CheckStartup.UNSET:
+                continue
+            # Note that CheckLevel.UNSET has a different meaning to CheckStart.UNSET.
+            # In the former, it means 'there is no level'; in the latter it means 'use the default'.
             else:
                 setattr(self, name, value)
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1109,8 +1109,8 @@ class Check:
             level = dct.get('level', '')
         self.level = level
         self.startup = CheckStartup(dct.get('startup', ''))
-        self.period: Optional[str] = dct.get('period')
-        self.timeout: Optional[str] = dct.get('timeout')
+        self.period: Optional[str] = dct.get('period', '')
+        self.timeout: Optional[str] = dct.get('timeout', '')
         self.threshold: Optional[int] = dct.get('threshold')
 
         http = dct.get('http')
@@ -1213,7 +1213,7 @@ class Check:
         attributes take precedence.
         """
         for name, value in other.__dict__.items():
-            if value is None or name == 'name':
+            if value is None or value == '' or name == 'name':
                 continue
             if name == 'http':
                 self._merge_http(value)

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1223,8 +1223,9 @@ class Check:
                 self._merge_exec(value)
             elif name == 'startup' and value == CheckStartup.UNSET:
                 continue
-            # Note that CheckLevel.UNSET has a different meaning to CheckStart.UNSET.
-            # In the former, it means 'there is no level'; in the latter it means 'use the default'.
+            # Note that CheckLevel.UNSET has a different meaning to
+            # CheckStartup.UNSET. In the former, it means 'there is no level';
+            # in the latter it means 'use the default'.
             else:
                 setattr(self, name, value)
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1213,7 +1213,10 @@ class Check:
         attributes take precedence.
         """
         for name, value in other.__dict__.items():
-            if value is None or value == '' or name == 'name':
+            # 'not value' is safe here because a threshold of 0 is valid but
+            # inconsistently applied and not of any actual use, and the other
+            # fields are strings where the empty string means 'not in the layer'.
+            if not value or name == 'name':
                 continue
             if name == 'http':
                 self._merge_http(value)

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -1064,8 +1064,8 @@ class TestCheck:
         assert check.override == ''
         assert check.level == pebble.CheckLevel.UNSET
         assert check.startup == pebble.CheckStartup.UNSET
-        assert check.period is None
-        assert check.timeout is None
+        assert check.period == ''
+        assert check.timeout == ''
         assert check.threshold is None
         assert check.http is None
         assert check.tcp is None

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -1063,8 +1063,9 @@ class TestCheck:
         assert check.name == name
         assert check.override == ''
         assert check.level == pebble.CheckLevel.UNSET
-        assert check.period == ''
-        assert check.timeout == ''
+        assert check.startup == pebble.CheckStartup.UNSET
+        assert check.period is None
+        assert check.timeout is None
         assert check.threshold is None
         assert check.http is None
         assert check.tcp is None
@@ -1078,6 +1079,7 @@ class TestCheck:
         d: pebble.CheckDict = {
             'override': 'replace',
             'level': 'alive',
+            'startup': 'enabled',
             'period': '10s',
             'timeout': '3s',
             'threshold': 5,
@@ -1091,6 +1093,7 @@ class TestCheck:
         assert check.name == 'chk-http'
         assert check.override == 'replace'
         assert check.level == pebble.CheckLevel.ALIVE
+        assert check.startup == pebble.CheckStartup.ENABLED
         assert check.period == '10s'
         assert check.timeout == '3s'
         assert check.threshold == 5
@@ -1139,7 +1142,6 @@ class TestCheck:
         assert two == two.to_dict()
         d['level'] = 'ready'
         assert one != d
-
         assert one != 5
 
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -7094,6 +7094,180 @@ class TestChecks:
             assert info.status == pebble.CheckStatus.UP
             assert info.change_id, 'Change ID should not be None or the empty string'
 
+    @pytest.mark.parametrize(
+        'combine,new_layer_name',
+        [
+            (False, 'new-layer'),
+            (True, 'base'),
+            (
+                True,
+                'new-layer',
+            ),  # This doesn't have anything to combine with, but for completeness.
+        ],
+    )
+    @pytest.mark.parametrize(
+        'new_layer_dict',
+        [
+            {
+                'checks': {
+                    'server-ready': {
+                        'override': 'merge',
+                        'level': 'ready',
+                        'http': {'url': 'http://localhost:5050/version'},
+                    }
+                }
+            },
+            {
+                'checks': {
+                    'server-ready': {
+                        'override': 'merge',
+                        'level': 'alive',
+                        'threshold': 30,
+                        'startup': 'disabled',
+                        'http': {'url': 'http://localhost:5050/version'},
+                    }
+                }
+            },
+        ],
+    )
+    def test_add_layer_merge_check(
+        self,
+        request: pytest.FixtureRequest,
+        new_layer_name: str,
+        combine: bool,
+        new_layer_dict: ops.pebble.LayerDict,
+    ):
+        class MyCharm(ops.CharmBase):
+            def __init__(self, framework: ops.Framework):
+                super().__init__(framework)
+                framework.observe(self.on['my-container'].pebble_ready, self._on_pebble_ready)
+
+            def _on_pebble_ready(self, _: ops.PebbleReadyEvent):
+                container = self.unit.get_container('my-container')
+                container.add_layer(
+                    new_layer_name, ops.pebble.Layer(new_layer_dict), combine=combine
+                )
+
+        layer_in = pebble.Layer({
+            'checks': {
+                'server-ready': {
+                    'override': 'replace',
+                    'level': 'ready',
+                    'startup': 'enabled',
+                    'threshold': 10,
+                    'http': {'url': 'http://localhost:5000/version'},
+                }
+            }
+        })
+        harness = ops.testing.Harness(MyCharm, meta='name: mycharm\ncontainers:\n  my-container:')
+        request.addfinalizer(harness.cleanup)
+        harness.set_can_connect('my-container', True)
+        harness.begin()
+        container_in = harness.charm.unit.get_container('my-container')
+        container_in.add_layer('base', layer_in)
+
+        harness.container_pebble_ready('my-container')
+
+        assert 'checks' in new_layer_dict and 'server-ready' in new_layer_dict['checks']
+        new_layer_check = new_layer_dict['checks']['server-ready']
+        container_out = harness.charm.unit.get_container('my-container')
+        check_out = container_out.get_checks('server-ready')['server-ready']
+        assert check_out.level == pebble.CheckLevel(new_layer_check.get('level', 'ready'))
+        assert check_out.startup == pebble.CheckStartup(new_layer_check.get('startup', 'enabled'))
+        assert check_out.threshold == new_layer_check.get('threshold', 10)
+
+
+@pytest.mark.parametrize('layer1_name,layer2_name', [('a-base', 'b-base'), ('b-base', 'a-base')])
+def test_layers_merge_in_plan(request: pytest.FixtureRequest, layer1_name: str, layer2_name: str):
+    layer1 = pebble.Layer({
+        'services': {
+            'server': {
+                'override': 'replace',
+                'command': '/bin/sleep 10',
+                'summary': 'sum',
+                'description': 'desc',
+                'startup': 'enabled',
+            },
+        },
+        'checks': {
+            'server-ready': {
+                'override': 'replace',
+                'level': 'ready',
+                'startup': 'enabled',
+                'threshold': 10,
+                'period': '1s',
+                'timeout': '28s',
+                'http': {'url': 'http://localhost:5000/version'},
+            }
+        },
+        'log-targets': {
+            'loki': {
+                'override': 'replace',
+                'type': 'loki',
+                'location': 'https://loki.example.com',
+                'services': ['server'],
+                'labels': {'foo': 'bar'},
+            }
+        },
+    })
+    layer2 = pebble.Layer({
+        'services': {
+            'server': {
+                'override': 'merge',
+                'command': '/bin/sleep 20',
+            }
+        },
+        'checks': {
+            'server-ready': {
+                'override': 'merge',
+                'level': 'alive',
+                'http': {'url': 'http://localhost:5050/version'},
+            }
+        },
+        'log-targets': {
+            'loki': {
+                'override': 'merge',
+                'location': 'https://loki2.example.com',
+            },
+        },
+    })
+    harness = ops.testing.Harness(
+        ops.CharmBase, meta='name: mycharm\ncontainers:\n  my-container:'
+    )
+    request.addfinalizer(harness.cleanup)
+    harness.set_can_connect('my-container', True)
+    harness.begin()
+    container_in = harness.charm.unit.get_container('my-container')
+    container_in.add_layer(layer1_name, layer1)
+    container_in.add_layer(layer2_name, layer2)
+    container_out = harness.charm.unit.get_container('my-container')
+    plan = container_out.get_plan()
+
+    service = plan.services['server']
+    assert service.summary == 'sum'
+    assert service.description == 'desc'
+    # Service.startup is always a string, even though we have the enum.
+    assert service.startup == pebble.ServiceStartup.ENABLED.value
+    assert service.override == 'merge'
+    assert service.command == '/bin/sleep 20'
+
+    check = plan.checks['server-ready']
+    assert check.startup == pebble.CheckStartup.ENABLED
+    assert check.threshold == 10
+    assert check.period == '1s'
+    assert check.timeout == '28s'
+    assert check.override == 'merge'
+    assert check.level == pebble.CheckLevel.ALIVE
+    assert check.http is not None
+    assert check.http.get('url') == 'http://localhost:5050/version'
+
+    log_target = plan.log_targets['loki']
+    assert log_target.type == 'loki'
+    assert log_target.services == ['server']
+    assert log_target.labels == {'foo': 'bar'}
+    assert log_target.override == 'merge'
+    assert log_target.location == 'https://loki2.example.com'
+
 
 @pytest.mark.skipif(
     not hasattr(ops.testing, 'Context'), reason='requires optional ops[testing] install'

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -7124,10 +7124,8 @@ class TestChecks:
         [
             (False, 'new-layer'),
             (True, 'base'),
-            (
-                True,
-                'new-layer',
-            ),  # This doesn't have anything to combine with, but for completeness.
+            # This doesn't have anything to combine with, but for completeness:
+            (True, 'new-layer'),
         ],
     )
     @pytest.mark.parametrize(

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1050,7 +1050,6 @@ class Container(_max_posargs(1)):
         _deepcopy_mutable_fields(self)
 
     def _render_services(self):
-        # copied over from ops.testing._TestingPebbleClient._render_services()
         services: dict[str, pebble.Service] = {}
         for layer in self.layers.values():
             for name, service in layer.services.items():
@@ -1061,7 +1060,6 @@ class Container(_max_posargs(1)):
         return services
 
     def _render_checks(self) -> Dict[str, pebble.Check]:
-        # copied over from ops.testing._TestingPebbleClient._render_checks()
         checks: Dict[str, pebble.Check] = {}
         for layer in self.layers.values():
             for name, check in layer.checks.items():
@@ -1072,7 +1070,6 @@ class Container(_max_posargs(1)):
         return checks
 
     def _render_log_targets(self) -> Dict[str, pebble.LogTarget]:
-        # copied over from ops.testing._TestingPebbleClient._render_log_targets()
         log_targets: Dict[str, pebble.LogTarget] = {}
         for layer in self.layers.values():
             for name, log_target in layer.log_targets.items():


### PR DESCRIPTION
* When merging `pebble.Check`s, an unset `startup` should not override a set `startup`. (Once set you can't go back to unset - you need to explicitly use enabled).
* When rendering services, checks, and log targets from a series of layers, Harness and Scenario were combining after sorting the items by name. Although Pebble uses filename sorting when reading initial layers from a directory, future layers are combined in the order they are added via the API. For Harness and Scenario, we need to use the order in which they were added - if the caller wants to simulate loading from the filesystem, they need to do that by calling `add_layer` in that order. The plan itself still sorts the services, checks, and log targets.
* When rendering services, checks, and log targets, if there are multiple services/checks/log-targets with the same name, and `override` is set to `merge`, the service/check/log-target needs to merge rather than replace. This was already done when adding layers with the same name (in `add_layer`) but not when there were differently named layers.
* The Scenario `Container.plan` property was ignoring any defined checks and log targets. Those are now included.
* The Scenario `Container` service, check, and log target rendering also needed the (no) sorting and merging fixes from above.
* When adding a layer in Harness or Scenario, update any existing `CheckInfo`s to match changes to the plan - in real Pebble the startup, level, and threshold fields are always pulled from the plan but we bake them in when testing, so need to make sure they continually track what's in the combined plan.

Also adds a `__repr__` for `pebble.Plan` - this helped while debugging issues, and it seems reasonable to keep it.