### PR TITLE
ci: hotfix, publish job for ops-tracing

### DIFF
--- a/.github/workflows/publish-ops-tracing.yaml
+++ b/.github/workflows/publish-ops-tracing.yaml
@@ -27,5 +27,6 @@ jobs:
       # is updated in the PYPI settings.
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          packages-dir: ./tracing/dist/
           skip-existing: true
           verbose: true


### PR DESCRIPTION
Fixes this:

```
Traceback (most recent call last):
  File "/app/print-pkg-names.py", line 30, in <module>
    pkg_name for file_path in packages_dir.iterdir() if
                              ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/pathlib.py", line 1056, in iterdir
    for name in os.listdir(self):
                ^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/github/workspace/dist'
Warning:  It looks like there are no Python distribution packages to publish in the directory 'dist/'. Please verify that they are in place should you face this problem.
ERROR    InvalidDistribution: Cannot find file (or expand pattern): 'dist/*'  
```
https://github.com/canonical/operator/actions/runs/15966668038/job/45029695664


Ofc, the test-publish job was correct and only the real publish job was busted.