### PR TITLE
ci: fix ops and ops-scenario injection for uv charms

### DIFF
--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -46,8 +46,8 @@ jobs:
             uv remove ops --optional dev --frozen || echo "maybe ops[testing] is not a dev dependency"
             uv remove ops-scenario --optional dev --frozen || echo "maybe ops-scenario is not a dev dependency"
             uv remove ops --frozen
-            uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA --raw-sources --prerelease=if-necessary-or-explicit
             uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#subdirectory=testing --optional dev --raw-sources --prerelease=if-necessary-or-explicit
+            uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA --raw-sources --prerelease=if-necessary-or-explicit
           else
             echo "Error: no requirements.txt or uv.lock file found"
             exit 1

--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -96,8 +96,8 @@ jobs:
             poetry add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA --lock
             poetry add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#subdirectory=testing --lock
           elif [ -e "uv.lock" ]; then
-            uv add --frozen --raw-sources git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA
             uv add --frozen --raw-sources git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#subdirectory=testing
+            uv add --frozen --raw-sources git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA
             uv lock
           else
             echo "Error: No requirements.txt or poetry.lock or uv.lock file found"

--- a/ops/version.py
+++ b/ops/version.py
@@ -19,4 +19,4 @@ This module is NOT to be used when developing charms using ops.
 
 from __future__ import annotations
 
-version: str = '2.23.0'
+version: str = '3.0.0.dev0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,10 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 testing = [
-    "ops-scenario==7.23.0",
+    "ops-scenario==7.24.0.dev0",
 ]
 tracing = [
-    "ops-tracing==2.23.0",
+    "ops-tracing==3.0.0.dev0",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 testing = [
-    "ops-scenario==7.24.0.dev0",
+    "ops-scenario==8.0.0.dev0",
 ]
 tracing = [
     "ops-tracing==3.0.0.dev0",

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "7.23.0"
+version = "7.24.0.dev0"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
@@ -21,7 +21,7 @@ license.text = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops==2.23.0",
+    "ops==3.0.0.dev0",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "7.24.0.dev0"
+version = "8.0.0.dev0"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }

--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ops-tracing"
-version = "2.23.0"
+version = "3.0.0.dev0"
 description = "The tracing facility for the Ops library."
 requires-python = ">=3.8"
 readme = "README.md"
@@ -32,7 +32,7 @@ classifiers = [
 ]
 dependencies = [
     "opentelemetry-sdk~=1.30",
-    "ops==2.23.0",
+    "ops==3.0.0.dev0",
     "pydantic",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2078,7 +2078,7 @@ xdist = [{ name = "pytest-xdist", specifier = "~=3.6" }]
 
 [[package]]
 name = "ops-scenario"
-version = "7.24.0.dev0"
+version = "8.0.0.dev0"
 source = { editable = "testing" }
 dependencies = [
     { name = "ops" },

--- a/uv.lock
+++ b/uv.lock
@@ -2078,7 +2078,7 @@ xdist = [{ name = "pytest-xdist", specifier = "~=3.6" }]
 
 [[package]]
 name = "ops-scenario"
-version = "7.23.0"
+version = "7.24.0.dev0"
 source = { editable = "testing" }
 dependencies = [
     { name = "ops" },
@@ -2093,7 +2093,7 @@ requires-dist = [
 
 [[package]]
 name = "ops-tracing"
-version = "2.23.0"
+version = "3.0.0.dev0"
 source = { editable = "tracing" }
 dependencies = [
     { name = "opentelemetry-sdk", version = "1.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
On top of #1866 meant to fix virtual env in downstream charms we test against local ops and ops-scenario.

* observability charms
* published charms (this takes 6 hours to validate, maybe best as a separate PR?)