### PR TITLE
chore: minor type checking fixes

### DIFF
--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -3713,7 +3713,9 @@ class _TestingPebbleClient:
                     f'not {data.__class__.__name__}'
                 )
             else:
-                return io.StringIO(typing.cast('str', data))
+                # pyright doesn't understand that data must be str at this point, but ty does.
+                assert isinstance(data, str)
+                return io.StringIO(data)
 
     def exec(
         self,

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -2220,7 +2220,10 @@ def _record_calls(cls: Any):
     return cls
 
 
-def _copy_docstrings(source_cls: Any):
+_T = TypeVar('_T')
+
+
+def _copy_docstrings(source_cls: type[object]) -> Callable[[_T], _T]:
     """Copy the docstrings from source_cls to target_cls.
 
     Use this as:

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -3587,7 +3587,7 @@ class _TestingPebbleClient:
                 file_path.write_bytes(source)
             else:
                 # If source is binary, open file in binary mode and ignore encoding param
-                is_binary = isinstance(source.read(0), bytes)  # type: ignore
+                is_binary = isinstance(source.read(0), bytes)
                 open_mode = 'wb' if is_binary else 'w'
                 open_encoding = None if is_binary else encoding
                 with file_path.open(open_mode, encoding=open_encoding) as f:
@@ -3716,8 +3716,6 @@ class _TestingPebbleClient:
                     f'not {data.__class__.__name__}'
                 )
             else:
-                # pyright doesn't understand that data must be str at this point, but ty does.
-                assert isinstance(data, str)
                 return io.StringIO(data)
 
     def exec(

--- a/ops/log.py
+++ b/ops/log.py
@@ -82,7 +82,9 @@ def setup_root_logging(
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
-    def except_hook(etype: type[BaseException], value: BaseException, tb: types.TracebackType):
+    def except_hook(
+        etype: type[BaseException], value: BaseException, tb: types.TracebackType | None
+    ):
         logger.error('Uncaught exception while in charm code:', exc_info=(etype, value, tb))
         if exc_stderr:
             print(f'Uncaught {etype.__name__} in charm code: {value}', file=sys.stderr)

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1940,8 +1940,6 @@ def _websocket_to_writer(ws: _WebSocket, writer: _WebsocketWriter, encoding: str
             # Received "end" command (EOF signal), stop thread
             break
 
-        # pyright doesn't understand that this must be bytes now, but ty does.
-        assert isinstance(chunk, bytes)
         if encoding is not None:
             chunk = chunk.decode(encoding)
         writer.write(chunk)

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1940,8 +1940,10 @@ def _websocket_to_writer(ws: _WebSocket, writer: _WebsocketWriter, encoding: str
             # Received "end" command (EOF signal), stop thread
             break
 
+        # pyright doesn't understand that this must be bytes now, but ty does.
+        assert isinstance(chunk, bytes)
         if encoding is not None:
-            chunk = typing.cast('bytes', chunk).decode(encoding)
+            chunk = chunk.decode(encoding)
         writer.write(chunk)
 
 

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -218,10 +218,10 @@ _ServiceInfoDict = TypedDict(
 
 
 class _BodyHandler(Protocol):
-    def __call__(self, data: bytes, done: bool = False) -> None: ...
+    def __call__(self, data: bytearray, done: bool = False) -> None: ...
 
 
-_HeaderHandler = Callable[[bytes], None]
+_HeaderHandler = Callable[[bytearray], None]
 
 # tempfile.NamedTemporaryFile has an odd interface because of that
 # 'name' attribute, so we need to make a Protocol for it.
@@ -230,7 +230,7 @@ _HeaderHandler = Callable[[bytes], None]
 class _Tempfile(Protocol):
     name = ''
 
-    def write(self, data: bytes): ...
+    def write(self, data: bytearray): ...
 
     def close(self): ...
 
@@ -2763,7 +2763,7 @@ class Client:
         elif isinstance(source, bytes):
             source_io: _AnyStrFileLikeIO = io.BytesIO(source)
         else:
-            source_io: _AnyStrFileLikeIO = source  # type: ignore
+            source_io: _AnyStrFileLikeIO = source
         boundary = binascii.hexlify(os.urandom(16))
         path_escaped = path.replace('"', '\\"').encode('utf-8')
         content_type = f'multipart/form-data; boundary="{boundary.decode("utf-8")}"'
@@ -3484,7 +3484,7 @@ class _FilesParser:
         # these, so we'll prime the parser buffer with that missing sequence.
         self._parser.feed(b'\r\n')
 
-    def _process_header(self, data: bytes):
+    def _process_header(self, data: bytearray):
         parser = email.parser.BytesFeedParser()
         parser.feed(data)
         self._headers = parser.close()
@@ -3504,7 +3504,7 @@ class _FilesParser:
 
         self._part_type = typing.cast('Literal["response", "files"]', name)
 
-    def _process_body(self, data: bytes, done: bool = False):
+    def _process_body(self, data: bytearray, done: bool = False):
         if self._part_type == 'response':
             self._response_data.extend(data)
             if done:
@@ -3655,15 +3655,15 @@ class _MultipartParser:
                         return  # terminal boundary reached
                 elif safe_bound > self._pos:
                     # write partial body data
-                    data = self._buf[self._pos : safe_bound]
+                    partial_data = self._buf[self._pos : safe_bound]
                     self._pos = safe_bound
-                    self._handle_body(data)
+                    self._handle_body(partial_data)
                     return  # waiting for more data
                 else:
                     return  # waiting for more data
 
 
-def _next_part_boundary(buf: bytes, marker: bytes, start: int = 0) -> tuple[int, int, bool]:
+def _next_part_boundary(buf: bytearray, marker: bytes, start: int = 0) -> tuple[int, int, bool]:
     """Returns the index of the next boundary marker in buf beginning at start.
 
     Returns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -332,7 +332,7 @@ reportPrivateUsage = false
 reportUnnecessaryIsInstance = false
 reportUnnecessaryComparison = false
 reportUnnecessaryTypeIgnoreComment = "error"
-disableBytesTypePromotions = false
+disableBytesTypePromotions = true
 stubPath = ""
 
 [tool.codespell]

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -1628,7 +1628,7 @@ class TestMultipartParser:
                 bodies.append(b'')  # noqa: B023
                 bodies_done.append(False)  # noqa: B023
 
-            def handle_body(data: bytes, done: bool = False):
+            def handle_body(data: bytearray, done: bool = False):
                 bodies[-1] += data  # noqa: B023
                 bodies_done[-1] = done  # noqa: B023
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -4763,7 +4763,7 @@ class TestTestingPebbleClient:
         # It is a common mistake to pass just a name vs a list of names, so catch it with a
         # TypeError
         with pytest.raises(TypeError):
-            client.get_services('foo')
+            client.get_services('foo')  # type: ignore
 
     def test_get_services_subset(self, client: _TestingPebbleClient):
         client.add_layer(
@@ -4816,7 +4816,7 @@ class TestTestingPebbleClient:
         # Start service takes a list of names, but it is really easy to accidentally pass just a
         # name
         with pytest.raises(TypeError):
-            client.start_services('unknown')
+            client.start_services('unknown')  # type: ignore
 
     def test_start_service_no_services(self, client: _TestingPebbleClient):
         with pytest.raises(pebble.APIError):
@@ -4826,7 +4826,7 @@ class TestTestingPebbleClient:
         # Start service takes a list of names, but it is really easy to accidentally pass just a
         # name
         with pytest.raises(TypeError):
-            client.stop_services('unknown')
+            client.stop_services('unknown')  # type: ignore
 
     def test_stop_service_no_services(self, client: _TestingPebbleClient):
         with pytest.raises(pebble.APIError):
@@ -4951,7 +4951,7 @@ class TestTestingPebbleClient:
         # Restart service takes a list of names, but it is really easy to
         # accidentally pass just a name.
         with pytest.raises(TypeError):
-            client.restart_services('unknown')
+            client.restart_services('unknown')  # type: ignore
 
     def test_restart_service_no_services(self, client: _TestingPebbleClient):
         with pytest.raises(pebble.APIError):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -4951,6 +4951,7 @@ class TestTestingPebbleClient:
         # Restart service takes a list of names, but it is really easy to
         # accidentally pass just a name.
         with pytest.raises(TypeError):
+            # This should have a type:ignore, but pyright gets that wrong (ty gets it right).
             client.restart_services('unknown')
 
     def test_restart_service_no_services(self, client: _TestingPebbleClient):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -4951,7 +4951,6 @@ class TestTestingPebbleClient:
         # Restart service takes a list of names, but it is really easy to
         # accidentally pass just a name.
         with pytest.raises(TypeError):
-            # This should have a type:ignore, but pyright gets that wrong (ty gets it right).
             client.restart_services('unknown')
 
     def test_restart_service_no_services(self, client: _TestingPebbleClient):

--- a/testing/src/scenario/_ops_main_mock.py
+++ b/testing/src/scenario/_ops_main_mock.py
@@ -229,9 +229,7 @@ class Ops(_Manager):
                     return storage
         return obj
 
-    def _get_event_args(
-        self, bound_event: ops.framework.BoundEvent
-    ) -> tuple[list[Any], dict[str, Any]]:
+    def _get_event_args(self, bound_event: ops.BoundEvent) -> tuple[list[Any], dict[str, Any]]:
         # For custom events, if the caller provided us with explicit args, we
         # merge them with the Juju ones (to handle libraries subclassing the
         # Juju events). We also handle converting from Scenario to ops types,

--- a/testing/src/scenario/_runtime.py
+++ b/testing/src/scenario/_runtime.py
@@ -226,7 +226,7 @@ class Runtime:
         config_yaml = virtual_charm_root / 'config.yaml'
         actions_yaml = virtual_charm_root / 'actions.yaml'
 
-        metadata_files_present: dict[Path | str | None] = {
+        metadata_files_present: dict[Path, str | None] = {
             file: file.read_text() if charm_virtual_root_is_custom and file.exists() else None
             for file in (metadata_yaml, config_yaml, actions_yaml)
         }
@@ -350,6 +350,9 @@ class Runtime:
                 # If ops raised _Abort(0) then we want to treat that as normal completion.
                 if e.exit_code != 0:
                     raise
+                # If _Abort was raised before we created the instance, we can't get the state, so
+                # still want to fail.
+                assert ops is not None
             except Exception as e:
                 # The following is intentionally on one long line, so that the last line of pdb
                 # output shows the error message (pdb shows the "raise" line).

--- a/testing/src/scenario/_runtime.py
+++ b/testing/src/scenario/_runtime.py
@@ -342,17 +342,16 @@ class Runtime:
                     juju_context=juju_context,
                 )
 
-                yield ops
+                try:
+                    yield ops
+                except _Abort as e:
+                    # If ops raised _Abort(0) within the charm code then we want to treat that as
+                    # normal completion.
+                    if e.exit_code != 0:
+                        raise
 
             except (NoObserverError, ActionFailed):
                 raise  # propagate along
-            except _Abort as e:
-                # If ops raised _Abort(0) then we want to treat that as normal completion.
-                if e.exit_code != 0:
-                    raise
-                # If _Abort was raised before we created the instance, we can't get the state, so
-                # still want to fail.
-                assert ops is not None
             except Exception as e:
                 # The following is intentionally on one long line, so that the last line of pdb
                 # output shows the error message (pdb shows the "raise" line).

--- a/testing/tests/helpers.py
+++ b/testing/tests/helpers.py
@@ -14,9 +14,10 @@ from typing import (
 import jsonpatch
 
 from scenario.context import _DEFAULT_JUJU_VERSION, Context
+from scenario.state import _Event
 
 if TYPE_CHECKING:  # pragma: no cover
-    from scenario.state import CharmType, State, _Event
+    from scenario.state import CharmType, State
 
     _CT = TypeVar('_CT', bound=Type[CharmType])
 
@@ -45,13 +46,14 @@ def trigger(
     )
     if isinstance(event, str):
         if event.startswith('relation_'):
-            assert len(state.relations) == 1, 'shortcut only works with one relation'
+            assert len(tuple(state.relations)) == 1, 'shortcut only works with one relation'
             event = getattr(ctx.on, event)(tuple(state.relations)[0])
         elif event.startswith('pebble_'):
-            assert len(state.containers) == 1, 'shortcut only works with one container'
+            assert len(tuple(state.containers)) == 1, 'shortcut only works with one container'
             event = getattr(ctx.on, event)(tuple(state.containers)[0])
         else:
             event = getattr(ctx.on, event)()
+    assert isinstance(event, _Event)
     with ctx(event, state=state) as mgr:
         if pre_event:
             pre_event(mgr.charm)

--- a/testing/tests/test_context.py
+++ b/testing/tests/test_context.py
@@ -18,7 +18,8 @@ def test_run():
     state = State()
 
     with patch.object(ctx, '_run') as p:
-        ctx._output_state = 'foo'  # would normally be set within the _run call scope
+        # This would normally be set within the _run call scope.
+        ctx._output_state = 'foo'  # type: ignore
         output = ctx.run(ctx.on.start(), state)
         assert output == 'foo'
 
@@ -37,7 +38,8 @@ def test_run_action():
     expected_id = _next_action_id(update=False)
 
     with patch.object(ctx, '_run') as p:
-        ctx._output_state = 'foo'  # would normally be set within the _run call scope
+        # This would normally be set within the _run call scope.
+        ctx._output_state = 'foo'  # type: ignore
         output = ctx.run(ctx.on.action('do-foo'), state)
         assert output == 'foo'
 

--- a/testing/tests/test_e2e/test_actions.py
+++ b/testing/tests/test_e2e/test_actions.py
@@ -38,6 +38,7 @@ def test_action_event(mycharm, baz_value):
 
     assert isinstance(state, State)
     evt = ctx.emitted_events[0]
+    assert isinstance(evt, ActionEvent)
     assert evt.params['bar'] == 10
     assert evt.params['baz'] is baz_value
 
@@ -103,6 +104,7 @@ def test_action_event_outputs(mycharm, res_value):
     ctx = Context(mycharm, meta={'name': 'foo'}, actions={'foo': {}})
     with pytest.raises(ActionFailed) as exc_info:
         ctx.run(ctx.on.action('foo'), State())
+    assert isinstance(exc_info.value, ActionFailed)
     assert exc_info.value.message == 'failed becozz'
     assert ctx.action_results == {'my-res': res_value}
     assert ctx.action_logs == ['log1', 'log2']
@@ -123,6 +125,7 @@ def test_action_continues_after_fail():
     ctx = Context(MyCharm, meta={'name': 'foo'}, actions={'foo': {}})
     with pytest.raises(ActionFailed) as exc_info:
         ctx.run(ctx.on.action('foo'), State())
+    assert isinstance(exc_info.value, ActionFailed)
     assert exc_info.value.message == 'oh no!'
     assert ctx.action_logs == ['starting']
     assert ctx.action_results == {'initial': 'result', 'final': 'result'}

--- a/testing/tests/test_e2e/test_actions.py
+++ b/testing/tests/test_e2e/test_actions.py
@@ -104,7 +104,6 @@ def test_action_event_outputs(mycharm, res_value):
     ctx = Context(mycharm, meta={'name': 'foo'}, actions={'foo': {}})
     with pytest.raises(ActionFailed) as exc_info:
         ctx.run(ctx.on.action('foo'), State())
-    assert isinstance(exc_info.value, ActionFailed)
     assert exc_info.value.message == 'failed becozz'
     assert ctx.action_results == {'my-res': res_value}
     assert ctx.action_logs == ['log1', 'log2']
@@ -125,7 +124,6 @@ def test_action_continues_after_fail():
     ctx = Context(MyCharm, meta={'name': 'foo'}, actions={'foo': {}})
     with pytest.raises(ActionFailed) as exc_info:
         ctx.run(ctx.on.action('foo'), State())
-    assert isinstance(exc_info.value, ActionFailed)
     assert exc_info.value.message == 'oh no!'
     assert ctx.action_logs == ['starting']
     assert ctx.action_results == {'initial': 'result', 'final': 'result'}

--- a/testing/tests/test_e2e/test_cloud_spec.py
+++ b/testing/tests/test_e2e/test_cloud_spec.py
@@ -60,7 +60,7 @@ def test_get_cloud_spec_error():
 
 
 def test_get_cloud_spec_untrusted():
-    cloud_spec = ops.CloudSpec(type='lxd', name='localhost')
+    cloud_spec = scenario.CloudSpec(type='lxd', name='localhost')
     ctx = scenario.Context(MyCharm, meta={'name': 'foo'})
     state = scenario.State(
         model=scenario.Model(name='lxd-model', type='lxd', cloud_spec=cloud_spec),

--- a/testing/tests/test_e2e/test_pebble.py
+++ b/testing/tests/test_e2e/test_pebble.py
@@ -347,7 +347,6 @@ def test_exec_wait_error(charm_cls):
         proc = container.exec(['foo'])
         with pytest.raises(ExecError) as exc_info:
             proc.wait_output()
-        assert isinstance(exc_info.value, ExecError)
         assert exc_info.value.stdout == 'hello pebble'
 
 

--- a/testing/tests/test_e2e/test_pebble.py
+++ b/testing/tests/test_e2e/test_pebble.py
@@ -347,6 +347,7 @@ def test_exec_wait_error(charm_cls):
         proc = container.exec(['foo'])
         with pytest.raises(ExecError) as exc_info:
             proc.wait_output()
+        assert isinstance(exc_info.value, ExecError)
         assert exc_info.value.stdout == 'hello pebble'
 
 
@@ -476,7 +477,10 @@ def test_pebble_check_failed():
             infos.append(event.info)
 
     ctx = Context(MyCharm, meta={'name': 'foo', 'containers': {'foo': {}}})
-    layer = pebble.Layer({'checks': {'http-check': {'override': 'replace', 'startup': 'enabled'}}})
+    layer = pebble.Layer({
+        'checks': {'http-check': {'override': 'replace', 'startup': 'enabled', 'threshold': 3}}
+    })
+    assert layer.checks['http-check'].threshold is not None
     check = CheckInfo(
         'http-check',
         successes=3,
@@ -508,7 +512,10 @@ def test_pebble_check_recovered():
             infos.append(event.info)
 
     ctx = Context(MyCharm, meta={'name': 'foo', 'containers': {'foo': {}}})
-    layer = pebble.Layer({'checks': {'http-check': {'override': 'replace', 'startup': 'enabled'}}})
+    layer = pebble.Layer({
+        'checks': {'http-check': {'override': 'replace', 'startup': 'enabled', 'threshold': 3}}
+    })
+    assert layer.checks['http-check'].threshold is not None
     check = CheckInfo(
         'http-check',
         successes=None,
@@ -532,7 +539,7 @@ def test_pebble_check_failed_two_containers():
     bar_infos = []
 
     class MyCharm(CharmBase):
-        def __init__(self, framework):
+        def __init__(self, framework: Framework):
             super().__init__(framework)
             framework.observe(self.on.foo_pebble_check_failed, self._on_foo_check_failed)
             framework.observe(self.on.bar_pebble_check_failed, self._on_bar_check_failed)
@@ -545,7 +552,10 @@ def test_pebble_check_failed_two_containers():
 
     ctx = Context(MyCharm, meta={'name': 'foo', 'containers': {'foo': {}, 'bar': {}}})
 
-    layer = pebble.Layer({'checks': {'http-check': {'override': 'replace', 'startup': 'enabled'}}})
+    layer = pebble.Layer({
+        'checks': {'http-check': {'override': 'replace', 'startup': 'enabled', 'threshold': 3}}
+    })
+    assert layer.checks['http-check'].threshold is not None
     check = CheckInfo(
         'http-check',
         failures=7,
@@ -637,7 +647,10 @@ def test_pebble_stop_check():
 
     ctx = Context(MyCharm, meta={'name': 'foo', 'containers': {'foo': {}}})
 
-    layer = pebble.Layer({'checks': {'chk1': {'override': 'replace', 'startup': 'enabled'}}})
+    layer = pebble.Layer({
+        'checks': {'chk1': {'override': 'replace', 'startup': 'enabled', 'threshold': 3}}
+    })
+    assert layer.checks['chk1'].threshold is not None
     info_in = CheckInfo(
         'chk1',
         status=pebble.CheckStatus.UP,
@@ -667,7 +680,10 @@ def test_pebble_replan_checks():
             container.replan()
 
     ctx = Context(MyCharm, meta={'name': 'foo', 'containers': {'foo': {}}})
-    layer = pebble.Layer({'checks': {'chk1': {'override': 'replace', 'startup': 'enabled'}}})
+    layer = pebble.Layer({
+        'checks': {'chk1': {'override': 'replace', 'startup': 'enabled', 'threshold': 3}}
+    })
+    assert layer.checks['chk1'].threshold is not None
     info_in = CheckInfo(
         'chk1',
         status=pebble.CheckStatus.INACTIVE,
@@ -718,7 +734,9 @@ def test_pebble_replan_checks():
         },
     ],
 )
-def test_add_layer_merge_check(new_layer_name: str, combine: bool, new_layer_dict: pebble.Layer):
+def test_add_layer_merge_check(
+    new_layer_name: str, combine: bool, new_layer_dict: pebble.LayerDict
+):
     class MyCharm(CharmBase):
         def __init__(self, framework: Framework):
             super().__init__(framework)
@@ -740,6 +758,7 @@ def test_add_layer_merge_check(new_layer_name: str, combine: bool, new_layer_dic
             }
         }
     })
+    assert layer_in.checks['server-ready'].threshold is not None
     check_in = CheckInfo(
         'server-ready',
         level=layer_in.checks['server-ready'].level,

--- a/testing/tests/test_e2e/test_play_assertions.py
+++ b/testing/tests/test_e2e/test_play_assertions.py
@@ -8,6 +8,7 @@ from ops.framework import Framework
 from ops.model import ActiveStatus, BlockedStatus
 
 from scenario.state import Relation, State
+from scenario.state import BlockedStatus as TestingBlockedStatus
 from ..helpers import jsonpatch_delta, trigger
 
 
@@ -33,7 +34,7 @@ def mycharm():
 
 def test_charm_heals_on_start(mycharm):
     def pre_event(charm):
-        pre_event._called = True
+        pre_event._called = True  # type: ignore
         assert charm.unit.status == BlockedStatus('foo')
         assert not charm.called
 
@@ -42,13 +43,15 @@ def test_charm_heals_on_start(mycharm):
             charm.unit.status = ActiveStatus('yabadoodle')
 
     def post_event(charm):
-        post_event._called = True
+        post_event._called = True  # type: ignore
         assert charm.unit.status == ActiveStatus('yabadoodle')
         assert charm.called
 
     mycharm._call = call
 
-    initial_state = State(config={'foo': 'bar'}, leader=True, unit_status=BlockedStatus('foo'))
+    initial_state = State(
+        config={'foo': 'bar'}, leader=True, unit_status=TestingBlockedStatus('foo')
+    )
 
     out = trigger(
         initial_state,

--- a/testing/tests/test_e2e/test_play_assertions.py
+++ b/testing/tests/test_e2e/test_play_assertions.py
@@ -8,7 +8,7 @@ from ops.framework import Framework
 from ops.model import ActiveStatus, BlockedStatus
 
 from scenario.state import Relation, State
-from scenario.state import BlockedStatus as TestingBlockedStatus
+from scenario.state import BlockedStatus as ScenarioBlockedStatus
 from ..helpers import jsonpatch_delta, trigger
 
 
@@ -48,7 +48,7 @@ def test_charm_heals_on_start(mycharm):
     mycharm._call = call
 
     initial_state = State(
-        config={'foo': 'bar'}, leader=True, unit_status=TestingBlockedStatus('foo')
+        config={'foo': 'bar'}, leader=True, unit_status=ScenarioBlockedStatus('foo')
     )
 
     out = trigger(

--- a/testing/tests/test_e2e/test_play_assertions.py
+++ b/testing/tests/test_e2e/test_play_assertions.py
@@ -34,7 +34,6 @@ def mycharm():
 
 def test_charm_heals_on_start(mycharm):
     def pre_event(charm):
-        pre_event._called = True  # type: ignore
         assert charm.unit.status == BlockedStatus('foo')
         assert not charm.called
 
@@ -43,7 +42,6 @@ def test_charm_heals_on_start(mycharm):
             charm.unit.status = ActiveStatus('yabadoodle')
 
     def post_event(charm):
-        post_event._called = True  # type: ignore
         assert charm.unit.status == ActiveStatus('yabadoodle')
         assert charm.called
 

--- a/testing/tests/test_e2e/test_relations.py
+++ b/testing/tests/test_e2e/test_relations.py
@@ -51,6 +51,7 @@ def mycharm():
         def _on_event(self, event):
             if self._call:
                 MyCharm.called = True
+                assert callable(MyCharm._call)
                 MyCharm._call(self, event)
 
     return MyCharm
@@ -344,6 +345,7 @@ def test_relation_events(mycharm, evt_name, remote_app_name):
             assert charm.model.get_relation('foo') is None
             assert e.relation.app.name == remote_app_name
         else:
+            assert charm.model.get_relation('foo').app is not None
             assert charm.model.get_relation('foo').app.name == remote_app_name
 
     mycharm._call = callback

--- a/testing/tests/test_e2e/test_relations.py
+++ b/testing/tests/test_e2e/test_relations.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Callable
+
 import ops
 import pytest
 from ops.charm import (
@@ -18,6 +20,7 @@ from scenario import Context
 from scenario.errors import UncaughtCharmError
 from scenario.state import (
     _DEFAULT_JUJU_DATABAG,
+    _Event,
     PeerRelation,
     Relation,
     RelationBase,
@@ -39,7 +42,7 @@ def mycharm():
             return super().define_event(event_kind, event_type)
 
     class MyCharm(CharmBase):
-        _call = None
+        _call: Callable[[MyCharm, _Event], None] | None = None
         called = False
         on = MyCharmEvents()
 
@@ -51,8 +54,7 @@ def mycharm():
         def _on_event(self, event):
             if self._call:
                 MyCharm.called = True
-                assert callable(MyCharm._call)
-                MyCharm._call(self, event)
+                self._call(event)
 
     return MyCharm
 

--- a/testing/tests/test_e2e/test_secrets.py
+++ b/testing/tests/test_e2e/test_secrets.py
@@ -432,6 +432,7 @@ def test_grant_nonowner(mycharm):
         secret = charm.model.get_secret(id=secret_id)
         secret = charm.model.get_secret(label='mylabel')
         foo = charm.model.get_relation('foo')
+        assert foo is not None
 
         with pytest.raises(ModelError):
             secret.grant(relation=foo)
@@ -575,7 +576,7 @@ def test_set_label_on_get():
 
 def test_no_additional_positional_arguments():
     with pytest.raises(TypeError):
-        Secret({}, {}, None)
+        Secret({}, {}, None)  # type: ignore
 
 
 def test_default_values():

--- a/testing/tests/test_e2e/test_secrets.py
+++ b/testing/tests/test_e2e/test_secrets.py
@@ -576,7 +576,7 @@ def test_set_label_on_get():
 
 def test_no_additional_positional_arguments():
     with pytest.raises(TypeError):
-        Secret({}, {}, None)  # type: ignore
+        Secret({}, {})
 
 
 def test_default_values():

--- a/testing/tests/test_e2e/test_state.py
+++ b/testing/tests/test_e2e/test_state.py
@@ -310,7 +310,7 @@ def test_model_positional_arguments():
 
 def test_container_positional_arguments():
     with pytest.raises(TypeError):
-        Container('', '')  # type: ignore
+        Container('', True)
 
 
 def test_container_default_values():

--- a/testing/tests/test_e2e/test_state.py
+++ b/testing/tests/test_e2e/test_state.py
@@ -15,6 +15,7 @@ from ops.model import ActiveStatus, UnknownStatus, WaitingStatus
 
 from scenario.state import (
     _DEFAULT_JUJU_DATABAG,
+    _Event,
     _next_storage_index,
     Address,
     BindAddress,
@@ -64,7 +65,7 @@ def mycharm():
             return super().define_event(event_kind, event_type)
 
     class MyCharm(CharmBase):
-        _call = None
+        _call: Callable[[MyCharm, _Event], None] | None = None
         called = False
         on = MyCharmEvents()
 
@@ -76,8 +77,7 @@ def mycharm():
         def _on_event(self, event):
             if self._call:
                 MyCharm.called = True
-                assert callable(MyCharm._call)
-                MyCharm._call(self, event)
+                self._call(event)
 
     return MyCharm
 

--- a/testing/tests/test_e2e/test_state.py
+++ b/testing/tests/test_e2e/test_state.py
@@ -76,6 +76,7 @@ def mycharm():
         def _on_event(self, event):
             if self._call:
                 MyCharm.called = True
+                assert callable(MyCharm._call)
                 MyCharm._call(self, event)
 
     return MyCharm
@@ -208,6 +209,7 @@ def test_relation_get(mycharm):
 def test_relation_set(mycharm):
     def event_handler(charm: CharmBase, _):
         rel = charm.model.get_relation('foo')
+        assert rel is not None
         rel.data[charm.app]['a'] = 'b'
         rel.data[charm.unit]['c'] = 'd'
 
@@ -308,7 +310,7 @@ def test_model_positional_arguments():
 
 def test_container_positional_arguments():
     with pytest.raises(TypeError):
-        Container('', '')
+        Container('', '')  # type: ignore
 
 
 def test_container_default_values():
@@ -522,9 +524,10 @@ def test_state_immutable(obj_in, attribute: str, get_method: str, key_attr: str,
         SubordinateRelation,
     ],
 )
-def test_state_immutable_with_changed_data_relation(relation_type, mycharm):
+def test_state_immutable_with_changed_data_relation(relation_type: type[RelationBase], mycharm):
     def event_handler(charm: CharmBase, _):
         rel = charm.model.get_relation(relation_type.__name__)
+        assert rel is not None
         rel.data[charm.app]['a'] = 'b'
         rel.data[charm.unit]['c'] = 'd'
 
@@ -771,11 +774,14 @@ def test_layer_from_rockcraft(rockcraft: dict[str, Any]):
         assert layer_check.override == check['override']
         layer_check_level = layer_check.level
         if hasattr(layer_check_level, 'value'):
+            assert isinstance(layer_check_level, ops.pebble.CheckLevel)
             layer_check_level = layer_check_level.value
         assert layer_check_level == check.get('level', ops.pebble.CheckLevel.UNSET.value)
         if 'exec' in check:
+            assert layer_check.exec is not None and 'command' in check['exec']
             assert layer_check.exec['command'] == check['exec']['command']
         if 'tcp' in check:
+            assert layer_check.tcp is not None and 'port' in check['tcp']
             assert layer_check.tcp['port'] == check['tcp']['port']
 
 
@@ -787,7 +793,7 @@ def test_layer_from_rockcraft_safe():
         f.write(dangerous_yaml)
         f.flush()
         rockcraft_path = f.name
-        with pytest.raises(yaml.error.YAMLError):
+        with pytest.raises(yaml.YAMLError):
             layer_from_rockcraft(rockcraft_path)
 
 
@@ -812,15 +818,19 @@ def test_state_from_context():
     )
     state = State.from_context(ctx)
     assert state.config == {'foo': 'bar'}
+    assert isinstance(state.containers, frozenset)
     assert len(state.containers) == 1
     assert state.get_container('container').can_connect
+    assert isinstance(state.relations, frozenset)
     assert len(state.relations) == 4
     assert state.get_relations('peer')[0].interface == 'friend'
     assert state.get_relations('relreq')[0].interface == 'across'
     assert state.get_relations('relpro')[0].interface == 'around'
     assert state.get_relations('sub')[0].interface == 'below'
+    assert isinstance(state.storages, frozenset)
     assert len(state.storages) == 1
     assert tuple(state.storages)[0].name == 'storage'
+    assert isinstance(state.stored_states, frozenset)
     assert len(state.stored_states) == 1
     assert state.get_stored_state('_stored', owner_path='Charm').name == '_stored'
 
@@ -857,17 +867,21 @@ def test_state_from_context_extend():
     )
     assert state.leader is True
     assert state.config == {'foo': 'baz'}
+    assert isinstance(state.containers, frozenset)
     assert len(state.containers) == 2
     assert state.get_container('container').can_connect
     assert not state.get_container('other-container').can_connect
+    assert isinstance(state.relations, frozenset)
     assert len(state.relations) == 5
     assert state.get_relations('peer')[0].interface == 'friend'
     assert state.get_relations('relreq')[0].interface == 'across'
     assert state.get_relations('relpro')[0].interface == 'around'
     assert state.get_relations('sub')[0].interface == 'below'
     assert state.get_relation(relation.id).remote_app_data == {'a': 'b'}
+    assert isinstance(state.storages, frozenset)
     assert len(state.storages) == 1
     assert tuple(state.storages)[0].name == 'storage'
+    assert isinstance(state.stored_states, frozenset)
     assert len(state.stored_states) == 1
     assert state.get_stored_state('_stored', owner_path='Charm').name == '_stored'
     assert state.get_stored_state('_stored', owner_path='Charm').content == {'foo': 'bar'}
@@ -984,11 +998,11 @@ def test_state_from_non_sets(iterable: Callable[..., Any]):
         relations=iterable({relation}),
         stored_states=iterable({stored_state}),
     )
-    assert len(state.containers) == 2
     assert isinstance(state.containers, frozenset)
-    assert len(state.relations) == 5
+    assert len(state.containers) == 2
     assert isinstance(state.relations, frozenset)
-    assert len(state.storages) == 1
+    assert len(state.relations) == 5
     assert isinstance(state.storages, frozenset)
-    assert len(state.stored_states) == 1
+    assert len(state.storages) == 1
     assert isinstance(state.stored_states, frozenset)
+    assert len(state.stored_states) == 1

--- a/testing/tests/test_runtime.py
+++ b/testing/tests/test_runtime.py
@@ -158,4 +158,5 @@ def test_ops_raises_abort(exit_code: int):
     else:
         with pytest.raises(_Abort) as exc:
             ctx.run(ctx.on.start(), State())
+        assert isinstance(exc.value, _Abort)
         assert exc.value.exit_code == exit_code

--- a/testing/tests/test_runtime.py
+++ b/testing/tests/test_runtime.py
@@ -158,5 +158,4 @@ def test_ops_raises_abort(exit_code: int):
     else:
         with pytest.raises(_Abort) as exc:
             ctx.run(ctx.on.start(), State())
-        assert isinstance(exc.value, _Abort)
         assert exc.value.exit_code == exit_code

--- a/testing/tests/test_runtime.py
+++ b/testing/tests/test_runtime.py
@@ -156,6 +156,7 @@ def test_ops_raises_abort(exit_code: int):
         assert {e.handle.kind for e in ctx.emitted_events} == {'start'}
         assert state_out.unit_status == ActiveStatus()
     else:
-        with pytest.raises(_Abort) as exc:
+        with pytest.raises(UncaughtCharmError) as exc:
             ctx.run(ctx.on.start(), State())
-        assert exc.value.exit_code == exit_code
+        assert isinstance(exc.value.__cause__, _Abort)
+        assert exc.value.__cause__.exit_code == exit_code


### PR DESCRIPTION
Fix a variety of small type annotation issues.

These are found with `ty` and missed by `pyright` but should be fixed both because they are issues and because it would be good to be more prepared for a stronger type checker in the future.  (Note that we can't move to `ty` yet because (a) it's marked as not ready, and (b) there are a bunch of false positives still.)