### PR TITLE
ci: use Charmcraft 3.x for smoke testing 20.04 and 22.04

### DIFF
--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -71,8 +71,8 @@ def pack(charm_dir: pathlib.Path):
 @pytest.mark.parametrize(
     'base,charmcraft_version,name',
     (
-        ('20.04', 2, 'focal'),
-        ('22.04', 2, 'jammy'),
+        ('20.04', 3, 'jammy'),
+        ('22.04', 3, 'jammy'),
         ('24.04', 3, 'noble'),
     ),
 )

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -71,7 +71,7 @@ def pack(charm_dir: pathlib.Path):
 @pytest.mark.parametrize(
     'base,charmcraft_version,name',
     (
-        ('20.04', 3, 'jammy'),
+        ('20.04', 3, 'focal'),
         ('22.04', 3, 'jammy'),
         ('24.04', 3, 'noble'),
     ),


### PR DESCRIPTION
In #1782, we removed Charmcraft 2.x from the smoke test matrix. However, the smoke test code was still specifying that 20.04 and 22.04 should use Charmcraft 2, so when the test ran a `KeyError` would be raised.

This PR changes those bases to use Charmcraft 3.

[The branch runs successfully in my fork](https://github.com/tonyandrewmeyer/operator/actions/runs/15601083025) - I must have missed testing that last time.