### PR TITLE
docs: fix links to Juju docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Let's use `ops` to build a Kubernetes charm:
 
 ### Set up
 
-> See [Juju | Set things up](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-your-deployment/manage-your-deployment-environment/#set-things-up). <br> Choose the automatic track and MicroK8s.
+> See [Juju | Set things up](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/manage-your-deployment-environment/#set-things-up). <br> Choose the automatic track and MicroK8s.
 
 
 ### Write your charm
@@ -142,7 +142,7 @@ Congratulations, you’ve just built your first Kubernetes charm using `ops`!
 
 ### Clean up
 
-> See [Juju | Tear things down](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-your-deployment/manage-your-deployment-environment/#tear-things-down). <br> Choose the automatic track.
+> See [Juju | Tear things down](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/manage-your-deployment-environment/#tear-things-down). <br> Choose the automatic track.
 
 ## Next steps
 

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -301,7 +301,7 @@ maximum_signature_line_length = 80
 # that should be linked to in this documentation.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'juju': ('https://canonical-juju.readthedocs-hosted.com/en/latest', None),
+    'juju': ('https://documentation.ubuntu.com/juju/3.6', None),
     'charmcraft': ('https://canonical-charmcraft.readthedocs-hosted.com/en/latest', None),
     'pebble': ('https://documentation.ubuntu.com/pebble', None),
 }

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -92,7 +92,7 @@ def _update_layer_and_restart(self) -> None:
     """
 
     # Learn more about statuses at:
-    # https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/status/
+    # https://documentation.ubuntu.com/juju/latest/reference/status/
     self.unit.status = ops.MaintenanceStatus('Assembling Pebble layers')
     try:
         self.container.add_layer('fastapi_demo', self._pebble_layer, combine=True)

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -92,7 +92,7 @@ def _update_layer_and_restart(self) -> None:
     """
 
     # Learn more about statuses at:
-    # https://documentation.ubuntu.com/juju/latest/reference/status/
+    # https://documentation.ubuntu.com/juju/3.6/reference/status/
     self.unit.status = ops.MaintenanceStatus('Assembling Pebble layers')
     try:
         self.container.add_layer('fastapi_demo', self._pebble_layer, combine=True)


### PR DESCRIPTION
Links to https://documentation.ubuntu.com/juju/latest/ now require a Read the Docs login. This PR updates links to point to https://documentation.ubuntu.com/juju/3.6/ instead.

Since I'm changing code in the Kubernetes tutorial, I'll also open a corresponding PR to the [juju-sdk-tutorial-k8s](https://github.com/canonical/juju-sdk-tutorial-k8s) repo.

**Note:** This PR doesn't update any links to `juju.is/docs/*`. Those links already redirect to the 3.6 branch of the docs. They ought to be updated, but not so urgently. I'll do that separately (#1626).