### PR TITLE
chore: change Python 3.11 to 3.10 and 3.12, when testing example charms

### DIFF
--- a/.github/workflows/example-charm-tests.yaml
+++ b/.github/workflows/example-charm-tests.yaml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python-version: ["3.10", "3.12"]
         dir:
           - examples/k8s-1-minimal
 

--- a/.github/workflows/example-charm-tests.yaml
+++ b/.github/workflows/example-charm-tests.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '${{ matrix.python-version }}'
       - name: Install tox
         run: pip install tox~=4.2
       - name: Run unit tests


### PR DESCRIPTION
This PR is a follow up to #1719 - specifically [this comment](https://github.com/canonical/operator/pull/1719/files#r2090751498).