### PR TITLE
fix: restrict the version of a dependency, opentelemetry-sdk

### DIFF
--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Framework :: OpenTelemetry",
 ]
 dependencies = [
-    "opentelemetry-sdk~=1.30",
+    "opentelemetry-sdk~=1.30,<1.34",
     "ops==2.23.0.dev0",
     "pydantic",
 ]


### PR DESCRIPTION
The newest release broke our code.
This is a quick fix that we could release to the charmers.

Upstream: https://github.com/open-telemetry/opentelemetry-python/issues/4616