### PR TITLE
chore: refactor and bug fix

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -235,9 +235,7 @@ the build frontend is [build](https://pypi.org/project/build/).
 
 Before you start, ensure that your environment variable GITHUB_TOKEN is set and that the token has sufficient permissions. The easiest way to set a token is to run `gh auth login` first, follow the steps to log in, then run `export GITHUB_TOKEN=$(gh auth token)`.
 
-Alternatively, you can also create a classic token. To do so, go to GitHub -> Settings -> Developer Settings -> Personal access tokens -> Tokens (classic), and click "Generate new token (classic)" (shortcut: click [this link](https://github.com/settings/tokens/new)), and under "Select scopes", "repo", select "repo:status" and "public_repo". Then, set the environment variable `GITHUB_TOKEN` with the newly generated token.
-
-> Note: A fine-grained token will not work because if the owner is your GitHub account, it can't create a PR on the canonical repo, and if the owner is Canonical, it can't push to your forked repo. 
+Alternatively, you can also create a personal access token. To do so, go to GitHub -> Settings -> Developer Settings -> Personal access tokens -> Fine-grained tokens, and click "Generate new token" (shortcut: click [this link](https://github.com/settings/personal-access-tokens/new)). For "Resource owner", choose "canonical". For "Expiration", choose a desired setting (maximum is 366 days). Under "Repository access", choose "Only select repositories" and select "canonical/operator". Under "Permissions", click "Add permissions", select "Contents" and "Pull requests", then set the access to both of them to "Read and write" (since we need to create draft releases and PRs); note that "Metadata" will be chosen automatically as well. Click "Generate token", then set the environment variable `GITHUB_TOKEN` with it.
 
 Then, check out the main branch of your forked operator repo and pull upstream to ensure the release automation script is the latest.
 
@@ -280,9 +278,7 @@ Then, check out the main branch of your forked operator repo and pull upstream t
 
 8. Follow the steps of the `tox -e post-release` output. If it succeeds, a PR named "chore: adjust versions after release" will be created. Get it reviewed and merged.
 
-After making the release, delete the two newly created branches `release-prep-*` and `post-release-*` both locally and in the origin.
-
-If the release automation script fails at a certain step, delete the draft release and the newly created branches (`release-prep-*`, `post-release-*`) both locally and in the origin, fix issues, and retry.
+If the release automation script fails, delete the draft release and the newly created branches (`release-prep-*`, `post-release-*`) both locally and in the origin, fix issues, and retry.
 
 ## Release Documentation
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -272,7 +272,7 @@ Then, check out the main branch of your forked operator repo and pull upstream t
 5. In the [SBOM and secscan workflow in the Actions Tab](https://github.com/canonical/operator/actions/workflows/sbom-secscan.yaml), verify that there is a run for the new release. In the workflow run, there will be two artifacts produced, `secscan-report-upload-sdist` and `secscan-report-upload-wheel`. Download both of these, and then upload them to the [SSDLC Ops folder in Drive](https://drive.google.com/drive/folders/17pOwak4LQ6sicr6OekuVPMECt2OcMRj8?usp=drive_link). Open the artifacts and verify that the security scan has not found any vulnerabilities. If you are releasing from the 2.23-maintenance branch, then follow the manual process instead, for both [SBOM generation](https://library.canonical.com/corporate-policies/information-security-policies/ssdlc/ssdlc---software-bill-of-materials-(sbom)) and [security scanning](https://library.canonical.com/corporate-policies/information-security-policies/ssdlc/ssdlc---vulnerability-identification).
 6. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and
 [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com).
-7. Post release: At the root directory of your forked `canonical/operator` repo, without the need to fetch, change branch, or anything else, run: `tox -e post-release`.
+7. Post release: At the root directory of your forked `canonical/operator` repo, check out to the main branch to ensure the release automation script is up-to-date, then run: `tox -e post-release`.
 
     > This assumes the same defaults as mentioned in step 1.
     > 

--- a/HACKING.md
+++ b/HACKING.md
@@ -233,7 +233,13 @@ the build frontend is [build](https://pypi.org/project/build/).
 
 # Publishing a Release
 
-Before you start, make sure you are at the main branch of your forked operator repo, and your main branch is up-to-date. This is to ensure the release automation script is the latest.
+Before you start, ensure that your environment variable GITHUB_TOKEN is set and that the token has sufficient permissions. The easiest way to set a token is to run `gh auth login` first, follow the steps to log in, then run `export GITHUB_TOKEN=$(gh auth token)`.
+
+Alternatively, you can also create a classic token. To do so, go to GitHub -> Settings -> Developer Settings -> Personal access tokens -> Tokens (classic), and click "Generate new token (classic)" (shortcut: click [this link](https://github.com/settings/tokens/new)), and under "Select scopes", "repo", select "repo:status" and "public_repo". Then, set the environment variable `GITHUB_TOKEN` with the newly generated token.
+
+> Note: A fine-grained token will not work because if the owner is your GitHub account, it can't create a PR on the canonical repo, and if the owner is Canonical, it can't push to your forked repo. 
+
+Then, check out the main branch of your forked operator repo and pull upstream to ensure the release automation script is the latest.
 
 1. Draft a release: Run: `tox -e draft-release` at the root directory of the forked repo.
 
@@ -249,7 +255,7 @@ Before you start, make sure you are at the main branch of your forked operator r
 
 2. Follow the steps of the `tox -e draft-release` output. You need to input the release title and an introduction section, which can be multiple paragraphs with empty lines in between. End the introduction section by typing a period sign (.) in a new line, then press enter.
 3. If drafting the release succeeds, a PR named "chore: update changelog and versions for X.Y.Z release" will be created. Get it reviewed and merged, then wait until the tests pass after merging. It takes around 10 minutes. If the tests don't pass at the tip of the main branch, do not continue.
-4. Go to the GitHub releases page, edit the latest draft release, and click "Publish release". GitHub will create the additional tag.
+4. Go to the GitHub releases page, edit the latest draft release. If you are releasing from the main branch, tick the "set as latest release" box. If you are releasing from a maintenance branch, uncheck the box for "set as latest release". Then, click "Publish release". GitHub will create the additional tag.
 
     > You can troubleshoot errors on the [Actions Tab](https://github.com/canonical/operator/actions).
 
@@ -273,6 +279,10 @@ Before you start, make sure you are at the main branch of your forked operator r
     > Add parameters accordingly if your setup differs, for example, if you are releasing from a maintenance branch.
 
 8. Follow the steps of the `tox -e post-release` output. If it succeeds, a PR named "chore: adjust versions after release" will be created. Get it reviewed and merged.
+
+After making the release, delete the two newly created branches `release-prep-*` and `post-release-*` both locally and in the origin.
+
+If the release automation script fails at a certain step, delete the draft release and the newly created branches (`release-prep-*`, `post-release-*`) both locally and in the origin, fix issues, and retry.
 
 ## Release Documentation
 

--- a/release.py
+++ b/release.py
@@ -23,6 +23,7 @@ import os
 import pathlib
 import re
 import subprocess
+import sys
 
 import github
 import github.GitRelease
@@ -117,7 +118,7 @@ def get_new_tag_for_release(
             logger.info(f'Suggested new version: {suggested_tag}')
 
     tag_prompt = f' (press enter to use the tag {suggested_tag})' if suggested_tag else ''
-    prompt = f'Input the new tag for the release{tag_prompt}\n'
+    prompt = f'\033[1mInput the new tag for the release{tag_prompt}:\n> \033[0m'
     while True:
         user_input = input(prompt).strip()
 
@@ -135,7 +136,10 @@ def get_new_tag_for_release(
         logger.warning(f'Check out the releases page: {release_page} before confirming!')
 
         confirm = (
-            input(f'Confirm creating tag {new_tag!r} on branch {branch_name!r}? [y/N]: ')
+            input(
+                f'\033[1mConfirm creating tag {new_tag!r} on branch {branch_name!r}? '
+                f'[y/N]: \n> \033[0m'
+            )
             .strip()
             .lower()
         )
@@ -191,13 +195,10 @@ def parse_release_notes(release_notes: str) -> tuple[dict[str, list[tuple[str, s
         if match := re.match(r'^\* (\w+): (.*) by @\w+ in (.*)', line.strip()):
             category = match.group(1)
             if category in categories:
-                description = match.group(2).strip().capitalize()
+                description = match.group(2).strip()
+                description = description[0].upper() + description[1:]
                 pr_link = match.group(3).strip()
                 categories[category].append((description, pr_link))
-            else:
-                logger.warning(
-                    f'Unexpected category {category} found in the auto-generated release notes'
-                )
 
         elif line.startswith('**Full Changelog**'):
             full_changelog_line = line
@@ -230,6 +231,8 @@ def print_release_notes(notes: str):
 
     So that user can review them and use them to write the title and summary.
     """
+    sys.stdout.flush()
+    sys.stderr.flush()
     print('=' * 80)
     print('Formatted release notes:')
     print('=' * 80)
@@ -240,11 +243,16 @@ def print_release_notes(notes: str):
 def input_title_and_summary(release: github.GitRelease.GitRelease) -> tuple[str, str]:
     """Ask user to input the release title and summary."""
     logger.info(f'The automatically generated title is: {release.title}')
-    title = input('Enter release title, press Enter to keep the auto-generated title:\n> ').strip()
+    title = input(
+        '\033[1mEnter release title, press Enter to keep the auto-generated title:\n> \033[0m'
+    ).strip()
     if not title:
         title = release.title
 
-    print("\nEnter release summary (multi-line supported; type '.' on a new line to finish):")
+    print(
+        '\n\033[1mEnter release summary (multi-line supported; type "." on a new line '
+        'to finish):\n> \033[0m'
+    )
 
     lines: list[str] = []
     while True:
@@ -282,8 +290,8 @@ def format_changes(categories: dict[str, list[tuple[str, str]]], tag: str) -> st
                 if match:
                     pr_num = match.group(1)
                 lines.append(f'* {description} (#{pr_num})')
-            lines.append('\n')
-    return '\n'.join(lines)
+            lines.append('')
+    return '\n'.join(lines) + '\n'
 
 
 def update_changes_file(changes: str, file: str):
@@ -477,8 +485,10 @@ def draft_release(
         subprocess.run(['/usr/bin/git', 'checkout', base_branch], check=True)
         subprocess.run(['/usr/bin/git', 'pull', canonical_remote, base_branch], check=True)
     else:
+        subprocess.run(['/usr/bin/git', 'fetch', canonical_remote], check=True)
         subprocess.run(
-            ['/usr/bin/git', 'checkout', '--track', f'{fork_remote}/{base_branch}'], check=True
+            ['/usr/bin/git', 'checkout', '--track', f'{canonical_remote}/{base_branch}'],
+            check=True,
         )
 
     org = gh_client.get_organization(owner)
@@ -528,7 +538,10 @@ def post_release(
     owner: str, repo_name: str, base_branch: str, canonical_remote: str, fork_remote: str
 ):
     """Post-release actions: update version files and create a PR."""
-    new_branch = 'post-release'
+    org = gh_client.get_organization(owner)
+    repo = org.get_repo(repo_name)
+    tag = get_latest_release_tag(repo, base_branch)
+    new_branch = f'post-release-{tag}'
     local_branch = subprocess.check_output(['/usr/bin/git', 'branch', '--list', new_branch])
     remote_branch = subprocess.check_output([
         '/usr/bin/git',
@@ -624,6 +637,6 @@ if __name__ == '__main__':
         fork_remote=args.fork_remote,
     )
     logger.info(
-        'Draft release created. Please merge the version bump PR, review and publish the draft'
+        'Draft release created. Please merge the version bump PR, review and publish the draft '
         'release, then run this script with --post-release to perform post-release actions.'
     )


### PR DESCRIPTION
A few bug fixes and refactoring of the release automation script.

Fixed:

- Mention how to create a token (either using `gh` or creating a classic token).
- When waiting for user input, use bold text, add ":" at ethe nd of the explanation line, and a "> " on the next line waiting for input.
- Remove "Unexpected category" logs.
- Before printing "Formatted release notes", flush stdout/stderr to avoid intermingled outputs from other subprocesses.
- Fix a typo "draftrelease".
- Changed the double blank lines to a single one in `CHANGES.md`.
- Fix PR description capitalization.
- Add a version for the post-release branch (`post-release-*` now).
- When releasing from a maintenance branch, track upstream instead of origin.
- Some other minor updates to `HACKING.md`.

Closes https://github.com/canonical/operator/issues/1933.
