### PR TITLE
ci: drop smoke test against 20.04

### DIFF
--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -71,7 +71,6 @@ def pack(charm_dir: pathlib.Path):
 @pytest.mark.parametrize(
     'base,charmcraft_version,name',
     (
-        ('20.04', 3, 'focal'),
         ('22.04', 3, 'jammy'),
         ('24.04', 3, 'noble'),
     ),


### PR DESCRIPTION
We don't support 20.04 any more so we shouldn't test against it (the tests now fail, because of the Python 3.10 requirement).