### PR TITLE
fix: fix link in breakpoint output, remove link from Harness error message

### DIFF
--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -2284,8 +2284,6 @@ class _TestingConfig(Dict[str, Union[str, int, float, bool]]):
             raise RuntimeError(
                 f'Unknown config option {key}; '
                 'not declared in `config.yaml`.'
-                'For help, see:'
-                'https://ops.readthedocs.io/en/latest/howto/manage-configurations.html'
             )
 
         declared_type = option.get('type')

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -2281,10 +2281,7 @@ class _TestingConfig(Dict[str, Union[str, int, float, bool]]):
         # has the expected type.
         option = self._spec.get('options', {}).get(key)
         if not option:
-            raise RuntimeError(
-                f'Unknown config option {key}; '
-                'not declared in `config.yaml`.'
-            )
+            raise RuntimeError(f'Unknown config option {key}; not declared in `config.yaml`.')
 
         declared_type = option.get('type')
         if not declared_type:

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -2284,8 +2284,8 @@ class _TestingConfig(Dict[str, Union[str, int, float, bool]]):
             raise RuntimeError(
                 f'Unknown config option {key}; '
                 'not declared in `config.yaml`.'
-                'Check https://juju.is/docs/sdk/config for the '
-                'spec.'
+                'For help, see:'
+                'https://ops.readthedocs.io/en/latest/howto/manage-configurations.html'
             )
 
         declared_type = option.get('type')

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -573,7 +573,8 @@ _BREAKPOINT_WELCOME_MESSAGE = """
 Starting pdb to debug charm operator.
 Run `h` for help, `c` to continue, or `exit`/CTRL-d to abort.
 Future breakpoints may interrupt execution again.
-More details at https://juju.is/docs/sdk/debugging
+For more information, see:
+https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/debug-code/
 
 """
 


### PR DESCRIPTION
This PR addresses a couple of issues:

- In the welcome message that's shown when a breakpoint is triggered, there's a link to https://juju.is/docs/sdk/debugging. This link is broken. I think a suitable replacement would be [`juju debug-code`](https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/debug-code/).

- Harness raises an error if the charm tries to update an unknown config option. The error message includes a link to https://juju.is/docs/sdk/config, which redirects to [https://ops.readthedocs.io/en/latest/howto/manage-configurations.html](https://ops.readthedocs.io/en/latest/howto/manage-configurations.html). I was going to replace the link, but since this is Harness, I then figured that removing the link would be the more maintainable option.