### PR TITLE
chore: bump documentation dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,30 +6,30 @@
 #
 alabaster==1.0.0
     # via sphinx
-anyio==4.8.0
+anyio==4.9.0
     # via
     #   starlette
     #   watchfiles
 babel==2.17.0
     # via sphinx
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   canonical-sphinx-extensions
     #   furo
     #   pyspelling
 bracex==2.5.post1
     # via wcmatch
-canonical-sphinx-extensions==0.0.23
+canonical-sphinx-extensions==0.0.27
     # via ops (pyproject.toml)
-certifi==2025.1.31
+certifi==2025.4.26
     # via requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
-click==8.1.8
+click==8.2.0
     # via uvicorn
 colorama==0.4.6
     # via sphinx-autobuild
-deprecated==1.2.15
+deprecated==1.2.18
     # via opentelemetry-api
 docutils==0.21.2
     # via
@@ -43,7 +43,7 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.44
     # via canonical-sphinx-extensions
-h11==0.14.0
+h11==0.16.0
     # via uvicorn
 html5lib==1.1
     # via pyspelling
@@ -53,7 +53,7 @@ idna==3.10
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via
     #   opentelemetry-api
     #   ops (pyproject.toml)
@@ -63,9 +63,9 @@ jinja2==3.1.6
     #   sphinx
 linkify-it-py==2.0.3
     # via ops (pyproject.toml)
-lxml==5.3.1
+lxml==5.4.0
     # via pyspelling
-markdown==3.7
+markdown==3.8
     # via pyspelling
 markdown-it-py==3.0.0
     # via
@@ -79,9 +79,9 @@ mdurl==0.1.2
     # via markdown-it-py
 myst-parser==4.0.1
     # via ops (pyproject.toml)
-opentelemetry-api==1.30.0
+opentelemetry-api==1.33.1
     # via ops (pyproject.toml)
-packaging==24.2
+packaging==25.0
     # via sphinx
 pygments==2.19.1
     # via
@@ -105,9 +105,9 @@ smmap==5.0.2
     # via gitdb
 sniffio==1.3.1
     # via anyio
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via sphinx
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   beautifulsoup4
     #   pyspelling
@@ -151,21 +151,21 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sphinxext-opengraph==0.9.1
+sphinxext-opengraph==0.10.0
     # via ops (pyproject.toml)
-starlette==0.46.1
+starlette==0.46.2
     # via sphinx-autobuild
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   anyio
     #   beautifulsoup4
 uc-micro-py==1.0.3
     # via linkify-it-py
-urllib3==2.3.0
+urllib3==2.4.0
     # via requests
-uvicorn==0.34.0
+uvicorn==0.34.2
     # via sphinx-autobuild
-watchfiles==1.0.4
+watchfiles==1.0.5
     # via sphinx-autobuild
 wcmatch==10.0
     # via pyspelling


### PR DESCRIPTION
Regenerate the documentation dependencies (`rm docs/requirements.txt; uvx --python=3.11 tox -e docs-deps`).

This is primarily to deal with `h11`, which has a security issue that's fixed in the new release (I don't believe we are impacted, but updating is safest and silences the alert).

Rather than only bumping `h11`, bump the rest as well. The ones that are not bug-fix releases only are:

* [anyio](https://anyio.readthedocs.io/en/stable/versionhistory.html) (seems unlikely to impact doc generation)
* certifi (the usual cert updates)
* [click](https://click.palletsprojects.com/en/stable/changes/) (drops Python 3.8 support but for docs that should be fine already, nothing else seems to impact us, awful release notes)
* [importlib-metadata](https://github.com/python/importlib_metadata/blob/main/NEWS.rst) (really just bug fixes)
* opentelemetry-api
* [lxml](https://github.com/lxml/lxml/releases) (apparently a security fix -- not sure why this isn't picked up)
* [markdown](https://github.com/Python-Markdown/markdown/releases/tag/3.8) (really just bug fixes)
* [packaging](https://packaging.pypa.io/en/stable/changelog.html) (shouldn't impact docs)
* [snowballstemmer](https://github.com/snowballstem/snowball/blob/master/NEWS) (the Python changes are just admin, the stemming changes are complex but I'm willing to assume would only improve things for us, however we are using this)
* [soupsieve](https://facelessuser.github.io/soupsieve/about/changelog/#27) (just new selectors)
* [sphinxext-opengraph](https://github.com/sphinx-doc/sphinxext-opengraph/releases/tag/v0.10.0) (nothing that should impact us, although the 3.12 support is good)
* [typing-extensions](https://github.com/python/typing_extensions/releases)
* [urllib3](https://github.com/urllib3/urllib3/releases/tag/2.4.0) (nothing that should impact us)

The two I wonder about are:
* typing-extensions: maybe this should always match what we use in static checking?
* opentelemetry-api: maybe this should always match what ops uses?

[Preview build](https://ops--1739.org.readthedocs.build/en/1739/)