### PR TITLE
docs: fix code snippet indentation

### DIFF
--- a/docs/explanation/holistic-vs-delta-charms.md
+++ b/docs/explanation/holistic-vs-delta-charms.md
@@ -32,9 +32,9 @@ class MyCharm(ops.CharmBase):
         # container's config file and restart Redis if needed.
         container = self.unit.get_container('redis')
         try:
-	        self._update_redis_config(container, redis_port)
-	    except ops.pebble.ConnectionError:
-	    	# config-changed happened first, wait for pebble-ready
+            self._update_redis_config(container, redis_port)
+        except ops.pebble.ConnectionError:
+            # config-changed happened first, wait for pebble-ready
             return
 ```
 


### PR DESCRIPTION
Fix indentation. It used a tab before, now everything is updated to spaces.

Before: https://ops.readthedocs.io/en/latest/explanation/holistic-vs-delta-charms.html

After: https://ops--1649.org.readthedocs.build/en/1649/explanation/holistic-vs-delta-charms.html