### PR TITLE
fix: fix type annotation of container check_infos in ops.testing

### DIFF
--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1016,7 +1016,7 @@ class Container(_max_posargs(1)):
     notices: Sequence[Notice] = dataclasses.field(default_factory=list)
     """Any Pebble notices that already exist in the container."""
 
-    check_infos: frozenset[CheckInfo] = frozenset()
+    check_infos: Iterable[CheckInfo] = frozenset()
     """All Pebble health checks that have been added to the container."""
 
     def __hash__(self) -> int:


### PR DESCRIPTION
Testing code such as `container = testing.Container("db", check_infos={check_info})` was failing type checks, with this error:

```
error: Argument of type "set[CheckInfo]" cannot be assigned to parameter "check_infos" of type "frozenset[CheckInfo]" in function "__init__"
    "set[CheckInfo]" is not assignable to "frozenset[CheckInfo]" (reportArgumentType)
```

This PR fixes the type annotation of `check_infos` so that non-frozen sets are acceptable.