### PR TITLE
chore: release 2.21.1 / 7.21.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,15 +1,28 @@
+# 2.21.1 - 1 May 2025
+
+## Reverted
+
+* Reverting "run deferred events with fresh charm instances" (#1711)
+
+## Documentation
+
+* Add best practices about status (#1689)
+
 # 2.21.0 - 30 Apr 2025
 
 ## Features
+
 * Ops[tracing] (with a first-party charm lib) (#1612)
 * Pebble identities (#1672)
 * Run deferred events with fresh charm instances (#1631)
 
 ## Fixes
-* Allow tls 1.2 in ops-tracing (#1705)
+
+* Allow TLS 1.2 in ops-tracing (#1705)
 * Try to fix flaky pebble exec test (#1664)
 
 ## Documentation
+
 * Add best practice note around using tooling provided by the charmcraft profile (#1700)
 * Clarify guidance about designing python modules (#1670)
 * Fix a bug in the k8s tutorial doc about unit test (#1688)
@@ -19,6 +32,7 @@
 * Improve landing page of kubernetes charm tutorial (#1660)
 
 ## CI
+
 * Add zizmor to static check github workflows (#1656)
 * Change prerelease setting used to add latest ops and scenario (#1682)
 * Don't pin release jobs to github environments (#1683)
@@ -28,6 +42,7 @@
 * Rename "tox -e fmt" to "tox -e format" (#1668)
 
 ## Tests
+
 * Fix overly specific test that fails sometimes with tracing (#1695)
 
 # 2.20.0 - 31 Mar 2025

--- a/ops/version.py
+++ b/ops/version.py
@@ -19,4 +19,4 @@ This module is NOT to be used when developing charms using ops.
 
 from __future__ import annotations
 
-version: str = '2.22.0.dev0'
+version: str = '2.21.1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,10 @@ docs = [
     "sphinxext-opengraph",
 ]
 testing = [
-    "ops-scenario==7.22.0.dev0",
+    "ops-scenario==7.21.1",
 ]
 tracing = [
-    "ops-tracing==2.22.0.dev0",
+    "ops-tracing==2.21.1",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "7.22.0.dev0"
+version = "7.21.1"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops==2.22.0.dev0",
+    "ops==2.21.1",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ops-tracing"
-version = "2.22.0.dev0"
+version = "2.21.1"
 description = "The tracing facility for the Ops library."
 requires-python = ">=3.8"
 readme = "README.md"
@@ -32,7 +32,7 @@ classifiers = [
 ]
 dependencies = [
     "opentelemetry-sdk~=1.30",
-    "ops==2.22.0.dev0",
+    "ops==2.21.1",
     "pydantic",
 ]
 


### PR DESCRIPTION
Includes:
- #1711 (revert separate charm instances for deferred events)
- #1709 (removes the `otlp-json` dependency as we're using the vendored version)