### PR TITLE
fix: correctly remove suffix from event string in ops.testing

### DIFF
--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1851,8 +1851,7 @@ class _EventPath(str):
         )
         # TODO: when we drop Python 3.8, we can change the whole if-else below to
         # instance.prefix = string.removesuffix(suffix)
-        if suffix:
-            assert string.endswith(suffix)  # due to _get_suffix_and_type logic
+        if suffix and string.endswith(suffix):
             instance.prefix = string[: -len(suffix)]
         else:
             instance.prefix = string

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1851,8 +1851,8 @@ class _EventPath(str):
         )
         # TODO: when we drop Python 3.8, we can change the whole if-else below to
         # instance.prefix = string.removesuffix(suffix)
-        if suffix and string.endswith(suffix):
-            instance.prefix = string[: -len(suffix)]
+        if suffix:
+            instance.prefix, _ = string.rsplit(suffix, maxsplit=1)
         else:
             instance.prefix = string
 

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1849,8 +1849,11 @@ class _EventPath(str):
         instance.suffix, instance.type = suffix, _ = _EventPath._get_suffix_and_type(
             name,
         )
+        # TODO: when we drop Python 3.8, we can change the whole if-else below to
+        # instance.prefix = string.removesuffix(suffix)
         if suffix:
-            instance.prefix, _ = string.rsplit(suffix)
+            assert string.endswith(suffix)  # due to _get_suffix_and_type logic
+            instance.prefix = string[: -len(suffix)]
         else:
             instance.prefix = string
 


### PR DESCRIPTION
In `ops.testing`, `scenario.state` contains logic that removes a suffix string from the event name. With the previous `rsplit` based implementation, suffix removal would fail if the suffix occurred multiple times in the string, since it would split the string into more than two parts.

For example, this would lead to failure when running `ctx.on.action('my-action')`, as the string `my_action_action` would be split into `'my', '', ''`, and the code expected the result of splitting to always be two items (the prefix, and an empty string).

This PR sets `maxsplit=1` for `rsplit` to handle this case.