### PR TITLE
docs: configurations -> configuration

### DIFF
--- a/docs/explanation/testing.md
+++ b/docs/explanation/testing.md
@@ -98,7 +98,7 @@ Integration tests typically take significantly longer to run than unit tests.
 * Packing and deploying the charm
 * Charm actions
 * Charm relations
-* Charm configurations
+* Charm configuration
 * That the workload is up and running, and responsive
 * Upgrade sequence
   * Regression test: upgrade stable/candidate/beta/edge from charmhub with the locally-built charm.

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -14,7 +14,7 @@ Run workloads with a Kubernetes charm <run-workloads-with-a-charm-kubernetes>
 Manage storage <manage-storage>
 Manage resources <manage-resources>
 Manage actions <manage-actions>
-Manage configurations <manage-configurations>
+Manage configuration <manage-configuration>
 Manage relations <manage-relations>
 Manage leadership changes <manage-leadership-changes>
 Manage libraries <manage-libraries>

--- a/docs/howto/manage-charms.md
+++ b/docs/howto/manage-charms.md
@@ -95,7 +95,7 @@ do it well.
 > * Add functionality
 >   - [Charmcraft | Add runtime details to a charm](https://canonical-charmcraft.readthedocs-hosted.com/en/latest/howto/manage-charms/#add-runtime-details-to-a-charm)
 >   - {ref}`manage-actions`
->   - {ref}`manage-configurations`
+>   - {ref}`manage-configuration`
 >   - {ref}`manage-opened-ports`
 > * {external+charmcraft:ref}`Charmcraft | Manage charms > Pack a charm <pack-a-charm>`
 > * {external+juju:ref}`Juju | Manage charms > Deploy a charm <deploy-a-charm>` (you'll need to follow the "Deploy a local charm" example)

--- a/docs/howto/manage-configuration.md
+++ b/docs/howto/manage-configuration.md
@@ -1,6 +1,6 @@
-(manage-configurations)=
-# Manage configurations
-> See first: {external+juju:ref}`Juju | <application-configuration>`, {external+juju:ref}`Juju | Manage applications > Configure <configure-an-application>`, {external+charmcraft:ref}`Charmcraft | Manage configurations <manage-configurations>`
+(manage-configuration)=
+# Manage configuration
+> See first: {external+juju:ref}`Juju | <application-configuration>`, {external+juju:ref}`Juju | Manage applications > Configure <configure-an-application>`, {external+charmcraft:ref}`Charmcraft | Manage configuration <manage-configuration>`
 
 
 ## Implement the feature

--- a/docs/howto/manage-configuration.md
+++ b/docs/howto/manage-configuration.md
@@ -1,6 +1,6 @@
 (manage-configuration)=
 # Manage configuration
-> See first: {external+juju:ref}`Juju | <application-configuration>`, {external+juju:ref}`Juju | Manage applications > Configure <configure-an-application>`, {external+charmcraft:ref}`Charmcraft | Manage configuration <manage-configuration>`
+> See first: {external+juju:ref}`Juju | <application-configuration>`, {external+juju:ref}`Juju | Manage applications > Configure <configure-an-application>`, {external+charmcraft:ref}`Charmcraft | Manage configurations <manage-configurations>`
 
 
 ## Implement the feature

--- a/docs/howto/manage-interfaces.md
+++ b/docs/howto/manage-interfaces.md
@@ -459,7 +459,7 @@ For reference, [here](https://github.com/IronCore864/my-fancy-database-operator)
 
 ### Troubleshooting and debugging the tests
 
-#### Your charm is missing some configurations/mocks
+#### Your charm is missing some configuration or mocks
 
 Solution to this is to add the missing mocks/patches to the `interface_tester` fixture in `conftest.py`.
 Essentially, you need to make it so that the charm runtime 'thinks' that everything is normal and ready to process and accept the interface you are testing.

--- a/docs/howto/manage-metrics.md
+++ b/docs/howto/manage-metrics.md
@@ -91,7 +91,7 @@ When Pebble receives a request to access the metrics endpoint, Pebble will verif
 
 > See more:
 > - {ref}`make-your-charm-configurable`
-> - {ref}`manage-configurations`
+> - {ref}`manage-configuration`
 > - {ref}`manage-secrets`
 
 ## Deploy the charm and grant access to the user secret

--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -188,7 +188,7 @@ async def test_my_integration(ops_test: OpsTest):
 
 ### Test a configuration
 
-> See first: {ref}`manage-configurations`
+> See first: {ref}`manage-configuration`
 
 You can set a configuration option in your application and check its results. 
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -635,7 +635,7 @@ APP_NAME = METADATA['name']
 async def test_build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it together with related charms.
 
-    Assert on the unit status before any relations/configurations take place.
+    Assert on the unit status before integration or configuration.
     """
     # Build and deploy charm from local source folder
     charm = await ops_test.build_charm('.')

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -423,7 +423,7 @@ Now that our charm integrates with the PostgreSQL database, if there's not a dat
 async def test_build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it together with related charms.
 
-    Assert on the unit status before any relations/configurations take place.
+    Assert on the unit status before integration or configuration.
     """
     # Build and deploy charm from local source folder
     charm = await ops_test.build_charm(".")

--- a/docs/tutorial/write-your-first-machine-charm.md
+++ b/docs/tutorial/write-your-first-machine-charm.md
@@ -376,7 +376,7 @@ Machine  State    Address         Inst id        Base          AZ  Message
 
 Congratulations, your charm users can now deploy the application from a specific channel!
 
-> See more: {ref}`manage-configurations`
+> See more: {ref}`manage-configuration`
 
 
 ## Enable `juju status` with `App Version`

--- a/examples/k8s-1-minimal/tests/integration/test_charm.py
+++ b/examples/k8s-1-minimal/tests/integration/test_charm.py
@@ -30,7 +30,7 @@ APP_NAME = METADATA['name']
 async def test_build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it together with related charms.
 
-    Assert on the unit status before any relations/configurations take place.
+    Assert on the unit status before integration or configuration.
     """
     # Build and deploy charm from local source folder
     charm = await ops_test.build_charm('.')


### PR DESCRIPTION
This PR changes "Manage configurations" to "Manage configuration", as the latter sounds much better to me. And we always call it "charm configuration" (singular) or "charm config", not "charm configs".