### PR TITLE
V2 docs tweaks

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -62,7 +62,7 @@ sphinx.ext.autodoc.py_ext_sig_re = re.compile(
 ############################################################
 
 # Product name
-project = 'The ops library'
+project = 'Ops'
 author = 'Canonical Ltd.'
 
 # The title you want to display for the documentation in the sidebar.

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -68,7 +68,8 @@ author = 'Canonical Ltd.'
 # The title you want to display for the documentation in the sidebar.
 # You might want to include a version number here.
 # To not display any title, set this option to an empty string.
-html_title = project + ' documentation'
+project_version = '2.23'
+html_title = project + ' ' + project_version + ' documentation'
 
 # The default value uses the current year as the copyright year.
 #

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -129,7 +129,7 @@ html_context = {
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/operator',
     # Change to the branch for this version of the documentation
-    'github_version': 'main',
+    'github_version': '2.23-maintenance',
     # Change to the folder that contains the documentation
     # (usually "/" or "/docs/")
     'github_folder': '/docs/',
@@ -149,7 +149,7 @@ if os.environ.get('READTHEDOCS', '') == 'True':
     html_context['display_github'] = True
     html_context['github_user'] = 'canonical'
     html_context['github_repo'] = 'operator'
-    html_context['github_version'] = 'main'
+    html_context['github_version'] = '2.23-maintenance'
     html_context['slug'] = 'operator'
 
 # If your project is on documentation.ubuntu.com, specify the project


### PR DESCRIPTION
This PR updates the docs for Ops 2.23:

- Change the title to "Ops 2.23 documentation" ([discussion in Matrix](https://matrix.to/#/!eNCNzcteYUDDYpStsu:ubuntu.com/$m7_sO5haoQoPm5SXSfBc5HEP53O-JPfNVZ03y9mT-g0?via=ubuntu.com&via=matrix.org&via=laquadrature.net))
- Change the GitHub branch to `2.23-maintenance`, so that "Edit this page on GitHub" links go to the proper place