### PR TITLE
feat: support for config schema as Python classes

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -342,6 +342,7 @@ nitpick_ignore = [
     ('py:class', 'IdentityDict'),
     ('py:obj', 'ops._private.harness.CharmType'),
     ('py:class', 'ops._private.harness.CharmType'),
+    ('py:class', 'ops.charm._ActionType'),
     ('py:class', 'ops.charm._ContainerBaseDict'),
     ('py:class', 'ops.model._AddressDict'),
     ('py:class', 'ops.model._GenericLazyMapping'),

--- a/docs/howto/manage-actions.md
+++ b/docs/howto/manage-actions.md
@@ -47,90 +47,66 @@ In the `src/charm.py` file, in the `__init__` function of your charm, set up an 
 self.framework.observe(self.on.grant_admin_role_action, self._on_grant_admin_role_action)
 ```
 
+Also in the `src/charm.py file`, create a class for each action that defines the schema of the action parameters. For example:
+
+```python
+class CompressionKind(enum.Enum):
+    GZIP = 'gzip'
+    BZIP = 'bzip2'
+    XZ = 'xz'
+
+class Compression(pydantic.BaseModel):
+    kind: CompressionKind = pydantic.Field(CompressionKind.BZIP)
+
+    quality: int = pydantic.Field(5, description="Compression quality.")
+
+    @pydantic.validator("quality")
+    def validate_quality(cls, value):
+        if 0 <= quality <= 9:
+            return value
+        raise ValueError("Quality must be an integer between 0 and 9 inclusive.")
+
+class SnapshotAction(pydantic.BaseModel):
+    """Take a snapshot of the database."""
+
+    filename: str = pydantic.Field(description="The name of the snapshot file.")
+
+    compression: Compression = pydantic.Field(
+        Compression.GZIP,
+        description="The type of compression to use.",
+    )
+```
+
 Now, in the body of the charm definition, define the action event handler. For example:
 
 ```python
-def _on_grant_admin_role_action(self, event):
-    """Handle the grant-admin-role action."""
-    # Fetch the user parameter from the ActionEvent params dict
-    user = event.params["user"]
-    # Do something useful with it
-    cmd = ["/usr/bin/myapp", "roles", "system_admin", user]
-    # Set a log message for the action
-    event.log(f"Running this command: {' '.join(cmd)}")
-    granted = subprocess.run(cmd, capture_output=True)
-    if granted.returncode != 0:
-        # Fail the action if there is an error
-        event.fail(
-            f"Failed to run '{' '.join(cmd)}'. Output was:\n{granted.stderr.decode('utf-8')}"
-        )
-    else:
-        # Set the results of the action
-        msg = f"Ran grant-admin-role for user '{user}'"
-        event.set_results({"result": msg})
+def _on_snapshot_action(self, event):
+    """Handle the snapshot action."""
+    # Fetch the parameters. If the user passes something invalid, this will
+    # fail the action with an appropriate message.
+    params = event.load_params(SnapshotAction, errors="fail")
+    # This might take a while, so let the user know we're working on it.
+    # This is sent back to the Juju user in real-time, and appears in the output
+    # of the `juju run` command.
+    event.log(f"Generating snapshot into {params.filename}")
+    # Do the snapshot.
+    success = self.do_snapshot(
+        filename=params.filename,
+        kind=params.compression.kind,
+        quality=params.compression.quality,
+    )
+    if not success:
+        # Report to the user that the action has failed.
+        event.fail(f"Failed to generate snapshot.")  # Ideally, include more details than this!
+        # Note that `fail()` doesn't interrupt code, so is typically followed by a `return`.
+        return
+    # Set the results of the action.
+    msg = f"Stored snapshot in {params.filename}."
+    # These will be displayed in the `juju run` output.
+    event.set_results({"result": msg})
 ```
 
-More detail below:
-
-#### Use action params
-
-To make use of action parameters, either ones that the user has explicitly passed, or default values, use the `params` attribute of the event object that is passed to the handler. This is a dictionary of parameter name (string) to parameter value. For example:
-
-```python
-def _on_snapshot(self, event: ops.ActionEvent):
-    filename = event.params["filename"]
-    ...
-```
-
-> See more: [](ops.ActionEvent.params)
-
-#### Report that an action has failed
-
-To report that an action has failed, in the event handler definition, use the fail() method along with a message explaining the failure to be shown to the person running the action. Note that the `fail()` method doesn’t interrupt code execution, so you will usually want to immediately follow the call to `fail()` with a `return`, rather than continue with the event handler. For example:
-
-```python
-def _on_snapshot(self, event: ops.ActionEvent):
-    filename = event.params['filename']
-    kind = event.params['compression']['kind']
-    quality = event.params['compression']['quality']
-    cmd = ['/usr/bin/do-snapshot', f'--kind={kind}', f'--quality={quality}', filename]
-    subprocess.run(cmd, capture_output=True)
-    if granted.returncode != 0:
-        event.fail(
-            f"Failed to run {' '.join(cmd)!r}. Output was:\n{granted.stderr.decode('utf-8')}"
-        )
-   ...
-```
-
-> See more: [](ops.ActionEvent.fail)
-
-#### Return the results of an action
-
-To pass back the results of an action to the user, use the `set_results` method of the action event. These will be displayed in the `juju run` output. For example:
-
-```python
-def _on_snapshot(self, event: ops.ActionEvent):
-    size = self.do_snapshot(event.params['filename'])
-    event.set_results({'snapshot-size': size})
-```
-
-> See more: [](ops.ActionEvent.set_results)
-
-#### Log the progress of an action
-
-In a long-running action, to give the user updates on progress, use the `.log()` method of the action event. This is sent back to the user, via Juju, in real-time, and appears in the output of the `juju run` command. For example:
-
-```python
-def _on_snapshot(self, event: ops.ActionEvent):
-    event.log('Starting snapshot')
-    self.snapshot_table1()
-    event.log('Table1 complete')
-    self.snapshot_table2()
-    event.log('Table2 complete')
-    self.snapshot_table3()
-```
-
-> See more: [](ops.ActionEvent.log)
+> See more: [](ops.ActionEvent.load_params), [](ops.ActionEvent.params), [](ops.ActionEvent.fail), [](ops.ActionEvent.set_results), [](ops.ActionEvent.log)
 
 #### Record the ID of an action task
 
@@ -141,7 +117,7 @@ def _on_snapshot(self, event: ops.ActionEvent):
     temp_filename = f'backup-{event.id}.tar.gz'
     logger.info("Using %s as the temporary backup filename in task %s", filename, event.id)
     self.create_backup(temp_filename)
-    ... 
+    ...
 ```
 > See more: [](ops.ActionEvent.id)
 
@@ -164,7 +140,6 @@ def test_backup_action():
 ```
 
 > See more: [](ops.testing.Context.action_logs), [](ops.testing.Context.action_results), [](ops.testing.ActionFailed)
-
 
 ### Write integration tests
 

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -546,7 +546,7 @@ class RelationBase(_max_posargs(2)):
 
     def _get_databag_for_remote(
         self,
-        unit_id: int,  # noqa: U100
+        unit_id: int,
     ) -> RawDataBagContents:
         """Return the databag for some remote unit ID."""
         raise NotImplementedError()

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ all_path = {[vars]src_path} {[vars]tst_path}
 testing_src_path = testing/src/scenario/
 testing_tst_path = testing/tests/
 tracing_tst_path = tracing/test/
+examples_path = examples/
 
 [testenv]
 basepython = python3
@@ -93,6 +94,7 @@ deps =
     pytest~=7.2
     typing_extensions~=4.2
     pydantic~=2.10
+    eval-type-backport~=0.2
     -e .
     -e testing
     -e tracing
@@ -123,6 +125,7 @@ commands =
         --ignore={[vars]tst_path}benchmark \
         --ignore={[vars]testing_tst_path}benchmark \
         --ignore={[vars]tracing_tst_path} \
+        --ignore={[vars]examples_path} \
         -v --tb native \
         -W 'ignore:Harness is deprecated:PendingDeprecationWarning' {posargs}
 
@@ -139,6 +142,8 @@ deps =
     pytest~=7.2
     typing_extensions~=4.2
     jsonpatch~=1.33
+    pydantic~=2.10
+    eval-type-backport~=0.2
     -e .
     -e testing
 commands =
@@ -167,7 +172,6 @@ deps =
     pytest~=7.2
     typing_extensions~=4.2
     jsonpatch~=1.33
-    eval-type-backport~=0.2
     -e .
     -e testing
     -e tracing

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ all_path = {[vars]src_path} {[vars]tst_path}
 testing_src_path = testing/src/scenario/
 testing_tst_path = testing/tests/
 tracing_tst_path = tracing/test/
-examples_path = examples/
 
 [testenv]
 basepython = python3
@@ -93,6 +92,7 @@ deps =
     pyright==1.1.385
     pytest~=7.2
     typing_extensions~=4.2
+    pydantic~=2.10
     -e .
     -e testing
     -e tracing
@@ -111,6 +111,8 @@ deps =
     pytest-xdist~=3.6
     typing_extensions~=4.2
     jsonpatch~=1.33
+    pydantic~=2.10
+    eval-type-backport~=0.2
     -e .
     -e testing
     -e tracing
@@ -121,7 +123,6 @@ commands =
         --ignore={[vars]tst_path}benchmark \
         --ignore={[vars]testing_tst_path}benchmark \
         --ignore={[vars]tracing_tst_path} \
-        --ignore={[vars]examples_path} \
         -v --tb native \
         -W 'ignore:Harness is deprecated:PendingDeprecationWarning' {posargs}
 
@@ -138,6 +139,7 @@ deps =
     pytest~=7.2
     typing_extensions~=4.2
     jsonpatch~=1.33
+    eval-type-backport~=0.2
     -e .
     -e testing
     -e tracing


### PR DESCRIPTION
A new method is added to `ops.ActionEvent`: `load_params`, which is the custom class equivalent of the `.params` property. The charmer passes a class to this method and gets back an instance of the class with the Juju action parameters loaded into it.

Two error-handling modes are provided for `load_params`. In the default, "raise", any exceptions raised creating the class are re-raised and must be handled by the charm (or left for the charm to go to error state). The alternative is "fail", where `load_params` will catch any `ValueError` (or subclass) and exit the charm with a zero exit status after setting an appropriate failure message. This mode should be suitable for the majority of actions.

The implementation is intended to be duck-typed, in that any class that accepts the data as keyword arguments and raises ValueError (or a subclass) in instantiation and/or setting attributes will work. However, the tests verify four specific cases:

* A generic Python class (no inheritance other than object).
* Standard library dataclasses (I personally believe these are the best choice for almost all cases).
* Pydantic dataclasses
* Pydantic 2.x BaseModel classes (we'll use these in our documentation, as they're in common use).

We don't explicitly promise that these exact cases work, but they should continue to do so while they rely on the current implementation. This leaves it open to support or not other cases (e.g. a potential Pydantic 3.x, attrs, and so on).

In order to test that these 4 types work, the unit tests add specific tests if Pydantic is installed, and the tox environment for static and unit install Pydantic. Ops itself does not require Pydantic (at run time or for tests).

This PR includes reference docs ([Preview]()) and updates the configuration how-to ([Preview]()). A follow-up PR is planned that would make use of this functionality in the zero-to-hero tutorial - it will be simplest to do that after #1734 and any follow-up PRs are complete, to avoid conflicts.

More details are available in the [spec](https://docs.google.com/document/d/1AiNvr1xfh078ieRczCCc9HSx4VW-dDJdF2p9FS2E_do/edit?usp=sharing).