### PR TITLE
ci: enable xdist for the 'unit' tox environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -86,7 +86,7 @@ passenv =
     PEBBLE
 dependency_groups = unit, xdist
 commands =
-    pytest \
+    pytest -n auto \
         --ignore={[vars]tst_path}smoke \
         --ignore={[vars]tst_path}integration \
         --ignore={[vars]tst_path}benchmark \


### PR DESCRIPTION
We think that [xdist was disabled accidentally](https://github.com/canonical/operator/pull/1819/commits/775168b6a7e723638151b9b217c48ecf4a35f07e). Turn it back on again.