### PR TITLE
chore: add ruff version bump + formatting to blame ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -9,3 +9,6 @@ d8148ab41869f6119683cf42b7e6e574f1a99bf1
 
 # Merge ops-scenario into operator
 45353978b19903813105f0da6dbe0fd626edb99e
+
+# bump ruff version to 0.11.2 and codespell version to 2.4.1
+eea8d273a6cc3717f495507d556b2e24a6e6ae79


### PR DESCRIPTION
This PR adds the mostly automatic changes from #1652 to the blame ignore file.