### PR TITLE
ci: remove explicit scopes and update HACKING.md

### DIFF
--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -32,4 +32,4 @@ jobs:
             refactor
             revert
             test
-          scopes: ""
+          disallowScopes: ".*"

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -32,8 +32,4 @@ jobs:
             refactor
             revert
             test
-          scopes: |
-            harness
-            testing
-            tracing
-          requireScope: false
+          scopes: ""

--- a/HACKING.md
+++ b/HACKING.md
@@ -183,25 +183,18 @@ Pull requests should have a short title that follows the
 * revert
 * test
 
-At present, we only add a scope in these cases:
-
-* If the PR is limited to optional features, use one of these scopes to clarify context:
-  * `(harness)` for changes in `ops/_private/harness.py`
-  * `(testing)` for changes in `testing/`
-  * `(tracing)` for changes in `tracing/`
-
-Use of these scopes makes it clear when a change is limited to test tooling or optional features, rather than core runtime behavior.
-
-For example:
+Some examples:
 
 * feat: add the ability to observe change-updated events
 * fix!: correct the type hinting for config data
-* docs(harness): clarify the types of exceptions that Harness.add_user_secret may raise
-* ci(testing): adjust the workflow that publishes ops-scenario
+* docs: clarify the types of exceptions that Harness.add_user_secret may raise
+* ci: adjust the workflow that publishes ops-scenario
 
 Note that the commit messages to the PR's branch do not need to follow the
 conventional commit format, as these will be squashed into a single commit to `main`
 using the PR title as the commit message.
+
+We consider Ops too small a project to use scopes, so we don't use them.
 
 ## Copyright
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -187,7 +187,7 @@ Some examples:
 
 * feat: add the ability to observe change-updated events
 * fix!: correct the type hinting for config data
-* docs: clarify the types of exceptions that Harness.add_user_secret may raise
+* docs: clarify how to use mounts in ops.testing.Container
 * ci: adjust the workflow that publishes ops-scenario
 
 Note that the commit messages to the PR's branch do not need to follow the


### PR DESCRIPTION
Per discussion at the sprint, we consider Ops too small a repo to use scopes, and no automation uses them, so we decided not not use scopes, and have validation error if you use one.

Fixes #1727