### PR TITLE
chore: ops[tracing], emit traceId for jhack, opt. 2

### DIFF
--- a/ops/_main.py
+++ b/ops/_main.py
@@ -446,12 +446,10 @@ class _Manager:
             return
 
         args, kwargs = self._get_event_args(event_to_emit)
-        logger.debug('Emitting Juju event %s.', event_name)
-        # If tracing is set up, log the trace id so that tools like jhack can pick it up.
-        # If tracing is not set up, span is non-recording and trace is zero.
-        trace_id = opentelemetry.trace.get_current_span().get_span_context().trace_id
-        if trace_id:
-            logger.debug("Starting root trace with id='%s'.", hex(trace_id)[2:])
+        trace_id = hex(opentelemetry.trace.get_current_span().get_span_context().trace_id)[
+            2:
+        ].rjust(32, '0')
+        logger.debug('Emitting Juju event %s, traceId: %s.', event_name, trace_id)
         event_to_emit.emit(*args, **kwargs)
 
     def _commit(self):

--- a/ops/_main.py
+++ b/ops/_main.py
@@ -25,6 +25,8 @@ import warnings
 from pathlib import Path
 from typing import Any, Union, cast
 
+import opentelemetry.trace
+
 from . import charm as _charm
 from . import framework as _framework
 from . import model as _model
@@ -445,6 +447,11 @@ class _Manager:
 
         args, kwargs = self._get_event_args(event_to_emit)
         logger.debug('Emitting Juju event %s.', event_name)
+        # If tracing is set up, log the trace id so that tools like jhack can pick it up.
+        # If tracing is not set up, span is non-recording and trace is zero.
+        trace_id = opentelemetry.trace.get_current_span().get_span_context().trace_id
+        if trace_id:
+            logger.debug("Starting root trace with id='%s'.", hex(trace_id)[2:])
         event_to_emit.emit(*args, **kwargs)
 
     def _commit(self):


### PR DESCRIPTION
### Context: correlating charm logs and traces.

Today, COS does not receive charm logs because Juju controller doesn't have a feature to relate it to COS.
Unit/python-side charm log forwarder lib was prototyped, but needs a spec, review, and it's not used in any charms.
Thus we don't have a good template how to enrich the log lines with trace and/or span ids -- what literal format, what id format, punctuation, etc.
In any case, given short-lived non-overlapping dispatch invocations, Grafana could, in theory, correlate logs and traces by unit name and timestamp range, without explicit trace ids.

This all means that in the large sense, providing for charm logs and traces correlation in ops is premature.

Jhack, however, does have this functionality in `hex(trace_id)[2:].rjust(32, "0")`, where processed charm events are annotated with trace ids that can be copy-pasted to Grafana.

### This PR

Enriches the existing `Emitting Juju event` log line with the trace id, in the most conventional format that I can think of right now.

### Alternatives

- do nothing
- add traceId into every log line today, flip-flop on format later
- #1806

P.S. I apologise for the way ruff auto-formatted this change 🙃 