### PR TITLE
docs: change title of docs site

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -62,7 +62,7 @@ sphinx.ext.autodoc.py_ext_sig_re = re.compile(
 ############################################################
 
 # Product name
-project = 'The ops library'
+project = 'Ops'
 author = 'Canonical Ltd.'
 
 # The title you want to display for the documentation in the sidebar.

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -62,13 +62,13 @@ sphinx.ext.autodoc.py_ext_sig_re = re.compile(
 ############################################################
 
 # Product name
-project = 'The ops library'
+project = 'Ops'
 author = 'Canonical Ltd.'
 
 # The title you want to display for the documentation in the sidebar.
 # You might want to include a version number here.
 # To not display any title, set this option to an empty string.
-html_title = project + ' documentation'
+html_title = f'{project} documentation'
 
 # The default value uses the current year as the copyright year.
 #

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -62,7 +62,7 @@ sphinx.ext.autodoc.py_ext_sig_re = re.compile(
 ############################################################
 
 # Product name
-project = 'Ops'
+project = 'The ops library'
 author = 'Canonical Ltd.'
 
 # The title you want to display for the documentation in the sidebar.


### PR DESCRIPTION
This PR changes the title of the docs site to "Ops documentation" ([discussion in Matrix](https://matrix.to/#/!eNCNzcteYUDDYpStsu:ubuntu.com/$m7_sO5haoQoPm5SXSfBc5HEP53O-JPfNVZ03y9mT-g0?via=ubuntu.com&via=matrix.org&via=laquadrature.net)).

**[Preview build](https://ops--1890.org.readthedocs.build/en/1890/)**