### PR TITLE
chore: define defaults in only one place in _JujuContext

### DIFF
--- a/ops/jujucontext.py
+++ b/ops/jujucontext.py
@@ -61,7 +61,7 @@ class _JujuContext:
     If true, write logs to stderr as well as to juju-log (from JUJU_DEBUG).
     """
 
-    debug_at: set[str] = dataclasses.field(default_factory=set)  # pyright: ignore[reportUnknownVariableType]
+    debug_at: set[str] = dataclasses.field(default_factory=set[str])
     """Where you want to stop when debugging.
 
     For example 'all' (from JUJU_DEBUG_AT).


### PR DESCRIPTION
As #1799 points out, the `_JujuContext` class sets default values for its arguments in two places: in its `dataclass` init, and in the `from_dict` method. Setting defaults in two places is a bit of an anti-pattern, and in this case where `_JujuContext` is always constructed with `from_dict`, one set of defaults is redundant.

This PR drops the defaults defined in `_JujuContext.from_dict` -- if a default would have been defined, instead the argument is not passed, falling back to the default values/factories in the `dataclass` init method. In all cases, the default values were the same in both places.

A simpler implementation option would have been to drop the default values from the `dataclass` init, since `from_dict` always passed all arguments explicitly, but as pointed out in [this comment](https://github.com/canonical/operator/issues/1799#issuecomment-3034458405), we'd likely want to add these back if we made `_JujuContext` public (as we are considering doing). The approach taken in this PR will require no such changes, as the `dataclass` init defaults are now the single source of truth.

---

One problematic aspect of the approach taken here is that we lose the static guarantee that we're passing validly named keyword arguments to `_JujuContext`. Additionally, because keys are added to `kwargs` conditionally, we need to rely on exhaustive branch coverage to catch badly named keys in tests.

We could solve this statically by defining a `TypedDict`. This is a bit verbose, and begins to feel like a second source of truth, though the type checker will warn us if the `TypedDict` names and types diverge from those permitted by `_JujuContext`, so it's not really. There would have been no guaranteed warning if the default values diverged, so arguably this is an improvement. A separate PR (#1894) tries this approach.

---

Ultimately I wonder if both of these approaches introduce too much to gain too little, in which case we should opt to close these PRs and #1799, deferring any further work until (if) we decide to make `_JujuContext` public.

---

Minor: pyright complains in my editor about `default_factory=set`, because it can't infer the type of its contents -- since we're Python 3.10 now, we can just write `set[str]` at runtime.