### PR TITLE
docs: link out to the 12-factor tutorials from the tutorial index page

### DIFF
--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -10,3 +10,11 @@ Writing a machine charm is not so different from writing a Kubernetes charm, but
 write-your-first-machine-charm
 from-zero-to-hero-write-your-first-kubernetes-charm/index
 ```
+
+To charm a 12-factor style Django, FastAPI, Flask, Go, or Express application, you're able to build a charm with just a few modifications to the `charmcraft` YAML template content. These {external+charmcraft:ref}`tutorials <tutorial>` are a great entry point for anyone new to making charms, particularly anyone building or managing applications that use these frameworks.
+
+* {external+charmcraft:ref}`Write your first Kubernetes charm for a Django app <write-your-first-kubernetes-charm-for-a-django-app>`
+* {external+charmcraft:ref}`Write your first Kubernetes charm for a FastAPI app <write-your-first-kubernetes-charm-for-a-fastapi-app>`
+* {external+charmcraft:ref}`Write your first Kubernetes charm for a Flask app <write-your-first-kubernetes-charm-for-a-flask-app>`
+* {external+charmcraft:ref}`Write your first Kubernetes charm for a Go app <write-your-first-kubernetes-charm-for-a-go-app>`
+* {external+charmcraft:ref}`Write your first Kubernetes charm for an Express app <write-your-first-kubernetes-charm-for-a-expressjs-app>`

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -11,10 +11,10 @@ write-your-first-machine-charm
 from-zero-to-hero-write-your-first-kubernetes-charm/index
 ```
 
-To charm a 12-factor style Django, FastAPI, Flask, Go, or Express application, you're able to build a charm with just a few modifications to the `charmcraft` YAML template content. These {external+charmcraft:ref}`tutorials <tutorial>` are a great entry point for anyone new to making charms, particularly anyone building or managing applications that use these frameworks.
+To charm a 12-factor style application, you're able to build a charm by running a Charmcraft command and making a few modifications to the provided content. The Charmcraft tutorials are a great entry point for anyone new to making charms, particularly anyone building or managing applications that use these frameworks:
 
 * {external+charmcraft:ref}`Write your first Kubernetes charm for a Django app <write-your-first-kubernetes-charm-for-a-django-app>`
+* {external+charmcraft:ref}`Write your first Kubernetes charm for an Express app <write-your-first-kubernetes-charm-for-a-expressjs-app>`
 * {external+charmcraft:ref}`Write your first Kubernetes charm for a FastAPI app <write-your-first-kubernetes-charm-for-a-fastapi-app>`
 * {external+charmcraft:ref}`Write your first Kubernetes charm for a Flask app <write-your-first-kubernetes-charm-for-a-flask-app>`
 * {external+charmcraft:ref}`Write your first Kubernetes charm for a Go app <write-your-first-kubernetes-charm-for-a-go-app>`
-* {external+charmcraft:ref}`Write your first Kubernetes charm for an Express app <write-your-first-kubernetes-charm-for-a-expressjs-app>`


### PR DESCRIPTION
The tutorials for building charms are split between ops (machine charms, K8s charms that aren't built using a common web framework) and charmcraft (12-factor style K8s charms using common frameworks). This means that when a new charmer lands on one of those sets of tutorials, they may miss that there are other ones.

To help address this, this PR adds links to the Charmcraft 12-factor tutorials from our tutorial index page.