### PR TITLE
feat: add security event logging

### DIFF
--- a/ops/_main.py
+++ b/ops/_main.py
@@ -31,7 +31,7 @@ from . import model as _model
 from . import storage as _storage
 from ._private import tracer
 from .jujucontext import _JujuContext
-from .log import setup_root_logging
+from .log import _security_event, setup_root_logging
 from .version import version
 
 CHARM_STATE_FILE = '.unit-state.db'
@@ -298,6 +298,12 @@ class _Manager:
         # Do this as early as possible to be sure to catch the most logs.
         self._setup_root_logging()
 
+        _security_event(
+            f'sys_startup:{os.getuid()}',
+            level='DEBUG',
+            description=f'Starting ops framework for {charm_class.__name__}',
+        )
+
         self._charm_root = self._juju_context.charm_dir
         self._charm_meta = self._load_charm_meta()
         self._use_juju_for_storage = use_juju_for_storage
@@ -478,3 +484,8 @@ def main(charm_class: type[_charm.CharmBase], use_juju_for_storage: bool | None 
     finally:
         if manager:
             manager._destroy()
+        _security_event(
+            f'sys_shutdown:{os.getuid()}',
+            level='DEBUG',
+            description='Stopping ops framework',
+        )

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -1384,6 +1384,7 @@ class MockClient(pebble.Client):
         self.responses: list[typing.Any] = []
         self.timeout = 5
         self.websockets: dict[typing.Any, MockWebsocket] = {}
+        self.app_id = 'pebble-tests'
 
     def _request(
         self,


### PR DESCRIPTION
Adds logging of security events, as specified in [SEC0045](https://docs.google.com/document/d/1nInWP9pEEhloKMfgzDsd4Pub4530OxQcKKh716Gvxfk/edit?usp=drivesdk).

A new `_security_event` helper is added to `ops.log`. Security events must be logged as structured data, so the helper does this, and provides some fields common to all events (a timestamp, the model UUID, and a type of "security") as well as the provided event, level, and description.

Logged security events are:
* `sys_startup`, immediately after the logging to Juju is configured.
* `sys_shutdown`, as the very last action of `ops.main`.
* `sys_crash`, if the charm exits because of an uncaught exception.
* `sys_restart`, if the unit's `reboot` command is executed.
* `authz_fail`, if any hook command fails with error text containing "access denied" (case insensitive).
* `user_added` and `user_updated` if the Pebble client is used to add, update, or remove identities.

In order to have the model UUID to log within `ops.pebble`, a new optional `app_id` argument to `pebble.Client` is added, which is used for logging (and the model backend passes in the model UUID for this, in the charm context).

TODO:
- [ ] Tests - the existing tests are updated, which cover startup, shutdown, and crashing, but we should add tests for the other events as well.

See also [OP067 - Security Event Logging for Charm SDK](https://docs.google.com/document/d/1VsxGDxuUOo6A3PfT_qzFssR3qTOJInrHPORitnbtiDk/edit?usp=sharing)