### PR TITLE
chore: fix magic tox py3.X-unit environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -76,6 +76,7 @@ dependency_groups = unit, static
 commands = pyright {posargs}
 
 [testenv:py{3.8,3.10,3.12}-unit]
+runner = uv-venv-lock-runner
 base=unit
 
 [testenv:unit]
@@ -151,6 +152,7 @@ commands =
         {posargs}
 
 [testenv:py{3.8,3.10,3.12}-pebble]
+runner = uv-venv-lock-runner
 base=pebble
 
 [testenv:pebble]


### PR DESCRIPTION
https://matrix.to/#/!eNCNzcteYUDDYpStsu:ubuntu.com/$3VbbgdzBttKnsqO8bDK2okMs6E-W3rM_lUF3135DIFY?via=ubuntu.com&via=matrix.org&via=laquadrature.net

`tox -e unit` runs correct environment

`tox -e py3.10-unit` oddly installed `ops` from PYPI

Upstream discussion: https://github.com/tox-dev/tox-uv/discussions/212

This plugs the hole, though we don't have RCA yet.