### PR TITLE
docs: remove expandable boxes of text

### DIFF
--- a/docs/howto/legacy/turn-a-hooks-based-charm-into-an-ops-charm.md
+++ b/docs/howto/legacy/turn-a-hooks-based-charm-into-an-ops-charm.md
@@ -91,9 +91,7 @@ If we remove that section, run `charmcraft pack`, and then attempt to deploy the
 Processing error: Failed to copy '/root/stage/src': no such file or directory.
 ```
 
-### The plan
-
-````{dropdown} Detour: exploration of a lazy approach which turns out to be a bad idea.
+### An approach to avoid
 
 The minimal-effort solution in this case could be to create a file `/src/charm.py` and translate the built-in `self.on` event hooks to subprocess calls to the Bash event hooks as-they-are. Roughly:
 
@@ -130,7 +128,7 @@ A more detailed explanation of this process is worthy of its own how-to guide, s
 
 ```
 
-````
+### A better plan
 
 It is in our interest to move the handler logic for each `/hooks/<hook_name>` to `Microsample._on_<hook_name>`, for several reasons:
 - We can avoid code duplication by accessing shared data via the CharmBase interface provided through `self`. 

--- a/docs/howto/manage-interfaces.md
+++ b/docs/howto/manage-interfaces.md
@@ -13,19 +13,6 @@ Suppose that your interface specification has the following data model:
 
 These are the steps you need to take in order to  register it with [`charm-relation-interfaces`](#charm-relation-interfaces).
 
-
-```{dropdown} Expand to preview some example results
-
-- [A bare-minimum example](https://github.com/IronCore864/charm-relation-interfaces/tree/my-fancy-database/interfaces/my_fancy_database/v0)
-- [A more realistic example](https://github.com/canonical/charm-relation-interfaces/tree/main/interfaces/ingress/v1): 
-   - As you can see from the [`interface.yaml`](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/ingress/v1/interface.yaml) file, the [`canonical/traefik-k8s-operator` charm](https://github.com/canonical/traefik-k8s-operator) plays the provider role in the interface.
-   - The schema of this interface is defined in [`schema.py`](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/ingress/v1/schema.py).
-   - You can find out more information about this interface in the [README](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/ingress/v1/README.md).
-
-
-```
-
-
 ### 1. Clone (a fork of) [the `charm-relation-interfaces` repo](https://github.com/canonical/charm-relation-interfaces) and set up an interface specification folder
 
 ```bash
@@ -214,6 +201,12 @@ units_data : {
 
 Finally, open a pull request to the `charm-relation-interfaces` repo and drive it to completion, addressing any feedback or concerns that the maintainers may have.
 
+## Example
+
+For an example of a registered interface, see [`ingress`](https://github.com/canonical/charm-relation-interfaces/tree/main/interfaces/ingress/v1):
+   - As you can see from the [`interface.yaml`](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/ingress/v1/interface.yaml) file, the [`canonical/traefik-k8s-operator` charm](https://github.com/canonical/traefik-k8s-operator) plays the provider role in the interface.
+   - The schema of this interface is defined in [`schema.py`](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/ingress/v1/schema.py).
+   - You can find out more information about this interface in the [README](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/ingress/v1/README.md).
 
 (write-tests-for-an-interface)=
 ## Write tests for an interface

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -383,9 +383,9 @@ You should see a JSON string with the version of the application:
 {"version":"1.0.0"}
 ```
 
+Congratulations, you've successfully created a minimal Kubernetes charm!
 
-```{dropdown} Expand if you wish to inspect your deployment further
-
+### Inspect your deployment further
 
 1. Run:
 
@@ -414,9 +414,8 @@ demo-api-charm-0                 2/2     Running   0               7d2h
 ```text
 kubectl -n welcome-k8s describe pod demo-api-charm-0
 ```
-In the output you should see the definition for both containers. You'll be able to verify that the default command and arguments for our application container (`demo-server`) have been displaced by the Pebble service. You should be able to verify the same for the charm container (`charm`).
 
-**Congratulations, you've successfully created a minimal Kubernetes charm!** 
+In the output you should see the definition for both containers. You'll be able to verify that the default command and arguments for our application container (`demo-server`) have been displaced by the Pebble service. You should be able to verify the same for the charm container (`charm`).
 
 (write-unit-tests-for-your-charm)=
 ## Write unit tests for your charm


### PR DESCRIPTION
Resolves #1653 by removing all expandable boxes of text (`{dropdown}` elements in the source). These can be awkward to read, especially in dark mode, where the styling is not great.