### PR TITLE
docs: small adjustments to the 'how to trace charm code' doc

### DIFF
--- a/docs/howto/trace-the-charm-code.md
+++ b/docs/howto/trace-the-charm-code.md
@@ -8,14 +8,6 @@ execution using OpenTelemetry.
 Refer to `ops.tracing` reference for the canonical usage example, configuration
 options and API details.
 
-This guide covers:
-- [Adding tracing to your charm](#getting-started-tracing-a-charm)
-- [Creating custom spans and events](#custom-spans-and-events)
-- [Adding tracing to charm libraries](#adding-tracing-to-charm-libraries)
-- [Migrating from the `charm_tracing` charm library](#migrating-from-charm_tracing-charm-library)
-- [How and when to use the lower-level API](#lower-level-api)
-
-(getting-started-tracing-a-charm)=
 ## Getting started
 
 To enable basic tracing:


### PR DESCRIPTION
A few small adjustments to the how-to guide for tracing, where I ran into trouble trying to do this:

* Typo: "configuration"
* Remove the table of contents, because that's provided in the right-hand sidebar.
* Provide an example for the charmcraft YAML.
* Provide an example for instantiating the tracing object.
* Tweak the wording of the list of traces ops will generate.
* Explain that after you've added the tracing you still need to integrate with a tracing provider before you can really see anything, and provide an example of doing that.
* Move the note about using the context manager rather than the decorator into a tip box.
* Provide an example of adding a custom span and a custom event.
* Remove a duplicate instruction to add `ops[tracing]` in the dependencies.