### PR TITLE
chore: create a span for ops.tracing.Tracing init

### DIFF
--- a/testing/tests/test_e2e/test_trace_data.py
+++ b/testing/tests/test_e2e/test_trace_data.py
@@ -28,6 +28,8 @@ def test_trace_data():
     assert {s.name for s in ctx.trace_data} == {
         # The entry point and root span.
         'ops.main',
+        # The first-party charm library.
+        'ops.tracing.Tracing',
         # Start event emitted on this charm.
         'start: TracedCharm',
         # Start event emitted on the first party charm lib.

--- a/tracing/ops_tracing/_api.py
+++ b/tracing/ops_tracing/_api.py
@@ -116,7 +116,7 @@ class Tracing(ops.Object):
             if relation.interface_name != 'tracing':
                 raise ValueError(
                     f"{tracing_relation_name=} {relation.interface_name=} when 'tracing' is"
-                    ' expected'
+                    f' expected'
                 )
 
             self._tracing = TracingEndpointRequirer(
@@ -145,7 +145,7 @@ class Tracing(ops.Object):
                 if relation.interface_name != 'certificate_transfer':
                     raise ValueError(
                         f'{ca_relation_name=} {relation.interface_name=} when'
-                        " 'certificate_transfer' is expected"
+                        f" 'certificate_transfer' is expected"
                     )
 
                 self._certificate_transfer = CertificateTransferRequires(charm, ca_relation_name)

--- a/tracing/ops_tracing/_api.py
+++ b/tracing/ops_tracing/_api.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 
+import opentelemetry.trace
 import ops
 
 from ._buffer import Destination
@@ -31,6 +32,7 @@ from .vendor.charms.tempo_coordinator_k8s.v0.tracing import (
 )
 
 logger = logging.getLogger(__name__)
+tracer = opentelemetry.trace.get_tracer('ops.tracing')
 
 
 class Tracing(ops.Object):
@@ -91,68 +93,70 @@ class Tracing(ops.Object):
         ca_data: str | None = None,
     ):
         """Initialise the tracing service."""
-        super().__init__(charm, f'{tracing_relation_name}+{ca_relation_name}')
-        self.charm = charm
-        self.tracing_relation_name = tracing_relation_name
-        self.ca_relation_name = ca_relation_name
-        self.ca_data = ca_data
+        with tracer.start_as_current_span('ops.tracing.Tracing'):
+            super().__init__(charm, f'{tracing_relation_name}+{ca_relation_name}')
+            self.charm = charm
+            self.tracing_relation_name = tracing_relation_name
+            self.ca_relation_name = ca_relation_name
+            self.ca_data = ca_data
 
-        if ca_relation_name is not None and ca_data is not None:
-            raise ValueError('At most one of ca_relation_name, ca_data is allowed')
+            if ca_relation_name is not None and ca_data is not None:
+                raise ValueError('At most one of ca_relation_name, ca_data is allowed')
 
-        # Validate the arguments manually to raise exceptions with helpful messages.
-        relation = self.charm.meta.relations.get(tracing_relation_name)
-        if not relation:
-            raise ValueError(f'{tracing_relation_name=} is not declared in charm metadata')
-
-        if relation.role is not ops.RelationRole.requires:
-            raise ValueError(
-                f"{tracing_relation_name=} {relation.role=} when 'requires' is expected"
-            )
-
-        if relation.interface_name != 'tracing':
-            raise ValueError(
-                f"{tracing_relation_name=} {relation.interface_name=} when 'tracing' is expected"
-            )
-
-        self._tracing = TracingEndpointRequirer(
-            self.charm,
-            tracing_relation_name,
-            protocols=['otlp_http'],
-        )
-
-        for event in (
-            self.charm.on.start,
-            self.charm.on.upgrade_charm,
-            self._tracing.on.endpoint_changed,
-            self._tracing.on.endpoint_removed,
-        ):
-            self.framework.observe(event, self._reconcile)
-
-        if ca_relation_name:
-            relation = self.charm.meta.relations.get(ca_relation_name)
+            # Validate the arguments manually to raise exceptions with helpful messages.
+            relation = self.charm.meta.relations.get(tracing_relation_name)
             if not relation:
-                raise ValueError(f'{ca_relation_name=} is not declared in charm metadata')
+                raise ValueError(f'{tracing_relation_name=} is not declared in charm metadata')
 
             if relation.role is not ops.RelationRole.requires:
                 raise ValueError(
-                    f"{ca_relation_name=} {relation.role=} when 'requires' is expected"
-                )
-            if relation.interface_name != 'certificate_transfer':
-                raise ValueError(
-                    f"{ca_relation_name=} {relation.interface_name=} when 'certificate_transfer' "
-                    'is expected'
+                    f"{tracing_relation_name=} {relation.role=} when 'requires' is expected"
                 )
 
-            self._certificate_transfer = CertificateTransferRequires(charm, ca_relation_name)
+            if relation.interface_name != 'tracing':
+                raise ValueError(
+                    f"{tracing_relation_name=} {relation.interface_name=} when 'tracing' is"
+                    ' expected'
+                )
+
+            self._tracing = TracingEndpointRequirer(
+                self.charm,
+                tracing_relation_name,
+                protocols=['otlp_http'],
+            )
 
             for event in (
-                self._certificate_transfer.on.certificate_set_updated,
-                self._certificate_transfer.on.certificates_removed,
+                self.charm.on.start,
+                self.charm.on.upgrade_charm,
+                self._tracing.on.endpoint_changed,
+                self._tracing.on.endpoint_removed,
             ):
                 self.framework.observe(event, self._reconcile)
-        else:
-            self._certificate_transfer = None
+
+            if ca_relation_name:
+                relation = self.charm.meta.relations.get(ca_relation_name)
+                if not relation:
+                    raise ValueError(f'{ca_relation_name=} is not declared in charm metadata')
+
+                if relation.role is not ops.RelationRole.requires:
+                    raise ValueError(
+                        f"{ca_relation_name=} {relation.role=} when 'requires' is expected"
+                    )
+                if relation.interface_name != 'certificate_transfer':
+                    raise ValueError(
+                        f'{ca_relation_name=} {relation.interface_name=} when'
+                        " 'certificate_transfer' is expected"
+                    )
+
+                self._certificate_transfer = CertificateTransferRequires(charm, ca_relation_name)
+
+                for event in (
+                    self._certificate_transfer.on.certificate_set_updated,
+                    self._certificate_transfer.on.certificates_removed,
+                ):
+                    self.framework.observe(event, self._reconcile)
+            else:
+                self._certificate_transfer = None
 
     def _reconcile(self, _event: ops.EventBase):
         dst = self._get_destination()

--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Framework :: OpenTelemetry",
 ]
 dependencies = [
+    "opentelemetry-api~=1.0",
     "opentelemetry-sdk~=1.30",
     "ops==3.1.0.dev0",
     "pydantic",

--- a/uv.lock
+++ b/uv.lock
@@ -1383,6 +1383,7 @@ name = "ops-tracing"
 version = "3.1.0.dev0"
 source = { editable = "tracing" }
 dependencies = [
+    { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
     { name = "ops" },
     { name = "pydantic" },
@@ -1399,6 +1400,7 @@ testing = [
 
 [package.metadata]
 requires-dist = [
+    { name = "opentelemetry-api", specifier = "~=1.0" },
     { name = "opentelemetry-sdk", specifier = "~=1.30" },
     { name = "ops", editable = "." },
     { name = "pydantic" },


### PR DESCRIPTION
In #1853, I argue that non-trivial charm library init should be wrapped in a span.

This PR does so for our first party `ops.tracing.Tracing` charm lib.