### PR TITLE
ci: don't run tests within the publish job

### DIFF
--- a/.github/workflows/publish-ops-scenario.yaml
+++ b/.github/workflows/publish-ops-scenario.yaml
@@ -5,12 +5,6 @@ on:
       - '2.*'
 
 jobs:
-  framework-tests:
-    uses: ./.github/workflows/framework-tests.yaml
-  observability-charm-tests:
-    uses: ./.github/workflows/observability-charm-tests.yaml
-  hello-charm-tests:
-    uses: ./.github/workflows/hello-charm-tests.yaml
   build-n-publish:
     name: Build and Publish ops-scenario to PyPI
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-ops-scenario.yaml
+++ b/.github/workflows/publish-ops-scenario.yaml
@@ -12,7 +12,6 @@ jobs:
       id-token: write
       attestations: write
       contents: read
-    needs: [framework-tests, observability-charm-tests, hello-charm-tests]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/publish-ops-tracing.yaml
+++ b/.github/workflows/publish-ops-tracing.yaml
@@ -11,7 +11,6 @@ jobs:
     permissions:
       id-token: write
       attestations: write
-    needs: [framework-tests, observability-charm-tests, hello-charm-tests]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5

--- a/.github/workflows/publish-ops-tracing.yaml
+++ b/.github/workflows/publish-ops-tracing.yaml
@@ -5,12 +5,6 @@ on:
       - '2.*'
 
 jobs:
-  framework-tests:
-    uses: ./.github/workflows/framework-tests.yaml
-  observability-charm-tests:
-    uses: ./.github/workflows/observability-charm-tests.yaml
-  hello-charm-tests:
-    uses: ./.github/workflows/hello-charm-tests.yaml
   release:
     runs-on: ubuntu-latest
     environment: release

--- a/.github/workflows/publish-ops.yaml
+++ b/.github/workflows/publish-ops.yaml
@@ -9,12 +9,6 @@ on:
       - '2.*'
 
 jobs:
-  framework-tests:
-    uses: ./.github/workflows/framework-tests.yaml
-  observability-charm-tests:
-    uses: ./.github/workflows/observability-charm-tests.yaml
-  hello-charm-tests:
-    uses: ./.github/workflows/hello-charm-tests.yaml
   build-n-publish:
     name: Build and Publish ops to PyPI
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-ops.yaml
+++ b/.github/workflows/publish-ops.yaml
@@ -16,7 +16,6 @@ jobs:
       id-token: write
       attestations: write
       contents: read
-    needs: [framework-tests, observability-charm-tests, hello-charm-tests]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/test-publish-ops-scenario.yaml
+++ b/.github/workflows/test-publish-ops-scenario.yaml
@@ -2,12 +2,6 @@ name: Test Publish (ops-scenario)
 on: [workflow_dispatch, workflow_call]
 
 jobs:
-  framework-tests:
-    uses: ./.github/workflows/framework-tests.yaml
-  observability-charm-tests:
-    uses: ./.github/workflows/observability-charm-tests.yaml
-  hello-charm-tests:
-    uses: ./.github/workflows/hello-charm-tests.yaml
   build-n-publish:
     name: Build and Publish ops-scenario to Test PyPI
     runs-on: ubuntu-latest

--- a/.github/workflows/test-publish-ops-scenario.yaml
+++ b/.github/workflows/test-publish-ops-scenario.yaml
@@ -9,7 +9,6 @@ jobs:
       id-token: write
       attestations: write
       contents: read
-    needs: [framework-tests, observability-charm-tests, hello-charm-tests]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/test-publish-ops-tracing.yaml
+++ b/.github/workflows/test-publish-ops-tracing.yaml
@@ -8,7 +8,6 @@ jobs:
     permissions:
       id-token: write
       attestations: write
-    needs: [framework-tests, observability-charm-tests, hello-charm-tests]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5

--- a/.github/workflows/test-publish-ops-tracing.yaml
+++ b/.github/workflows/test-publish-ops-tracing.yaml
@@ -2,12 +2,6 @@ name: Test Publish (ops-tracing)
 on: [workflow_call, workflow_dispatch]
 
 jobs:
-  framework-tests:
-    uses: ./.github/workflows/framework-tests.yaml
-  observability-charm-tests:
-    uses: ./.github/workflows/observability-charm-tests.yaml
-  hello-charm-tests:
-    uses: ./.github/workflows/hello-charm-tests.yaml
   release:
     runs-on: ubuntu-latest
     environment: release

--- a/.github/workflows/test-publish-ops.yaml
+++ b/.github/workflows/test-publish-ops.yaml
@@ -9,7 +9,6 @@ jobs:
       id-token: write
       attestations: write
       contents: read
-    needs: [framework-tests, observability-charm-tests, hello-charm-tests]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/test-publish-ops.yaml
+++ b/.github/workflows/test-publish-ops.yaml
@@ -2,12 +2,6 @@ name: Test Publish (ops)
 on: [workflow_dispatch, workflow_call]
 
 jobs:
-  framework-tests:
-    uses: ./.github/workflows/framework-tests.yaml
-  observability-charm-tests:
-    uses: ./.github/workflows/observability-charm-tests.yaml
-  hello-charm-tests:
-    uses: ./.github/workflows/hello-charm-tests.yaml
   build-n-publish:
     name: Build and Publish ops to Test PyPI
     runs-on: ubuntu-latest

--- a/HACKING.md
+++ b/HACKING.md
@@ -376,7 +376,7 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
    using the same Python version as specified in the `.readthedocs.yaml` file.
 12. Add, commit, and push, and open a PR to get the `CHANGES.md` update, version bumps,
    and doc requirement bumps into main (and get it merged).
-13. Wait until the tests pass after the PR is merged. CI should within 10 minutes.
+13. Wait until the tests pass after the PR is merged. It takes around 10 minutes.
    If the tests don't pass at the tip of the main branch, do not release.
 14. When you are ready, click "Publish". GitHub will create the additional tag.
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -376,7 +376,9 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
    using the same Python version as specified in the `.readthedocs.yaml` file.
 12. Add, commit, and push, and open a PR to get the `CHANGES.md` update, version bumps,
    and doc requirement bumps into main (and get it merged).
-13. When you are ready, click "Publish". GitHub will create the additional tag.
+13. Wait until the tests pass after the PR is merged. CI should within 10 minutes.
+   If the tests don't pass at the tip of the main branch, do not release.
+14. When you are ready, click "Publish". GitHub will create the additional tag.
 
     Pushing the tags will trigger automatic builds for the Python packages and
     publish them to PyPI ([ops](https://pypi.org/project/ops/) and
@@ -389,9 +391,9 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
     (Note that the versions in the YAML refer to versions of the GitHub actions, not the versions of the ops  library.)
 
     You can troubleshoot errors on the [Actions Tab](https://github.com/canonical/operator/actions).
-14. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42)
+15. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42)
     and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com).
-15. Open a PR to change the version strings to the expected next version, with ".dev0" appended.
+16. Open a PR to change the version strings to the expected next version, with ".dev0" appended.
    For example, if 2.90.0 is the next expected `ops` version, use
    `ops==2.90.0.dev0 ops-tracing==2.90.0.dev0 ops-scenario==7.90.0.dev0`.
    There will be a total of seven changes:


### PR DESCRIPTION
Assuming that I understood Ben correctly about his earlier conversation with Tony, we have CI running in the PR context and on the main branch after each PR is merged.

Thus, we need not run the tests at the start of the publish job.

I'm not sure if this was about all tests or only integration tests.

I've added a step into the release process to wait after the release PR is merged to make sure tests are indeed passing.