### PR TITLE
ci: stop smoke testing Charmcraft 2

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -14,9 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # pylibjuju does not currently support Juju 4.x
+        # pylibjuju does not support Juju 4.x
+        # We need to migrate the test to use Jubilant for Juju>2.
         juju-channel: ['2.9/stable', '3/stable']
-        charmcraft-channel: ['2.x/stable', '3.x/stable']
+        charmcraft-channel: ['3.x/stable']
         preset: ['machine', 'microk8s']
 
     steps:

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -29,17 +29,6 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 
 
-CHARMCRAFT2_YAML = """
-type: "charm"
-bases:
-  - build-on:
-    - name: "ubuntu"
-      channel: "{base}"
-    run-on:
-    - name: "ubuntu"
-      channel: "{base}"
-"""
-
 CHARMCRAFT3_YAML = """
 type: "charm"
 base: ubuntu@{base}
@@ -100,7 +89,6 @@ async def test_smoke(ops_test: OpsTest, base: str, charmcraft_version: int, name
         pytest.skip(f'charmcraft version {available_charmcraft_version} is too old for this test')
         return
     charmcraft_yaml = {
-        2: CHARMCRAFT2_YAML,
         3: CHARMCRAFT3_YAML,
     }[charmcraft_version].format(base=base)
     with open('./test/charms/test_smoke/charmcraft.yaml', 'w') as outf:


### PR DESCRIPTION
The smoke tests [fail](https://github.com/canonical/operator/actions/runs/15235348271/job/42848398516) when using Charmcraft 2 because of the [setuptools / importlib changes](https://github.com/canonical/charmcraft/issues/2259), which are fixed in Charmcraft 3 but not in Charmcraft 2.

Rather than work around this, since we expect charmers to be using Charmcraft 3 by now, and don't expect charmers to be using very new ops with old Charmcraft, drop testing against Charmcraft 2.