### PR TITLE
feat: port the venv hotfix for https://bugs.launchpad.net/juju/+bug/2058335

### DIFF
--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -187,6 +187,8 @@ __all__ = [  # noqa: RUF022 `__all__` is not sorted
 # isort:skip_file
 from typing import Optional, Type
 
+from . import _aaa_venv_workaround as _aaa_venv_workaround
+
 # Import pebble explicitly. It's the one module we don't import names from below.
 from . import pebble
 

--- a/ops/_aaa_venv_workaround.py
+++ b/ops/_aaa_venv_workaround.py
@@ -26,7 +26,10 @@ import shutil
 from collections import defaultdict
 from typing import Any
 
-from importlib_metadata import distributions  # type: ignore
+try:
+    from importlib.metadata import distributions
+except ImportError:
+    from importlib_metadata import distributions  # type: ignore
 
 logger = logging.getLogger(__name__)
 
@@ -50,8 +53,9 @@ def remove_stale_otel_sdk_packages() -> None:
     logger.debug('Applying _remove_stale_otel_sdk_packages patch on charm upgrade')
     # group by name all distributions starting with "opentelemetry_"
     otel_distributions: dict[str, list[Any]] = defaultdict(list)
-    for distribution in distributions():
-        name = distribution._normalized_name
+    for distribution in distributions():  # type: ignore
+        # it's already a string, but pyright can't grok that
+        name = str(distribution._normalized_name)  # type: ignore
         if name.startswith('opentelemetry_'):
             otel_distributions[name].append(distribution)
 

--- a/ops/_aaa_venv_workaround.py
+++ b/ops/_aaa_venv_workaround.py
@@ -1,0 +1,76 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+"""Workarounds for various Juju bugs.
+
+https://github.com/juju/charm/pull/435
+
+> It is important to note that this change will only ensure the proper cleanup of files
+> for charms that are newly deployed, as charms that are already deployed have their
+> manifests written to the manifest files on disk.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from collections import defaultdict
+from typing import Any
+
+from importlib_metadata import distributions  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+def remove_stale_otel_sdk_packages() -> None:
+    """Remove stale opentelemetry sdk packages from the charm's Python venv.
+
+    Charmcraft doesn't record empty directories in the charm (zip) file.
+    Juju creates directories on demand when a contained file is unpacked.
+    Juju removes what it has installed before the upgrade is unpacked.
+    Juju prior to 3.5.4 left unrecorded, stale directories.
+
+    See https://github.com/canonical/grafana-agent-operator/issues/146
+    and https://bugs.launchpad.net/juju/+bug/2058335
+
+    This only has an effect if executed on an upgrade-charm event.
+    """
+    if os.getenv('JUJU_DISPATCH_PATH') != 'hooks/upgrade-charm':
+        return
+
+    logger.debug('Applying _remove_stale_otel_sdk_packages patch on charm upgrade')
+    # group by name all distributions starting with "opentelemetry_"
+    otel_distributions: dict[str, list[Any]] = defaultdict(list)
+    for distribution in distributions():
+        name = distribution._normalized_name
+        if name.startswith('opentelemetry_'):
+            otel_distributions[name].append(distribution)
+
+    logger.debug(f'Found {len(otel_distributions)} opentelemetry distributions')
+
+    # If we have multiple distributions with the same name, remove any that have 0
+    # associated files
+    for name, distributions_ in otel_distributions.items():
+        if len(distributions_) <= 1:
+            continue
+
+        logger.debug(f'Package {name} has multiple ({len(distributions_)}) distributions.')
+        for distribution in distributions_:
+            if not distribution.files:  # Not None or empty list
+                path = distribution._path
+                logger.info(f'Removing empty distribution of {name} at {path}.')
+                shutil.rmtree(path)
+
+    logger.debug('Successfully applied _remove_stale_otel_sdk_packages patch. ')
+
+
+remove_stale_otel_sdk_packages()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 dependencies = [
     "PyYAML==6.*",
     "websocket-client==1.*",
+    "importlib-metadata; python_version < '3.10'",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
https://github.com/canonical/tempo-coordinator-k8s-operator/blame/42bd218789af89fb349f87a70267e6f52123c616/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py#L237-L252

Moved out from #1612 

Ref: https://bugs.launchpad.net/juju/+bug/2058335

⚠️ discussion needed if we want to adopt this fix ⚠️ 

### Why adopt it

There are deployed apps that cannot be upgraded to `ops[tracing]` without it.

The fix on the Juju side works at deploy time, meaning that a machine charm that was originally deployed with older Juju is still in a broken state. The Juju change doesn't fix those.

### Why not adopt it

K8s charms are not affected, because a new pod is provisioned on charm upgrade.

There's a command-line `juju exec` fix for deployed machine charms (ssh into charm, find empty dirs, nuke them).