### PR TITLE
chore: bump zizmor to 1.11

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v6.1.0
 
       - name: Run zizmor
-        run: uvx zizmor@v1.9.0 --format=sarif . > results.sarif
+        run: uvx zizmor@v1.11.0 --format=sarif . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,6 @@ repos:
         - tomli
   # Check workflow security.
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.9.0
+    rev: v1.11.0
     hooks:
     - id: zizmor


### PR DESCRIPTION
Bumps Zizmor to 1.11 both in pre-commit and the workflow. There are various [new checks](https://docs.zizmor.sh/release-notes/) as well as a fix mode, but no new issues are found with our workflows.