### PR TITLE
fix: correctly load an empty Juju config options map

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1541,7 +1541,7 @@ class CharmMeta:
     ):
         raw_: dict[str, Any] = raw or {}
         actions_raw_: dict[str, Any] = actions_raw or {}
-        config_raw_: dict[str, Any] = config_raw or {}
+        options_raw: dict[str, Any] = (config_raw or {}).get('options', {}) or {}
 
         # When running in production, this data is generally loaded from
         # metadata.yaml. However, when running tests, this data is
@@ -1606,7 +1606,7 @@ class CharmMeta:
         # This is predominately for backwards compatibility with Harness. In a
         # real Juju environment this shouldn't be possible, because charmcraft
         # validates the config when packing.
-        for name, config in config_raw_.get('options', {}).items():
+        for name, config in options_raw.items():
             if 'type' not in config:
                 raise RuntimeError(
                     f'Incorrectly formatted config in YAML, option {name} is '
@@ -1619,7 +1619,7 @@ class CharmMeta:
                 default=config.get('default'),
                 description=config.get('description'),
             )
-            for name, config in config_raw_.get('options', {}).items()
+            for name, config in options_raw.items()
         }
         self.containers = {
             name: ContainerMeta(name, container)


### PR DESCRIPTION
There are many forms that "no Juju config options" can take, for example:

* No `config` section in charmcraft.yaml, and no config.yaml
* An empty `config` section in charmcraft yaml
* An empty config.yaml
* A `config` section in charmcraft yaml with an empty `options` subsection
* No `config` section in charmcraft.yaml, and an empty `options` map in config.yaml

For the cases where there *was* an `options` map, but it was empty, we were failing to load the meta. Add more extensive tests to cover the different cases, and fix loading in that case.

Fixes #1775