### PR TITLE
ci: re-enable alertmanager-k8s-operator in observability charm tests

### DIFF
--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - charm-repo: canonical/alertmanager-k8s-operator
-            commit: 2f12ce579d4a52149d810a92bfe52189cb4ce20e  # 2025-04-09T08:01:25Z
+            commit: 2257e3fc46e3162a092b3de70807d4b9f76e7380
           - charm-repo: canonical/prometheus-k8s-operator
             commit: 3c01180a1d35c7de262af81eddf2847fc71bd1c1  # 2025-04-24T12:34:41Z
           - charm-repo: canonical/grafana-k8s-operator

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -20,8 +20,6 @@ jobs:
         include:
           - charm-repo: canonical/alertmanager-k8s-operator
             commit: 2f12ce579d4a52149d810a92bfe52189cb4ce20e  # 2025-04-09T08:01:25Z
-            # https://github.com/canonical/alertmanager-k8s-operator/pull/329
-            disabled: true
           - charm-repo: canonical/prometheus-k8s-operator
             commit: 3c01180a1d35c7de262af81eddf2847fc71bd1c1  # 2025-04-24T12:34:41Z
           - charm-repo: canonical/grafana-k8s-operator


### PR DESCRIPTION
Now that https://github.com/canonical/alertmanager-k8s-operator/pull/329 has been merged, updating the charm's unit tests to use Scenario 7, this PR re-enables this charm in the Observability Charm Tests, and updates the pinned commit to include the updated unit tests.