### PR TITLE
chore: update style guide

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -137,9 +137,4 @@ if status is not pebble.ServiceStatus.ACTIVE:
 
 It's a bit less clear when we're dealing with code and APIs, as those normally use US English, for example, `pytest.mark.parametrize`, and `color: #fff`.
 
-
-### Spell out abbreviations
-
-Abbreviations and acronyms in docstrings should usually be spelled out, for example, "for example" rather than "e.g.", "that is" rather than "i.e.", "and so on" rather than "etc", and "unit testing" rather than UT.
-
-However, it's okay to use acronyms that are very well known in our domain, like HTTP or JSON or RPC.
+See more doc style guide [here](https://github.com/canonical/pebble/blob/master/STYLE.md#docs-and-docstrings).


### PR DESCRIPTION
Update the style guide, add most content in the Pebble repo and link it there.

Based on a discussion with David, we agreed to have fewer places to store the style guide for docs. Meaning we should not store it in both the ops repo and the Pebble repo, but rather, store it in one place and link it in the other.

After discussion, we think maybe the Pebble repo should be the right place, reasons:

- Examples are all based on Pebble.
- Keep the existing "British English" item in the ops repo, then use a link to link to the Pebble repo's `STYLE.md`. This makes British English an exception in the ops repo to the main style guide.

If we prefer to keep the docs guide in the ops repo, I can rework the PRs.

The other PR in the pebble repo: 