### PR TITLE
feat: add a new log target type opentelemetry

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -151,7 +151,7 @@ LogTargetDict = typing.TypedDict(
     'LogTargetDict',
     {
         'override': Union[Literal['merge'], Literal['replace']],
-        'type': Literal['loki'],
+        'type': Literal['loki', 'opentelemetry'],
         'location': str,
         'services': List[str],
         'labels': Dict[str, str],


### PR DESCRIPTION
This PR adds a new log target type "opentelemetry", which is added to Pebble in [this PR](https://github.com/canonical/pebble/pull/663).