### PR TITLE
docs: improve testing.errors.UncaughtCharmError message

### DIFF
--- a/testing/src/scenario/_runtime.py
+++ b/testing/src/scenario/_runtime.py
@@ -340,9 +340,9 @@ class Runtime:
             except (NoObserverError, ActionFailed):
                 raise  # propagate along
             except Exception as e:
-                raise UncaughtCharmError(
-                    f'Uncaught exception ({type(e)}) in operator/charm code: {e!r}',
-                ) from e
+                # The following is intentionally on one long line, so that the last line of pdb
+                # output shows the error message (pdb shows the "raise" line).
+                raise UncaughtCharmError(f'Uncaught {type(e).__name__} in charm, try "exceptions [n]" if using pdb on Python 3.13+. Details: {e!r}') from e  # fmt: skip
 
             finally:
                 for key in tuple(os.environ):


### PR DESCRIPTION
This changes the UncaughtCharmError message and puts the message on the same source line as the "raise", so that when using "pytest --pdb" to debug a charm exception, it shows more clearly what to do.

In Python 3.13 the [`exceptions [n]`](https://docs.python.org/3/library/pdb.html#pdbcommand-exceptions) command was added to pdb, which allows you to go back up the exception cause stack. For example:

```
$ pytest --pdb
...
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB post_mortem (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /home/ben/.cache/uv/archive-v0/gz1Vrbxq-976wQzrfehra/lib/python3.13/site-packages/scenario/_runtime.py(345)exec()
-> raise UncaughtCharmError(f'Uncaught {type(e).__name__} in charm, try "exceptions [n]" if using pdb on Python 3.13+. Details: {e!r}') from e  # fmt: skip
(Pdb) exceptions
    0 ValueError('a value error')
>   1 UncaughtCharmError('Uncaught ValueError in charm, try "exceptions [n]" if usi...
(Pdb) exceptions 0
> /home/ben/w/test-charms/database/src/charm.py(75)_on_debug_action()
-> raise ValueError("a value error")
(Pdb) event
<ActionEvent self.id='2' via DatabaseCharm/on/debug_action[1]>
```

Previously it would just show the "raise UncaughtCharmError" part:

```
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB post_mortem >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /code/hexanator/.tox/unit/lib/python3.12/site-packages/scenario/runtime.py(469)exec()
-> raise UncaughtCharmError(
(Pdb)
```

Note that the above only shows the last line -- the full output from pdb did already include more context:

```
...
>               raise UncaughtCharmError(f'Uncaught {type(e).__name__} in charm, try "exceptions [n]" if using pdb on Python 3.13+. Details: {e!r}') from e  # fmt: skip
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E               scenario.errors.UncaughtCharmError: Uncaught ValueError in charm, try "exceptions [n]" if using pdb on Python 3.13+. Details: ValueError('a value error')

../../../.cache/uv/archive-v0/gz1Vrbxq-976wQzrfehra/lib/python3.13/site-packages/scenario/_runtime.py:345: UncaughtCharmError
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> entering PDB >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB post_mortem (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /home/ben/.cache/uv/archive-v0/gz1Vrbxq-976wQzrfehra/lib/python3.13/site-packages/scenario/_runtime.py(345)exec()
-> raise UncaughtCharmError(f'Uncaught {type(e).__name__} in charm, try "exceptions [n]" if using pdb on Python 3.13+. Details: {e!r}') from e  # fmt: skip
(Pdb)
```

In any case, hopefully this minor fix helps point people in the right direction.

I'm labelling this "docs" as it doesn't change any behaviour, just slightly improves the exception message.

Fixes #1428.