### PR TITLE
test: fix overly specific test that fails sometimes with tracing

### DIFF
--- a/testing/tests/test_e2e/test_juju_log.py
+++ b/testing/tests/test_e2e/test_juju_log.py
@@ -31,6 +31,8 @@ def mycharm():
 def test_juju_log(mycharm):
     ctx = Context(mycharm, meta=mycharm.META)
     ctx.run(ctx.on.start(), State())
-    assert ctx.juju_log[-2] == JujuLogLine(level='DEBUG', message='Emitting Juju event start.')
-    assert ctx.juju_log[-1] == JujuLogLine(level='WARNING', message='bar!')
+    line = JujuLogLine(level='DEBUG', message='Emitting Juju event start.')
+    assert line in ctx.juju_log
+    lines = ctx.juju_log[ctx.juju_log.index(line) :]
+    assert JujuLogLine(level='WARNING', message='bar!') in lines
     # prints are not juju-logged.

--- a/testing/tests/test_e2e/test_juju_log.py
+++ b/testing/tests/test_e2e/test_juju_log.py
@@ -31,8 +31,6 @@ def mycharm():
 def test_juju_log(mycharm):
     ctx = Context(mycharm, meta=mycharm.META)
     ctx.run(ctx.on.start(), State())
-    line = JujuLogLine(level='DEBUG', message='Emitting Juju event start.')
-    assert line in ctx.juju_log
-    lines = ctx.juju_log[ctx.juju_log.index(line) :]
-    assert JujuLogLine(level='WARNING', message='bar!') in lines
+    assert JujuLogLine(level='DEBUG', message='Emitting Juju event start.') in ctx.juju_log
+    assert JujuLogLine(level='WARNING', message='bar!') in ctx.juju_log
     # prints are not juju-logged.


### PR DESCRIPTION
This PR fixes a test that fails intermittently on main. It failed because it asserted that the last two log lines were specific ones, while the addition of tracing means that sometimes (but not always), tracing log lines are emitted afterwards instead. This PR modifies the test to only assert that both lines are present in the logs instead.