### PR TITLE
ci: disable alertmanager compatibility tests until upstream fix

### DIFF
--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -20,6 +20,8 @@ jobs:
         include:
           - charm-repo: canonical/alertmanager-k8s-operator
             commit: 2f12ce579d4a52149d810a92bfe52189cb4ce20e  # 2025-04-09T08:01:25Z
+            # https://github.com/canonical/alertmanager-k8s-operator/pull/329
+            disabled: true
           - charm-repo: canonical/prometheus-k8s-operator
             commit: 3c01180a1d35c7de262af81eddf2847fc71bd1c1  # 2025-04-24T12:34:41Z
           - charm-repo: canonical/grafana-k8s-operator


### PR DESCRIPTION
[Upstream PR](https://github.com/canonical/alertmanager-k8s-operator/pull/329). Once it's resolved, we can re-enable. For now, having it continually failing is annoying.