### PR TITLE
docs: be consistent with recommending self.app and self.unit

### DIFF
--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -1975,8 +1975,8 @@ class Harness(Generic[CharmType]):
         this will trigger ``collect_app_status``, and set the application status if any
         statuses were added.
 
-        Tests should normally call this and then assert that ``self.app.status``
-        or ``self.unit.status`` is the value expected.
+        Tests should normally call this and then assert that ``self.model.app.status``
+        or ``self.model.unit.status`` is the value expected.
 
         Evaluation is not "additive"; this method resets the added statuses before
         triggering each collect-status event.

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -1975,8 +1975,8 @@ class Harness(Generic[CharmType]):
         this will trigger ``collect_app_status``, and set the application status if any
         statuses were added.
 
-        Tests should normally call this and then assert that ``self.model.app.status``
-        or ``self.model.unit.status`` is the value expected.
+        Tests should normally call this and then assert that ``self.app.status``
+        or ``self.unit.status`` is the value expected.
 
         Evaluation is not "additive"; this method resets the added statuses before
         triggering each collect-status event.

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1472,7 +1472,7 @@ class CharmBase(Object):
 
     @property
     def unit(self) -> model.Unit:
-        """Unit that this execution is responsible for."""
+        """The current unit."""
         return self.framework.model.unit
 
     @property

--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1467,7 +1467,7 @@ class CharmBase(Object):
 
     @property
     def app(self) -> model.Application:
-        """Application that this unit is part of."""
+        """The application that this unit is part of."""
         return self.framework.model.app
 
     @property

--- a/ops/model.py
+++ b/ops/model.py
@@ -167,9 +167,9 @@ class Model:
 
     @property
     def app(self) -> Application:
-        """The application this unit is a part of.
+        """The application that this unit is part of. Equivalent to :attr:`CharmBase.app`.
 
-        Use :meth:`get_app` to get an arbitrary application by name.
+        To get an application by name, use :meth:`get_app`.
         """
         return self._unit.app
 
@@ -250,10 +250,10 @@ class Model:
     def get_app(self, app_name: str) -> Application:
         """Get an application by name.
 
-        Use :attr:`app` to get this charm's application.
-
         Internally this uses a cache, so asking for the same application two times will
         return the same object.
+
+        To get the application that this unit is part of, use :attr:`CharmBase.app` or :attr:`app`.
         """
         return self._cache.get(Application, app_name)
 
@@ -380,9 +380,8 @@ class Application:
     """Represents a named application in the model.
 
     This might be this charm's application, or might be an application this charm is integrated
-    with. Charmers should not instantiate Application objects directly, but should use
-    :attr:`Model.app` to get the application this unit is part of, or
-    :meth:`Model.get_app` if they need a reference to a given application.
+    with. Don't instantiate Application objects directly. To get the application that this unit is
+    part of, use :attr:`CharmBase.app`. To get an application by name, use :meth:`Model.get_app`.
     """
 
     name: str

--- a/ops/model.py
+++ b/ops/model.py
@@ -380,7 +380,9 @@ class Application:
     """Represents a named application in the model.
 
     This might be this charm's application, or might be an application this charm is integrated
-    with. Don't instantiate Application objects directly. To get the application that this unit is
+    with.
+
+    Don't instantiate Application objects directly. To get the application that this unit is
     part of, use :attr:`CharmBase.app`. To get an application by name, use :meth:`Model.get_app`.
     """
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -557,6 +557,9 @@ class Unit:
 
     This might be the current unit, another unit of the charm's application, or a unit of
     another application that the charm is integrated with.
+
+    Don't instantiate Unit objects directly. To get the current unit, use :attr:`CharmBase.unit`.
+    To get a unit by name, use :meth:`Model.get_unit`.
     """
 
     name: str

--- a/ops/model.py
+++ b/ops/model.py
@@ -159,9 +159,9 @@ class Model:
 
     @property
     def unit(self) -> Unit:
-        """The unit that is running this code.
+        """The current unit. Equivalent to :attr:`CharmBase.unit`.
 
-        Use :meth:`get_unit` to get an arbitrary unit by name.
+        To get a unit by name, use :meth:`get_unit`.
         """
         return self._unit
 
@@ -238,12 +238,12 @@ class Model:
         return self._backend._juju_context.version
 
     def get_unit(self, unit_name: str) -> Unit:
-        """Get an arbitrary unit by name.
-
-        Use :attr:`unit` to get the current unit.
+        """Get a unit by name.
 
         Internally this uses a cache, so asking for the same unit two times will
         return the same object.
+
+        To get the current unit, use :attr:`CharmBase.unit` or :attr:`unit`.
         """
         return self._cache.get(Unit, unit_name)
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -426,7 +426,7 @@ class Application:
 
         Example::
 
-            self.model.app.status = ops.BlockedStatus('I need a human to come help me')
+            self.app.status = ops.BlockedStatus('I need a human to come help me')
         """
         if not self._is_our_app:
             return UnknownStatus()
@@ -609,7 +609,7 @@ class Unit:
 
         Example::
 
-            self.model.unit.status = ops.MaintenanceStatus('reconfiguring the frobnicators')
+            self.unit.status = ops.MaintenanceStatus('reconfiguring the frobnicators')
         """
         if not self._is_our_unit:
             return UnknownStatus()


### PR DESCRIPTION
This PR starts work on #1783. In the interests of making progress, I've kept the scope focused on docs related to `self.app` and `self.unit`.

I've updated several docstrings to hopefully steer people away from using `Model.app` and `Model.unit` when `CharmBase.app` and `CharmBase.unit` are appropriate. While I was doing this, I also updated some of the wording to be more consistent.

Main updated parts:
- Descriptions of [`Application`](https://ops--1856.org.readthedocs.build/en/1856/reference/ops.html#ops.Application), [`Model.app`](https://ops--1856.org.readthedocs.build/en/1856/reference/ops.html#ops.Model.app), and [`Model.get_app()`](https://ops--1856.org.readthedocs.build/en/1856/reference/ops.html#ops.Model.get_app)
- Descriptions of [`Unit`](https://ops--1856.org.readthedocs.build/en/1856/reference/ops.html#ops.Unit), [`Model.unit`](https://ops--1856.org.readthedocs.build/en/1856/reference/ops.html#ops.Model.unit), and [`Model.get_unit()`](https://ops--1856.org.readthedocs.build/en/1856/reference/ops.html#ops.Model.get_unit)

I didn't find any places that needed updating in the markdown source.