### PR TITLE
ci: use httpbin demo charm for the Charmcraft pack test

### DIFF
--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -39,7 +39,7 @@ jobs:
         run: sudo snap install yq
 
       - name: Add 'git' as a build package 
-      - run: |
+        run: |
           cd examples/httpbin-demo
           if yq 'has("parts")' charmcraft.yaml; then
             echo "'parts' already exists in charmcraft.yaml"

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -10,23 +10,16 @@ permissions: {}
 
 jobs:
   charmcraft-pack:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04  # Not ubuntu-latest?
 
-    strategy:
-      matrix:
-        include: []
-#          - charm-repo: jnsgruk/hello-kubecon
-#            commit: eb3225860cc7db0e071d0ea6cd4a01b47e66b1e5  # 2025-03-27T12:05:21Z
     steps:
-      - name: Checkout test charm repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
-          repository: ${{ matrix.charm-repo }}
           persist-credentials: false
-          ref: ${{ matrix.commit }}
 
       - name: Update 'ops' dependency in test charm to latest
         run: |
+          cd examples/httpbin-demo
           sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" requirements.txt
           if [ -z "$CLONE_SHA" ]
           then

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Add 'git' as a build package 
         run: |
           cd examples/httpbin-demo
-          if yq 'has("parts")' charmcraft.yaml; then
+          if yq -e 'has("parts")' charmcraft.yaml; then
             echo "'parts' already exists in charmcraft.yaml"
             exit 1
           fi

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -44,4 +44,6 @@ jobs:
         run: sudo snap install charmcraft --classic
 
       - name: Pack the charm
-        run: sudo charmcraft pack --verbose
+        run: |
+          cd examples/httpbin-demo
+          sudo charmcraft pack --verbose

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -41,11 +41,11 @@ jobs:
       - name: Add 'git' as a build package 
         run: |
           cd examples/httpbin-demo
-          if yq -e 'has("parts")' charmcraft.yaml; then
+          if yq --exit-status 'has("parts")' charmcraft.yaml; then
             echo "'parts' already exists in charmcraft.yaml"
             exit 1
           fi
-          yq -i '.parts.charm.build-packages = ["git"]' charmcraft.yaml
+          yq --inplace '.parts.charm.build-packages = ["git"]' charmcraft.yaml
           cat charmcraft.yaml
 
       - name: Set up LXD

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -35,6 +35,19 @@ jobs:
           CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
           CLONE_SHA: ${{ github.event.pull_request.head.sha }}
 
+      - name: Install yq
+        run: sudo snap install yq
+
+      - name: Add 'git' as a build package 
+      - run: |
+          cd examples/httpbin-demo
+          if yq 'has("parts")' charmcraft.yaml; then
+            echo "'parts' already exists in charmcraft.yaml"
+            exit 1
+          fi
+          yq -i '.parts.charm.build-packages = ["git"]' charmcraft.yaml
+          cat charmcraft.yaml
+
       - name: Set up LXD
         uses: canonical/setup-lxd@a3c85fc6fb7fff43fcfeae87659e41a8f635b7dd
         with:

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   charmcraft-pack:
-    runs-on: ubuntu-22.04  # Not ubuntu-latest?
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -36,7 +36,7 @@ jobs:
           CLONE_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Install yq
-        run: snap install yq
+        run: sudo snap install yq
 
       - name: Add 'git' as a build package 
         run: |

--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -36,7 +36,7 @@ jobs:
           CLONE_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Install yq
-        run: sudo snap install yq
+        run: snap install yq
 
       - name: Add 'git' as a build package 
         run: |
@@ -59,4 +59,4 @@ jobs:
       - name: Pack the charm
         run: |
           cd examples/httpbin-demo
-          sudo charmcraft pack --verbose
+          charmcraft pack --verbose

--- a/.github/workflows/update-charm-tests.yaml
+++ b/.github/workflows/update-charm-tests.yaml
@@ -24,7 +24,6 @@ jobs:
           workflows: |-
             .github/workflows/db-charm-tests.yaml
             .github/workflows/hello-charm-tests.yaml
-            .github/workflows/charmcraft-pack.yaml
             .github/workflows/observability-charm-tests.yaml
           gh-pat: ${{ secrets.UPDATE_CHARM_PINS_ACCESS_TOKEN }}
 


### PR DESCRIPTION
This PR uses the [httpbin](https://github.com/canonical/operator/tree/main/examples/httpbin-demo) demo charm for the "Charmcraft Pack Test" check.

Since the charm doesn't use pyproject.toml (yet? see https://github.com/canonical/operator/issues/1805), I've kept the step that modifies requirements.txt. And since we're getting the `ops` package from a git repo, I've added a step that adds git as a build package in charmcraft.yaml. The hello-kubecon charm already had git specified as a build package.