### PR TITLE
ci: install the ops[tracing] dependencies for the TIOBE action

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
       - name: Install dependencies
-        run: pip install tox~=4.2 coverage[toml] flake8 pylint websocket-client==1.* pyyaml==6.* pytest~=7.2 pytest-operator~=0.23 opentelemetry-api~=1.0 importlib-metadata
+        run: pip install tox~=4.2 coverage[toml] flake8 pylint websocket-client==1.* pyyaml==6.* pytest~=7.2 pytest-operator~=0.23 opentelemetry-api~=1.0 importlib-metadata opentelemetry-sdk~=1.30 pydantic
       - name: Generate coverage report
         run: |
           tox -e coverage,coverage-tracing,coverage-report


### PR DESCRIPTION
TIOBE gives this error in two of the tracing modules:

> [ERROR 5073] The following error(s) occurred while 'pylint' was running: 'E0401:20:0:Unable to import 'opentelemetry.sdk.resources'. Module 'opentelemetry.sdk.resources' not installed or specified on PYTHONPATH in the TICS configuration.

Fix this by installing the dependencies for ops-tracing as well, when running the TIOBE action.