### PR TITLE
chore: bump ruff version to 0.11.2 and codespell version to 2.4.1

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1751,9 +1751,9 @@ class RelationMeta:
     VALID_SCOPES: ClassVar[List[str]] = ['global', 'container']
 
     def __init__(self, role: RelationRole, relation_name: str, raw: '_RelationMetaDict'):
-        assert isinstance(
-            role, RelationRole
-        ), f'role should be one of {list(RelationRole)!r}, not {role!r}'
+        assert isinstance(role, RelationRole), (
+            f'role should be one of {list(RelationRole)!r}, not {role!r}'
+        )
         self._default_scope = self.VALID_SCOPES[0]
         self.role = role
         self.relation_name = relation_name

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1752,7 +1752,7 @@ class RelationMeta:
 
     def __init__(self, role: RelationRole, relation_name: str, raw: '_RelationMetaDict'):
         assert isinstance(role, RelationRole), (
-            f'role should be one of {list(RelationRole)!r}, not {role!r}'
+            f'role should be one of {list(RelationRole)}, not {role!r}'
         )
         self._default_scope = self.VALID_SCOPES[0]
         self.role = role

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1613,15 +1613,15 @@ class CharmMeta:
     @staticmethod
     def from_charm_root(charm_root: Union[pathlib.Path, str]):
         """Initialise CharmMeta from the path to a charm repository root folder."""
-        _charm_root = pathlib.Path(charm_root)
-        metadata_path = _charm_root / 'metadata.yaml'
+        charm_root = pathlib.Path(charm_root)
+        metadata_path = charm_root / 'metadata.yaml'
 
         with metadata_path.open() as f:
             meta = yaml.safe_load(f.read())
 
         actions = None
 
-        actions_path = _charm_root / 'actions.yaml'
+        actions_path = charm_root / 'actions.yaml'
         if actions_path.exists():
             with actions_path.open() as f:
                 actions = yaml.safe_load(f.read())

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1627,7 +1627,7 @@ class CharmMeta:
                 actions = yaml.safe_load(f.read())
 
         options = None
-        config_path = _charm_root / 'config.yaml'
+        config_path = charm_root / 'config.yaml'
         if config_path.exists():
             with config_path.open() as f:
                 options = yaml.safe_load(f.read())

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -811,9 +811,9 @@ class Framework(Object):
 
         method_name = observer.__name__
 
-        assert isinstance(
-            observer.__self__, Object
-        ), "can't register observers that aren't `Object`s"
+        assert isinstance(observer.__self__, Object), (
+            "can't register observers that aren't `Object`s"
+        )
         observer_obj = observer.__self__
 
         # Validate that the method has an acceptable call signature.

--- a/ops/model.py
+++ b/ops/model.py
@@ -3996,7 +3996,7 @@ class _ModelBackendValidator:
         if not value:
             raise ModelError(f'metric label {label} has an empty value, which is not allowed')
         v = str(value)
-        if re.search('[,=]', v) is not None:
+        if re.search(r'[,=]', v) is not None:
             raise ModelError(f'metric label values must not contain "," or "=": {label}={value!r}')
 
 

--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -156,9 +156,9 @@ class Charm(ops.CharmBase):
         self._stored.db_relation_joined_data = event.snapshot()
 
     def _on_mon_relation_changed(self, event: ops.RelationChangedEvent):
-        assert (
-            event.app is not None
-        ), 'application name cannot be None for a relation-changed event'
+        assert event.app is not None, (
+            'application name cannot be None for a relation-changed event'
+        )
         if os.environ.get('JUJU_REMOTE_UNIT'):
             assert event.unit is not None, (
                 'a unit name cannot be None for a relation-changed event'
@@ -171,9 +171,9 @@ class Charm(ops.CharmBase):
         self._stored.mon_relation_changed_data = event.snapshot()
 
     def _on_mon_relation_departed(self, event: ops.RelationDepartedEvent):
-        assert (
-            event.app is not None
-        ), 'application name cannot be None for a relation-departed event'
+        assert event.app is not None, (
+            'application name cannot be None for a relation-departed event'
+        )
         assert event.relation.active, 'a departed relation is still active'
         assert self.model.relations['mon']
         self._stored.on_mon_relation_departed.append(type(event).__name__)
@@ -181,12 +181,12 @@ class Charm(ops.CharmBase):
         self._stored.mon_relation_departed_data = event.snapshot()
 
     def _on_ha_relation_broken(self, event: ops.RelationBrokenEvent):
-        assert (
-            event.app is None
-        ), 'relation-broken events cannot have a reference to a remote application'
-        assert (
-            event.unit is None
-        ), 'relation broken events cannot have a reference to a remote unit'
+        assert event.app is None, (
+            'relation-broken events cannot have a reference to a remote application'
+        )
+        assert event.unit is None, (
+            'relation broken events cannot have a reference to a remote unit'
+        )
         assert not event.relation.active, 'relation broken events always have a broken relation'
         assert not self.model.relations['ha']
         self._stored.on_ha_relation_broken.append(type(event).__name__)
@@ -221,17 +221,17 @@ class Charm(ops.CharmBase):
         self._stored.test_pebble_check_recovered_data = event.snapshot()
 
     def _on_start_action(self, event: ops.ActionEvent):
-        assert (
-            event.handle.kind == 'start_action'
-        ), 'event action name cannot be different from the one being handled'
+        assert event.handle.kind == 'start_action', (
+            'event action name cannot be different from the one being handled'
+        )
         self._stored.on_start_action.append(type(event).__name__)
         self._stored.observed_event_types.append(type(event).__name__)
 
     def _on_secret_changed(self, event: ops.SecretChangedEvent):
         # subprocess and isinstance don't mix well
-        assert (
-            type(event.secret).__name__ == 'Secret'
-        ), f'SecretEvent.secret must be a Secret instance, not {type(event.secret)}'
+        assert type(event.secret).__name__ == 'Secret', (
+            f'SecretEvent.secret must be a Secret instance, not {type(event.secret)}'
+        )
         assert event.secret.id, 'secret must have an ID'
         self._stored.on_secret_changed.append(type(event).__name__)
         self._stored.observed_event_types.append(type(event).__name__)
@@ -239,9 +239,9 @@ class Charm(ops.CharmBase):
 
     def _on_secret_remove(self, event: ops.SecretRemoveEvent):
         # subprocess and isinstance don't mix well
-        assert (
-            type(event.secret).__name__ == 'Secret'
-        ), f'SecretEvent.secret must be a Secret instance, not {type(event.secret)}'
+        assert type(event.secret).__name__ == 'Secret', (
+            f'SecretEvent.secret must be a Secret instance, not {type(event.secret)}'
+        )
         assert event.secret.id, 'secret must have an ID'
         self._stored.on_secret_remove.append(type(event).__name__)
         self._stored.observed_event_types.append(type(event).__name__)
@@ -249,9 +249,9 @@ class Charm(ops.CharmBase):
 
     def _on_secret_rotate(self, event: ops.SecretRotateEvent):
         # subprocess and isinstance don't mix well
-        assert (
-            type(event.secret).__name__ == 'Secret'
-        ), f'SecretEvent.secret must be a Secret instance, not {type(event.secret)}'
+        assert type(event.secret).__name__ == 'Secret', (
+            f'SecretEvent.secret must be a Secret instance, not {type(event.secret)}'
+        )
         assert event.secret.id, 'secret must have an ID'
         self._stored.on_secret_rotate.append(type(event).__name__)
         self._stored.observed_event_types.append(type(event).__name__)
@@ -259,18 +259,18 @@ class Charm(ops.CharmBase):
 
     def _on_secret_expired(self, event: ops.SecretExpiredEvent):
         # subprocess and isinstance don't mix well
-        assert (
-            type(event.secret).__name__ == 'Secret'
-        ), f'SecretEvent.secret must be a Secret instance, not {type(event.secret)}'
+        assert type(event.secret).__name__ == 'Secret', (
+            f'SecretEvent.secret must be a Secret instance, not {type(event.secret)}'
+        )
         assert event.secret.id, 'secret must have an ID'
         self._stored.on_secret_expired.append(type(event).__name__)
         self._stored.observed_event_types.append(type(event).__name__)
         self._stored.secret_expired_data = event.snapshot()
 
     def _on_foo_bar_action(self, event: ops.ActionEvent):
-        assert (
-            event.handle.kind == 'foo_bar_action'
-        ), 'event action name cannot be different from the one being handled'
+        assert event.handle.kind == 'foo_bar_action', (
+            'event action name cannot be different from the one being handled'
+        )
         self._stored.on_foo_bar_action.append(type(event).__name__)
         self._stored.observed_event_types.append(type(event).__name__)
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -229,7 +229,7 @@ class TestFramework:
         framework.observe(pub.foo, obs.on_any)
         framework.observe(pub.bar, obs.on_any)
 
-        with pytest.raises(TypeError, match='^Framework.observe requires a method'):
+        with pytest.raises(TypeError, match=r'^Framework\.observe requires a method'):
             framework.observe(pub.baz, obs)  # type: ignore
 
         pub.foo.emit()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1046,7 +1046,7 @@ class TestMainWithNoDispatch(_TestMain):
     ):
         """Test auto-creation of symlinks caused by initial events."""
         all_event_hooks = [
-            f"hooks/{name.replace('_', '-')}"
+            f'hooks/{name.replace("_", "-")}'
             for name, event_source in self.charm_module.Charm.on.events().items()
             if issubclass(event_source.event_type, (ops.CommitEvent, ops.PreCommitEvent))
         ]
@@ -1138,7 +1138,7 @@ class _TestMainWithDispatch(_TestMain):
         Symlink creation caused by initial events should _not_ happen when using dispatch.
         """
         all_event_hooks = [
-            f"hooks/{e.replace('_', '-')}" for e in self.charm_module.Charm.on.events()
+            f'hooks/{e.replace("_", "-")}' for e in self.charm_module.Charm.on.events()
         ]
         initial_events = {
             EventSpec(ops.InstallEvent, 'install'),
@@ -1150,9 +1150,9 @@ class _TestMainWithDispatch(_TestMain):
         def _assess_event_links(event_spec: EventSpec):
             assert self.hooks_dir / event_spec.event_name not in self.hooks_dir.iterdir()
             for event_hook in all_event_hooks:
-                assert not (
-                    self.JUJU_CHARM_DIR / event_hook
-                ).exists(), f'Spurious hook: {event_hook}'
+                assert not (self.JUJU_CHARM_DIR / event_hook).exists(), (
+                    f'Spurious hook: {event_hook}'
+                )
 
         for initial_event in initial_events:
             self._setup_charm_dir(request)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -24,6 +24,7 @@ import sys
 import tempfile
 import typing
 import warnings
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import patch
 
@@ -56,44 +57,25 @@ class SymlinkTargetError(Exception):
     pass
 
 
+@dataclass
 class EventSpec:
-    def __init__(
-        self,
-        event_type: typing.Type[ops.EventBase],
-        event_name: str,
-        env_var: typing.Optional[str] = None,
-        relation_id: typing.Optional[int] = None,
-        remote_app: typing.Optional[str] = None,
-        remote_unit: typing.Optional[str] = None,
-        model_name: typing.Optional[str] = None,
-        set_in_env: typing.Optional[typing.Dict[str, str]] = None,
-        workload_name: typing.Optional[str] = None,
-        notice_id: typing.Optional[str] = None,
-        notice_type: typing.Optional[str] = None,
-        notice_key: typing.Optional[str] = None,
-        departing_unit_name: typing.Optional[str] = None,
-        secret_id: typing.Optional[str] = None,
-        secret_label: typing.Optional[str] = None,
-        secret_revision: typing.Optional[str] = None,
-        check_name: typing.Optional[str] = None,
-    ):
-        self.event_type = event_type
-        self.event_name = event_name
-        self.env_var = env_var
-        self.relation_id = relation_id
-        self.remote_app = remote_app
-        self.remote_unit = remote_unit
-        self.departing_unit_name = departing_unit_name
-        self.model_name = model_name
-        self.set_in_env = set_in_env
-        self.workload_name = workload_name
-        self.notice_id = notice_id
-        self.notice_type = notice_type
-        self.notice_key = notice_key
-        self.secret_id = secret_id
-        self.secret_label = secret_label
-        self.secret_revision = secret_revision
-        self.check_name = check_name
+    event_type: typing.Type[ops.EventBase]
+    event_name: str
+    env_var: typing.Optional[str] = None
+    relation_id: typing.Optional[int] = None
+    remote_app: typing.Optional[str] = None
+    remote_unit: typing.Optional[str] = None
+    model_name: typing.Optional[str] = None
+    set_in_env: typing.Optional[typing.Dict[str, str]] = None
+    workload_name: typing.Optional[str] = None
+    notice_id: typing.Optional[str] = None
+    notice_type: typing.Optional[str] = None
+    notice_key: typing.Optional[str] = None
+    departing_unit_name: typing.Optional[str] = None
+    secret_id: typing.Optional[str] = None
+    secret_label: typing.Optional[str] = None
+    secret_revision: typing.Optional[str] = None
+    check_name: typing.Optional[str] = None
 
 
 @patch('ops._main.setup_root_logging', new=lambda *a, **kw: None)  # type: ignore

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -57,7 +57,7 @@ class SymlinkTargetError(Exception):
     pass
 
 
-@dataclass
+@dataclass(frozen=True)
 class EventSpec:
     event_type: typing.Type[ops.EventBase]
     event_name: str

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -165,7 +165,7 @@ class TestCharmInit:
             juju_backend_available.return_value = False
             with pytest.raises(
                 RuntimeError,
-                match='charm set use_juju_for_storage=True, but Juju .* does not support it',
+                match=r'charm set use_juju_for_storage=True, but Juju .* does not support it',
             ):
                 self._check(ops.CharmBase, use_juju_for_storage=True)
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -915,11 +915,11 @@ class _TestMain(abc.ABC):
         assert 'Using local storage: not a Kubernetes podspec charm' in calls.pop(0)
         assert 'Initializing SQLite local storage: ' in calls.pop(0)
         assert re.search(
-            '(?ms)juju-log --log-level ERROR -- Uncaught exception while in charm code:\n'
-            'Traceback .most recent call last.:\n'
-            '  .*'
-            "    raise RuntimeError.'failing as requested'.\n"
-            'RuntimeError: failing as requested',
+            r'(?ms)juju-log --log-level ERROR -- Uncaught exception while in charm code:\n'
+            r'Traceback .most recent call last.:\n'
+            r'  .*'
+            r"    raise RuntimeError.'failing as requested'.\n"
+            r'RuntimeError: failing as requested',
             calls[0],
         )
         assert len(calls) == 1, f'expected 1 call, but got extra: {calls[1:]}'

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import abc
+import dataclasses
 import importlib.util
 import io
 import logging
@@ -24,7 +25,6 @@ import sys
 import tempfile
 import typing
 import warnings
-import dataclasses
 from pathlib import Path
 from unittest.mock import patch
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -912,8 +912,8 @@ class _TestMain(abc.ABC):
         calls = [' '.join(i) for i in fake_script.calls()]
 
         assert calls.pop(0) == ' '.join(VERSION_LOGLINE)
-        assert re.search('Using local storage: not a Kubernetes podspec charm', calls.pop(0))
-        assert re.search('Initializing SQLite local storage: ', calls.pop(0))
+        assert 'Using local storage: not a Kubernetes podspec charm' in calls.pop(0)
+        assert 'Initializing SQLite local storage: ' in calls.pop(0)
         assert re.search(
             '(?ms)juju-log --log-level ERROR -- Uncaught exception while in charm code:\n'
             'Traceback .most recent call last.:\n'
@@ -1191,7 +1191,7 @@ class _TestMainWithDispatch(_TestMain):
             ['is-leader', '--format=json'],
         ]
         calls = fake_script.calls()
-        assert re.search('Initializing SQLite local storage: ', ' '.join(calls.pop(-3)))
+        assert 'Initializing SQLite local storage: ' in ' '.join(calls.pop(-3))
         assert calls == expected
 
     @pytest.mark.usefixtures('setup_charm')
@@ -1222,7 +1222,7 @@ class _TestMainWithDispatch(_TestMain):
             ['is-leader', '--format=json'],
         ]
         calls = fake_script.calls()
-        assert re.search('Initializing SQLite local storage: ', ' '.join(calls.pop(-3)))
+        assert 'Initializing SQLite local storage: ' in ' '.join(calls.pop(-3))
         assert calls == expected
 
     @pytest.mark.usefixtures('setup_charm')
@@ -1313,7 +1313,7 @@ class _TestMainWithDispatch(_TestMain):
             ['is-leader', '--format=json'],
         ]
         calls = fake_script.calls()
-        assert re.search('Initializing SQLite local storage: ', ' '.join(calls.pop(-3)))
+        assert 'Initializing SQLite local storage: ' in ' '.join(calls.pop(-3))
 
         assert calls == expected
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -24,7 +24,7 @@ import sys
 import tempfile
 import typing
 import warnings
-from dataclasses import dataclass
+import dataclasses
 from pathlib import Path
 from unittest.mock import patch
 
@@ -57,7 +57,7 @@ class SymlinkTargetError(Exception):
     pass
 
 
-@dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True)
 class EventSpec:
     event_type: typing.Type[ops.EventBase]
     event_name: str

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -2115,7 +2115,7 @@ containers:
         with caplog.at_level(level='DEBUG', logger='ops'):
             assert not container.can_connect()
         assert len(caplog.records) == 1
-        assert re.search(r'connection error!', caplog.text)
+        assert 'connection error!' in caplog.text
 
     def test_can_connect_file_not_found_error(
         self,
@@ -2129,7 +2129,7 @@ containers:
         with caplog.at_level(level='DEBUG', logger='ops'):
             assert not container.can_connect()
         assert len(caplog.records) == 1
-        assert re.search(r'file not found!', caplog.text)
+        assert 'file not found!' in caplog.text
 
     def test_can_connect_api_error(
         self,
@@ -2143,7 +2143,7 @@ containers:
         with caplog.at_level(level='WARNING', logger='ops'):
             assert not container.can_connect()
         assert len(caplog.records) == 1
-        assert re.search(r'api error!', caplog.text)
+        assert 'api error!' in caplog.text
 
     def test_exec(self, container: ops.Container, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr(container, '_juju_version', JujuVersion('3.1.6'))

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -2856,7 +2856,7 @@ class TestModelBackend:
         monkeypatch.setattr(
             self.backend, '_juju_context', _JujuContext.from_dict({'JUJU_VERSION': '2.6.9'})
         )
-        with pytest.raises(RuntimeError, match='not supported on Juju version 2.6.9'):
+        with pytest.raises(RuntimeError, match=r'not supported on Juju version 2\.6\.9'):
             self.backend.relation_get(1, 'foo/0', is_app=True)
         assert fake_script.calls() == []
 
@@ -2893,7 +2893,7 @@ class TestModelBackend:
         monkeypatch.setattr(
             self.backend, '_juju_context', _JujuContext.from_dict({'JUJU_VERSION': '2.6.9'})
         )
-        with pytest.raises(RuntimeError, match='not supported on Juju version 2.6.9'):
+        with pytest.raises(RuntimeError, match=r'not supported on Juju version 2\.6\.9'):
             self.backend.relation_set(1, {'foo': 'bar'}, is_app=True)
         assert fake_script.calls() == []
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1450,9 +1450,9 @@ def test_recursive_push_and_pull(case: PushPullCase):
             raise
         errors = {src[len(push_src.name) :] for src, _ in err.errors}
 
-    assert (
-        case.errors == errors
-    ), f'push_path gave wrong expected errors: want {case.errors}, got {errors}'
+    assert case.errors == errors, (
+        f'push_path gave wrong expected errors: want {case.errors}, got {errors}'
+    )
     for fpath in case.want:
         assert c.exists(fpath), f'push_path failed: file {fpath} missing at destination'
         content = c.pull(fpath, encoding=None).read()
@@ -1477,9 +1477,9 @@ def test_recursive_push_and_pull(case: PushPullCase):
             raise
         errors = {src for src, _ in err.errors}
 
-    assert (
-        case.errors == errors
-    ), f'pull_path gave wrong expected errors: want {case.errors}, got {errors}'
+    assert case.errors == errors, (
+        f'pull_path gave wrong expected errors: want {case.errors}, got {errors}'
+    )
     for fpath in case.want:
         assert c.exists(fpath), f'pull_path failed: file {fpath} missing at destination'
     for fdir in case.want_dirs:

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -24,6 +24,7 @@ import typing
 import unittest
 import unittest.mock
 import unittest.util
+from dataclasses import dataclass
 
 import pytest
 import websocket
@@ -1471,26 +1472,16 @@ def build_mock_change_dict(change_id: str = '70') -> 'pebble._ChangeDict':
     }
 
 
+@dataclass
 class MultipartParserTestCase:
-    def __init__(
-        self,
-        name: str,
-        data: bytes,
-        want_headers: typing.List[bytes],
-        want_bodies: typing.List[bytes],
-        want_bodies_done: typing.List[bool],
-        max_boundary: int = 14,
-        max_lookahead: int = 8 * 1024,
-        error: str = '',
-    ):
-        self.name = name
-        self.data = data
-        self.want_headers = want_headers
-        self.want_bodies = want_bodies
-        self.want_bodies_done = want_bodies_done
-        self.max_boundary = max_boundary
-        self.max_lookahead = max_lookahead
-        self.error = error
+    name: str
+    data: bytes
+    want_headers: typing.List[bytes]
+    want_bodies: typing.List[bytes]
+    want_bodies_done: typing.List[bool]
+    max_boundary: int = 14
+    max_lookahead: int = 8 * 1024
+    error: str = ''
 
 
 class TestMultipartParser:

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import datetime
 import email.message
 import email.parser
@@ -24,7 +25,6 @@ import typing
 import unittest
 import unittest.mock
 import unittest.util
-import dataclasses
 
 import pytest
 import websocket

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -1472,7 +1472,7 @@ def build_mock_change_dict(change_id: str = '70') -> 'pebble._ChangeDict':
     }
 
 
-@dataclass
+@dataclass(frozen=True)
 class MultipartParserTestCase:
     name: str
     data: bytes

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -24,7 +24,7 @@ import typing
 import unittest
 import unittest.mock
 import unittest.util
-from dataclasses import dataclass
+import dataclasses
 
 import pytest
 import websocket
@@ -1472,7 +1472,7 @@ def build_mock_change_dict(change_id: str = '70') -> 'pebble._ChangeDict':
     }
 
 
-@dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True)
 class MultipartParserTestCase:
     name: str
     data: bytes

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1726,9 +1726,9 @@ class TestHarness:
 
         harness.add_storage('test')
         harness.begin()
-        assert (
-            len(harness.model.storages['test']) == 0
-        ), 'storage should start in detached state and be excluded from storage listing'
+        assert len(harness.model.storages['test']) == 0, (
+            'storage should start in detached state and be excluded from storage listing'
+        )
 
     def test_add_storage_without_metadata_key_fails(self, request: pytest.FixtureRequest):
         harness = ops.testing.Harness(
@@ -3809,9 +3809,9 @@ class TestTestingModelBackend:
         assert backend._resource_dir is None
         path = backend.resource_get('image')
         assert backend._resource_dir is not None
-        assert str(path).startswith(
-            str(backend._resource_dir.name)
-        ), f'expected {path} to be a subdirectory of {backend._resource_dir.name}'
+        assert str(path).startswith(str(backend._resource_dir.name)), (
+            f'expected {path} to be a subdirectory of {backend._resource_dir.name}'
+        )
 
     def test_resource_get_no_resource(self, request: pytest.FixtureRequest):
         harness = ops.testing.Harness(

--- a/tox.ini
+++ b/tox.ini
@@ -63,15 +63,15 @@ commands =
 [testenv:fmt]
 description = Apply coding style standards to code
 deps =
-    ruff==0.7.0
+    ruff==0.11.2
 commands =
     ruff format --preview
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    ruff==0.7.0
-    codespell==2.3.0
+    ruff==0.11.2
+    codespell==2.4.1
 commands =
     ruff check --preview
     ruff format --preview --check


### PR DESCRIPTION
This PR bumps the ruff and codespell versions to their latest releases, and makes the changes recommended by ruff.