### PR TITLE
docs: clarify guidance about designing Python modules

### DIFF
--- a/docs/howto/write-and-structure-charm-code.md
+++ b/docs/howto/write-and-structure-charm-code.md
@@ -165,8 +165,10 @@ Arrange the methods of this class in the following order:
 1. An `__init__` method that observes all relevant events and instantiates objects.
    For example, in a Kubernetes charm:
    ```python
-   framework.observe(self.on["workload_container"].pebble_ready, self._on_pebble_ready)
-   self.container = self.unit.get_container("workload-container")
+   def __init__(self, framework: ops.Framework):
+       super().__init__(framework)
+       framework.observe(self.on["workload_container"].pebble_ready, self._on_pebble_ready)
+       self.container = self.unit.get_container("workload-container")
    ```
 2. Event handlers, in the order that they're observed in `__init__`.
    Make the event handlers private.

--- a/docs/howto/write-and-structure-charm-code.md
+++ b/docs/howto/write-and-structure-charm-code.md
@@ -174,8 +174,7 @@ Arrange the methods of this class in the following order:
 2. Event handlers, in the order that they're observed in `__init__`.
    Make the event handlers private.
    For example, `def _on_pebble_ready(...)` instead of `def on_pebble_ready(...)`.
-3. Other helper methods, which can be public. If you're writing a charm that will be extended
-   by other charms, you could use private helper methods instead.
+3. Other helper methods, which may be private or public.
 
 ```{admonition} Best practice
 :class: hint

--- a/docs/howto/write-and-structure-charm-code.md
+++ b/docs/howto/write-and-structure-charm-code.md
@@ -229,6 +229,9 @@ class DemoServerCharm(ops.CharmBase):
         self.unit.set_workload_version(version)
         self.unit.status = ops.ActiveStatus()
 
+    # Put helper methods here.
+    # If a method doesn't depend on Ops, put it in src/demo_server.py instead.
+
 
 if __name__ == "__main__":  # pragma: nocover
     ops.main(DemoServerCharm)

--- a/docs/howto/write-and-structure-charm-code.md
+++ b/docs/howto/write-and-structure-charm-code.md
@@ -157,7 +157,7 @@ control, so that exact versions of charms can be reproduced.
 (design-your-python-modules)=
 ## Design your Python modules
 
-In your `src/charm.py` file, define a class for managing the charm's interface with Juju.
+In your `src/charm.py` file, define a class for managing how the charm interacts with Juju.
 
 You'll have a single class that inherits from [](ops.CharmBase).
 Arrange the methods of this class in the following order:

--- a/docs/howto/write-and-structure-charm-code.md
+++ b/docs/howto/write-and-structure-charm-code.md
@@ -162,7 +162,8 @@ In your `src/charm.py` file, define a class for managing the charm's interface w
 You'll have a single class that inherits from [](ops.CharmBase).
 Arrange the methods of this class in the following order:
 
-1. An `__init__` method that observes all relevant events and instantiates objects.
+1. An `__init__` method that observes all relevant events and instantiates any objects that
+   the charm needs.
    For example, in a Kubernetes charm:
    ```python
    def __init__(self, framework: ops.Framework):


### PR DESCRIPTION
This PR clarifies the guidance in [Design your Python modules](https://ops.readthedocs.io/en/latest/howto/write-and-structure-charm-code.html#design-your-python-modules).

Main things that I'm clarifying:

- When to use private vs public methods
- What would go in `<workload>.py`

**[Preview docs build](https://ops--1670.org.readthedocs.build/en/1670/howto/write-and-structure-charm-code.html#design-your-python-modules)**