### PR TITLE
fix: try to fix flaky pebble exec test

### DIFF
--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -3346,8 +3346,13 @@ class TestExec:
         with pytest.warns(ResourceWarning) as record:
             process = client.exec(['true'])
             del process
+
+        # GC might collect other warnings. Filter the warnings to only
+        # those from ExecProcess.
+        warnings = [r for r in record if 'ExecProcess' in str(r.message)]
+        assert len(warnings) == 1
         assert (
-            str(record[0].message)
+            str(warnings[0].message)
             == 'ExecProcess instance garbage collected without call to wait() or wait_output()'
         )
 

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -3347,8 +3347,8 @@ class TestExec:
             process = client.exec(['true'])
             del process
 
-        # GC might collect other warnings. Filter the warnings to only
-        # those from ExecProcess.
+        # GC may trigger unrelated warnings (for example, from TemporaryDirectory).
+        # Filter the warnings to only those from ExecProcess.
         warnings = [r for r in record if 'ExecProcess' in str(r.message)]
         assert len(warnings) == 1
         assert (


### PR DESCRIPTION
Fix a flaky Pebble exec test.

Resolves https://github.com/canonical/operator/issues/1360.

After looking into it, I found that the flaky test happens because garbage collection (GC) can clean up other temporary objects when this test (`test_no_wait_call`) runs. If other temporary objects are cleaned up right before the `ExecProcess` object's cleanup method `__del__` is called, it makes the test sometimes catch the wrong ResourceWarning.

Since it's hard to reproduce this problem (not to mention consistently), I've been thinking about how to fix it. Here are a few ideas:

1. Force garbage collection: Call `gc.collect()` right after `del process`. Or even move the `client.exec` part outside the `with` block to shorten the time in the `with` block before GC happens.
  - This would lower the chance of catching unrelated warnings.
  - Problem: This is still not a valid solution, because we can't be sure that no other GC happens inside the `with` block before our forced cleanup.
2. Turn off automatic GC: Disable automatic GC temporarily during the test and re-enable it afterward.
  - This would reduce the chance of catching other warnings caused by automatic GC.
  - Problem: Even with automatic GC off, reference-counting GC can still happen, and we might still catch unwanted warnings. So, this (and the previous idea) is still non-deterministic and could still be flaky- maybe a lot less flaky, but still non-deterministic.
3. Filter Warnings (best fix?): Only check for the `ExecProcess` warnings by messages and ignore others.
  - This guarantees we catch the right warning, no matter when GC runs, so it is probably the most deterministic way.

So, in this PR, I'm suggesting the last choice.