### PR TITLE
ci: store the charmcraft logs if packing fails

### DIFF
--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install yq
         run: sudo snap install yq
 
-      - name: Add 'git' as a build package 
+      - name: Add 'git' as a build package
         run: |
           cd examples/httpbin-demo
           if yq --exit-status 'has("parts")' charmcraft.yaml; then
@@ -60,3 +60,10 @@ jobs:
         run: |
           cd examples/httpbin-demo
           charmcraft pack --verbose
+
+      - name: Archive charmcraft logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: charmcraft-logs
+          path: /root/.local/state/charmcraft/log/*.log


### PR DESCRIPTION
If the charmcraft pack workflow fails, we get output like:

```
Run sudo charmcraft pack --verbose
Starting charmcraft, version 3.5.2
Logging execution to '/root/.local/state/charmcraft/log/charmcraft-20250730-063104.414518.log'
Launching managed ubuntu 20.04 instance...
Creating new instance from remote
Creating new base instance from remote
Creating new instance from base instance
Starting instance
Starting charmcraft, version 3.5.2
Logging execution to '/tmp/charmcraft.log'
Initialising lifecycle
Installing build-packages
Failed to refresh package list: failed to run apt update.
Failed to execute charmcraft in instance.
Full execution log: '/root/.local/state/charmcraft/log/charmcraft-20250730-063104.414518.log'
Error: Process completed with exit code 1.
```

This doesn't really tell us what went wrong. This PR will store the charmcraft log if packing fails, so that the error can be more easily investigated.