### PR TITLE
docs: stack args vertically for long signature lines

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -292,6 +292,9 @@ autodoc_default_options = {
     'show-inheritance': None,
 }
 
+# This value stacks args vertically if a signature is too long.
+maximum_signature_line_length = 80
+
 # -- Options for sphinx.ext.intersphinx --------------------------------------
 
 # This config value contains the locations and names of other projects


### PR DESCRIPTION
This PR sets [maximum_signature_line_length](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-maximum_signature_line_length) to limit the length of signature lines. I've gone with 80 chars. If we want to squeeze out a few more chars, I think we'd be alright with 85 too. But even single-line long lines can be hard to read, so stacking at 80 seems good to me.

**[Preview build](https://ops--1641.org.readthedocs.build/en/1641/reference/ops.html)**