### PR TITLE
ci: rename "tox -e fmt" to "tox -e format"

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -24,7 +24,7 @@ tox -e unit
 tox -e unit -- test/test_charm.py
 
 # Format the code using Ruff
-tox -e fmt
+tox -e format
 
 # Compile the requirements.txt file for docs
 tox -e docs-deps

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ commands_pre =
 commands =
     sphinx-autobuild docs/ docs/_build/html --watch ops/ --port 8000 {posargs}
 
-[testenv:fmt]
+[testenv:format]
 description = Apply coding style standards to code
 deps =
     ruff==0.11.2


### PR DESCRIPTION
This is consistent with what we're recommending in OP061.