### PR TITLE
docs: add notice about Ops 2 and Ops 3

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,14 @@ reference/index
 explanation/index
 ```
 
+```{important}
+This is the documentation for version 2 of Ops, which stopped being actively developed in June 2025.
 
+- If your charm needs to support Python 3.8 (Ubuntu 20.04), use Ops 2.
+- Otherwise, use Ops 3.
+
+Ops 3 removed support for Python 3.8, but is otherwise compatible with Ops 2. See the [latest documentation](https://ops.readthedocs.io).
+```
 
 The Ops library (`ops`) is a Python framework for writing and testing Juju charms.
 


### PR DESCRIPTION
This PR adds a notice at the top of the docs for Ops 2.23. The notice should help readers understand which version of Ops to use, and how to find the docs for the latest version of Ops.