### PR TITLE
fix: testing.PeerRelation properly defaults to no peers

### DIFF
--- a/testing/src/scenario/_consistency_checker.py
+++ b/testing/src/scenario/_consistency_checker.py
@@ -68,7 +68,7 @@ def check_consistency(
     juju_version: str,
     unit_id: int,
 ):
-    """Validate the combination of a state, an event, a charm spec, and a Juju version.
+    """Validate the combination of a state, event, charm spec, Juju version, and unit.
 
     When invoked, it performs a series of checks that validate that the state is
     consistent with itself, with the event being emitted, the charm metadata,

--- a/testing/src/scenario/_runtime.py
+++ b/testing/src/scenario/_runtime.py
@@ -296,7 +296,7 @@ class Runtime:
         """
         from ._consistency_checker import check_consistency  # avoid cycles
 
-        check_consistency(state, event, self._charm_spec, self._juju_version)
+        check_consistency(state, event, self._charm_spec, self._juju_version, self._unit_id)
 
         charm_type = self._charm_spec.charm_type
         logger.info(f'Preparing to fire {event.name} on {charm_type.__name__}')

--- a/testing/src/scenario/mocking.py
+++ b/testing/src/scenario/mocking.py
@@ -294,6 +294,9 @@ class _MockModelBackend(_ModelBackend):  # type: ignore
         relation = self._get_relation_by_id(relation_id)
 
         if isinstance(relation, PeerRelation):
+            # The current unit should never be in `peers_data`, and there is a
+            # consistency check to enforce that, but in case something has gone
+            # wrong, filter it out to match Juju's behaviour.
             this_unit = int(self.unit_name.split('/')[-1])
             return tuple(
                 f'{self.app_name}/{unit_id}'

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -711,7 +711,12 @@ class PeerRelation(RelationBase):
     """A relation to share data between units of the charm."""
 
     peers_data: dict[UnitID, RawDataBagContents] = dataclasses.field(default_factory=dict)
-    """Current contents of the peer databags."""
+    """Current contents of the peer databags.
+
+    Note that this does not include data for the unit being tested. Data for
+    that unit must be added to :attr:`RelationBase.local_unit_data`. To control
+    which unit is being tested, pass ``unit_id`` to the :class:`Context`.
+    """
     # Consistency checks will validate that *this unit*'s ID is not in here.
 
     def __hash__(self) -> int:

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -710,9 +710,7 @@ class SubordinateRelation(RelationBase):
 class PeerRelation(RelationBase):
     """A relation to share data between units of the charm."""
 
-    peers_data: dict[UnitID, RawDataBagContents] = dataclasses.field(
-        default_factory=lambda: {0: _DEFAULT_JUJU_DATABAG.copy()},
-    )
+    peers_data: dict[UnitID, RawDataBagContents] = dataclasses.field(default_factory=dict)
     """Current contents of the peer databags."""
     # Consistency checks will validate that *this unit*'s ID is not in here.
 

--- a/testing/tests/test_e2e/test_relations.py
+++ b/testing/tests/test_e2e/test_relations.py
@@ -712,7 +712,7 @@ def test_peer_relation_default_values():
     assert relation.interface == interface
     assert relation.local_app_data == {}
     assert relation.local_unit_data == _DEFAULT_JUJU_DATABAG
-    assert relation.peers_data == {0: _DEFAULT_JUJU_DATABAG}
+    assert relation.peers_data == {}
 
 
 def test_relation_remote_model():


### PR DESCRIPTION
The intention of Scenario's `PeerRelation` is that it defaults to no peers (the charm only has the one unit). In addition, `PeerRelation.peers_data` should only contain unit data for the *peers*, not for the unit that is under test - that is found in `local_unit_data`.

We were breaking these rules when creating a `PeerRelation` without an explicit `peers_data`. We would add in the default Juju relation data - but that was already present in `local_unit_data`, and we used `0` as the unit ID. In most cases, `0` is the unit being tested, so this data was mostly ignored and unable to be reached, although it was the underlying cause of the bug fixed in #1828. The worse situation is if someone provides a unit ID to `Context`, other than 0, and has a `PeerRelation` with default `peers_data`, the charm would 'magically' have two units.

The main fix here is that `peers_data` should be the empty dictionary by default. If charmers want peers, then they need to pass in an appropriate dictionary (and handle the default Juju keys themselves if relevant).

Since it's very simple to get `peers_data` wrong and put in data that should be in `local_unit_data`, the PR also adds a consistency check that verifies that everything is ok and suggests a fix if not.