### PR TITLE
docs: link to our docs from the top of our readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The `ops` library is a Python framework for developing and testing Kubernetes an
 
 > - `ops` is  [available on PyPI](https://pypi.org/project/ops/).
 > - The latest version of `ops` requires Python 3.8 or above.
+> - Read our [docs](https://ops.readthedocs.io/en/latest/) for tutorials, how-to guides, reference, and more.
 
 ## Give it a try
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `ops` library is a Python framework for developing and testing Kubernetes an
 
 > - `ops` is  [available on PyPI](https://pypi.org/project/ops/).
 > - The latest version of `ops` requires Python 3.8 or above.
-> - Read our [docs](https://ops.readthedocs.io/en/latest/) for tutorials, how-to guides, reference, and more.
+> - Read our [docs](https://ops.readthedocs.io/en/latest/) for tutorials, how-to guides, the library reference, and more.
 
 ## Give it a try
 


### PR DESCRIPTION
A charming survey response suggested linking to our docs from the top of our readme. I think this is a good idea. Currently I believe the only link is at the end of the (now quite long) readme.