### PR TITLE
ci: disable non-essential checks that need adjustments to work with a Python 3.10 minimum

### DIFF
--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - charm-repo: jnsgruk/hello-kubecon
-            commit: eb3225860cc7db0e071d0ea6cd4a01b47e66b1e5  # 2025-03-27T12:05:21Z
+#          - charm-repo: jnsgruk/hello-kubecon
+#            commit: eb3225860cc7db0e071d0ea6cd4a01b47e66b1e5  # 2025-03-27T12:05:21Z
     steps:
       - name: Checkout test charm repository
         uses: actions/checkout@v4

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        include:
+        include: []
 #          - charm-repo: jnsgruk/hello-kubecon
 #            commit: eb3225860cc7db0e071d0ea6cd4a01b47e66b1e5  # 2025-03-27T12:05:21Z
     steps:

--- a/.github/workflows/hello-charm-tests.yaml
+++ b/.github/workflows/hello-charm-tests.yaml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       matrix:
         include:
-#          - charm-repo: jnsgruk/hello-kubecon
-#            commit: eb3225860cc7db0e071d0ea6cd4a01b47e66b1e5  # 2025-03-27T12:05:21Z
+          - charm-repo: jnsgruk/hello-kubecon
+            commit: eb3225860cc7db0e071d0ea6cd4a01b47e66b1e5  # 2025-03-27T12:05:21Z
           - charm-repo: juju/hello-juju-charm
             commit: 046b8ce758660d5aa9cf05207e2370fcbab688d0  # 2021-12-16T10:10:24Z
     steps:

--- a/.github/workflows/hello-charm-tests.yaml
+++ b/.github/workflows/hello-charm-tests.yaml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - charm-repo: jnsgruk/hello-kubecon
-            commit: eb3225860cc7db0e071d0ea6cd4a01b47e66b1e5  # 2025-03-27T12:05:21Z
+#          - charm-repo: jnsgruk/hello-kubecon
+#            commit: eb3225860cc7db0e071d0ea6cd4a01b47e66b1e5  # 2025-03-27T12:05:21Z
           - charm-repo: juju/hello-juju-charm
             commit: 046b8ce758660d5aa9cf05207e2370fcbab688d0  # 2021-12-16T10:10:24Z
     steps:

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -39,6 +39,7 @@ jobs:
         run: pip install tox~=4.2 uv~=0.6
 
       - name: Update 'ops' and 'ops-scenario' dependencies in test charm to latest
+        if: ${{ !(matrix.disabled) }}
         run: |
           if [ -e "requirements.txt" ]; then
             sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" requirements.txt

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -20,10 +20,13 @@ jobs:
         include:
           - charm-repo: canonical/alertmanager-k8s-operator
             commit: cc7bd1db35589fd63e44fb0e8813cd3b4362943e  # rev171 2025-06-22T16:01:16Z
+            disabled: true
           - charm-repo: canonical/prometheus-k8s-operator
             commit: ca0a31dab4497eac1bcdc3ca3eb47bbbc7365dc9  # rev253 2025-06-23T08:45:58Z
+            disabled: true
           - charm-repo: canonical/grafana-k8s-operator
             commit: a2770608526f2c82ddc3d225870f1a48eaa87179  # 2025-06-12T17:55:14Z
+            disabled: true
     steps:
       - name: Checkout the ${{ matrix.charm-repo }} repository
         uses: actions/checkout@v4


### PR DESCRIPTION
To be resolved by:
* Pack (hello-kubecon): https://github.com/canonical/operator/issues/1876
* Observability compatibility tests: https://github.com/canonical/operator/issues/1877

We're confident that nothing will have changed in Ops that breaks these, and they aren't required to merge, but we should get them green (by explicitly disabling them, as here) before we do the next release.