### PR TITLE
ci: fix smoke test

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         # pylibjuju does not currently support Juju 4.x
         juju-channel: ['2.9/stable', '3/stable']

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -110,3 +110,9 @@ async def test_smoke(ops_test: OpsTest, base: str, charmcraft_version: int, name
     await ops_test.model.wait_for_idle(timeout=600)
 
     assert app.status == 'active', f"Base ubuntu@{base} failed with '{app.status}' status"
+
+
+@pytest.fixture
+def setup_tracing():
+    """Stub out the top-level fixture."""
+    pass


### PR DESCRIPTION
@tonyandrewmeyer reports

> The [smoke tests are failing](https://github.com/canonical/operator/actions/runs/14658930717/job/41138918710), unable to import opentelemetry.

It's my fault, I didn't try running smoke before/after I've merged `ops[tracing]`.

That added a fixture into the top-level `conftest.py` which monkey-patches `ops`, which pytest takes as an instruction to import `ops` which in turn imports `opentelemetry`.

That's fine for unit tests. Integration and smoke tests don't import `ops` in the first place, and thus `tox.ini` never declared their dependencies. This PR stubs out the offending fixture.

In the long term, let's move all the unit tests under `test/unit` or something.
> What do we say to the god of refactor?
> Not today.