### PR TITLE
test: replace Python version to 3.10 for observability charm tests

### DIFF
--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -39,12 +39,12 @@ jobs:
         if: ${{ !(matrix.disabled) }}
         run: |
           if [ -e "uv.lock" ]; then
-            sed -i 's/requires-python = ">=3.8, <4"/requires-python = ">=3.10, <4"/g' uv.lock
             uv remove ops --optional dev --frozen || echo "maybe ops[testing] is not a dev dependency"
             uv remove ops-scenario --optional dev --frozen || echo "maybe ops-scenario is not a dev dependency"
             uv remove ops --frozen
             uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#subdirectory=testing --optional dev --raw-sources --prerelease=if-necessary-or-explicit
             uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA --raw-sources --prerelease=if-necessary-or-explicit
+            sed -i 's/requires-python = ">=3.8, <4"/requires-python = ">=3.10, <4"/g' uv.lock
           else
             echo "Error: no uv.lock file found"
             exit 1

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -42,9 +42,10 @@ jobs:
             uv remove ops --optional dev --frozen || echo "maybe ops[testing] is not a dev dependency"
             uv remove ops-scenario --optional dev --frozen || echo "maybe ops-scenario is not a dev dependency"
             uv remove ops --frozen
+            sed -i 's/requires-python = "~=3.8"/requires-python = "~=3.10"/g' pyproject.toml
+            # sed -i 's/requires-python = ">=3.8, <4"/requires-python = ">=3.10, <4"/g' uv.lock
             uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#subdirectory=testing --optional dev --raw-sources --prerelease=if-necessary-or-explicit
             uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA --raw-sources --prerelease=if-necessary-or-explicit
-            sed -i 's/requires-python = ">=3.8, <4"/requires-python = ">=3.10, <4"/g' uv.lock
           else
             echo "Error: no uv.lock file found"
             exit 1

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -20,13 +20,10 @@ jobs:
         include:
           - charm-repo: canonical/alertmanager-k8s-operator
             commit: cc7bd1db35589fd63e44fb0e8813cd3b4362943e  # rev171 2025-06-22T16:01:16Z
-            disabled: true
           - charm-repo: canonical/prometheus-k8s-operator
             commit: ca0a31dab4497eac1bcdc3ca3eb47bbbc7365dc9  # rev253 2025-06-23T08:45:58Z
-            disabled: true
           - charm-repo: canonical/grafana-k8s-operator
             commit: a2770608526f2c82ddc3d225870f1a48eaa87179  # 2025-06-12T17:55:14Z
-            disabled: true
     steps:
       - name: Checkout the ${{ matrix.charm-repo }} repository
         uses: actions/checkout@v4
@@ -41,19 +38,15 @@ jobs:
       - name: Update 'ops' and 'ops-scenario' dependencies in test charm to latest
         if: ${{ !(matrix.disabled) }}
         run: |
-          if [ -e "requirements.txt" ]; then
-            sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" requirements.txt
-            echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> requirements.txt
-            sed -i -e "/^ops-scenario[ ><=]/d" -e "/^ops\[testing\][ ><=]/d" requirements.txt
-            echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops-scenario&subdirectory=testing" >> requirements.txt
-          elif [ -e "uv.lock" ]; then
+          if [ -e "uv.lock" ]; then
+            sed -i 's/requires-python = ">=3.8, <4"/requires-python = ">=3.10, <4"/g' uv.lock
             uv remove ops --optional dev --frozen || echo "maybe ops[testing] is not a dev dependency"
             uv remove ops-scenario --optional dev --frozen || echo "maybe ops-scenario is not a dev dependency"
             uv remove ops --frozen
             uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#subdirectory=testing --optional dev --raw-sources --prerelease=if-necessary-or-explicit
             uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA --raw-sources --prerelease=if-necessary-or-explicit
           else
-            echo "Error: no requirements.txt or uv.lock file found"
+            echo "Error: no uv.lock file found"
             exit 1
           fi
 

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -43,7 +43,6 @@ jobs:
             uv remove ops-scenario --optional dev --frozen || echo "maybe ops-scenario is not a dev dependency"
             uv remove ops --frozen
             sed -i 's/requires-python = "~=3.8"/requires-python = "~=3.10"/g' pyproject.toml
-            # sed -i 's/requires-python = ">=3.8, <4"/requires-python = ">=3.10, <4"/g' uv.lock
             uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#subdirectory=testing --optional dev --raw-sources --prerelease=if-necessary-or-explicit
             uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA --raw-sources --prerelease=if-necessary-or-explicit
           else


### PR DESCRIPTION
Replace Python version to 3.10 for observability charm tests.

See discussion [here](https://github.com/canonical/operator/issues/1877#issuecomment-3026362687).

Closes https://github.com/canonical/operator/issues/1877.

Also, the logic for handling `requirements.txt` is removed, since all three charms from observability teams don't use it any more.