### PR TITLE
docs: add best practice note around using tooling provided by the charmcraft profile

### DIFF
--- a/docs/howto/manage-charms.md
+++ b/docs/howto/manage-charms.md
@@ -3,25 +3,13 @@
 
 > See first: {external+juju:ref}`Juju | Build a charm <build-a-charm>`, {external+charmcraft:ref}`Charmcraft | Manage charms <manage-charms>`
 
+## Prepare your environment
+
 Hit the ground running with Ops by setting up standard project structure and tools.
 
 > See more: {external+charmcraft:ref}`Charmcraft | Manage Charmcraft <manage-charmcraft>`
 
-Use Charmcraft to quickly initialise your charm project. This generates the
-folder structure, creates placeholder configuration and code files, and
-configures development tooling.
-
-The Charmcraft profiles also all provide the recommended tooling and
-configuration for developing charms. You'll need to install
-[`tox`](https://tox.wiki/en/stable/), and can then run ``tox list`` in the root
-folder to see the available commands.
-
-```{admonition} Best practice
-:class: hint
-
-The quality assurance pipeline of a charm should be automated using a
-continuous integration (CI) system.
-```
+Other useful tools:
 
 ```{tip}
 To prepare an environment for running integration tests, such as in CI, use
@@ -35,7 +23,23 @@ repository includes actions to ensure that libraries are up-to-date, publish
 charms and libraries, and more.
 ```
 
-## Use the provided tooling to maintain style and detect issues early
+## Initialise your charm project
+
+Use Charmcraft to quickly initialise your charm project. This generates the
+folder structure, creates placeholder configuration and code files, and
+configures development tooling.
+
+The Charmcraft profiles also all provide the recommended tooling and
+configuration for developing charms. You'll need to install
+[`tox`](https://tox.wiki/en/stable/), and can then run ``tox list`` in the root
+folder to see the available commands.
+
+> See more:
+>
+> * {external+charmcraft:ref}`Charmcraft | Manage charms > Initialize a charm <initialise-a-charm>` (see also the best practice note on setting up a repository and considering your CI)
+> * [Charmcraft | Manage charms > Add charm project metadata, an icon, docs](https://canonical-charmcraft.readthedocs-hosted.com/en/latest/howto/manage-charms/#add-charm-project-metadata-an-icon-docs)
+
+## Develop your charm
 
 The Charmcraft profile you've chosen has configured a number of recommended
 tools for developing charms. To use these, [install
@@ -62,10 +66,12 @@ configuration of individual tools, or to add additional commands, but keep the
 command names and meanings that the profiles provide.
 ```
 
-> See more:
->
-> * {external+charmcraft:ref}`Charmcraft | Manage charms > Initialize a charm <initialise-a-charm>` (see also the best practice note on setting up a repository and considering your CI)
-> * [Charmcraft | Manage charms > Add charm project metadata, an icon, docs](https://canonical-charmcraft.readthedocs-hosted.com/en/latest/howto/manage-charms/#add-charm-project-metadata-an-icon-docs)
+```{admonition} Best practice
+:class: hint
+
+The quality assurance pipeline of a charm should be automated using a
+continuous integration (CI) system.
+```
 
 <!--
 TODO: Add a reference link in charmcraft for the link above and the 'runtime details' one below, and switch over to external refs.
@@ -108,6 +114,13 @@ do it well.
 > * {external+charmcraft:ref}`Charmcraft | Manage charms > Pack a charm <pack-a-charm>`
 > * {external+juju:ref}`Juju | Manage charms > Deploy a charm <deploy-a-charm>` (you'll need to follow the "Deploy a local charm" example)
 > * {external+juju:ref}`Juju | Manage charms > Debug a charm <debug-a-charm>`
+
+## Publish your charm
+
+When you're ready, you'll publish your charm on Charmhub.
+
+> See more:
+>
 > * {external+charmcraft:ref}`Charmcraft | Publish a charm on Charmhub <publish-a-charm>` (see especially the note on requesting formal review for your charm)
 
 A charm is software: while there can be milestones, there is never a finish

--- a/docs/howto/manage-charms.md
+++ b/docs/howto/manage-charms.md
@@ -5,23 +5,12 @@
 
 ## Prepare your environment
 
-Hit the ground running with Ops by setting up standard project structure and tools.
+You'll need the following tools:
 
-> See more: {external+charmcraft:ref}`Charmcraft | Manage Charmcraft <manage-charmcraft>`
+- Charmcraft. See {external+charmcraft:ref}`Charmcraft | Manage Charmcraft <manage-charmcraft>`.
+- tox. See the [tox installation instructions](https://tox.wiki/en/stable/installation.html#as-tool).
 
-Other useful tools:
-
-```{tip}
-To prepare an environment for running integration tests, such as in CI, use
-the `concierge tool <https://github.com/jnsgruk/concierge>`_ or the
-`actions-operator <https://github.com/charmed-kubernetes/actions-operator>`_.
-```
-
-```{tip}
-The `charming-actions <https://github.com/canonical/charming-actions>`_
-repository includes actions to ensure that libraries are up-to-date, publish
-charms and libraries, and more.
-```
+Instead of installing these tools manually, consider using the `charm-dev` [Multipass](https://canonical.com/multipass) blueprint or [`concierge`](https://github.com/jnsgruk/concierge) to prepare your environment.
 
 ## Initialise your charm project
 
@@ -29,28 +18,18 @@ Use Charmcraft to quickly initialise your charm project. This generates the
 folder structure, creates placeholder configuration and code files, and
 configures development tooling.
 
-The Charmcraft profiles also all provide the recommended tooling and
-configuration for developing charms. You'll need to install
-[`tox`](https://tox.wiki/en/stable/), and can then run ``tox list`` in the root
-folder to see the available commands.
-
 > See more:
 >
 > * {external+charmcraft:ref}`Charmcraft | Manage charms > Initialize a charm <initialise-a-charm>` (see also the best practice note on setting up a repository and considering your CI)
 > * [Charmcraft | Manage charms > Add charm project metadata, an icon, docs](https://canonical-charmcraft.readthedocs-hosted.com/en/latest/howto/manage-charms/#add-charm-project-metadata-an-icon-docs)
 
+<!--
+TODO: Add a reference link in charmcraft for the link above and the 'runtime details' one below, and switch over to external refs.
+-->
+
 ## Develop your charm
 
-The Charmcraft profile you've chosen has configured a number of recommended
-tools for developing charms. To use these, [install
-`tox`](https://tox.wiki/en/stable/installation.html#as-tool) on your development
-server.
-
-```{tip}
-If you use the `charm-dev` [Multipass](https://canonical.com/multipass)
-blueprint or the [`concierge`](https://github.com/jnsgruk/concierge) tool to
-configure your development environment, you'll already have `tox` installed.
-```
+The Charmcraft profile has configured some commands to help you develop your charm:
 
 - Run `tox` to format and lint the code, and run static type checking and the
   charm unit tests.
@@ -60,11 +39,16 @@ configure your development environment, you'll already have `tox` installed.
 ```{admonition} Best practice
 :class: hint
 
-All charms should provide the commands configured by the charmcraft profiles, to
-allow easily testing across the charm ecosystem. It's fine to tweak the
+All charms should provide the commands configured by the Charmcraft profile, to
+allow easy testing across the charm ecosystem. It's fine to tweak the
 configuration of individual tools, or to add additional commands, but keep the
-command names and meanings that the profiles provide.
+command names and meanings that the profile provides.
 ```
+
+The following tools can also be useful during development:
+
+- To prepare an environment for running integration tests, such as in continuous integration, use [`concierge`](https://github.com/jnsgruk/concierge) or [`actions-operator`](https://github.com/charmed-kubernetes/actions-operator).
+- The [`charming-actions`](https://github.com/canonical/charming-actions) repository includes actions to ensure that libraries are up-to-date, publish charms and libraries, and more.
 
 ```{admonition} Best practice
 :class: hint
@@ -73,19 +57,21 @@ The quality assurance pipeline of a charm should be automated using a
 continuous integration (CI) system.
 ```
 
-<!--
-TODO: Add a reference link in charmcraft for the link above and the 'runtime details' one below, and switch over to external refs.
--->
-
 The essence of a charm is the ``src/charm.py`` file. This is the entry point for
 your code whenever Juju emits an event, and defines the interface between Juju
 and the charm workflow.
 
-> See more: {ref}`run-workloads-with-a-charm-kubernetes`, {ref}`run-workloads-with-a-charm-machines`, {ref}`write-and-structure-charm-code`, {ref}`write-unit-tests-for-a-charm`, {ref}`write-integration-tests-for-a-charm`, {ref}`manage-logs`
+> See more:
+>
+> - {ref}`run-workloads-with-a-charm-kubernetes`
+> - {ref}`run-workloads-with-a-charm-machines`
+> - {ref}`write-and-structure-charm-code`
+> - {ref}`write-unit-tests-for-a-charm`
+> - {ref}`write-integration-tests-for-a-charm`
+> - {ref}`manage-logs`
 
 The next thing to do is add functionality to your charm.
 As you do that, you'll frequently pack, test, and debug your charm.
-Finally, when you're ready, you'll publish your charm on Charmhub.
 
 ```{admonition} Best practice
 :class: hint

--- a/docs/howto/manage-charms.md
+++ b/docs/howto/manage-charms.md
@@ -11,6 +11,57 @@ Use Charmcraft to quickly initialise your charm project. This generates the
 folder structure, creates placeholder configuration and code files, and
 configures development tooling.
 
+The Charmcraft profiles also all provide the recommended tooling and
+configuration for developing charms. You'll need to install
+[`tox`](https://tox.wiki/en/stable/), and can then run ``tox list`` in the root
+folder to see the available commands.
+
+```{admonition} Best practice
+:class: hint
+
+The quality assurance pipeline of a charm should be automated using a
+continuous integration (CI) system.
+```
+
+```{tip}
+To prepare an environment for running integration tests, such as in CI, use
+the `concierge tool <https://github.com/jnsgruk/concierge>`_ or the
+`actions-operator <https://github.com/charmed-kubernetes/actions-operator>`_.
+```
+
+```{tip}
+The `charming-actions <https://github.com/canonical/charming-actions>`_
+repository includes actions to ensure that libraries are up-to-date, publish
+charms and libraries, and more.
+```
+
+## Use the provided tooling to maintain style and detect issues early
+
+The Charmcraft profile you've chosen has configured a number of recommended
+tools for developing charms. To use these, [install
+`tox`](https://tox.wiki/en/stable/installation.html#as-tool) on your development
+server.
+
+```{tip}
+If you use the `charm-dev` [Multipass](https://canonical.com/multipass)
+blueprint or the [`concierge`](https://github.com/jnsgruk/concierge) tool to
+configure your development environment, you'll already have `tox` installed.
+```
+
+- Run `tox` to format and lint the code, and run static type checking and the
+  charm unit tests.
+- Run `tox -e integration` to run the charm integration tests.
+- Run `tox list` to see the available commands.
+
+```{admonition} Best practice
+:class: hint
+
+All charms should provide the commands configured by the charmcraft profiles, to
+allow easily testing across the charm ecosystem. It's fine to tweak the
+configuration of individual tools, or to add additional commands, but keep the
+command names and meanings that the profiles provide.
+```
+
 > See more:
 >
 > * {external+charmcraft:ref}`Charmcraft | Manage charms > Initialize a charm <initialise-a-charm>` (see also the best practice note on setting up a repository and considering your CI)
@@ -44,7 +95,7 @@ do it well.
 ```
 
 > See more:
-> 
+>
 > * Make use of core Juju functionality
 >   - {ref}`manage-storage`
 >   - {ref}`manage-resources`
@@ -65,4 +116,4 @@ professional – from polishing metadata (including an icon, a website, docs, an
 so on) through polishing features (for example, working to ensure correct and
 reliable behavior, adding libraries so people can quickly integrate with your
 charm, and so on) all the way to turning it into a successful open source
-project with a community that enjoys it and wants to contribute to it. 
+project with a community that enjoys it and wants to contribute to it.

--- a/docs/howto/manage-charms.md
+++ b/docs/howto/manage-charms.md
@@ -109,6 +109,8 @@ When you're ready, you'll publish your charm on Charmhub.
 >
 > * {external+charmcraft:ref}`Charmcraft | Publish a charm on Charmhub <publish-a-charm>` (see especially the note on requesting formal review for your charm)
 
+If your charm depends on resources that are binary files, make sure to provide binaries for all the CPU architectures you intend to support.
+
 A charm is software: while there can be milestones, there is never a finish
 line. So, keep investing in every bit of your charm so that it looks and feels
 professional – from polishing metadata (including an icon, a website, docs, and

--- a/docs/howto/manage-charms.md
+++ b/docs/howto/manage-charms.md
@@ -10,7 +10,7 @@ You'll need the following tools:
 - Charmcraft. See {external+charmcraft:ref}`Charmcraft | Manage Charmcraft <manage-charmcraft>`.
 - tox. See the [tox installation instructions](https://tox.wiki/en/stable/installation.html#as-tool).
 
-Instead of installing these tools manually, consider using the `charm-dev` [Multipass](https://canonical.com/multipass) blueprint or [`concierge`](https://github.com/jnsgruk/concierge) to prepare your environment.
+Instead of installing these tools manually, consider using the `charm-dev` [Multipass](https://canonical.com/multipass) blueprint or [`concierge`](https://github.com/canonical/concierge) to prepare your environment.
 
 ## Initialise your charm project
 
@@ -47,7 +47,7 @@ command names and meanings that the profile provides.
 
 The following tools can also be useful during development:
 
-- To prepare an environment for running integration tests, such as in continuous integration, use [`concierge`](https://github.com/jnsgruk/concierge) or [`actions-operator`](https://github.com/charmed-kubernetes/actions-operator).
+- To prepare an environment for running integration tests, such as in continuous integration, use [`concierge`](https://github.com/canonical/concierge) or [`actions-operator`](https://github.com/charmed-kubernetes/actions-operator).
 - The [`charming-actions`](https://github.com/canonical/charming-actions) repository includes actions to ensure that libraries are up-to-date, publish charms and libraries, and more.
 
 ```{admonition} Best practice

--- a/docs/howto/manage-resources.md
+++ b/docs/howto/manage-resources.md
@@ -5,7 +5,7 @@
 
 ## Implement the feature
 
-<!--COMMENT: MOVE TO HOW TO UPLOAD 
+<!--COMMENT: MOVE TO HOW TO UPLOAD
 Because resources are defined in a charm’s `charmcraft.yaml`, they are intrinsically linked to a charm. As such, there is no need to register them separately in Charmhub. Other charms may have resources with the same name, but this is not a problem; references to resources always contain the charm name and resource name.
 -->
 
@@ -38,7 +38,7 @@ def _on_config_changed(self, event):
         self.unit.status = ops.BlockedStatus(
             "Something went wrong when claiming resource 'my-resource; "
             "run `juju debug-log` for more info'"
-        ) 
+        )
        # might actually be worth it to just reraise this exception and let the charm error out;
        # depends on whether we can recover from this.
         logger.error(e)
@@ -60,6 +60,9 @@ def _on_config_changed(self, event):
 The [`fetch()`](ops.Resources.fetch) method will raise a [`NameError`](https://docs.python.org/3/library/exceptions.html#NameError) if the resource does not exist, and returns a Python [`Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) object to the resource if it does.
 
 Note: During development, it may be useful to specify the resource at deploy time to facilitate faster testing without the need to publish a new charm/resource in between minor fixes. In the below snippet, we create a simple file with some text content, and pass it to the Juju controller to use in place of any published `my-resource` resource:
+
+For resources that are binary files, make sure that you provide binaries for all
+the CPU architectures you intend to support.
 
 ```text
 echo "TEST" > /tmp/somefile.txt

--- a/docs/howto/manage-resources.md
+++ b/docs/howto/manage-resources.md
@@ -61,9 +61,6 @@ The [`fetch()`](ops.Resources.fetch) method will raise a [`NameError`](https://d
 
 Note: During development, it may be useful to specify the resource at deploy time to facilitate faster testing without the need to publish a new charm/resource in between minor fixes. In the below snippet, we create a simple file with some text content, and pass it to the Juju controller to use in place of any published `my-resource` resource:
 
-For resources that are binary files, make sure that you provide binaries for all
-the CPU architectures you intend to support.
-
 ```text
 echo "TEST" > /tmp/somefile.txt
 charmcraft pack


### PR DESCRIPTION
This content was originally intended to [move from Juju to Charmcraft](https://github.com/canonical/charmcraft/pull/2203), but the Charmcraft team prefer that it's not in their docs.

There is one main addition, to the "manage charms" how-to, which covers our recommendation to use the tooling provided by `charmcraft init`.

**[Preview doc](https://ops--1700.org.readthedocs.build/en/1700/howto/manage-charms.html)**