### PR TITLE
docs: fix external OTLP link

### DIFF
--- a/docs/explanation/tracing.md
+++ b/docs/explanation/tracing.md
@@ -1,11 +1,9 @@
-Tracing
-=======
+(tracing)=
+# Tracing
 
-Storage
--------
+## Storage
 
-Priority
-^^^^^^^^
+### Priority
 
 An application is deployed and the charm tracing relation can only be established after that.
 The trace data collected during this period may be important. The tracing backend stores up
@@ -19,13 +17,11 @@ important bits of trace data from the buffer.
 
 This hopefully ensures that you can see the trace data for your "install" and "start" events.
 
-Data format
-^^^^^^^^^^^
+### Data format
 
 The data is stored and sent to the OpenTelemetry collector in the [OLTP 1.5.0 JSON format]
 (https://opentelemetry.io/docs/specs/otlp/) (aka protobuf JSON representation with OTLP gotchas).
 
-Backwards and forwards compatibility
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+### Backwards and forwards compatibility
 
 The ``ops==2.20.0`` is the first Ops library release that supports tracing.

--- a/docs/explanation/tracing.md
+++ b/docs/explanation/tracing.md
@@ -19,8 +19,9 @@ This hopefully ensures that you can see the trace data for your "install" and "s
 
 ### Data format
 
-The data is stored and sent to the OpenTelemetry collector in the [OLTP 1.5.0 JSON format]
-(https://opentelemetry.io/docs/specs/otlp/) (aka protobuf JSON representation with OTLP gotchas).
+The data is stored and sent to the OpenTelemetry collector in the
+[OLTP 1.5.0 JSON format](https://opentelemetry.io/docs/specs/otlp/)
+(protobuf JSON representation with OTLP gotchas).
 
 ### Backwards and forwards compatibility
 


### PR DESCRIPTION
I must have moved this block from a docstring at some point.
This PR updates the link format from MD to RST.