### PR TITLE
chore: update pyproject.toml and add future annotations commit to ignore list

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -15,3 +15,6 @@ eea8d273a6cc3717f495507d556b2e24a6e6ae79
 
 # drop quote-style double from testing and run format
 54f03272439e1e7c450afc5e6b65222f640351fa
+
+# from __future__ import annotations
+425eae45307338f353279d7ae788581195393290

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,8 +125,18 @@ select = [
     "PERF",
     # pyflakes-docstrings
     "D",
+    # flake8-future-annotations
+    "FA",
+    # flake8-type-checking
+    "TC",
 ]
 ignore = [
+    # Move application import into a type-checking block
+    "TC001",
+    # Move third-party import into a type-checking block
+    "TC002",
+    # Move standard library import into a type-checking block
+    "TC003",
     # Use of `assert` detected
     "S101",
     # Do not `assert False`
@@ -166,11 +176,6 @@ ignore = [
     "S603",
 ]
 exclude = ["tracing/ops_tracing/vendor/*"]
-
-[tool.ruff.lint.pyupgrade]
-# Preserve types, even if a file imports `from __future__ import annotations`.
-# Since we target py 3.8, we want to keep using List[str] and Optional[str]
-keep-runtime-typing = true
 
 [tool.ruff.lint.per-file-ignores]
 "test/*" = [


### PR DESCRIPTION
This PR removes `tool.ruff.lint.pyupgrade.keep-runtime-typing`, and adds `flake8-future-annotations` and `flake8-type-checking`.

The rules `TC001`, `TC002`, and `TC003` are ignored, because these rules would move typing only imports into `if TYPE_CHECKING` blocks (when running `ruff check --preview --fix` with `--unsafe-fixes`), which is not a backwards compatible change for users who aren't also using `from __future__ import annotations`, stringified `typing.cast` argument, etc.

This PR also adds 425eae45307338f353279d7ae788581195393290 to the git blame ignore list, as that PR touched many lines in a mostly automated way when updating the annotation style to use `from __future__ import annotations`.