### PR TITLE
ci: fix reporting to TIOBE after ops-tracing addition

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -19,10 +19,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       - name: Install dependencies
-        run: pip install tox~=4.2 coverage[toml] flake8 pylint websocket-client==1.* pyyaml==6.* pytest~=7.2 pytest-operator~=0.23
+        run: pip install tox~=4.2 coverage[toml] flake8 pylint websocket-client==1.* pyyaml==6.* pytest~=7.2 pytest-operator~=0.23 opentelemetry-api~=1.0 importlib-metadata
       - name: Generate coverage report
         run: |
-          tox -e coverage
+          tox -e coverage,coverage-tracing,coverage-report
 
       - name: TICS GitHub Action
         uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7  # v3.4.0

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ venv
 /docsenv
 .vscode
 .coverage
+.coverage-ops
+.coverage-tracing
 coverage.xml
 .coverage.data
 /.tox

--- a/tox.ini
+++ b/tox.ini
@@ -150,6 +150,7 @@ commands =
              --ignore={[vars]examples_path} \
              -v --tb native \
              -W 'ignore:Harness is deprecated:PendingDeprecationWarning' {posargs}
+    coverage report
     mv .coverage .coverage-ops
 
 [testenv:coverage-tracing]
@@ -173,6 +174,7 @@ commands =
     coverage run --source=. --branch -m pytest \
              -v --tb native \
              -W 'ignore:Harness is deprecated:PendingDeprecationWarning' {posargs}
+    coverage report
     mv .coverage ../.coverage-tracing
 
 [testenv:coverage-report]

--- a/tox.ini
+++ b/tox.ini
@@ -127,7 +127,34 @@ commands =
 
 [testenv:coverage]
 description = Run unit tests with coverage
-allowlist_externals = mkdir
+allowlist_externals = mv
+passenv =
+    RUN_REAL_PEBBLE_TESTS
+    PEBBLE
+deps =
+    PyYAML==6.*
+    websocket-client==1.*
+    coverage[toml]~=7.0
+    pytest~=7.2
+    typing_extensions~=4.2
+    jsonpatch~=1.33
+    -e .
+    -e testing
+commands =
+    coverage run --source={[vars]src_path},{[vars]testing_src_path} \
+             --branch -m pytest --ignore={[vars]tst_path}smoke \
+             --ignore={[vars]tst_path}integration \
+             --ignore={[vars]tst_path}benchmark \
+             --ignore={[vars]testing_tst_path}benchmark \
+             --ignore={[vars]tracing_tst_path} \
+             --ignore={[vars]examples_path} \
+             -v --tb native \
+             -W 'ignore:Harness is deprecated:PendingDeprecationWarning' {posargs}
+    mv .coverage .coverage-ops
+
+[testenv:coverage-tracing]
+description = Run tracing unit tests with coverage
+allowlist_externals = mv
 passenv =
     RUN_REAL_PEBBLE_TESTS
     PEBBLE
@@ -141,16 +168,22 @@ deps =
     -e .
     -e testing
     -e tracing
+changedir = ./tracing/
 commands =
-    mkdir -p .report
-    coverage run --source={[vars]src_path},{[vars]testing_src_path} \
-             -m pytest --ignore={[vars]tst_path}smoke \
-             --ignore={[vars]tst_path}integration \
-             --ignore={[vars]tst_path}benchmark \
-             --ignore={[vars]testing_tst_path}benchmark \
-             --ignore={[vars]tracing_tst_path} \
+    coverage run --source=. --branch -m pytest \
              -v --tb native \
              -W 'ignore:Harness is deprecated:PendingDeprecationWarning' {posargs}
+    mv .coverage ../.coverage-tracing
+
+[testenv:coverage-report]
+description = Report on coverage
+allowlist_externals = mkdir
+deps =
+    coverage[toml]~=7.0
+commands =
+    mkdir -p .report
+    coverage combine -a .coverage-ops
+    coverage combine -a .coverage-tracing
     coverage xml -o .report/coverage.xml
     coverage report
 

--- a/tracing/ops_tracing/_api.py
+++ b/tracing/ops_tracing/_api.py
@@ -169,7 +169,7 @@ class Tracing(ops.Object):
                 return Destination(None, None)
 
             if not base_url.startswith(('http://', 'https://')):
-                logger.warning(f'The {base_url=} must be an HTTP or an HTTPS URL')
+                logger.warning('The base_url=%s must be an HTTP or an HTTPS URL', base_url)
                 return Destination(None, None)
 
             url = f'{base_url.rstrip("/")}/v1/traces'


### PR DESCRIPTION
A collection of changes to fix reporting to TIOBE after the addition of the ops-tracing package:

* The TIOBE run needs all the dependencies explicitly installed, so add the new ones of importlib-metadata and opentelemetry-api. Presumably when we shift over to using `uv` for dependency management we can clean this up.
* Add a new tox environment for running unit tests with coverage for tracing, and split off the reporting part of the existing coverage environment, and add a new environment for combining and report. This is very messy, but works for now, and will presumably be able to be cleaned up when we do the planned repository restructuring.
* Fix one of the issues identified by TIOBE (oddly not by our regular tooling), where an f-string is used with logging.