### PR TITLE
ci: persist credentials for update-charm-pins workflow

### DIFF
--- a/.github/workflows/update-charm-tests.yaml
+++ b/.github/workflows/update-charm-tests.yaml
@@ -16,7 +16,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.UPDATE_CHARM_PINS_ACCESS_TOKEN }}
-          persist-credentials: false
 
       - uses: ./.github/actions/update-charm-pins
         with:


### PR DESCRIPTION
This workflow is failing due to a permissions error on the `git push`. Remove the `persist-credentials: false` line on checkout.