### PR TITLE
refactor: move the testing event capture into a framework subclass

### DIFF
--- a/test/charms/test_main/src/charm.py
+++ b/test/charms/test_main/src/charm.py
@@ -28,6 +28,12 @@ sys.path.append('lib')
 
 logger = logging.getLogger()
 
+# Note for ops developers: juju-log doesn't go anywhere useful much of the time
+# during unit tests, and test_main failures that subprocess out are often
+# difficult to debug. Uncomment this line to get more informative errors when
+# running the tests.
+# logger.addHandler(logging.StreamHandler(sys.stderr))
+
 
 class CustomEvent(ops.EventBase):
     pass


### PR DESCRIPTION
This extracts the event-capturing `Framework` subclass out of #1631 (merged then reverted).

This replaces the context handler that monkeypatches `Framework` to capture events with a subclass of `Framework` that provides the same functionality. This is a simpler implementation that can't leak across tests and is thread-safe.