### PR TITLE
ci: exclude vault-k8s-operator until the system can handle monorepos

### DIFF
--- a/.github/update-published-charms-tests-workflow.py
+++ b/.github/update-published-charms-tests-workflow.py
@@ -55,6 +55,7 @@ SKIP = {
     'notebook-operators',
     'argo-operators',
     'k8s-operator',
+    'vault-k8s-operator',
     # Not ops.
     'charm-prometheus-libvirt-exporter',
     'juju-dashboard',

--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -59,7 +59,6 @@ jobs:
           - charm-repo: canonical/temporal-worker-k8s-operator
           - charm-repo: canonical/traefik-k8s-operator
           - charm-repo: canonical/trino-k8s-operator
-          - charm-repo: canonical/vault-k8s-operator
           - charm-repo: canonical/wordpress-k8s-operator
           - charm-repo: canonical/zookeeper-operator
     steps:


### PR DESCRIPTION
The vault-k8s-operator repository is now a monorepo with both machine and k8s charms. The published charms broad compatibility test workflow doesn't know how to handle repositories where there are multiple charms yet, so disable checking that charm until it does.