### PR TITLE
ci: Install release dependencies for the TIOBE analysis

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install TIOBE and project dependencies
         run: |
-          uv export --no-emit-project --frozen --no-hashes --group unit --group static > requirements.txt
+          uv export --no-emit-project --frozen --no-hashes --group unit --group static --group release > requirements.txt
           pip install flake8 pylint -e . -r requirements.txt --break-system-packages
 
       - name: TICS GitHub Action


### PR DESCRIPTION
The TIOBE analysis tool checks everything in the repository, so that includes [release.py][./release.py] as well as the three packages. Some of the analysis is failing because the dependencies (the `github` package) aren't available.

This PR adds the `release` group to the TIOBE dependencies to install.