### PR TITLE
docs: in the "manage the charm version" how-to, give an example of using override-build

### DIFF
--- a/docs/howto/manage-the-charm-version.md
+++ b/docs/howto/manage-the-charm-version.md
@@ -23,12 +23,12 @@ $ cat version
 0522e1fd009dac78adb3d0652d91a1e8ff7982ae
 ```
 
-Typically, your publishing or packing workflow takes care of updating file file, so
+Typically, your publishing or packing workflow takes care of updating this file, so
 that it will automatically match the revision that you're creating and publishing.
 Generally, using a version control revision is the best choice, as it unambiguously
 identifies the code that was used to build the charm.
 
-One way to achieve this is to include in your `charmcraft.yaml` a parts build
+One way to achieve this is to modify your `charmcraft.yaml` file to include a parts build
 override, such as:
 
 ```yaml
@@ -39,7 +39,7 @@ parts:
     build-packages: [git]
     build-snaps: [astral-uv]
     override-build: |
-      craftctl default
+      craftctl default  # Run the default build steps.
       git describe --always > $CRAFT_PART_INSTALL/version
 ```
 

--- a/docs/howto/manage-the-charm-version.md
+++ b/docs/howto/manage-the-charm-version.md
@@ -23,13 +23,24 @@ $ cat version
 0522e1fd009dac78adb3d0652d91a1e8ff7982ae
 ```
 
-```{note}
-
-Normally, your publishing workflow would take care of updating this file, so
-that it will automatically match the revision that you're publishing. Generally,
-using a version control revision is the best choice, as it unambiguously
+Typically, your publishing or packing workflow takes care of updating file file, so
+that it will automatically match the revision that you're creating and publishing.
+Generally, using a version control revision is the best choice, as it unambiguously
 identifies the code that was used to build the charm.
 
+One way to achieve this is to include in your `charmcraft.yaml` a parts build
+override, such as:
+
+```yaml
+parts:
+  charm:
+    source: .
+    plugin: uv
+    build-packages: [git]
+    build-snaps: [astral-uv]
+    override-build: |
+      craftctl default
+      git describe --always > $CRAFT_PART_INSTALL/version
 ```
 
 Juju admins using your charm can find this information with `juju status` in the


### PR DESCRIPTION
Inspired by the [parca-k8s charm](https://github.com/canonical/parca-k8s-operator/blob/afdc784503a0ea7ac52172f417fd0a379b137632/charmcraft.yaml#L26), include an example in the how-to guide for managing the charm version of using a override-build step in the parts to automatically set the version.