### PR TITLE
chore: pyproject.toml changes and blame ignore for ops-scenario ruff formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,6 @@ d8148ab41869f6119683cf42b7e6e574f1a99bf1
 
 # bump ruff version to 0.11.2 and codespell version to 2.4.1
 eea8d273a6cc3717f495507d556b2e24a6e6ae79
+
+# drop quote-style double from testing and run format
+54f03272439e1e7c450afc5e6b65222f640351fa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,51 @@ keep-runtime-typing = true
     # "Useless" expression.
     "B018"
 ]
+"testing/*" = [
+    # TODO: the below ignores should be fixed
+    "A001",  # Variable is shadowing a Python builtin
+    "B033",  # Sets should not contain duplicate item
+    "B904",  # Use raise from within except
+    "D101",  # Missing docstring in public class
+    "D102",  # Missing docstring in public method
+    "D202",  # No blank lines allowed after function docstring
+    "D205",  # 1 blank line required between summary line and description
+    "D212",  # Multi-line docstring summary should start at the first line
+    "D403",  # First word of the docstring should be capitalized
+    "D415",  # First line should end with a period, question mark, or exclamation point
+    "E501",  # Line too long
+    "I001",  # isort
+    "N818",  # Exception name should end with Error
+    "S105",  # Possible hardcoded password
+    "S311",  # Standard pseudo-random generators are not suitable for cryptographic purposes
+    "RUF009",  # Do not perform function call in dataclass defaults
+    "RUF052",  # Local dummy variable is accessed
+    "RUF100",  # Unused `noqa` directive
+    "SIM102",  # Use single if instead of nested if
+    "SIM108",  # Use ternary operator instead if if-else block
+    "PERF102",  # Use dict.values()
+    "PERF203",  # try-except in loop body
+    "PERF401",  # Use list.extend
+]
+"testing/tests/*" = [
+    # All documentation linting.
+    "D",
+    # TODO: the below ignores should be fixed
+    "CPY",  # flake8-copyright
+    "I001",  # isort
+    "B017",  # Do not assert blind exception
+    "B018",  # Useless attribute access
+    "E501",  # Line too long
+    "N999",  # Invalid module name
+    "N813",  # CamelCase imported as lowercase
+    "S105",  # Possible hardcoded password
+    "S108",  # Probably insecure usage of /tmp
+    "W291",  # Trailing whitespace
+    "UP037",  # Remove quotes from type annotation
+    "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar`
+    "RUF015",  # Prefer `next` over single element slice
+    "SIM115",  # Use a context manager for opening files
+]
 "ops/_private/timeconv.py" = [
     "RUF001",  # String contains ambiguous `µ` (MICRO SIGN). Did you mean `μ` (GREEK SMALL LETTER MU)?
     "RUF002",  # Docstring contains ambiguous `µ` (MICRO SIGN). Did you mean `μ` (GREEK SMALL LETTER MU)?

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -41,9 +41,5 @@ classifiers = [
 "Homepage" = "https://github.com/canonical/operator"
 "Bug Tracker" = "https://github.com/canonical/operator/issues"
 
-[tool.ruff.format]
-# Like Black, use double quotes for strings.
-quote-style = "double"
-
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
This PR adds the config changes that drove the formatting changes made in #1691. This includes adding a number of `per-file-ignores`, as the removal of the `tool.ruff.format` table in `testing/pyproject.toml` means that a number of `ops` linting rules are now being applied to `ops-scenario` for the first time. These will be fixed in subsequent PRs (issue: #1693).

This PR also adds the merge commit (https://github.com/canonical/operator/commit/54f03272439e1e7c450afc5e6b65222f640351fa) for #1691 to the git blame ignore list (which is why the formatting changes and config changes are being made in separate PRs).