### PR TITLE
fix: add the remote unit to Relation.data but not Relation.units

### DIFF
--- a/ops/_main.py
+++ b/ops/_main.py
@@ -368,24 +368,30 @@ class _Manager:
     def _make_framework(self, dispatcher: _Dispatcher):
         # If we are in a RelationBroken event, we want to know which relation is
         # broken within the model, not only in the event's `.relation` attribute.
-        if self._juju_context.dispatch_path.endswith(('-relation-broken', '_relation_broken')):
+        if dispatcher.event_name.endswith('_relation_broken'):
             broken_relation_id = self._juju_context.relation_id
         else:
             broken_relation_id = None
+
+        # In a RelationDeparted event, the unit is not included in the Juju
+        # `relation-list` output, but the charm still has access to the remote
+        # relation data. To provide the charm with a mechanism for getting
+        # access to that data, we include the remote unit in Relation.units.
+        # We also expect it to be available in RelationBroken events, so ensure
+        # that it's available then as well. For other relation events, the unit
+        # will either already be in the set via `relation-list` (such as in a
+        # RelationChanged event) or correctly not in the list yet because the
+        # relation has not been fully set up (such as in a RelationJoined event).
+        if dispatcher.event_name.endswith(('_relation_departed', '_relation_broken')):
+            remote_unit_name = self._juju_context.remote_unit_name
+        else:
+            remote_unit_name = None
 
         model = _model.Model(
             self._charm_meta,
             self._model_backend,
             broken_relation_id=broken_relation_id,
-            # In a RelationDeparted event, the unit is not included in the Juju
-            # `relation-list` output, but the charm still has access to the remote
-            # relation data. To provide the charm with a mechanism for getting
-            # access to that data, we include the remote unit in Relation.units.
-            # In other relation events (such as RelationChanged) the unit will
-            # already be in the set via `relation-list` - adding it via this extra
-            # mechanism will not change the final set, and is simpler than only
-            # adding it in specific events.
-            remote_unit_name=self._juju_context.remote_unit_name,
+            remote_unit_name=remote_unit_name,
         )
         store = self._make_storage(dispatcher)
         framework = _framework.Framework(

--- a/ops/model.py
+++ b/ops/model.py
@@ -1774,7 +1774,6 @@ class Relation:
 
         # self.app will not be None and always be set because of the fallback mechanism above.
         self.app = typing.cast('Application', app)
-        self.data = RelationData(self, our_unit, backend)
 
         # In relation-departed `relation-list` doesn't include the remote unit,
         # but the data should still be available.
@@ -1788,6 +1787,8 @@ class Relation:
             and _remote_unit.name.startswith(f'{self.app.name}/')
         ):
             self.units.add(_remote_unit)
+
+        self.data = RelationData(self, our_unit, backend)
 
         self._remote_model: RemoteModel | None = None
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -1781,6 +1781,10 @@ class Relation:
         if (
             _remote_unit is not None
             and not is_peer
+            # In practice, the "self.app will not be None" statement above is not
+            # necessarily true. Once https://bugs.launchpad.net/juju/+bug/1960934
+            # is resolved, we should be able to remove the next line.
+            and self.app is not None
             and _remote_unit.name.startswith(f'{self.app.name}/')
         ):
             self.units.add(_remote_unit)

--- a/ops/model.py
+++ b/ops/model.py
@@ -1786,9 +1786,11 @@ class Relation:
             and self.app is not None
             and _remote_unit.name.startswith(f'{self.app.name}/')
         ):
-            self.units.add(_remote_unit)
+            remote_unit = _remote_unit
+        else:
+            remote_unit = None
 
-        self.data = RelationData(self, our_unit, backend)
+        self.data = RelationData(self, our_unit, backend, remote_unit)
 
         self._remote_model: RemoteModel | None = None
 
@@ -1984,7 +1986,13 @@ class RelationData(Mapping[Union[Unit, Application], 'RelationDataContent']):
     :attr:`Relation.data`
     """
 
-    def __init__(self, relation: Relation, our_unit: Unit, backend: _ModelBackend):
+    def __init__(
+        self,
+        relation: Relation,
+        our_unit: Unit,
+        backend: _ModelBackend,
+        remote_unit: Unit | None = None,
+    ):
         self.relation = weakref.proxy(relation)
         self._data: dict[Unit | Application, RelationDataContent] = {
             our_unit: RelationDataContent(self.relation, our_unit, backend),
@@ -1998,6 +2006,9 @@ class RelationData(Mapping[Union[Unit, Application], 'RelationDataContent']):
             self._data.update({
                 self.relation.app: RelationDataContent(self.relation, self.relation.app, backend),
             })
+        # The unit might be departing or broken, so not in relation-list, but accessible.
+        if remote_unit is not None and remote_unit not in self._data:
+            self._data[remote_unit] = RelationDataContent(self.relation, remote_unit, backend)
 
     def __contains__(self, key: Unit | Application):
         return key in self._data

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -4426,15 +4426,15 @@ def test_departing_unit_data_available(fake_script: FakeScript):
     fake_script.write('relation-list', """echo '["db/0"]'""")
     fake_script.write('relation-get', """echo '{"db": "data"}'""")
 
-    model = ops.model.Model(
-        ops.charm.CharmMeta({'name': 'mycharm', 'requires': {'db': {'interface': 'db'}}}),
-        ops.model._ModelBackend('myapp/0'),
-        remote_unit_name='db/1',
-    )
+    meta = ops.charm.CharmMeta({'name': 'mycharm', 'requires': {'db': {'interface': 'db'}}})
+    backend = ops.model._ModelBackend('myapp/0')
+    model = ops.model.Model(meta, backend, remote_unit_name='db/1')
     relation = model.get_relation('db')
     assert relation is not None
     for unit in relation.units:
         assert relation.data[unit] == {'db': 'data'}
+    unit = model.get_unit('db/1')
+    assert relation.data[unit] == {'db': 'data'}
     calls = fake_script.calls(clear=True)
     assert calls[:2] == [
         ['relation-ids', 'db', '--format=json'],
@@ -4442,104 +4442,6 @@ def test_departing_unit_data_available(fake_script: FakeScript):
     ]
     assert ['relation-get', '-r', '1', '-', 'db/0', '--format=json'] in calls
     assert ['relation-get', '-r', '1', '-', 'db/1', '--format=json'] in calls
-
-
-@pytest.mark.skipif(
-    not hasattr(ops.testing, 'Context'), reason='requires optional ops[testing] install'
-)
-def test_departing_unit_in_relations():
-    ctx = ops.testing.Context(
-        ops.CharmBase, meta={'name': 'mycharm', 'requires': {'db': {'interface': 'db'}}}
-    )
-    # In this mocked Juju data, only unit/0 is included.
-    rel = ops.testing.Relation('db', remote_units_data={0: {}, 1: {}}, remote_app_name='db')
-    state_in = ops.testing.State(relations={rel})
-    # We simulate a relation-departed event where the departing unit is unit/1.
-    with ctx(ctx.on.relation_departed(rel, remote_unit=1), state_in) as mgr:
-        mgr.run()
-        # The departing unit, unit/1, should be in the .units set for the relation
-        # even though it was not in the mocked Juju data.
-        relation = mgr.charm.model.relations['db'][0]
-        assert {unit.name for unit in relation.units} == {'db/0', 'db/1'}
-        # We should also be able to get the data.
-        for unit in relation.units:
-            assert relation.data[unit] == {}
-
-
-@pytest.mark.skipif(
-    not hasattr(ops.testing, 'Context'), reason='requires optional ops[testing] install'
-)
-def test_no_inject_unit_in_relation_joined():
-    ctx = ops.testing.Context(
-        ops.CharmBase, meta={'name': 'mycharm', 'requires': {'db': {'interface': 'db'}}}
-    )
-    rel = ops.testing.Relation('db', remote_units_data={0: {}}, remote_app_name='db')
-    state_in = ops.testing.State(relations={rel})
-    with ctx(ctx.on.relation_joined(rel, remote_unit=1), state_in) as mgr:
-        mgr.run()
-        assert {unit.name for unit in mgr.charm.model.relations['db'][0].units} == {'db/0'}
-
-
-@pytest.mark.skipif(
-    not hasattr(ops.testing, 'Context'), reason='requires optional ops[testing] install'
-)
-def test_relation_has_correct_units():
-    class Charm(ops.CharmBase):
-        def __init__(self, framework: ops.Framework):
-            super().__init__(framework)
-            framework.observe(self.on['db'].relation_changed, self._on_peer_relation_changed)
-            framework.observe(self.on['peer'].relation_changed, self._on_peer_relation_changed)
-
-        def _on_peer_relation_changed(self, event: ops.RelationChangedEvent):
-            self.event = event
-
-    ctx = ops.testing.Context(
-        Charm,
-        meta={
-            'name': 'mycharm',
-            'requires': {'db': {'interface': 'db'}, 'ingress': {'interface': 'ingress'}},
-            'peers': {'peer': {'interface': 'gossip'}},
-        },
-    )
-    rel1 = ops.testing.Relation(
-        'db', remote_units_data={1: {}, 2: {}, 3: {}}, remote_app_name='test-db'
-    )
-    rel2 = ops.testing.Relation(
-        'ingress', remote_units_data={4: {}, 6: {}}, remote_app_name='test-ingress'
-    )
-    peer = ops.testing.PeerRelation('peer', peers_data={1: {}, 2: {}})
-    state_in = ops.testing.State(relations={rel1, rel2, peer})
-
-    def unit_names(relation: ops.Relation):
-        return {unit.name for unit in relation.units}
-
-    with ctx(ctx.on.relation_changed(peer, remote_unit=1), state_in) as mgr:
-        mgr.run()
-        assert unit_names(mgr.charm.event.relation) == {'mycharm/1', 'mycharm/2'}
-        assert unit_names(mgr.charm.model.relations['peer'][0]) == {'mycharm/1', 'mycharm/2'}
-        assert unit_names(mgr.charm.model.relations['db'][0]) == {
-            'test-db/1',
-            'test-db/2',
-            'test-db/3',
-        }
-        assert unit_names(mgr.charm.model.relations['ingress'][0]) == {
-            'test-ingress/4',
-            'test-ingress/6',
-        }
-
-    with ctx(ctx.on.relation_changed(rel1, remote_unit=1), state_in) as mgr:
-        mgr.run()
-        assert unit_names(mgr.charm.event.relation) == {'test-db/1', 'test-db/2', 'test-db/3'}
-        assert unit_names(mgr.charm.model.relations['peer'][0]) == {'mycharm/1', 'mycharm/2'}
-        assert unit_names(mgr.charm.model.relations['db'][0]) == {
-            'test-db/1',
-            'test-db/2',
-            'test-db/3',
-        }
-        assert unit_names(mgr.charm.model.relations['ingress'][0]) == {
-            'test-ingress/4',
-            'test-ingress/6',
-        }
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This cherry-picks from main:

* a93d676363efb269d7459a27a17fd35804fb47e5
* 5a63e01e2b2eec9e23f226f08f9c47c6ddeb3e0a
* 5a999fa49e34afec21c1bf2906343473f15702a5

These are fairly critical fixes in that the issues they fix can cause charms to completely crash in new ways, and also unexpectedly change the behaviour of Relation.units.

None of the code in the commits requires Python > 3.8.