### PR TITLE
fix: if an event ends with _Abort(0) tests should behave as if it ended successfully

### DIFF
--- a/testing/src/scenario/_runtime.py
+++ b/testing/src/scenario/_runtime.py
@@ -30,6 +30,7 @@ from ops import (
     PreCommitEvent,
 )
 from ops.jujucontext import _JujuContext
+from ops._main import _Abort
 from ops._private.harness import ActionFailed
 
 from .errors import NoObserverError, UncaughtCharmError
@@ -345,6 +346,10 @@ class Runtime:
 
             except (NoObserverError, ActionFailed):
                 raise  # propagate along
+            except _Abort as e:
+                # If ops raised _Abort(0) then we want to treat that as normal completion.
+                if e.exit_code != 0:
+                    raise
             except Exception as e:
                 # The following is intentionally on one long line, so that the last line of pdb
                 # output shows the error message (pdb shows the "raise" line).


### PR DESCRIPTION
If ops code raises `_Abort(0)`, then the event completes successfully as far as Juju is concerned. The fact that ops has shortcut things to jump right to exit isn't really relevant from the Juju point of view.

This means that for Scenario tests, we should treat `_Abort(0)` as a normal successful event completion, because it's simulating the events from the point of view of Juju.

Raising `_Abort` with any other exit code still ends up as `UncaughtCharmError`, as that indicates that something has gone wrong, and from the Juju perspective changes will be rolled back and the charm will end up in error status.