### PR TITLE
docs: remove the charm-tech@lists.launchpad.net email address

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "The Python library behind great charms"
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [
-    {name="The Charm Tech team at Canonical Ltd.", email="charm-tech@lists.launchpad.net"},
+    {name="The Charm Tech team at Canonical Ltd."},
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
 ]
 maintainers = [
-    { name = "The Charm Tech team at Canonical Ltd.", email = "charm-tech@lists.launchpad.net" }
+    { name = "The Charm Tech team at Canonical Ltd." }
 ]
 description = "Python library providing a state-transition testing API for Operator Framework charms."
 license.text = "Apache-2.0"


### PR DESCRIPTION
We've had issues with the reliability of the `charm-tech` launchpad email address, and we don't ever actually get any contact via it.

This PR therefore drops the `charm-tech@lists.launchpad.net` email address from `pyproject.toml` (and therefore PyPI) for both `ops` and `ops-scenario`. Both projects have links to the GitHub repositories where issues and PRs and security reports can be created, and it's also pretty clear from both repositories who is actively working on the projects and so if someone needs to be privately contacted, they can always go via the GitHub profile.

Note that our CoC has an address `charmcrafters@lists.launchpad.net` -- I'm assuming that still works and is the correct one to have (a private contact method in the CoC does make sense).