### PR TITLE
docs: move {posargs} to the end of pytest command lines in tox.ini

### DIFF
--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -38,8 +38,8 @@ commands =
            -s \
            --tb native \
            --log-cli-level=INFO \
-           {posargs} \
-           {[vars]tests_path}/integration
+           {[vars]tests_path}/integration \
+           {posargs}
 ```
 
 ## Create a test file

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -468,8 +468,8 @@ commands =
         -v \
         -s \
         --tb native \
-        {posargs} \
-        {[vars]tests_path}/unit
+        {[vars]tests_path}/unit \
+        {posargs}
     coverage report
 ```
 > Read more: [`tox.ini`](https://tox.wiki/en/latest/config.html#tox-ini)
@@ -594,8 +594,8 @@ commands =
         -s \
         --tb native \
         --log-cli-level=INFO \
-        {posargs} \
-        {[vars]tests_path}/integration
+        {[vars]tests_path}/integration \
+        {posargs}
 ```
 
 If you used `charmcraft init --profile kubernetes` at the beginning of your project, the `testenv:integration` section is already in the `tox.ini` file.

--- a/examples/httpbin-demo/tox.ini
+++ b/examples/httpbin-demo/tox.ini
@@ -52,8 +52,8 @@ commands =
         -v \
         -s \
         --tb native \
-        {posargs} \
-        {[vars]tests_path}/unit
+        {[vars]tests_path}/unit \
+        {posargs}
     coverage report
 
 [testenv:integration]
@@ -69,5 +69,5 @@ commands =
         -s \
         --tb native \
         --log-cli-level=INFO \
-        {posargs} \
-        {[vars]tests_path}/integration
+        {[vars]tests_path}/integration \
+        {posargs}

--- a/examples/k8s-1-minimal/tox.ini
+++ b/examples/k8s-1-minimal/tox.ini
@@ -45,8 +45,8 @@ commands =
         -v \
         -s \
         --tb native \
-        {posargs} \
-        {[vars]tests_path}/unit
+        {[vars]tests_path}/unit \
+        {posargs}
     coverage report
 
 [testenv:integration]
@@ -62,5 +62,5 @@ commands =
         -s \
         --tb native \
         --log-cli-level=INFO \
-        {posargs} \
-        {[vars]tests_path}/integration
+        {[vars]tests_path}/integration \
+        {posargs}

--- a/examples/k8s-2-configurable/tox.ini
+++ b/examples/k8s-2-configurable/tox.ini
@@ -45,8 +45,8 @@ commands =
         -v \
         -s \
         --tb native \
-        {posargs} \
-        {[vars]tests_path}/unit
+        {[vars]tests_path}/unit \
+        {posargs}
     coverage report
 
 [testenv:integration]
@@ -62,5 +62,5 @@ commands =
         -s \
         --tb native \
         --log-cli-level=INFO \
-        {posargs} \
-        {[vars]tests_path}/integration
+        {[vars]tests_path}/integration \
+        {posargs}

--- a/examples/k8s-3-postgresql/tox.ini
+++ b/examples/k8s-3-postgresql/tox.ini
@@ -45,8 +45,8 @@ commands =
         -v \
         -s \
         --tb native \
-        {posargs} \
-        {[vars]tests_path}/unit
+        {[vars]tests_path}/unit \
+        {posargs}
     coverage report
 
 [testenv:integration]
@@ -62,5 +62,5 @@ commands =
         -s \
         --tb native \
         --log-cli-level=INFO \
-        {posargs} \
-        {[vars]tests_path}/integration
+        {[vars]tests_path}/integration \
+        {posargs}

--- a/examples/k8s-4-action/tox.ini
+++ b/examples/k8s-4-action/tox.ini
@@ -45,8 +45,8 @@ commands =
         -v \
         -s \
         --tb native \
-        {posargs} \
-        {[vars]tests_path}/unit
+        {[vars]tests_path}/unit \
+        {posargs}
     coverage report
 
 [testenv:integration]
@@ -62,5 +62,5 @@ commands =
         -s \
         --tb native \
         --log-cli-level=INFO \
-        {posargs} \
-        {[vars]tests_path}/integration
+        {[vars]tests_path}/integration \
+        {posargs}

--- a/examples/k8s-5-observe/tox.ini
+++ b/examples/k8s-5-observe/tox.ini
@@ -45,8 +45,8 @@ commands =
         -v \
         -s \
         --tb native \
-        {posargs} \
-        {[vars]tests_path}/unit
+        {[vars]tests_path}/unit \
+        {posargs}
     coverage report
 
 [testenv:integration]
@@ -62,5 +62,5 @@ commands =
         -s \
         --tb native \
         --log-cli-level=INFO \
-        {posargs} \
-        {[vars]tests_path}/integration
+        {[vars]tests_path}/integration \
+        {posargs}


### PR DESCRIPTION
Per https://github.com/canonical/charmcraft/pull/2312#discussion_r2163084188 and discussion within Charm Tech, we decided that `{posargs}` should come at the end of `pytest` command lines in tox.ini files. This to match expectations when doing `tox -e some-env -- extra args`.

This PR updates tox.ini files in our docs and example charms.