### PR TITLE
ci: add ops-scenario and ops-tracing as explicit installs for TIOBE

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
       - name: Install dependencies
-        run: pip install tox~=4.2 coverage[toml] flake8 pylint websocket-client==1.* pyyaml==6.* pytest~=7.2 pytest-operator~=0.23 opentelemetry-api~=1.0 importlib-metadata
+        run: pip install tox~=4.2 coverage[toml] flake8 pylint websocket-client==1.* pyyaml==6.* pytest~=7.2 pytest-operator~=0.23 opentelemetry-api~=1.0 importlib-metadata ops-scenario ops-tracing
       - name: Generate coverage report
         run: |
           tox -e coverage,coverage-tracing,coverage-report


### PR DESCRIPTION
This seems to have been missed when we added ops-scenario into the TIOBE checks - the error doesn't seem to show up anywhere except in the ops/testing.py results (which just show outdated results).

As well as explicitly installing ops-scenario, also install ops-tracing, for consistency.