### PR TITLE
docs: clarify how to use mounts in ops.testing.Container

### DIFF
--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -796,7 +796,7 @@ class Exec(_max_posargs(1)):
 
 @dataclasses.dataclass(frozen=True)
 class Mount(_max_posargs(0)):
-    """Maps local files to a :class:`Container` filesystem."""
+    """Maps a local path to a :class:`Container` filesystem."""
 
     location: str | pathlib.PurePosixPath
     """The location inside of the container."""

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -997,11 +997,11 @@ class Container(_max_posargs(1)):
             'bin': Mount(location='/bin', source=pathlib.Path('/path/to/local/bin')),
         }
 
-    The simulated container filesystem will have symlinks to `/path/to/local/foo.py` and
-    `/path/to/local/bin` at the specified locations.
+    When your charm runs, the simulated container filesystem will have symlinks to
+    ``/path/to/local/foo.py`` and ``/path/to/local/bin`` at the specified locations.
 
-    If you're testing charm code that uses :meth:`ops.pebble.push` to write files to the container
-    filesystem, make sure to specify *source* files/directories that can be safely modified.
+    If you're testing charm code that uses :meth:`ops.pebble.Client.push` to write files to the
+    container filesystem, make sure to specify source files/directories that can be safely modified.
     """
 
     execs: Iterable[Exec] = frozenset()

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1001,15 +1001,14 @@ class Container(_max_posargs(1)):
 
     For example, suppose you want to express that your container has:
 
-    * ``/home/foo/bar.py``
-    * ``/bin/bash``
-    * ``/bin/baz``
+    * A file ``/home/foo.py``
+    * A directory ``/bin``
 
-    this becomes::
+    This becomes::
 
         mounts = {
-            'foo': Mount('/home/foo', pathlib.Path('/path/to/local/dir/containing/bar/py/')),
-            'bin': Mount('/bin/', pathlib.Path('/path/to/local/dir/containing/bash/and/baz/')),
+            'foo': Mount('/home/foo.py', pathlib.Path('/path/to/local/foo.py')),
+            'bin': Mount('/bin', pathlib.Path('/path/to/local/bin')),
         }
     """
 

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1007,8 +1007,8 @@ class Container(_max_posargs(1)):
     This becomes::
 
         mounts = {
-            'foo': Mount('/home/foo.py', pathlib.Path('/path/to/local/foo.py')),
-            'bin': Mount('/bin', pathlib.Path('/path/to/local/bin')),
+            'foo': Mount(location='/home/foo.py', source=pathlib.Path('/path/to/local/foo.py')),
+            'bin': Mount(location='/bin', source=pathlib.Path('/path/to/local/bin')),
         }
     """
 

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -982,20 +982,6 @@ class Container(_max_posargs(1)):
     )
     """The current status of each Pebble service running in the container."""
 
-    # this is how you specify the contents of the filesystem: suppose you want to express that your
-    # container has:
-    # - /home/foo/bar.py
-    # - /bin/bash
-    # - /bin/baz
-    #
-    # this becomes:
-    # mounts = {
-    #     'foo': Mount(location='/home/foo/', source=Path('/path/to/local/dir/containing/bar/py/'))
-    #     'bin': Mount(location='/bin/', source=Path('/path/to/local/dir/containing/bash/and/baz/'))
-    # }
-    # when the charm runs `pebble.pull`, it will return .open() from one of those paths.
-    # when the charm pushes, it will either overwrite one of those paths (careful!) or it will
-    # create a tempfile and insert its path in the mock filesystem tree
     mounts: Mapping[str, Mount] = dataclasses.field(default_factory=dict)
     """Provides access to the contents of the simulated container filesystem.
 
@@ -1011,6 +997,9 @@ class Container(_max_posargs(1)):
             'bin': Mount(location='/bin', source=pathlib.Path('/path/to/local/bin')),
         }
     """
+    # when the charm runs `pebble.pull`, it will return .open() from one of those paths.
+    # when the charm pushes, it will either overwrite one of those paths (careful!) or it will
+    # create a tempfile and insert its path in the mock filesystem tree
 
     execs: Iterable[Exec] = frozenset()
     """Simulate executing commands in the container.

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -996,10 +996,13 @@ class Container(_max_posargs(1)):
             'foo': Mount(location='/home/foo.py', source=pathlib.Path('/path/to/local/foo.py')),
             'bin': Mount(location='/bin', source=pathlib.Path('/path/to/local/bin')),
         }
+
+    The simulated container filesystem will have symlinks to `/path/to/local/foo.py` and
+    `/path/to/local/bin` at the specified locations.
+
+    If you're testing charm code that uses :meth:`ops.pebble.push` to write files to the container
+    filesystem, make sure to specify *source* files/directories that can be safely modified.
     """
-    # when the charm runs `pebble.pull`, it will return .open() from one of those paths.
-    # when the charm pushes, it will either overwrite one of those paths (careful!) or it will
-    # create a tempfile and insert its path in the mock filesystem tree
 
     execs: Iterable[Exec] = frozenset()
     """Simulate executing commands in the container.


### PR DESCRIPTION
This PR fixes items 3 and 4 in https://github.com/canonical/operator/issues/1623. Changes:

- In the description of `ops.testing.Mount`, changed "file" to "path". I verified that files and directories can both be mounted.
- In the description of `mounts` in `ops.testing.Container`:
    - Simplified the example to show one file and one directory.
    - Added the missing `location` and `source` keywords.
    - Removed the part of the comment that duplicated the example in the docstring.

**[Preview build](https://ops--1637.org.readthedocs.build/en/1637/reference/ops-testing.html#ops.testing.Container.mounts)**

A couple of things I'm not 100% sure about:

- Is it worth wrapping the `source` args in `pathlib.Path`? `Mount()` accepts a string or a Path.
- Is it worth keeping the remaining part of the comment (with more details about pushing and pulling)?