### PR TITLE
feat: add add_name and unit_id attributes to testing.Context

### DIFF
--- a/testing/src/scenario/_runtime.py
+++ b/testing/src/scenario/_runtime.py
@@ -48,19 +48,15 @@ class Runtime:
 
     def __init__(
         self,
+        app_name: str,
         charm_spec: _CharmSpec[CharmType],
         charm_root: str | Path | None = None,
         juju_version: str = '3.0.0',
-        app_name: str | None = None,
         unit_id: int | None = 0,
     ):
         self._charm_spec = charm_spec
         self._juju_version = juju_version
         self._charm_root = charm_root
-
-        app_name = app_name or self._charm_spec.meta.get('name')
-        if not app_name:
-            raise ValueError('invalid metadata: mandatory "name" field is missing.')
 
         self._app_name = app_name
         self._unit_id = unit_id

--- a/testing/src/scenario/context.py
+++ b/testing/src/scenario/context.py
@@ -477,6 +477,12 @@ class Context(Generic[CharmType]):
     can't emit multiple events in a single charm execution.
     """
 
+    app_name: str
+    """The name of the application that this charm is deployed as."""
+
+    unit_id: int
+    """The unit ID that this charm is deployed to."""
+
     juju_log: list[JujuLogLine]
     """A record of what the charm has sent to juju-log"""
     app_status_history: list[_EntityStatus]
@@ -666,8 +672,8 @@ class Context(Generic[CharmType]):
                 'Juju 2.x is closed and unsupported. You may encounter inconsistencies.',
             )
 
-        self._app_name = app_name
-        self._unit_id = unit_id
+        self.app_name = app_name or self.charm_spec.meta.get('name')
+        self.unit_id = unit_id
         self.app_trusted = app_trusted
         self._tmp = tempfile.TemporaryDirectory()
 
@@ -825,11 +831,11 @@ class Context(Generic[CharmType]):
     @contextmanager
     def _run(self, event: _Event, state: State):
         runtime = Runtime(
+            app_name=self.app_name,
             charm_spec=self.charm_spec,
             juju_version=self.juju_version,
             charm_root=self.charm_root,
-            app_name=self._app_name,
-            unit_id=self._unit_id,
+            unit_id=self.unit_id,
         )
         with runtime.exec(
             state=state,

--- a/testing/tests/test_context.py
+++ b/testing/tests/test_context.py
@@ -72,3 +72,15 @@ def test_context_manager():
     with ctx(ctx.on.action('act'), state) as mgr:
         mgr.run()
         assert mgr.charm.meta.name == 'foo'
+
+
+def test_app_name_and_unit_id_default():
+    ctx = Context(MyCharm, meta={'name': 'foo'})
+    assert ctx.app_name == 'foo'
+    assert ctx.unit_id == 0
+
+
+def test_app_name_and_unit_id():
+    ctx = Context(MyCharm, meta={'name': 'foo'}, app_name='notfoo', unit_id=42)
+    assert ctx.app_name == 'notfoo'
+    assert ctx.unit_id == 42

--- a/testing/tests/test_runtime.py
+++ b/testing/tests/test_runtime.py
@@ -49,6 +49,7 @@ def test_event_emission():
         my_charm_type.on.define_event('bar', MyEvt)
 
         runtime = Runtime(
+            'foo',
             _CharmSpec(
                 my_charm_type,
                 meta=meta,
@@ -76,12 +77,12 @@ def test_unit_name(app_name, unit_id):
     my_charm_type = charm_type()
 
     runtime = Runtime(
+        app_name,
         _CharmSpec(
             my_charm_type,
             meta=meta,
         ),
         unit_id=unit_id,
-        app_name=app_name,
     )
 
     with runtime.exec(
@@ -98,6 +99,7 @@ def test_env_clean_on_charm_error():
     my_charm_type = charm_type()
 
     runtime = Runtime(
+        'frank',
         _CharmSpec(
             my_charm_type,
             meta=meta,


### PR DESCRIPTION
Two changes, to allow tests to access the (mocked) app name and unit ID:

* Change `Context._unit_id` to `Context.unit_id`
* Change `Context._app_name` to `Context.app_name`, and resolve it to the app name from the charm metadata inside of the `Context` `__init__` rather than in `Runtime`, so that it's available before the event is run.

Fixes #1911