### PR TITLE
chore: fix pebble tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -155,16 +155,16 @@ base=pebble
 
 [testenv:pebble]
 description = Run real pebble tests
-allowlist_externals = pebble
-                      mkdir
-                      bash
+allowlist_externals = bash
+                      killall
 setenv =
   PEBBLE=/tmp/pebble
   RUN_REAL_PEBBLE_TESTS=1
 passenv = PATH
 dependency_groups = unit
-commands =
-    bash -c "umask 0; (pebble run --http=':4000' --create-dirs &>/dev/null & ) ; sleep 1; pytest -v --tb native test/test_real_pebble.py {posargs} ; killall -y 3m pebble"
+commands_pre = bash -c "umask 0; pebble run --http=':4000' --create-dirs &>/dev/null& sleep 1"
+commands = pytest -v --tb native test/test_real_pebble.py {posargs}
+commands_post = killall -y 3m pebble
 
 [testenv:smoke]
 description = Run a smoke test against a Juju controller.


### PR DESCRIPTION
#1804 introduced a false positive to pebble tests: pytest failures are ignored.

This PR updates tox to modern pattern (commands_pre/commands/commands_post) where the errors are surfaced correctly.