### PR TITLE
fix: allow TLS 1.2 in ops-tracing

### DIFF
--- a/docs/reference/ops-tracing.rst
+++ b/docs/reference/ops-tracing.rst
@@ -14,6 +14,16 @@ Open Telemetry resource attributes
 - ``service.instance.id`` the unit number, like ``0``.
 - ``service.charm`` the charm class name, like ``DbCharm``.
 
+
+Security considerations
+-----------------------
+
+The trace data can be sent out over HTTP or HTTPS. If your charm uses the
+``ops.tracing.Tracing()`` object, the protocol is determined by the URL that
+the charm tracing integration counterpart posts in the databag.
+
+This release supports TLS 1.2 and 1.3 for HTTPS connections.
+
 Tracing behaviour across test frameworks
 ----------------------------------------
 


### PR DESCRIPTION
Relax our, client-side TLS version requirement to allow TLS 1.2 or 1.3.

This roughly corresponds to allowing "Intermediate" config in addition to "Modern" in the Mozilla SSL Configuration Generator

Ref: https://ssl-config.mozilla.org/

Although https://github.com/canonical/tempo-coordinator-k8s-operator/pull/147 has been merged, I don't have clarity on all the trace data sinks and their deployment options.

Additionally some versions of the telemetry stack are in production and we'd have to analyse those very carefully if we enforce TLS 1.3 from the get-go, lest we force COS deployment upgrades merely because the first "random" application charm is switched to `ops[tracing]`.