### PR TITLE
chore: fix integration ci

### DIFF
--- a/docs/explanation/testing.md
+++ b/docs/explanation/testing.md
@@ -181,11 +181,12 @@ Integration tests are a bit more complex, because these tests require a Juju con
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+          channel: 1.32-strict/stable
       - name: Run integration tests
         # Set a predictable model name so it can be consumed by charm-logdump-action
         run: tox -e integration -- --model testing


### PR DESCRIPTION
This PR adds a channel for microk8s for the test explanation doc in the CI section.

More information: when using the [charmed-kubernetes/actions-operator action](https://github.com/charmed-kubernetes/actions-operator) to setup an environment for integration test, with Juju 3.3+, microk8s needs a strict channel version. Without this setting, there will be an error like `juju "3.x.x" can only work with strictly confined microk8s`. See an [existing issue here](https://github.com/charmed-kubernetes/actions-operator/issues/70) and [an unmerged PR here](https://github.com/charmed-kubernetes/actions-operator/pull/57).

Related: https://github.com/canonical/juju-sdk-tutorial-k8s/pull/72.