### PR TITLE
fix: only add the remote unit for departed and broken relation events, fix ordering

### DIFF
--- a/ops/_main.py
+++ b/ops/_main.py
@@ -370,7 +370,7 @@ class _Manager:
     def _make_framework(self, dispatcher: _Dispatcher):
         # If we are in a RelationBroken event, we want to know which relation is
         # broken within the model, not only in the event's `.relation` attribute.
-        if self._juju_context.dispatch_path.endswith(('-relation-broken', '_relation_broken')):
+        if dispatcher.event_name.endswith('_relation_broken'):
             broken_relation_id = self._juju_context.relation_id
         else:
             broken_relation_id = None
@@ -383,13 +383,8 @@ class _Manager:
         # that it's available then as well. For other relation events, the unit
         # will either already be in the set via `relation-list` (such as in a
         # RelationChanged event) or correctly not in the list yet because the
-        # relation has not been rully set up (such as in a RelationJoined event).
-        if self._juju_context.dispatch_path.endswith((
-            '-relation-departed',
-            '_relation_departed',
-            '-relation-broken',
-            '_relation_broken',
-        )):
+        # relation has not been fully set up (such as in a RelationJoined event).
+        if dispatcher.event_name.endswith(('_relation_departed', '_relation_broken')):
             remote_unit_name = self._juju_context.remote_unit_name
         else:
             remote_unit_name = None

--- a/ops/model.py
+++ b/ops/model.py
@@ -1774,7 +1774,6 @@ class Relation:
 
         # self.app will not be None and always be set because of the fallback mechanism above.
         self.app = typing.cast('Application', app)
-        self.data = RelationData(self, our_unit, backend)
 
         # In relation-departed `relation-list` doesn't include the remote unit,
         # but the data should still be available.
@@ -1788,6 +1787,8 @@ class Relation:
             and _remote_unit.name.startswith(f'{self.app.name}/')
         ):
             self.units.add(_remote_unit)
+
+        self.data = RelationData(self, our_unit, backend)
 
         self._remote_model: RemoteModel | None = None
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -4442,6 +4442,20 @@ def test_departing_unit_in_relations():
 @pytest.mark.skipif(
     not hasattr(ops.testing, 'Context'), reason='requires optional ops[testing] install'
 )
+def test_no_inject_unit_in_relation_joined():
+    ctx = ops.testing.Context(
+        ops.CharmBase, meta={'name': 'mycharm', 'requires': {'db': {'interface': 'db'}}}
+    )
+    rel = ops.testing.Relation('db', remote_units_data={0: {}}, remote_app_name='db')
+    state_in = ops.testing.State(relations={rel})
+    with ctx(ctx.on.relation_joined(rel, remote_unit=1), state_in) as mgr:
+        mgr.run()
+        assert {unit.name for unit in mgr.charm.model.relations['db'][0].units} == {'db/0'}
+
+
+@pytest.mark.skipif(
+    not hasattr(ops.testing, 'Context'), reason='requires optional ops[testing] install'
+)
 def test_relation_has_correct_units():
     class Charm(ops.CharmBase):
         def __init__(self, framework: ops.Framework):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -4421,6 +4421,29 @@ class TestGetCloudSpec:
         assert str(excinfo.value) == 'ERROR cannot access cloud credentials\n'
 
 
+def test_departing_unit_data_available(fake_script: FakeScript):
+    fake_script.write('relation-ids', """echo '["db0:1"]'""")
+    fake_script.write('relation-list', """echo '["db/0"]'""")
+    fake_script.write('relation-get', """echo '{"db": "data"}'""")
+
+    model = ops.model.Model(
+        ops.charm.CharmMeta({'name': 'mycharm', 'requires': {'db': {'interface': 'db'}}}),
+        ops.model._ModelBackend('myapp/0'),
+        remote_unit_name='db/1',
+    )
+    relation = model.get_relation('db')
+    assert relation is not None
+    for unit in relation.units:
+        assert relation.data[unit] == {'db': 'data'}
+    calls = fake_script.calls(clear=True)
+    assert calls[:2] == [
+        ['relation-ids', 'db', '--format=json'],
+        ['relation-list', '-r', '1', '--format=json'],
+    ]
+    assert ['relation-get', '-r', '1', '-', 'db/0', '--format=json'] in calls
+    assert ['relation-get', '-r', '1', '-', 'db/1', '--format=json'] in calls
+
+
 @pytest.mark.skipif(
     not hasattr(ops.testing, 'Context'), reason='requires optional ops[testing] install'
 )
@@ -4429,14 +4452,18 @@ def test_departing_unit_in_relations():
         ops.CharmBase, meta={'name': 'mycharm', 'requires': {'db': {'interface': 'db'}}}
     )
     # In this mocked Juju data, only unit/0 is included.
-    rel = ops.testing.Relation('db', remote_units_data={0: {}}, remote_app_name='db')
+    rel = ops.testing.Relation('db', remote_units_data={0: {}, 1: {}}, remote_app_name='db')
     state_in = ops.testing.State(relations={rel})
     # We simulate a relation-departed event where the departing unit is unit/1.
     with ctx(ctx.on.relation_departed(rel, remote_unit=1), state_in) as mgr:
         mgr.run()
         # The departing unit, unit/1, should be in the .units set for the relation
         # even though it was not in the mocked Juju data.
-        assert {unit.name for unit in mgr.charm.model.relations['db'][0].units} == {'db/0', 'db/1'}
+        relation = mgr.charm.model.relations['db'][0]
+        assert {unit.name for unit in relation.units} == {'db/0', 'db/1'}
+        # We should also be able to get the data.
+        for unit in relation.units:
+            assert relation.data[unit] == {}
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
We inject the `JUJU_REMOTE_UNIT` unit into the relation's unit so that the databag is available during relation-departed events. When this was added in #1364 the thinking was that it was cleaner to just always add that unit rather than check for the specific events. However, that was not correct: this means that the unit may be added before the data is available (in relation joined, for example).

This PR changes the injection so that it only happens in relation departed and relation broken events.

In addition, we inserted the unit into the relation *after* setting up the relation's `.data`, which meant that the data would not be accessible for the inserted unit. The PR adjusts the ordering so that the inserting is done first.

Fixes #1917