### PR TITLE
fix: if self.app is not actually set avoid a new crash location

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1781,6 +1781,10 @@ class Relation:
         if (
             _remote_unit is not None
             and not is_peer
+            # In practice, the "self.app will not be None" statement above is not
+            # necessarily true. Once https://bugs.launchpad.net/juju/+bug/1960934
+            # is resolved, we should be able to remove the next line.
+            and self.app is not None
             and _remote_unit.name.startswith(f'{self.app.name}/')
         ):
             self.units.add(_remote_unit)


### PR DESCRIPTION
`Model.app` should always be set (and code comments explicitly state that). However, [a Juju bug where JUJU_REMOTE_APP is not set](https://bugs.launchpad.net/juju/+bug/1960934) means that is not always true.

We work around this [elsewhere](https://github.com/canonical/operator/blob/a15646475eab8d243ef03c31d0e76ccb02941050/ops/charm.py#L570), so we should do it when potentially adding in the departing unit as well. Once the upstream issue is solved, we should be able to remove this.