### PR TITLE
ci: post-release versioning, release process update + workflow fix

### DIFF
--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -40,7 +40,6 @@ jobs:
             sed -i -e "/^ops-scenario[ ><=]/d" -e "/^ops\[testing\][ ><=]/d" requirements.txt
             echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops-scenario&subdirectory=testing" >> requirements.txt
           elif [ -e "uv.lock" ]; then
-            set -vex
             uv remove ops --optional dev --frozen || echo "maybe ops[testing] is not a dev dependency"
             uv remove ops-scenario --optional dev --frozen || echo "maybe ops-scenario is not a dev dependency"
             uv remove ops --frozen

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -40,8 +40,12 @@ jobs:
             sed -i -e "/^ops-scenario[ ><=]/d" -e "/^ops\[testing\][ ><=]/d" requirements.txt
             echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops-scenario&subdirectory=testing" >> requirements.txt
           elif [ -e "uv.lock" ]; then
-            uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA --raw-sources
-            uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#subdirectory=testing --raw-sources
+            set -vex
+            uv remove ops --optional dev --frozen || echo "maybe ops[testing] is not a dev dependency"
+            uv remove ops-scenario --optional dev --frozen || echo "maybe ops-scenario is not a dev dependency"
+            uv remove ops --frozen
+            uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA --raw-sources --prerelease=allow
+            uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#subdirectory=testing --optional dev --raw-sources --prerelease=allow
           else
             echo "Error: no requirements.txt or uv.lock file found"
             exit 1

--- a/.github/workflows/publish-ops-scenario.yaml
+++ b/.github/workflows/publish-ops-scenario.yaml
@@ -7,8 +7,8 @@ on:
 jobs:
   framework-tests:
     uses: ./.github/workflows/framework-tests.yaml
-  # observability-charm-tests:  # TODO: re-enable when we update to work with lockstep releases
-  #   uses: ./.github/workflows/observability-charm-tests.yaml
+  observability-charm-tests:
+    uses: ./.github/workflows/observability-charm-tests.yaml
   hello-charm-tests:
     uses: ./.github/workflows/hello-charm-tests.yaml
   build-n-publish:
@@ -18,11 +18,7 @@ jobs:
       id-token: write
       attestations: write
       contents: read
-    needs: [
-      framework-tests,
-      # observability-charm-tests,  # TODO: re-enable when we update to work with lockstep releases
-      hello-charm-tests,
-    ]
+    needs: [framework-tests, observability-charm-tests, hello-charm-tests]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/publish-ops-scenario.yaml
+++ b/.github/workflows/publish-ops-scenario.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   framework-tests:
     uses: ./.github/workflows/framework-tests.yaml
-  # observability-charm-tests:
+  # observability-charm-tests:  # TODO: re-enable when we update to work with lockstep releases
   #   uses: ./.github/workflows/observability-charm-tests.yaml
   hello-charm-tests:
     uses: ./.github/workflows/hello-charm-tests.yaml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     needs: [
       framework-tests,
-      # observability-charm-tests,
+      # observability-charm-tests,  # TODO: re-enable when we update to work with lockstep releases
       hello-charm-tests,
     ]
     steps:

--- a/.github/workflows/publish-ops.yaml
+++ b/.github/workflows/publish-ops.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   framework-tests:
     uses: ./.github/workflows/framework-tests.yaml
-  # observability-charm-tests:
+  # observability-charm-tests:  # TODO: re-enable when we update to work with lockstep releases
   #   uses: ./.github/workflows/observability-charm-tests.yaml
   hello-charm-tests:
     uses: ./.github/workflows/hello-charm-tests.yaml
@@ -24,7 +24,7 @@ jobs:
       contents: read
     needs: [
       framework-tests,
-      # observability-charm-tests,
+      # observability-charm-tests,  # TODO: re-enable when we update to work with lockstep releases
       hello-charm-tests,
     ]
     steps:

--- a/.github/workflows/publish-ops.yaml
+++ b/.github/workflows/publish-ops.yaml
@@ -11,8 +11,8 @@ on:
 jobs:
   framework-tests:
     uses: ./.github/workflows/framework-tests.yaml
-  # observability-charm-tests:  # TODO: re-enable when we update to work with lockstep releases
-  #   uses: ./.github/workflows/observability-charm-tests.yaml
+  observability-charm-tests:
+    uses: ./.github/workflows/observability-charm-tests.yaml
   hello-charm-tests:
     uses: ./.github/workflows/hello-charm-tests.yaml
   build-n-publish:
@@ -22,11 +22,7 @@ jobs:
       id-token: write
       attestations: write
       contents: read
-    needs: [
-      framework-tests,
-      # observability-charm-tests,  # TODO: re-enable when we update to work with lockstep releases
-      hello-charm-tests,
-    ]
+    needs: [framework-tests, observability-charm-tests, hello-charm-tests]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/HACKING.md
+++ b/HACKING.md
@@ -401,8 +401,7 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
    next version, with ".dev0" appended (for example, if 3.14.1 is the next
    expected version, use `'3.14.1.dev0'`).
    In this PR, also update the requirements in the respective pyproject.toml files
-   to be >= the latest release rather than == the latest release, to allow the development
-   versions to be used during our tests.
+   to be == the new development versions, to allow these versions to be used during our tests.
 
 ## Release Documentation
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -397,12 +397,11 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
 
 16. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com).
 
-17. Open a PR to change the version strings to the expected
-   next version, with ".dev0" appended (for example, if 3.14.1 is the next
-   expected version, use `'3.14.1.dev0'`).
-   In this PR, also update the requirements in the respective pyproject.toml files
-   to be ~= the latest release versions, to allow the development versions to be used
-   during our tests.
+17. Open a PR to change the version strings to the expected next version, with ".dev0" appended
+    (for example, if 3.14.0 is the next expected version, use `'3.14.0.dev0'`).
+   In this PR, also update the requirements in the respective pyproject.toml files to be >= the
+   latest release versions, to allow the development versions to be used during our tests.
+   Also cap these to be less than the next major just in case (for example `ops>=3.14,<4`).
 
 ## Release Documentation
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -401,7 +401,8 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
    next version, with ".dev0" appended (for example, if 3.14.1 is the next
    expected version, use `'3.14.1.dev0'`).
    In this PR, also update the requirements in the respective pyproject.toml files
-   to be == the new development versions, to allow these versions to be used during our tests.
+   to be ~= the latest release versions, to allow the development versions to be used
+   during our tests.
 
 ## Release Documentation
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -398,10 +398,10 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
 16. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com).
 
 17. Open a PR to change the version strings to the expected next version, with ".dev0" appended
-    (for example, if 3.14.0 is the next expected version, use `'3.14.0.dev0'`).
+   (for example, if 3.14.0 is the next expected version, use `'3.14.0.dev0'`).
    In this PR, also update the requirements in the respective pyproject.toml files to be >= the
    latest release versions, to allow the development versions to be used during our tests.
-   Also cap these to be less than the next major just in case (for example `ops>=3.14,<4`).
+   Also cap these to be less than the next major just in case (for example `ops>=3.14.0,<4`).
 
 ## Release Documentation
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -349,16 +349,12 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
    charms and ops get tested.
 2. Visit the [releases page on GitHub](https://github.com/canonical/operator/releases).
 3. Click "Draft a new release"
-4. The "Release Title" is the full version numbers of ops and/or ops-scenario,
+4. The "Release Title" is the full version numbers of ops and ops-scenario,
    in the form `ops <major>.<minor>.<patch> and ops-scenario <major>.<minor>.<patch>`
    and a brief summary of the main changes in the release.
    For example: `2.3.12 Bug fixes for the Juju foobar feature when using Python 3.12`
-5. Have the release create a new tag, in the form `<major>.<minor>.<patch>` for
-   `ops` and `scenario-<major>.<minor>.<patch>` for `ops-scenario`. If releasing
-   both packages, use the ops tag.
-6. If the last release was for both `ops` and `ops-scenario`, leave the previous
-   tag choice on `auto`. If the last release was for only one package, change
-   the previous tag to be the last time the same package(s) were being released.
+5. Have the release create a new tag, in the form `<major>.<minor>.<patch>` for `ops`.
+6. Leave the previous tag choice on `auto`.
 7. Use the "Generate Release Notes" button to get a copy of the changes into the
    notes field.
 8. Format the auto-generated release notes according to the 'Release Documentation'
@@ -368,20 +364,24 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
    and add it to `CHANGES.md`.
 10. For `ops`, change [version.py](ops/version.py)'s `version` to the
    appropriate string. For `ops-scenario`, change the version in
-   [testing/pyproject.toml](testing/pyproject.toml). Both packages use
-   [semantic versioning](https://semver.org/), and adjust independently
-   (that is: ops 2.18 doesn't imply ops-scenario 2.18, or any other number).
-11. Run `uvx -p 3.11 tox -e docs-deps` to recompile the `requirements.txt` file
+   [testing/pyproject.toml](testing/pyproject.toml). We use both
+   [semantic versioning](https://semver.org/) and lockstep releases, so if
+   one library requires a major or minor version bump, the other will too.
+   The minor and patch versions should therefore be identical.
+11. Bump the `ops-scenario` version required by `ops[testing]` in [pyproject.toml](pyproject.toml)
+    to the new `ops-scenario` version being released. Bump the version of `ops` required by
+    `ops-scenario` in [testing/pyproject.toml](testing/pyproject.toml) to the new `ops` verrsion
+    being released.
+12. Run `uvx -p 3.11 tox -e docs-deps` to recompile the `requirements.txt` file
    used for docs (in case dependencies have been updated in `pyproject.toml`)
    using the same Python version as specified in the `.readthedocs.yaml` file.
-12. Add, commit, and push, and open a PR to get the `CHANGES.md` update, version bumps,
+13. Add, commit, and push, and open a PR to get the `CHANGES.md` update, version bumps,
    and doc requirement bumps into main (and get it merged).
-13. If the release includes both `ops` and `ops-scenario` packages, then push a
-   new tag in the form `scenario-<major>.<minor>.<patch>`. This is done by
+14. Push a new tag in the form `scenario-<major>.<minor>.<patch>`. This is done by
    executing `git tag scenario-x.y.z`, then `git push upstream tag scenario-x.y.z` locally
    (assuming you have configured `canonical/operator` as a remote named
    `upstream`).
-14. When you are ready, click "Publish". GitHub will create the additional tag.
+15. When you are ready, click "Publish". GitHub will create the additional tag.
 
     Pushing the tags will trigger automatic builds for the Python packages and
     publish them to PyPI ([ops](https://pypi.org/project/ops/) and
@@ -395,9 +395,9 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
 
     You can troubleshoot errors on the [Actions Tab](https://github.com/canonical/operator/actions).
 
-15. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com).
+16. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com).
 
-16. Open a PR to change the version strings to the expected
+17. Open a PR to change the version strings to the expected
    next version, with ".dev0" appended (for example, if 3.14.1 is the next
    expected version, use `'3.14.1.dev0'`).
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -369,8 +369,8 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
    one library requires a major or minor version bump, the other will too.
    The minor and patch versions should therefore be identical.
 11. Bump the `ops-scenario` version required by `ops[testing]` in [pyproject.toml](pyproject.toml)
-    to the new `ops-scenario` version being released. Bump the version of `ops` required by
-    `ops-scenario` in [testing/pyproject.toml](testing/pyproject.toml) to the new `ops` verrsion
+    to == the new `ops-scenario` version being released. Bump the version of `ops` required by
+    `ops-scenario` in [testing/pyproject.toml](testing/pyproject.toml) to == the new `ops` version
     being released.
 12. Run `uvx -p 3.11 tox -e docs-deps` to recompile the `requirements.txt` file
    used for docs (in case dependencies have been updated in `pyproject.toml`)
@@ -400,6 +400,9 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
 17. Open a PR to change the version strings to the expected
    next version, with ".dev0" appended (for example, if 3.14.1 is the next
    expected version, use `'3.14.1.dev0'`).
+   In this PR, also update the requirements in the respective pyproject.toml files
+   to be >= the latest release rather than == the latest release, to allow the development
+   versions to be used during our tests.
 
 ## Release Documentation
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -366,7 +366,7 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
    appropriate string. For `ops-scenario`, change the version in
    [testing/pyproject.toml](testing/pyproject.toml). We use both
    [semantic versioning](https://semver.org/) and lockstep releases, so if
-   one library requires a major or minor version bump, the other will too.
+   one library requires a version bump, the other will too.
    The minor and patch versions should therefore be identical.
 11. Bump the `ops-scenario` version required by `ops[testing]` in [pyproject.toml](pyproject.toml)
     to == the new `ops-scenario` version being released. Bump the version of `ops` required by
@@ -398,10 +398,9 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
 16. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com).
 
 17. Open a PR to change the version strings to the expected next version, with ".dev0" appended
-   (for example, if 3.14.0 is the next expected version, use `'3.14.0.dev0'`).
-   In this PR, also update the requirements in the respective pyproject.toml files to be >= the
-   latest release versions, to allow the development versions to be used during our tests.
-   Also cap these to be less than the next major just in case (for example `ops>=3.14.0,<4`).
+   (for example, if 3.14.0 is the next expected `ops` version, use `'3.14.0.dev0'`).
+   In this PR, also update the requirements in the respective pyproject.toml files to be == these
+   development versions (for example, `ops==3.14.0.dev0` for `ops-scenario`).
 
 ## Release Documentation
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -167,4 +167,5 @@ websocket-client==1.8.0
     # via ops (pyproject.toml)
 websockets==15.0.1
     # via sphinx-autobuild
+.
 ./testing/

--- a/ops/version.py
+++ b/ops/version.py
@@ -17,4 +17,4 @@
 This module is NOT to be used when developing charms using ops.
 """
 
-version: str = '2.20.0'
+version: str = '2.21.0.dev0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario>=7.20.0,<8",
+    "ops-scenario==7.20.1.dev0",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario==7.20.1.dev0",
+    "ops-scenario==7.21.0.dev0",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario==7.20.0",
+    "ops-scenario==7.21.0.dev0",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario==7.20.0",
+    "ops-scenario>=7.20.0",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario~=7.20.0",
+    "ops-scenario>=7.20.0,<8",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario==7.20.1.dev0",
+    "ops-scenario>=7.20.0,<8",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario>=7.20.0",
+    "ops-scenario==7.21.0.dev0",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario==7.21.0.dev0 @ git+https://github.com/canonical/operator@main#subdirectory=testing",
+    "ops-scenario @ git+https://github.com/canonical/operator@main#subdirectory=testing",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario==7.21.0.dev0",
+    "ops-scenario==7.21.0.dev0 @ git+https://github.com/canonical/operator@main#subdirectory=testing",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario==7.21.0.dev0",
+    "ops-scenario==7.20.0",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario @ git+https://github.com/canonical/operator@main#subdirectory=testing",
+    "ops-scenario~=7.20.0",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops==2.21.0.dev0",
+    "ops>=2.20.0,<3",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops>=2.20.0",
+    "ops==2.21.0.dev0",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops==2.21.0.dev0",
+    "ops==2.21.0.dev0 @ git+https://github.com/canonical/operator@main",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops>=2.20.0,<3",
+    "ops==2.21.0.dev0",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops==2.21.0.dev0 @ git+https://github.com/canonical/operator@main",
+    "ops @ git+https://github.com/canonical/operator@main",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops==2.20.0",
+    "ops>=2.20.0",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops~=2.20.0",
+    "ops>=2.20.0,<3",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "7.20.0"
+version = "7.21.0.dev0"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops @ git+https://github.com/canonical/operator@main",
+    "ops~=2.20.0",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ description = Compile the requirements.txt file for docs
 deps = pip-tools
 commands =
     pip-compile --extra=docs -o docs/requirements.txt pyproject.toml
-    python -c 'open("docs/requirements.txt", "a").write("./testing/\n")'
+    python -c 'open("docs/requirements.txt", "a").write(".\n./testing/\n")'
 
 [testenv:docs]
 description = Build the Sphinx docs


### PR DESCRIPTION
This PR bumps the post-release versions of `ops` and `ops-scenario`, and updates `HACKING.md` to reflect the process followed in this release. It also adds a fix for the failing `observability-charm-tests` (needed for the new versions in this PR), which should fix them for releases too, and updates the `docs-deps` tox environment that the docs build with the development version requirements.

Post-release, I've changed the dependency versions from `==$latest_release` to `==$dev_version`. To allow the docs to build with this change, I've modified the `docs-deps` tox environment to add the line `.` to the requirements before `./testing/`, which means that ops is installed from the local files first, then `ops-scenario`'s requirements requests the dev version when it's installed, and finds it already installed.

This PR also includes a fix to `observability-charm-tests` from https://github.com/dimaqq/operator/pull/33#discussion_r2018070161, without which the test fails due to the development version requirements. Dima's fix also works with exact unreleased dependency versions (like the dev versions used in this PR), which I believe allows us to re-enable the `observability-charm-tests` for releases.