### PR TITLE
fix: Juju allows access to the remote app databag in relation-broken, so Harness should too

### DIFF
--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -2476,13 +2476,6 @@ class _TestingModelBackend:
         if not isinstance(is_app, bool):
             raise TypeError('is_app parameter to relation_set must be a boolean')
 
-        if 'relation_broken' in self._hook_is_running and not self.relation_remote_app_name(
-            relation_id
-        ):
-            raise RuntimeError(
-                'remote-side relation data cannot be accessed during a relation-broken event'
-            )
-
         if relation_id not in self._relation_data_raw:
             raise RelationNotFoundError(relation_id)
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -1858,16 +1858,12 @@ class RelationDataContent(LazyMapping, MutableMapping[str, str]):
             # leaders have no read restrictions
             return
 
-        # type guard; we should not be accessing relation data
-        # if the remote app does not exist.
-        app = self.relation.app
-        if app is None:
-            raise RelationDataAccessError(
-                f'Remote application instance cannot be retrieved for {self.relation}.'
-            )
-
         # is this a peer relation?
-        if app.name == self._entity.name:
+        # The 'hasattr' check here is to protect against a Juju bug where
+        # JUJU_REMOTE_APP is sometimes not set. In that case, self.relation.app
+        # will be None (even though it is typed to always be an Application).
+        # https://bugs.launchpad.net/juju/+bug/1960934
+        if hasattr(self.relation.app, 'name') and self.relation.app.name == self._entity.name:
             # peer relation data is always publicly readable
             return
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -1858,12 +1858,16 @@ class RelationDataContent(LazyMapping, MutableMapping[str, str]):
             # leaders have no read restrictions
             return
 
+        # type guard; we should not be accessing relation data
+        # if the remote app does not exist.
+        app = self.relation.app
+        if app is None:
+            raise RelationDataAccessError(
+                f'Remote application instance cannot be retrieved for {self.relation}.'
+            )
+
         # is this a peer relation?
-        # The 'hasattr' check here is to protect against a Juju bug where
-        # JUJU_REMOTE_APP is sometimes not set. In that case, self.relation.app
-        # will be None (even though it is typed to always be an Application).
-        # https://bugs.launchpad.net/juju/+bug/1960934
-        if hasattr(self.relation.app, 'name') and self.relation.app.name == self._entity.name:
+        if app.name == self._entity.name:
             # peer relation data is always publicly readable
             return
 


### PR DESCRIPTION
Removes an outdated (or perhaps always wrong) check in Harness that prevents accessing the remote app databag during relation-broken events. Juju does allow this, so Harness should have the same behaviour.

This check is specific to Harness and there's no equivalent check in Scenario.

Fixes #888