### PR TITLE
chore: dev versions for all package after release

### DIFF
--- a/ops/version.py
+++ b/ops/version.py
@@ -19,4 +19,4 @@ This module is NOT to be used when developing charms using ops.
 
 from __future__ import annotations
 
-version: str = '2.21.0'
+version: str = '2.22.0.dev0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,10 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario==7.21.0",
+    "ops-scenario==7.22.0.dev0",
 ]
 tracing = [
-    "ops-tracing==2.21.0",
+    "ops-tracing==2.22.0.dev0",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "7.21.0"
+version = "7.22.0.dev0"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops==2.21.0",
+    "ops==2.22.0.dev0",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
     "Framework :: OpenTelemetry",
 ]
 dependencies = [
-    "otlp-json>=0.9.7",
     "opentelemetry-sdk~=1.30",
     "ops==2.22.0.dev0",
     "pydantic",

--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ops-tracing"
-version = "2.21.0"
+version = "2.22.0.dev0"
 description = "The tracing facility for the Ops library."
 requires-python = ">=3.8"
 readme = "README.md"
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
     "otlp-json>=0.9.7",
     "opentelemetry-sdk~=1.30",
-    "ops==2.21.0",  # pin to the exact version before release
+    "ops==2.22.0.dev0",
     "pydantic",
 ]
 


### PR DESCRIPTION
- ops '2.22.0.dev0'
- ops-tracing '2.22.0.dev0'
- ops-scenario '7.22.0.dev0'
- remove the otlp-json dependency since the package is vendored