### PR TITLE
ci: don't pin release jobs to github environments

### DIFF
--- a/.github/workflows/publish-ops-scenario.yaml
+++ b/.github/workflows/publish-ops-scenario.yaml
@@ -14,6 +14,7 @@ jobs:
   build-n-publish:
     name: Build and Publish ops-scenario to PyPI
     runs-on: ubuntu-latest
+    environment: publish-pypi
     permissions:
       id-token: write
       attestations: write

--- a/.github/workflows/publish-ops-tracing.yaml
+++ b/.github/workflows/publish-ops-tracing.yaml
@@ -13,6 +13,7 @@ jobs:
     uses: ./.github/workflows/hello-charm-tests.yaml
   release:
     runs-on: ubuntu-latest
+    environment: publish-pypi
     permissions:
       id-token: write
       attestations: write

--- a/.github/workflows/publish-ops-tracing.yaml
+++ b/.github/workflows/publish-ops-tracing.yaml
@@ -13,7 +13,6 @@ jobs:
     uses: ./.github/workflows/hello-charm-tests.yaml
   release:
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       id-token: write
       attestations: write

--- a/.github/workflows/publish-ops.yaml
+++ b/.github/workflows/publish-ops.yaml
@@ -18,6 +18,7 @@ jobs:
   build-n-publish:
     name: Build and Publish ops to PyPI
     runs-on: ubuntu-latest
+    environment: publish-pypi
     permissions:
       id-token: write
       attestations: write

--- a/.github/workflows/test-publish-ops-tracing.yaml
+++ b/.github/workflows/test-publish-ops-tracing.yaml
@@ -10,7 +10,6 @@ jobs:
     uses: ./.github/workflows/hello-charm-tests.yaml
   release:
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       id-token: write
       attestations: write


### PR DESCRIPTION
The `ops` and `ops-scenario` release jobs don't specify the github (secret) environments, so let's remove these from the `ops-tracing` release jobs.