### PR TITLE
feat: check that the check-infos in testing.Container match the plan

### DIFF
--- a/testing/src/scenario/_consistency_checker.py
+++ b/testing/src/scenario/_consistency_checker.py
@@ -685,14 +685,12 @@ def check_containers_consistency(
                 )
                 continue
             plan_check = plan.checks[check.name]
-            for attr_from_plan in ("level", "startup", "threshold"):
-                if getattr(check, attr_from_plan) != getattr(
-                    plan_check, attr_from_plan
-                ):
+            for attr in ("level", "startup", "threshold"):
+                if getattr(check, attr) != getattr(plan_check, attr):
                     errors.append(
                         f"container {container.name!r} has a check {check.name!r} with a "
-                        f"different {attr_from_plan!r} ({getattr(check, attr_from_plan)}) "
-                        f"than the plan ({getattr(plan_check, attr_from_plan)}).",
+                        f"different {attr!r} ({getattr(check, attr)}) "
+                        f"than the plan ({getattr(plan_check, attr)}).",
                     )
 
     return Results(errors, [])

--- a/testing/src/scenario/_consistency_checker.py
+++ b/testing/src/scenario/_consistency_checker.py
@@ -670,7 +670,7 @@ def check_containers_consistency(
             f"Missing from metadata: {diff}.",
         )
 
-    # If you have check-infos, then they must match the plan.
+    # If you have check-infos, then they must match the computed plan.
     for container in state.containers:
         plan = container.plan
         for check in container.check_infos:

--- a/testing/src/scenario/_consistency_checker.py
+++ b/testing/src/scenario/_consistency_checker.py
@@ -683,21 +683,16 @@ def check_containers_consistency(
                     f"container {container.name!r} has a check {check.name!r} "
                     f"but the {plan_has}.",
                 )
-            else:
-                if check.level != plan.checks[check].level:
+                continue
+            plan_check = plan.checks[check.name]
+            for attr_from_plan in ("level", "startup", "threshold"):
+                if getattr(check, attr_from_plan) != getattr(
+                    plan_check, attr_from_plan
+                ):
                     errors.append(
-                        f"container {container.name!r} has a check {check.name!r} with a different "
-                        f"'level' than the plan ({plan.checks[check].level}).",
-                    )
-                if check.startup != plan.checks[check].startup:
-                    errors.append(
-                        f"container {container.name!r} has a check {check.name!r} with a different "
-                        f"'startup' than the plan ({plan.checks[check].startup}).",
-                    )
-                if check.threshold != plan.checks[check].threshold:
-                    errors.append(
-                        f"container {container.name!r} has a check {check.name!r} with a different "
-                        f"'threshold' than the plan ({plan.checks[check].threshold}).",
+                        f"container {container.name!r} has a check {check.name!r} with a "
+                        f"different {attr_from_plan!r} ({getattr(check, attr_from_plan)}) "
+                        f"than the plan ({getattr(plan_check, attr_from_plan)}).",
                     )
 
     return Results(errors, [])

--- a/testing/src/scenario/_consistency_checker.py
+++ b/testing/src/scenario/_consistency_checker.py
@@ -670,6 +670,36 @@ def check_containers_consistency(
             f"Missing from metadata: {diff}.",
         )
 
+    # If you have check-infos, then they must match the plan.
+    for container in state.containers:
+        plan = container.plan
+        for check in container.check_infos:
+            if check.name not in plan.checks:
+                if plan.checks:
+                    plan_has = f"plan has only checks: {', '.join(plan.checks)}"
+                else:
+                    plan_has = "plan has no checks"
+                errors.append(
+                    f"container {container.name!r} has a check {check.name!r} "
+                    f"but the {plan_has}.",
+                )
+            else:
+                if check.level != plan.checks[check].level:
+                    errors.append(
+                        f"container {container.name!r} has a check {check.name!r} with a different "
+                        f"'level' than the plan ({plan.checks[check].level}).",
+                    )
+                if check.startup != plan.checks[check].startup:
+                    errors.append(
+                        f"container {container.name!r} has a check {check.name!r} with a different "
+                        f"'startup' than the plan ({plan.checks[check].startup}).",
+                    )
+                if check.threshold != plan.checks[check].threshold:
+                    errors.append(
+                        f"container {container.name!r} has a check {check.name!r} with a different "
+                        f"'threshold' than the plan ({plan.checks[check].threshold}).",
+                    )
+
     return Results(errors, [])
 
 

--- a/testing/tests/test_context_on.py
+++ b/testing/tests/test_context_on.py
@@ -551,9 +551,14 @@ def test_custom_event_with_scenario_args():
     peerrelation = scenario.PeerRelation("peer-endpoint")
     subordinaterelation = scenario.SubordinateRelation("sub-endpoint")
     notice = scenario.Notice("key.example.com")
-    checkinfo = scenario.CheckInfo("check1")
+    layer = ops.pebble.Layer({
+        "checks": {
+            "check1": {"override": "replace", "startup": "enabled", "threshold": 3}
+        }
+    })
+    checkinfo = scenario.CheckInfo("check1", level=ops.pebble.CheckLevel.UNSET)
     container = scenario.Container(
-        "container", notices=[notice], check_infos={checkinfo}
+        "container", notices=[notice], check_infos={checkinfo}, layers={"layer": layer}
     )
     errorstatus = scenario.ErrorStatus("error")
     activestatus = scenario.ActiveStatus("working")


### PR DESCRIPTION
Add some consistency checks for the `CheckInfo`s in `testing.Container`:

* If there is a `CheckInfo`, then the plan must have a check by that name, or Pebble would never have generated that info.
* The threshold, startup, and level values of the `CheckInfo` come from the check definition itself, so must match the plan.