### PR TITLE
docs: remove two best practices, and drop two to tips

### DIFF
--- a/docs/howto/manage-charms.md
+++ b/docs/howto/manage-charms.md
@@ -73,8 +73,6 @@ and the charm workflow.
 The next thing to do is add functionality to your charm.
 As you do that, you'll frequently pack, test, and debug your charm.
 
-```{admonition} Best practice
-:class: hint
 One of the powers of charms is their reusability. As such, do not try to
 duplicate functionality already achieved by an existing charm – rather, make
 your charm take advantage of the [charm ecosystem](https://charmhub.io) by
@@ -84,7 +82,6 @@ identity, scaling, and so on.
 This also helps you stay compliant with another fundamental rule in charms,
 namely that, following the Unix philosophy, each charm should do one thing and
 do it well.
-```
 
 > See more:
 >

--- a/docs/howto/run-workloads-with-a-charm-machines.md
+++ b/docs/howto/run-workloads-with-a-charm-machines.md
@@ -1,16 +1,9 @@
 (run-workloads-with-a-charm-machines)=
 # How to run workloads with a machine charm
 
-There are several ways your charm might start a workload, depending on the type of charm you're authoring. 
+There are several ways your charm might start a workload, depending on the type of charm you're authoring.
 
 For a machine charm, it is likely that packages will need to be fetched, installed and started to provide the desired charm functionality. This can be achieved by interacting with the system's package manager, ensuring that package and service status is maintained by reacting to events accordingly.
-
-```{admonition} Best practice
-:class: hint
-
-Limit the use of shell scripts and commands as much as possible in favour of
-writing Python for charm code.
-```
 
 It is important to consider which events to respond to in the context of your charm. A simple example might be:
 
@@ -75,8 +68,7 @@ class MachineCharm(ops.CharmBase):
         self.unit.status = ops.ActiveStatus()
 ```
 
-```{admonition} Best practice
-:class: hint
+```{tip}
 
 When running subprocesses, log the return (exit) code as well as `stderr` when
 errors occur.

--- a/docs/howto/write-and-structure-charm-code.md
+++ b/docs/howto/write-and-structure-charm-code.md
@@ -16,7 +16,7 @@ charm, or ``<base charm name>-operators`` when the repository will hold
 multiple related charms. For the charm name, see
 {external+charmcraft:ref}`Charmcraft | Specify a name <specify-a-name>`.
 ```
-    
+
 In your new repository, run `charmcraft init` to generate the recommended
 structure for building a charm.
 
@@ -176,8 +176,7 @@ Arrange the methods of this class in the following order:
    For example, `def _on_pebble_ready(...)` instead of `def on_pebble_ready(...)`.
 3. Other helper methods, which may be private or public.
 
-```{admonition} Best practice
-:class: hint
+```{tip}
 
 If an event handler needs to pass event data to a helper method, extract the relevant data
 from the event object and pass that data to the helper method. Don't pass the event object itself.


### PR DESCRIPTION
Some small adjustments to the "best practices" set, as per the [Matrix discussion](https://matrix.to/#/!eNCNzcteYUDDYpStsu:ubuntu.com/$X4iGYgVZwjud0GUSy5yinak-OoxqxBaGBatrnaEVcfk?via=ubuntu.com&via=matrix.org&via=laquadrature.net):

* Change the "reusability" best practice note to just be regular text.
* Remove the "Use Python rather than subprocess" best practice note -- this is more Python than charming.
* Change the "log the exit code" best practice note to a tip.
* Change the "pass things in the custom object" best practice note to a tip.