### PR TITLE
ci: allow 'tracing' scope in PR titles

### DIFF
--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -34,4 +34,5 @@ jobs:
             test
           scopes: |
             harness
+            tracing
           requireScope: false

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -34,5 +34,6 @@ jobs:
             test
           scopes: |
             harness
+            testing
             tracing
           requireScope: false

--- a/HACKING.md
+++ b/HACKING.md
@@ -185,8 +185,12 @@ Pull requests should have a short title that follows the
 
 At present, we only add a scope in these cases:
 
-* If the PR is limited to changes in ops/_private/harness.py, also include the scope `(harness)`
-* If the PR is limited to changes in testing/, also include the scope `(testing)`
+* If the PR is limited to optional features, use one of these scopes to clarify context:
+  * `(harness)` for changes in `ops/_private/harness.py`
+  * `(testing)` for changes in `testing/`
+  * `(tracing)` for changes in `tracing/`
+
+Use of these scopes makes it clear when a change is limited to test tooling or optional features, rather than core runtime behavior.
 
 For example:
 


### PR DESCRIPTION
I'm proposing to add the 'tracing' scope to our conventional commit (pr title) checker.
This would allow issuing PRs like #1705 with a title like `fix(tracing): blah blah`.

P.S. I don't feel strongly about this. For example, we seem to have decided against `testing` the last time we discussed scopes.