### PR TITLE
docs: update links to juju.is/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ class OpsExampleCharm(ops.CharmBase):
         Change this example to suit your needs. You'll need to specify the right entrypoint and
         environment configuration for your specific workload.
 
-        Learn more about interacting with Pebble at at https://juju.is/docs/sdk/pebble.
+        Learn more about interacting with Pebble at
+            https://ops.readthedocs.io/en/latest/reference/pebble.html
         """
         # Get a reference the container attribute on the PebbleReadyEvent
         container = event.workload

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ class OpsExampleCharm(ops.CharmBase):
         container.add_layer("httpbin", self._pebble_layer, combine=True)
         # Make Pebble reevaluate its plan, ensuring any services are started if enabled.
         container.replan()
-        # Learn more about statuses in the SDK docs:
-        # https://juju.is/docs/sdk/constructs#heading--statuses
+        # Learn more about statuses at
+        # https://documentation.ubuntu.com/juju/3.6/reference/status/
         self.unit.status = ops.ActiveStatus()
 ```
 

--- a/docs/reference/ops-testing-harness.rst
+++ b/docs/reference/ops-testing-harness.rst
@@ -28,7 +28,7 @@ The Harness API includes:
 
 .. note::
     Unit testing is only one aspect of a comprehensive testing strategy. For more
-    on testing charms, see `Charm SDK | Testing <https://juju.is/docs/sdk/testing>`_.
+    on testing charms, see :doc:`/explanation/testing`.
 
 
 .. autoclass:: ops.testing.ActionFailed

--- a/docs/reference/ops-testing.rst
+++ b/docs/reference/ops-testing.rst
@@ -66,7 +66,7 @@ A test consists of three broad steps:
 
 .. note::
     Unit testing is only one aspect of a comprehensive testing strategy. For more
-    on testing charms, see `Charm SDK | Testing <https://juju.is/docs/sdk/testing>`_.
+    on testing charms, see :doc:`/explanation/testing`.
 
 
 ..

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -2863,7 +2863,7 @@ class _TestingModelBackend:
         # https://discourse.charmhub.io/t/secret-access-permissions/12627
         # For user secrets the secret owner is the model, that is,
         # when `secret.owner_name == self.model.uuid`, only model admins have
-        # manage permissions: https://juju.is/docs/juju/secret.
+        # manage permissions: https://documentation.ubuntu.com/juju/3.6/reference/secret/.
 
         unit_secret = secret.owner_name == self.unit_name
         app_secret = secret.owner_name == self.app_name

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1911,8 +1911,8 @@ class JujuAssumesCondition(enum.Enum):
 class JujuAssumes:
     """Juju model features that are required by the charm.
 
-    See the `Juju docs <https://juju.is/docs/olm/supported-features>`_ for a
-    list of available features.
+    See the `Charmcraft docs <https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/charmcraft-yaml-file/#assumes>`_
+    for a list of available features.
     """
 
     features: list[str | JujuAssumes]

--- a/ops/jujucontext.py
+++ b/ops/jujucontext.py
@@ -27,7 +27,7 @@ from .jujuversion import JujuVersion
 class _JujuContext:
     """_JujuContext collects information from environment variables named 'JUJU_*'.
 
-    Source: https://juju.is/docs/juju/charm-environment-variables.
+    Source: https://documentation.ubuntu.com/juju/3.6/reference/hook/#hook-execution.
     The HookVars function: https://github.com/juju/juju/blob/3.6/worker/uniter/runner/context/context.go#L1398.
     Only a subset of the above source, because these are what are used in ops.
     """

--- a/ops/lib/__init__.py
+++ b/ops/lib/__init__.py
@@ -16,7 +16,7 @@
 
 .. deprecated:: 2.1.0
     The ops.lib functionality is deprecated, and is superseded by
-    charm libraries (https://juju.is/docs/sdk/library) and regular Python imports.
+    `charm libraries and regular Python imports.
     We now prefer to do version selection at build (charmcraft pack) time.
 """
 
@@ -62,8 +62,7 @@ def use(name: str, api: int, author: str) -> ModuleType:
         ValueError: if the name, api, or author are invalid.
 
     .. deprecated:: 2.1.0
-        This function is deprecated. Prefer charm libraries instead
-        (https://juju.is/docs/sdk/library).
+        This function is deprecated. Prefer charm libraries instead.
     """
     warnings.warn(
         'ops.lib is deprecated, prefer charm libraries instead', category=DeprecationWarning
@@ -106,8 +105,7 @@ def autoimport():
     Otherwise libraries are found on first call of `use`.
 
     .. deprecated:: 2.1.0
-        This function is deprecated. Prefer charm libraries instead
-        (https://juju.is/docs/sdk/library).
+        This function is deprecated. Prefer charm libraries instead.
     """
     warnings.warn(
         'ops.lib is deprecated, prefer charm libraries instead', category=DeprecationWarning

--- a/ops/lib/__init__.py
+++ b/ops/lib/__init__.py
@@ -16,7 +16,7 @@
 
 .. deprecated:: 2.1.0
     The ops.lib functionality is deprecated, and is superseded by
-    `charm libraries and regular Python imports.
+    charm libraries and regular Python imports.
     We now prefer to do version selection at build (charmcraft pack) time.
 """
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -719,7 +719,7 @@ class Unit:
         Some behaviour, such as whether the port is opened externally without
         using "juju expose" and whether the opened ports are per-unit, differs
         between Kubernetes and machine charms. See the
-        `Juju documentation <https://juju.is/docs/sdk/hook-tool#heading--open-port>`__
+        `Juju documentation <https://documentation.ubuntu.com/juju/3.6/reference/hook-command/list-of-hook-commands/open-port/#details>`_
         for more detail.
 
         Use :meth:`set_ports` for a more declarative approach where all of
@@ -747,7 +747,7 @@ class Unit:
         Some behaviour, such as whether the port is closed externally without
         using "juju unexpose", differs between Kubernetes and machine charms.
         See the
-        `Juju documentation <https://juju.is/docs/sdk/hook-tool#heading--close-port>`__
+        `Juju documentation <https://documentation.ubuntu.com/juju/3.6/reference/hook-command/list-of-hook-commands/open-port/#details>`_
         for more detail.
 
         Use :meth:`set_ports` for a more declarative approach where all
@@ -778,7 +778,7 @@ class Unit:
         Some behaviour, such as whether the port is opened or closed externally without
         using Juju's ``expose`` and ``unexpose`` commands, differs between Kubernetes
         and machine charms. See the
-        `Juju documentation <https://juju.is/docs/sdk/hook-tool#heading--networking>`__
+        `Juju documentation <https://documentation.ubuntu.com/juju/3.6/reference/hook-command/list-of-hook-commands/open-port/#details>`_
         for more detail.
 
         Use :meth:`open_port` and :meth:`close_port` to manage ports

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -29,7 +29,7 @@ The module includes:
 
 .. note::
     Unit testing is only one aspect of a comprehensive testing strategy. For more
-    on testing charms, see `Charm SDK | Testing <https://juju.is/docs/sdk/testing>`_.
+    on testing charms, see `Testing <https://ops.readthedocs.io/en/latest/explanation/testing.html>`_.
 """
 
 # ruff: noqa: F401 (unused import)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ tracing = [
 harness = []
 
 [project.urls]
-"Homepage" = "https://juju.is/docs/sdk"
+"Homepage" = "https://ops.readthedocs.io/en/latest/"
 "Repository" = "https://github.com/canonical/operator"
 "Issues" = "https://github.com/canonical/operator/issues"
 "Documentation" = "https://ops.readthedocs.io"

--- a/test/charms/test_smoke/metadata.yaml
+++ b/test/charms/test_smoke/metadata.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # For a complete list of supported options, see:
-# https://juju.is/docs/sdk/metadata-reference
+# https://canonical-charmcraft.readthedocs-hosted.com/en/latest/reference/files/metadata-yaml-file/
 name: smoke
 display-name: |
   smoke

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Learn more about testing at: https://juju.is/docs/sdk/testing
+# Learn more about testing at
+# https://ops.readthedocs.io/en/latest/explanation/testing.html
+
 from __future__ import annotations
 
 import logging

--- a/test/integration/test_tracing.py
+++ b/test/integration/test_tracing.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Learn more about testing at: https://juju.is/docs/sdk/testing
+# Learn more about testing at
+# https://ops.readthedocs.io/en/latest/explanation/testing.html
+
 from __future__ import annotations
 
 import json

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Learn more about testing at: https://juju.is/docs/sdk/testing
+# Learn more about testing at
+# https://ops.readthedocs.io/en/latest/explanation/testing.html
 
 from __future__ import annotations
 


### PR DESCRIPTION
This PR updates old `juju.is/docs` links in docstrings, comments, and the README.

This addresses most of #1626. The other parts of that issue will be done separately:
- Links in the Kubernetes tutorial will be covered by https://github.com/canonical/operator/issues/1718
- The link in `testing/CONTRIBUTING.md` will be covered by https://github.com/canonical/operator/pull/1724
- The remaining links are technically behavior changes, because they're in output/errors from Ops. Covered by https://github.com/canonical/operator/pull/1726