### PR TITLE
fix: support newer OpenTelemetry SDK

### DIFF
--- a/tracing/ops_tracing/_backend.py
+++ b/tracing/ops_tracing/_backend.py
@@ -74,11 +74,17 @@ def _create_provider(resource: Resource, charm_dir: pathlib.Path) -> TracerProvi
 
 def get_exporter() -> BufferingSpanExporter | None:
     """Get our export from OpenTelemetry SDK."""
+    exporter = None
     try:
+        # opentelemetry-sdk versions xx ~ xx
         exporter = get_tracer_provider()._active_span_processor.span_exporter  # type: ignore
     except AttributeError:
-        # The global tracer provider was not configured by us and has a wrong processor.
-        return None
+        pass
+    try:
+        # opentelemetry-sdk versions yy ~ yy
+        exporter = get_tracer_provider()._active_span_processor._batch_processor._exporter
+    except AttributeError:
+        pass
     if not exporter or not isinstance(exporter, BufferingSpanExporter):
         return None
     return exporter

--- a/tracing/ops_tracing/_backend.py
+++ b/tracing/ops_tracing/_backend.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import pathlib
 from typing import TYPE_CHECKING
 
@@ -78,12 +77,16 @@ def get_exporter() -> BufferingSpanExporter | None:
     exporter = None
 
     # opentelemetry-sdk < 1.34.0
-    with contextlib.suppress(AttributeError):
+    try:
         exporter = get_tracer_provider()._active_span_processor.span_exporter  # type: ignore
+    except AttributeError:
+        pass
 
     # opentelemetry-sdk >= 1.34.0
-    with contextlib.suppress(AttributeError):
+    try:
         exporter = get_tracer_provider()._active_span_processor._batch_processor._exporter  # type: ignore
+    except AttributeError:
+        pass
 
     if not exporter or not isinstance(exporter, BufferingSpanExporter):
         return None

--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -104,6 +104,8 @@ ignore = [
     "D213",
     # we don't add a blank line after Args: in a function docstring
     "D413",
+    # Use contextlib.suppress() instead of try/except: pass
+    "SIM105",
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
I'm proposing this as a hot-fix to support both older and newer style of the OpenTelemetry SDK.

Upstream change that broke our code: https://github.com/open-telemetry/opentelemetry-python/pull/4580