### PR TITLE
docs: add best practices about status

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -230,6 +230,7 @@ The diagram below illustrates the workflow for the case where the database relat
 
 ![Integrate your charm with PostgreSQL](../../resources/integrate_your_charm_with_postgresql.png) 
 
+(integrate-your-charm-with-postgresql-update-unit-status)=
 ## Update the unit status to reflect the relation state
 
 Now that the charm is getting more complex, there are many more cases where the unit status needs to be set. It's often convenient to do this in a more declarative fashion, which is where the collect-status event can be used.


### PR DESCRIPTION
This PR adds a section called "Handle status" to [How to write and structure charm code](https://ops.readthedocs.io/en/latest/howto/write-and-structure-charm-code.html).