### PR TITLE
docs: Use config and action classes in the Kubernetes tutorial

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
@@ -13,12 +13,12 @@ This document is part of a  series, and we recommend you follow it in sequence. 
 git clone https://github.com/canonical/juju-sdk-tutorial-k8s.git
 cd juju-sdk-tutorial-k8s
 git checkout 03_integrate_with_psql
-git checkout -b  04_create_actions 
+git checkout -b  04_create_actions
 ```
 
 ````
 
-A charm should ideally cover all the complex operational logic within the code, to help avoid the need for manual human intervention. 
+A charm should ideally cover all the complex operational logic within the code, to help avoid the need for manual human intervention.
 
 Unfortunately, that is not always possible. As a charm developer, it is thus useful to know that you can also expose charm operational tasks to the charm user by defining special methods called `actions`.
 
@@ -40,6 +40,22 @@ actions:
         type: boolean
         default: False
 ```
+
+## Define an action class
+
+Open your `src/charm.py` file, and add an action class that matches the definition you used in `charmcraft.yaml`:
+
+```python
+# Note that this action is also defined in charmcraft.yaml
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class GetDbInfoAction:
+    """Fetches database authentication information."""
+
+    show_password: bool
+    """Show username and password in output information."""
+```
+
+Now that we have defined the action with a Python class, IDEs will use it to provide hints when we are accessing the action parameters, and static type checkers are able to validate that we are using the parameters correctly.
 
 ## Define the action event handlers
 
@@ -69,7 +85,7 @@ def _on_get_db_info_action(self, event: ops.ActionEvent) -> None:
 
     Learn more about actions at https://ops.readthedocs.io/en/latest/howto/manage-actions.html
     """
-    show_password = event.params['show-password']  # see charmcraft.yaml
+    params = event.load_params(GetDbInfoAction, errors='fail')
     db_data = self.fetch_postgres_relation_data()
     if not db_data:
         event.fail('No database connected')
@@ -99,7 +115,7 @@ juju refresh \
 ```
 
 Next, test that the basic action invocation works:
- 
+
 ```text
 juju run demo-api-charm/0 get-db-info
 ```

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
@@ -54,7 +54,7 @@ class GetDbInfoAction:
     """Show username and password in output information."""
 ```
 
-Now that we have defined the action with a Python class, IDEs will use it to provide hints when we are accessing the action parameter, and static type checkers are able to validate that we are using the parameter correctly.
+We'll use [](ActionEvent.load_params) to create an instance of your config class from the Juju action event. This allows IDEs to provide hints when we are accessing the action parameter, and static type checkers are able to validate that we are using the parameter correctly.
 
 ## Define the action event handlers
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
@@ -94,7 +94,7 @@ def _on_get_db_info_action(self, event: ops.ActionEvent) -> None:
         'db-host': db_data.get('db_host', None),
         'db-port': db_data.get('db_port', None),
     }
-    if show_password:
+    if params.show_password:
         output.update({
             'db-username': db_data.get('db_username', None),
             'db-password': db_data.get('db_password', None),

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
@@ -55,7 +55,7 @@ class GetDbInfoAction:
     """Show username and password in output information."""
 ```
 
-Now that we have defined the action with a Python class, IDEs will use it to provide hints when we are accessing the action parameters, and static type checkers are able to validate that we are using the parameters correctly.
+Now that we have defined the action with a Python class, IDEs will use it to provide hints when we are accessing the action parameter, and static type checkers are able to validate that we are using the parameter correctly.
 
 ## Define the action event handlers
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
@@ -46,7 +46,6 @@ actions:
 Open your `src/charm.py` file, and add an action class that matches the definition you used in `charmcraft.yaml`:
 
 ```python
-# Note that this action is also defined in charmcraft.yaml
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetDbInfoAction:
     """Fetches database authentication information."""

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -236,7 +236,7 @@ def app_environment(self) -> dict[str, str]:
 Finally, let's define the method that is called on the database created event:
 
 ```python
-def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
+def _on_database_created(self, _: DatabaseCreatedEvent) -> None:
     """Event is fired when postgres database is created."""
     self._update_layer_and_restart()
 ```

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -210,8 +210,6 @@ def _update_layer_and_restart(self) -> None:
         # service if required.
         self.container.replan()
         logger.info(f"Replanned with '{self.pebble_service_name}' service")
-    except ValueError as e:
-        logger.error('Configuration error: %s', e)
     except (ops.pebble.APIError, ops.pebble.ConnectionError) as e:
         logger.info('Unable to connect to Pebble: %s', e)
 ```

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -246,7 +246,7 @@ def _get_pebble_layer(self, port: int, environment: dict[str, str]) -> ops.pebbl
 Now, let's define this method such that, every time it is called, it dynamically fetches database authentication data and also prepares the output in a form that our application can consume, as below:
 
 ```python
-def app_environment(self) -> dict[str, str]:
+def get_app_environment(self) -> dict[str, str]:
     """Prepare environment variables for the application.
 
     This property method creates a dictionary containing environment variables

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -64,7 +64,7 @@ class FastAPIConfig:
 
 Then, still in `src/charm.py`, add `import dataclasses` in the imports at the top of the file.
 
-Now that we have defined the configuration with a Python class, IDEs will use it to provide hints when we are accessing the configuration, and static type checkers are able to validate that we are using the config options correctly.
+Now that we have defined the configuration with a Python class, IDEs will use it to provide hints when we are accessing the configuration, and static type checkers are able to validate that we are using the config option correctly.
 
 ## Define the configuration event handlers
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -46,7 +46,6 @@ config:
 Open your `src/charm.py` file, and add a configuration class that matches the configuration you added in `charmcraft.yaml`:
 
 ```python
-# This configuration is also defined in charmcraft.yaml
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class FastAPIConfig:
     """Configuration for the FastAPI demo charm."""

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -83,6 +83,8 @@ def _on_config_changed(self, _: ops.ConfigChangedEvent) -> None:
     self._update_layer_and_restart()
 ```
 
+We'll define `_update_layer_and_restart` shortly.
+
 ```{caution}
 
 A charm does not know which configuration option has been changed. Thus, make sure to validate all the values. This is especially important since multiple values can be changed in one call. Using a config class simplifies this, as all validation should be done when the config object is created.

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -130,7 +130,7 @@ def _update_layer_and_restart(self) -> None:
         self.unit.status = ops.MaintenanceStatus('Waiting for Pebble in workload container')
 ```
 
-When the config is loaded as part of creating the Pebble layer, if it is invalid (in our case, if the port is set to 22), then a `ValueError` will be raised. The `_update_layer_and_restart` method handles that by logging the issue and setting the status of the unit to blocked, letting the Juju user know that they need to take action.
+When the config is loaded as part of creating the Pebble layer, if the config is invalid (in our case, if the port is set to 22), then a `ValueError` will be raised. The `_update_layer_and_restart` method handles that by logging the error and setting the status of the unit to blocked, letting the Juju user know that they need to take action.
 
 Now, crucially, update the `_pebble_layer` property to make the layer definition dynamic, as shown below. This will replace the static port `8000` with `f"--port={config.server_port}"`.
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -135,7 +135,7 @@ def _update_layer_and_restart(self) -> None:
 
 When the config is loaded as part of creating the Pebble layer, if the config is invalid (in our case, if the port is set to 22), then a `ValueError` will be raised. The `_update_layer_and_restart` method handles that by logging the error and setting the status of the unit to blocked, letting the Juju user know that they need to take action.
 
-Now, crucially, update the `_get_pebble_layer` method to make the layer definition dynamic, as shown below. This will replace the static port `8000` with `f"--port={port}"`, using the port passed to the method.
+Now, crucially, update the `_get_pebble_layer` method to make the layer definition dynamic, as shown below. This will replace the static port `8000` with the port passed to the method.
 
 ```python
     def _get_pebble_layer(self, port: int) -> ops.pebble.Layer:

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -46,12 +46,10 @@ config:
 Open your `src/charm.py` file, and add a configuration class that matches the configuration you added in `charmcraft.yaml`:
 
 ```python
+# This configuration is also defined in charmcraft.yaml
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class FastAPIConfig:
-    """Configuration for the FastAPI demo charm.
-
-    This configuration is also defined in charmcraft.yaml
-    """
+    """Configuration for the FastAPI demo charm."""
 
     server_port: int = 8000
     """Default port on which FastAPI is available."""

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -50,7 +50,7 @@ Open your `src/charm.py` file, and add a configuration class that matches the co
 class FastAPIConfig:
     """Configuration for the FastAPI demo charm.
 
-    Note that this configuration is also defined in charmcraft.yaml
+    This configuration is also defined in charmcraft.yaml
     """
 
     server_port: int = 8000

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -61,7 +61,7 @@ class FastAPIConfig:
 
 Then, still in `src/charm.py`, add `import dataclasses` in the imports at the top of the file.
 
-Now that we have defined the configuration with a Python class, IDEs will use it to provide hints when we are accessing the configuration, and static type checkers are able to validate that we are using the config option correctly.
+We'll use [](CharmBase.load_config) to create an instance of your config class from the Juju config data. This allows IDEs to provide hints when we are accessing the configuration, and static type checkers are able to validate that we are using the config option correctly.
 
 ## Define the configuration event handlers
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -113,53 +113,54 @@ def _update_layer_and_restart(self) -> None:
     """
     # Learn more about statuses at
     # https://documentation.ubuntu.com/juju/3.6/reference/status/
-    self.unit.status = ops.MaintenanceStatus('Assembling Pebble layers')
-    try:
-        self.container.add_layer('fastapi_demo', self._pebble_layer, combine=True)
-        logger.info("Added updated layer 'fastapi_demo' to Pebble plan")
+        self.unit.status = ops.MaintenanceStatus('Assembling Pebble layers')
+        try:
+            config = self.load_config(FastAPIConfig)
+        except ValueError as e:
+            logger.error('Configuration error: %s', e)
+            self.unit.status = ops.BlockedStatus(str(e))
+            return
+        try:
+            self.container.add_layer('fastapi_demo', self._get_pebble_layer(config.server_port), combine=True)
+            logger.info("Added updated layer 'fastapi_demo' to Pebble plan")
 
-        # Tell Pebble to incorporate the changes, including restarting the
-        # service if required.
-        self.container.replan()
-        logger.info(f"Replanned with '{self.pebble_service_name}' service")
+            # Tell Pebble to incorporate the changes, including restarting the
+            # service if required.
+            self.container.replan()
+            logger.info(f"Replanned with '{self.pebble_service_name}' service")
 
-        self.unit.status = ops.ActiveStatus()
-    except ValueError as e:
-        logger.error('Configuration error: %s', e)
-        self.unit.status = ops.BlockedStatus(str(e))
-    except (ops.pebble.APIError, ops.pebble.ConnectionError) as e:
-        logger.info('Unable to connect to Pebble: %s', e)
-        self.unit.status = ops.MaintenanceStatus('Waiting for Pebble in workload container')
+            self.unit.status = ops.ActiveStatus()
+        except (ops.pebble.APIError, ops.pebble.ConnectionError) as e:
+            logger.info('Unable to connect to Pebble: %s', e)
+            self.unit.status = ops.MaintenanceStatus('Waiting for Pebble in workload container')
 ```
 
 When the config is loaded as part of creating the Pebble layer, if the config is invalid (in our case, if the port is set to 22), then a `ValueError` will be raised. The `_update_layer_and_restart` method handles that by logging the error and setting the status of the unit to blocked, letting the Juju user know that they need to take action.
 
-Now, crucially, update the `_pebble_layer` property to make the layer definition dynamic, as shown below. This will replace the static port `8000` with `f"--port={config.server_port}"`.
+Now, crucially, update the `_get_pebble_layer` method to make the layer definition dynamic, as shown below. This will replace the static port `8000` with `f"--port={port}"`, using the port passed to the method.
 
 ```python
-@property
-def _pebble_layer(self) -> ops.pebble.Layer:
-    config = self.load_config(FastAPIConfig)
-    """A Pebble layer for the FastAPI demo services."""
-    command = ' '.join([
-        'uvicorn',
-        'api_demo_server.app:app',
-        '--host=0.0.0.0',
-        f'--port={config.server_port}',
-    ])
-    pebble_layer: ops.pebble.LayerDict = {
-        'summary': 'FastAPI demo service',
-        'description': 'pebble config layer for FastAPI demo server',
-        'services': {
-            self.pebble_service_name: {
-                'override': 'replace',
-                'summary': 'fastapi demo',
-                'command': command,
-                'startup': 'enabled',
-            }
-        },
-    }
-    return ops.pebble.Layer(pebble_layer)
+    def _get_pebble_layer(self, port: int) -> ops.pebble.Layer:
+        """A Pebble layer for the FastAPI demo services."""
+        command = ' '.join([
+            'uvicorn',
+            'api_demo_server.app:app',
+            '--host=0.0.0.0',
+            f'--port={port}',
+        ])
+        pebble_layer: ops.pebble.LayerDict = {
+            'summary': 'FastAPI demo service',
+            'description': 'pebble config layer for FastAPI demo server',
+            'services': {
+                self.pebble_service_name: {
+                    'override': 'replace',
+                    'summary': 'fastapi demo',
+                    'command': command,
+                    'startup': 'enabled',
+                }
+            },
+        }
+        return ops.pebble.Layer(pebble_layer)
 ```
 
 As you may have noticed, the new `_update_layer_and_restart` method looks like a more advanced variant of the existing `_on_demo_server_pebble_ready` method. Remove the body of the `_on_demo_server_pebble_ready` method and replace it a call to `_update_layer_and_restart` like this:

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -224,7 +224,7 @@ Congratulations, you now know how to make your charm configurable!
 
 ## Write unit tests
 
-Since we added a new feature to configure `server-port` and use it in the `_pebble_layer` dynamically, we should write tests for the feature.
+Since we added a new feature to configure `server-port` and use it in the Pebble layer dynamically, we should write tests for the feature.
 
 First, we'll add a test that sets the port in the input state and asserts that the port is used in the service's command in the container layer:
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -76,7 +76,7 @@ In the `__init__` function, add an observer for the `config_changed` event and p
 framework.observe(self.on.config_changed, self._on_config_changed)
 ```
 
-Now, define the handler, as below. Since configuring something like a port affects the way we call our workload application, we need to update our Pebble configuration, which we will do via a newly created method `_update_layer_and_restart` that we will define shortly.
+Now, define the handler, as below. Since configuring something like a port affects the way we call our workload application, we need to update our Pebble configuration.
 
 ```python
 def _on_config_changed(self, _: ops.ConfigChangedEvent) -> None:

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -62,7 +62,7 @@ class FastAPIConfig:
             raise ValueError('Invalid port number, 22 is reserved for SSH')
 ```
 
-You will also need to add `import dataclasses` in the imports at the top of the file.
+Then, still in `src/charm.py`, add `import dataclasses` in the imports at the top of the file.
 
 Now that we have defined the configuration with a Python class, IDEs will use it to provide hints when we are accessing the configuration, and static type checkers are able to validate that we are using the config options correctly.
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -3,7 +3,7 @@
 
 > <small> {ref}`From Zero to Hero: Write your first Kubernetes charm <from-zero-to-hero-write-your-first-kubernetes-charm>` > Observe your charm with COS Lite </small>
 >
-> **See previous: {ref}`Expose your charm's operational tasks via actions <expose-operational-tasks-via-actions>`** 
+> **See previous: {ref}`Expose your charm's operational tasks via actions <expose-operational-tasks-via-actions>`**
 
 
 ````{important}
@@ -23,7 +23,7 @@ In a production deployment it is essential to observe and monitor the health of 
 
 Our application is prepared for that -- as you might recall, it uses [`starlette-exporter`](https://pypi.org/project/starlette-exporter/) to generate real-time application metrics and to expose them via a `/metrics` endpoint that is designed to be scraped by [Prometheus](https://prometheus.io/). As a charm developer, you'll want to use that to make your charm observable.
 
-In the charming universe, what you would do is deploy the existing [Canonical Observability Stack (COS) lite bundle](https://charmhub.io/cos-lite) -- a convenient collection of charms that includes all of [Prometheus](https://charmhub.io/prometheus-k8s), [Loki](https://charmhub.io/loki-k8s), and [Grafana](https://charmhub.io/grafana-k8s) -- and then integrate your charm with Prometheus to collect real-time application metrics; with Loki to collect application logs; and with Grafana to create dashboards and visualise collected data. 
+In the charming universe, what you would do is deploy the existing [Canonical Observability Stack (COS) lite bundle](https://charmhub.io/cos-lite) -- a convenient collection of charms that includes all of [Prometheus](https://charmhub.io/prometheus-k8s), [Loki](https://charmhub.io/loki-k8s), and [Grafana](https://charmhub.io/grafana-k8s) -- and then integrate your charm with Prometheus to collect real-time application metrics; with Loki to collect application logs; and with Grafana to create dashboards and visualise collected data.
 
 In this part of the tutorial we will follow this process to collect various metrics and logs about your application and visualise them on a dashboard.
 
@@ -104,16 +104,21 @@ First, at the top of the file, import the `prometheus_scrape` library:
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 ```
 
-Now, in your charm's `__init__` method, initialise the `MetricsEndpointProvider` instance with the desired scrape target, as below. Note that this uses the relation name that you specified earlier in the `charmcraft.yaml` file. Also, reflecting the fact that you've made your charm's port configurable (see previous chapter {ref}`Make the charm configurable <make-your-charm-configurable>`), the target job is set to be consumed from config. The URL path is not included because it is predictable (defaults to /metrics), so the Prometheus library uses it automatically. The last line, which sets the `refresh_event` to the `config_change` event, ensures that the Prometheus charm will change its scraping target every time someone changes the port configuration. Overall, this code will allow your application to be scraped by Prometheus once they've been integrated. 
+Now, in your charm's `__init__` method, initialise the `MetricsEndpointProvider` instance with the desired scrape target, as below. Note that this uses the relation name that you specified earlier in the `charmcraft.yaml` file. Also, reflecting the fact that you've made your charm's port configurable (see previous chapter {ref}`Make the charm configurable <make-your-charm-configurable>`), the target job is set to be consumed from config. The URL path is not included because it is predictable (defaults to /metrics), so the Prometheus library uses it automatically. The last line, which sets the `refresh_event` to the `config_change` event, ensures that the Prometheus charm will change its scraping target every time someone changes the port configuration. Overall, this code will allow your application to be scraped by Prometheus once they've been integrated.
 
 ```python
 # Provide a metrics endpoint for Prometheus to scrape.
-self._prometheus_scraping = MetricsEndpointProvider(
-    self,
-    relation_name='metrics-endpoint',
-    jobs=[{'static_configs': [{'targets': [f'*:{self.config["server-port"]}']}]}],
-    refresh_event=self.on.config_changed,
-)
+try:
+    config = self.load_config(FastAPIConfig)
+except ValueError as e:
+    logger.warning('Unable to add metrics: invalid configuration: %s', e)
+else:
+    self._prometheus_scraping = MetricsEndpointProvider(
+        self,
+        relation_name='metrics-endpoint',
+        jobs=[{'static_configs': [{'targets': [f'*:{config.server_port}']}]}],
+        refresh_event=self.on.config_changed,
+    )
 ```
 
 Congratulations, your charm is ready to be integrated with Prometheus!
@@ -199,12 +204,12 @@ We probably shouldn't link to a file on Discourse any more. Do we want to have t
 
 -->
 
-Now, in your `src` directory, create a subdirectory called `grafana_dashboards` and, in this directory, create a file called `FastAPI-Monitoring.json.tmpl` with the following content:  
+Now, in your `src` directory, create a subdirectory called `grafana_dashboards` and, in this directory, create a file called `FastAPI-Monitoring.json.tmpl` with the following content:
 [FastAPI-Monitoring.json.tmpl|attachment](https://github.com/canonical/juju-sdk-tutorial-k8s/raw/refs/heads/05_cos_integration/src/grafana_dashboards/FastAPI-Monitoring.json.tmpl). Once your charm has been integrated with Grafana, the `GrafanaDashboardProvider` you defined just before will take this file as well as any other files defined in this directory and put them into a Grafana files tree to be read by Grafana.
 
 ```{important}
 
-**How to build a Grafana dashboard is beyond the scope of this tutorial. However, if you'd like to get a quick idea:** The dashboard template file was created by manually building a Grafana dashboard using the Grafana web UI, then exporting it to a JSON file and updating the `datasource` `uid` for Prometheus and Loki from constant values to the dynamic variables `"${prometheusds}"` and `"${lokids}"`, respectively. 
+**How to build a Grafana dashboard is beyond the scope of this tutorial. However, if you'd like to get a quick idea:** The dashboard template file was created by manually building a Grafana dashboard using the Grafana web UI, then exporting it to a JSON file and updating the `datasource` `uid` for Prometheus and Loki from constant values to the dynamic variables `"${prometheusds}"` and `"${lokids}"`, respectively.
 
 ```
 
@@ -236,7 +241,7 @@ juju refresh \
   demo-server-image=ghcr.io/canonical/api_demo_server:1.0.1
 ```
 
-Next, test your charm's ability to integrate with Prometheus, Loki, and Grafana by following the steps below. 
+Next, test your charm's ability to integrate with Prometheus, Loki, and Grafana by following the steps below.
 
 ### Deploy COS Lite
 
@@ -254,7 +259,7 @@ juju deploy cos-lite --trust
 
 ### Expose the application relation endpoints
 
-Once all the COS Lite applications are deployed and settled down (you can monitor this by using `juju status --watch 2s`),  expose the relation points you are interested in for your charm -- `loki:logging`, `grafana-dashboard`, and `metrics-endpoint` -- as below. 
+Once all the COS Lite applications are deployed and settled down (you can monitor this by using `juju status --watch 2s`),  expose the relation points you are interested in for your charm -- `loki:logging`, `grafana-dashboard`, and `metrics-endpoint` -- as below.
 
 ```text
 juju offer prometheus:metrics-endpoint
@@ -277,7 +282,7 @@ tutorial-controller  admin/cos-lite.prometheus  admin   prometheus_scrape:metric
 tutorial-controller  admin/cos-lite.grafana     admin   grafana_dashboard:grafana-dashboard
 ```
 
-As you might notice from your knowledge of Juju, this is essentially preparing these endpoints, which exist in the `cos-lite` model, for a cross-model relation with your charm, which you've deployed to the `charm-model` model. 
+As you might notice from your knowledge of Juju, this is essentially preparing these endpoints, which exist in the `cos-lite` model, for a cross-model relation with your charm, which you've deployed to the `charm-model` model.
 
 ## Integrate your charm with COS Lite
 
@@ -295,7 +300,7 @@ juju integrate demo-api-charm admin/cos-lite.prometheus
 ```{important}
 
 The power of Grafana lies in the way it allows you to visualise metrics on a dashboard. Thus, in the general case you will want to open the Grafana Web UI in a web browser. However, you are now working in a headless VM that does not have any user interface. This means that you will need to open Grafana in a web browser on your host machine. To do this, you will need to add IP routes to the Kubernetes (MicroK8s) network inside of our VM. You can skip this step if you have decided to follow this tutorial directly on your host machine.
-``` 
+```
 
 First, run:
 
@@ -310,12 +315,12 @@ Model     Controller            Cloud/Region        Version  SLA          Timest
 cos-lite  tutorial-controller  microk8s/localhost  3.0.0    unsupported  18:05:07+01:00
 
 App           Version  Status   Scale  Charm             Channel  Rev  Address         Exposed  Message
-alertmanager  0.23.0   active       1  alertmanager-k8s  stable    36  10.152.183.70   no       
-catalogue              active       1  catalogue-k8s     stable     4  10.152.183.19   no       
-grafana       9.2.1    active       1  grafana-k8s       stable    52  10.152.183.132  no       
-loki          2.4.1    active       1  loki-k8s          stable    47  10.152.183.207  no       
-prometheus    2.33.5   active       1  prometheus-k8s    stable    79  10.152.183.196  no       
-traefik                active       1  traefik-k8s       stable    93  10.152.183.83   no  
+alertmanager  0.23.0   active       1  alertmanager-k8s  stable    36  10.152.183.70   no
+catalogue              active       1  catalogue-k8s     stable     4  10.152.183.19   no
+grafana       9.2.1    active       1  grafana-k8s       stable    52  10.152.183.132  no
+loki          2.4.1    active       1  loki-k8s          stable    47  10.152.183.207  no
+prometheus    2.33.5   active       1  prometheus-k8s    stable    79  10.152.183.196  no
+traefik                active       1  traefik-k8s       stable    93  10.152.183.83   no
 ```
 
 From this output, from the `Address` column, retrieve the IP address for each app to obtain the  Kubernetes service IP address range. Make a note of each as well as the range. (In our output we got the `10.152.183.0-10.152.183.255` range.)
@@ -328,8 +333,8 @@ Do not mix up Apps and Units -- Units represent Kubernetes pods while Apps repre
 Now open a terminal on your host machine and run:
 
 ```text
-multipass info charm-dev 
-``` 
+multipass info charm-dev
+```
 
 This should result in an output similar to the one below:
 
@@ -361,7 +366,7 @@ sudo ip route add 10.152.183.0/24 via 10.112.13.157
 
 In a terminal inside your VM, do all of the following:
 
-First, run `juju status` again to retrieve the IP address of your Grafana service.  For us it is `http://10.152.183.132:3000` (see the output above). 
+First, run `juju status` again to retrieve the IP address of your Grafana service.  For us it is `http://10.152.183.132:3000` (see the output above).
 
 Now, use `juju run` to retrieve your Grafana password, as shown below.
 
@@ -375,7 +380,7 @@ Now, on your host machine, open a web browser, enter the Grafana IP address, and
 
 In your Grafana web page, do all of the following:
 
-Click `FastAPI Monitoring`. You should see the Grafana Dashboard that we uploaded to the `grafana_dashboards` directory of your charm. 
+Click `FastAPI Monitoring`. You should see the Grafana Dashboard that we uploaded to the `grafana_dashboards` directory of your charm.
 
 <!--
 Open following URL (replace to your IP address):
@@ -401,7 +406,7 @@ curl 10.1.157.94:8000/error
 
 where `10.1.157.94` is the IP of our application unit (pod).
 
-<!--Now, generate some data that you can then visualise on the dashboard. Let's call a couple of API endpoints on our application. 
+<!--Now, generate some data that you can then visualise on the dashboard. Let's call a couple of API endpoints on our application.
 -->
 
 In a while you should see the following data appearing on the dashboard:
@@ -414,7 +419,7 @@ In a while you should see the following data appearing on the dashboard:
 
 ```{important}
 
-If you are interested in the Prometheus metrics produced by your application that were used to build these dashboards you can run following command in your VM: `curl <your app pod IP>:8000/metrics`  
+If you are interested in the Prometheus metrics produced by your application that were used to build these dashboards you can run following command in your VM: `curl <your app pod IP>:8000/metrics`
 Also, you can reach Prometheus in your web browser (similar to Grafana) at `http://<Prometheus pod IP>:9090/graph` .
 ```
 

--- a/examples/k8s-1-minimal/src/charm.py
+++ b/examples/k8s-1-minimal/src/charm.py
@@ -48,15 +48,14 @@ class FastAPIDemoCharm(ops.CharmBase):
         # Get a reference the container attribute on the PebbleReadyEvent
         container = event.workload
         # Add initial Pebble config layer using the Pebble API
-        container.add_layer('fastapi_demo', self._pebble_layer, combine=True)
+        container.add_layer('fastapi_demo', self._get_pebble_layer(), combine=True)
         # Make Pebble reevaluate its plan, ensuring any services are started if enabled.
         container.replan()
         # Learn more about statuses at
         # https://documentation.ubuntu.com/juju/3.6/reference/status/
         self.unit.status = ops.ActiveStatus()
 
-    @property
-    def _pebble_layer(self) -> ops.pebble.Layer:
+    def _get_pebble_layer(self) -> ops.pebble.Layer:
         """A Pebble layer for the FastAPI demo services."""
         command = ' '.join([
             'uvicorn',

--- a/examples/k8s-2-configurable/src/charm.py
+++ b/examples/k8s-2-configurable/src/charm.py
@@ -18,12 +18,29 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 
 import ops
 
 # Log messages can be retrieved using juju debug-log
 logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class FastAPIConfig:
+    """Configuration for the FastAPI demo charm.
+
+    Note that this configuration is also defined in charmcraft.yaml
+    """
+
+    server_port: int = 8000
+    """Default port on which FastAPI is available."""
+
+    def __post_init__(self):
+        """Validate the configuration."""
+        if self.server_port == 22:
+            raise ValueError('Invalid port number, 22 is reserved for SSH')
 
 
 class FastAPIDemoCharm(ops.CharmBase):
@@ -37,17 +54,10 @@ class FastAPIDemoCharm(ops.CharmBase):
         framework.observe(self.on.demo_server_pebble_ready, self._on_demo_server_pebble_ready)
         framework.observe(self.on.config_changed, self._on_config_changed)
 
-    def _on_demo_server_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
+    def _on_demo_server_pebble_ready(self, _: ops.PebbleReadyEvent) -> None:
         self._update_layer_and_restart()
 
-    def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:
-        port = self.config['server-port']  # See charmcraft.yaml
-
-        if port == 22:
-            self.unit.status = ops.BlockedStatus('Invalid port number, 22 is reserved for SSH')
-            return
-
-        logger.debug('New application port is requested: %s', port)
+    def _on_config_changed(self, _: ops.ConfigChangedEvent) -> None:
         self._update_layer_and_restart()
 
     def _update_layer_and_restart(self) -> None:
@@ -74,18 +84,22 @@ class FastAPIDemoCharm(ops.CharmBase):
             logger.info(f"Replanned with '{self.pebble_service_name}' service")
 
             self.unit.status = ops.ActiveStatus()
+        except ValueError as e:
+            logger.error('Configuration error: %s', e)
+            self.unit.status = ops.BlockedStatus(str(e))
         except (ops.pebble.APIError, ops.pebble.ConnectionError) as e:
             logger.info('Unable to connect to Pebble: %s', e)
             self.unit.status = ops.MaintenanceStatus('Waiting for Pebble in workload container')
 
     @property
     def _pebble_layer(self) -> ops.pebble.Layer:
+        config = self.load_config(FastAPIConfig)
         """A Pebble layer for the FastAPI demo services."""
         command = ' '.join([
             'uvicorn',
             'api_demo_server.app:app',
             '--host=0.0.0.0',
-            f'--port={self.config["server-port"]}',
+            f'--port={config.server_port}',
         ])
         pebble_layer: ops.pebble.LayerDict = {
             'summary': 'FastAPI demo service',

--- a/examples/k8s-3-postgresql/src/charm.py
+++ b/examples/k8s-3-postgresql/src/charm.py
@@ -128,8 +128,6 @@ class FastAPIDemoCharm(ops.CharmBase):
             # service if required.
             self.container.replan()
             logger.info(f"Replanned with '{self.pebble_service_name}' service")
-        except ValueError as e:
-            logger.error('Configuration error: %s', e)
         except (ops.pebble.APIError, ops.pebble.ConnectionError) as e:
             logger.info('Unable to connect to Pebble: %s', e)
 

--- a/examples/k8s-4-action/src/charm.py
+++ b/examples/k8s-4-action/src/charm.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 
 # Import the 'data_interfaces' library.
@@ -29,6 +30,31 @@ import ops
 
 # Log messages can be retrieved using juju debug-log
 logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class FastAPIConfig:
+    """Configuration for the FastAPI demo charm.
+
+    Note that this configuration is also defined in charmcraft.yaml
+    """
+
+    server_port: int = 8000
+    """Default port on which FastAPI is available."""
+
+    def __post_init__(self):
+        """Validate the configuration."""
+        if self.server_port == 22:
+            raise ValueError('Invalid port number, 22 is reserved for SSH')
+
+
+# Note that this action is also defined in charmcraft.yaml
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class GetDbInfoAction:
+    """Fetches database authentication information."""
+
+    show_password: bool
+    """Show username and password in output information."""
 
 
 class FastAPIDemoCharm(ops.CharmBase):
@@ -52,24 +78,17 @@ class FastAPIDemoCharm(ops.CharmBase):
         # Events on charm actions that are run via 'juju run'.
         framework.observe(self.on.get_db_info_action, self._on_get_db_info_action)
 
-    def _on_demo_server_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
+    def _on_demo_server_pebble_ready(self, _: ops.PebbleReadyEvent) -> None:
         self._update_layer_and_restart()
 
-    def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:
-        port = self.config['server-port']  # See charmcraft.yaml
-
-        if port == 22:
-            # The collect-status handler will set the status to blocked.
-            logger.debug('Invalid port number: 22 is reserved for SSH')
-            return
-
-        logger.debug('New application port is requested: %s', port)
+    def _on_config_changed(self, _: ops.ConfigChangedEvent) -> None:
         self._update_layer_and_restart()
 
     def _on_collect_status(self, event: ops.CollectStatusEvent) -> None:
-        port = self.config['server-port']
-        if port == 22:
-            event.add_status(ops.BlockedStatus('Invalid port number, 22 is reserved for SSH'))
+        try:
+            self.load_config(FastAPIConfig)
+        except ValueError as e:
+            event.add_status(ops.BlockedStatus(str(e)))
         if not self.model.get_relation('database'):
             # We need the user to do 'juju integrate'.
             event.add_status(ops.BlockedStatus('Waiting for database relation'))
@@ -102,7 +121,7 @@ class FastAPIDemoCharm(ops.CharmBase):
 
         Learn more about actions at https://ops.readthedocs.io/en/latest/howto/manage-actions.html
         """
-        show_password = event.params['show-password']  # see charmcraft.yaml
+        params = event.load_params(GetDbInfoAction, errors='fail')
         db_data = self.fetch_postgres_relation_data()
         if not db_data:
             event.fail('No database connected')
@@ -111,7 +130,7 @@ class FastAPIDemoCharm(ops.CharmBase):
             'db-host': db_data.get('db_host', None),
             'db-port': db_data.get('db_port', None),
         }
-        if show_password:
+        if params.show_password:
             output.update({
                 'db-username': db_data.get('db_username', None),
                 'db-password': db_data.get('db_password', None),
@@ -142,17 +161,20 @@ class FastAPIDemoCharm(ops.CharmBase):
             logger.info(f"Replanned with '{self.pebble_service_name}' service")
 
             self.unit.status = ops.ActiveStatus()
+        except ValueError as e:
+            logger.error('Configuration error: %s', e)
         except (ops.pebble.APIError, ops.pebble.ConnectionError) as e:
             logger.info('Unable to connect to Pebble: %s', e)
 
     @property
     def _pebble_layer(self) -> ops.pebble.Layer:
         """A Pebble layer for the FastAPI demo services."""
+        config = self.load_config(FastAPIConfig)
         command = ' '.join([
             'uvicorn',
             'api_demo_server.app:app',
             '--host=0.0.0.0',
-            f'--port={self.config["server-port"]}',
+            f'--port={config.server_port}',
         ])
         pebble_layer: ops.pebble.LayerDict = {
             'summary': 'FastAPI demo service',

--- a/examples/k8s-4-action/src/charm.py
+++ b/examples/k8s-4-action/src/charm.py
@@ -167,8 +167,6 @@ class FastAPIDemoCharm(ops.CharmBase):
             # service if required.
             self.container.replan()
             logger.info(f"Replanned with '{self.pebble_service_name}' service")
-        except ValueError as e:
-            logger.error('Configuration error: %s', e)
         except (ops.pebble.APIError, ops.pebble.ConnectionError) as e:
             logger.info('Unable to connect to Pebble: %s', e)
 

--- a/examples/k8s-4-action/src/charm.py
+++ b/examples/k8s-4-action/src/charm.py
@@ -32,12 +32,10 @@ import ops
 logger = logging.getLogger(__name__)
 
 
+# Note that this configuration is also defined in charmcraft.yaml
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class FastAPIConfig:
-    """Configuration for the FastAPI demo charm.
-
-    Note that this configuration is also defined in charmcraft.yaml
-    """
+    """Configuration for the FastAPI demo charm."""
 
     server_port: int = 8000
     """Default port on which FastAPI is available."""
@@ -152,29 +150,35 @@ class FastAPIDemoCharm(ops.CharmBase):
         # https://documentation.ubuntu.com/juju/3.6/reference/status/
         self.unit.status = ops.MaintenanceStatus('Assembling Pebble layers')
         try:
-            self.container.add_layer('fastapi_demo', self._pebble_layer, combine=True)
+            config = self.load_config(FastAPIConfig)
+        except ValueError as e:
+            logger.error('Configuration error: %s', e)
+            return
+        env = self.get_app_environment()
+        try:
+            self.container.add_layer(
+                'fastapi_demo',
+                self._get_pebble_layer(config.server_port, env),
+                combine=True,
+            )
             logger.info("Added updated layer 'fastapi_demo' to Pebble plan")
 
             # Tell Pebble to incorporate the changes, including restarting the
             # service if required.
             self.container.replan()
             logger.info(f"Replanned with '{self.pebble_service_name}' service")
-
-            self.unit.status = ops.ActiveStatus()
         except ValueError as e:
             logger.error('Configuration error: %s', e)
         except (ops.pebble.APIError, ops.pebble.ConnectionError) as e:
             logger.info('Unable to connect to Pebble: %s', e)
 
-    @property
-    def _pebble_layer(self) -> ops.pebble.Layer:
+    def _get_pebble_layer(self, port: int, environment: dict[str, str]) -> ops.pebble.Layer:
         """A Pebble layer for the FastAPI demo services."""
-        config = self.load_config(FastAPIConfig)
         command = ' '.join([
             'uvicorn',
             'api_demo_server.app:app',
             '--host=0.0.0.0',
-            f'--port={config.server_port}',
+            f'--port={port}',
         ])
         pebble_layer: ops.pebble.LayerDict = {
             'summary': 'FastAPI demo service',
@@ -185,14 +189,13 @@ class FastAPIDemoCharm(ops.CharmBase):
                     'summary': 'fastapi demo',
                     'command': command,
                     'startup': 'enabled',
-                    'environment': self.app_environment,
+                    'environment': environment,
                 }
             },
         }
         return ops.pebble.Layer(pebble_layer)
 
-    @property
-    def app_environment(self) -> dict[str, str]:
+    def get_app_environment(self) -> dict[str, str]:
         """Prepare environment variables for the application.
 
         This property method creates a dictionary containing environment variables

--- a/examples/k8s-4-action/src/charm.py
+++ b/examples/k8s-4-action/src/charm.py
@@ -105,7 +105,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         # If nothing is wrong, then the status is active.
         event.add_status(ops.ActiveStatus())
 
-    def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
+    def _on_database_created(self, _: DatabaseCreatedEvent) -> None:
         """Event is fired when postgres database is created."""
         self._update_layer_and_restart()
 

--- a/examples/k8s-5-observe/src/charm.py
+++ b/examples/k8s-5-observe/src/charm.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 class FastAPIConfig:
     """Configuration for the FastAPI demo charm.
 
-    Note that this configuration is also defined in charmcraft.yaml
+    That this configuration is also defined in charmcraft.yaml
     """
 
     server_port: int = 8000

--- a/examples/k8s-5-observe/src/charm.py
+++ b/examples/k8s-5-observe/src/charm.py
@@ -188,8 +188,6 @@ class FastAPIDemoCharm(ops.CharmBase):
             # service if required.
             self.container.replan()
             logger.info(f"Replanned with '{self.pebble_service_name}' service")
-        except ValueError as e:
-            logger.error('Configuration error: %s', e)
         except (ops.pebble.APIError, ops.pebble.ConnectionError) as e:
             logger.info('Unable to connect to Pebble: %s', e)
 

--- a/examples/k8s-5-observe/src/charm.py
+++ b/examples/k8s-5-observe/src/charm.py
@@ -255,7 +255,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         for data in relations.values():
             if not data:
                 continue
-            logger.info('New PSQL database endpoint is %s', data['endpoints'])
+            logger.info('New database endpoint is %s', data['endpoints'])
             host, port = data['endpoints'].split(':')
             db_data = {
                 'db_host': host,

--- a/examples/k8s-5-observe/src/charm.py
+++ b/examples/k8s-5-observe/src/charm.py
@@ -35,12 +35,10 @@ import ops
 logger = logging.getLogger(__name__)
 
 
+# Note that this configuration is also defined in charmcraft.yaml
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class FastAPIConfig:
-    """Configuration for the FastAPI demo charm.
-
-    That this configuration is also defined in charmcraft.yaml
-    """
+    """Configuration for the FastAPI demo charm."""
 
     server_port: int = 8000
     """Default port on which FastAPI is available."""
@@ -173,29 +171,35 @@ class FastAPIDemoCharm(ops.CharmBase):
         # https://documentation.ubuntu.com/juju/3.6/reference/status/
         self.unit.status = ops.MaintenanceStatus('Assembling Pebble layers')
         try:
-            self.container.add_layer('fastapi_demo', self._pebble_layer, combine=True)
+            config = self.load_config(FastAPIConfig)
+        except ValueError as e:
+            logger.error('Configuration error: %s', e)
+            return
+        env = self.get_app_environment()
+        try:
+            self.container.add_layer(
+                'fastapi_demo',
+                self._get_pebble_layer(config.server_port, env),
+                combine=True,
+            )
             logger.info("Added updated layer 'fastapi_demo' to Pebble plan")
 
             # Tell Pebble to incorporate the changes, including restarting the
             # service if required.
             self.container.replan()
             logger.info(f"Replanned with '{self.pebble_service_name}' service")
-
-            self.unit.status = ops.ActiveStatus()
         except ValueError as e:
             logger.error('Configuration error: %s', e)
         except (ops.pebble.APIError, ops.pebble.ConnectionError) as e:
             logger.info('Unable to connect to Pebble: %s', e)
 
-    @property
-    def _pebble_layer(self) -> ops.pebble.Layer:
+    def _get_pebble_layer(self, port: int, environment: dict[str, str]) -> ops.pebble.Layer:
         """A Pebble layer for the FastAPI demo services."""
-        config = self.load_config(FastAPIConfig)
         command = ' '.join([
             'uvicorn',
             'api_demo_server.app:app',
             '--host=0.0.0.0',
-            f'--port={config.server_port}',
+            f'--port={port}',
         ])
         pebble_layer: ops.pebble.LayerDict = {
             'summary': 'FastAPI demo service',
@@ -206,14 +210,13 @@ class FastAPIDemoCharm(ops.CharmBase):
                     'summary': 'fastapi demo',
                     'command': command,
                     'startup': 'enabled',
-                    'environment': self.app_environment,
+                    'environment': environment,
                 }
             },
         }
         return ops.pebble.Layer(pebble_layer)
 
-    @property
-    def app_environment(self) -> dict[str, str]:
+    def get_app_environment(self) -> dict[str, str]:
         """Prepare environment variables for the application.
 
         This property method creates a dictionary containing environment variables


### PR DESCRIPTION
1. In the config chapter, we add a config class (with the single option) and add validation for it. I've put the loading into the pebble layer property, as that's (initially) the only place that it's used and it seemed cleanest for the tutorial. The invalid value handling is then moved to a small except block in the update and restart code.
2. In following chapters, continue with the approach for config, but when we move to collect-status also add validation of the value there. In the observability chapter, also handle getting the config for metrics.
3. In the actions chapter, we add an action class (with the single parameter of the action), and use it when loading the parameters. This is a very minimal change, but demonstrates the use of the feature, and encourages continuing with it when there are more complex actions. This uses `errors='fail'` because that is appropriate for actions with most charms and is cleaner code -- in this specific case, Juju will prevent any invalid value, so there will never be a failure.

pre-commit also fixed some unrelated trailing whitespace - you probably want to review with whitespace changes removed.

[Preview](https://ops--1891.org.readthedocs.build/en/1891/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/index.html)