### PR TITLE
docs: update links and config for switch to documentation.ubuntu.com/ops

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ To help us review your changes, please rebase your pull request onto the `main` 
 
 # Tests
 
-Changes should include tests. Where reasonable, prefer to write 'Scenario' tests using [ops.testing](https://ops.readthedocs.io/en/latest/reference/ops-testing.html) instead of legacy [ops.testing.Harness](https://ops.readthedocs.io/en/latest/reference/ops-testing-harness.html) tests.
+Changes should include tests. Where reasonable, prefer to write 'Scenario' tests using [ops.testing](https://documentation.ubuntu.com/ops/latest/reference/ops-testing.html) instead of legacy [ops.testing.Harness](https://documentation.ubuntu.com/ops/latest/reference/ops-testing-harness.html) tests.
 
 Tests for Ops should go in the test module corresponding to the code. For example, a feature added in `ops/main.py` would go in `test/test_main.py`. However, when adding a large number of logically related tests, consider putting these in their own file, named accordingly. For example, if adding a feature `foo` in `ops/main.py`, the tests might go in `test/test_main_foo.py`.
 
@@ -43,11 +43,11 @@ Tests for [`ops-scenario`](https://github.com/canonical/operator/tree/main/testi
 
 # Coding style
 
-We have a team [Python style guide](./STYLE.md), most of which is enforced by CI checks. Please be complete with docstrings and keep them informative for _users_, as the [Ops library reference](https://ops.readthedocs.io/en/latest/reference/index.html) is automatically generated from Python docstrings.
+We have a team [Python style guide](./STYLE.md), most of which is enforced by CI checks. Please be complete with docstrings and keep them informative for _users_, as the [Ops library reference](https://documentation.ubuntu.com/ops/latest/reference/index.html) is automatically generated from Python docstrings.
 
 # Documentation
 
-The published docs at [ops.readthedocs.io](https://ops.readthedocs.io/en/latest/index.html) are built automatically from [the top-level `docs` directory](./docs). We use [MyST Markdown](https://mystmd.org/) for most pages and arrange the pages according to [Diátaxis](https://diataxis.fr/).
+The published docs at [documentation.ubuntu.com/ops](https://documentation.ubuntu.com/ops/latest/) are built automatically from [the top-level `docs` directory](./docs). We use [MyST Markdown](https://mystmd.org/) for most pages and arrange the pages according to [Diátaxis](https://diataxis.fr/).
 
 To contribute docs:
 
@@ -91,7 +91,7 @@ tox -e docs-live
 
 ## How to document version dependencies
 
-We don't publish separate documentation for separate versions of Ops. The published docs at [ops.readthedocs.io](https://ops.readthedocs.io/en/latest/index.html) are always for the in-development (main branch) of Ops, and do not include any notes indicating changes or additions across Ops versions. We encourage all charmers to promptly upgrade to the latest version of Ops, and to refer to the release notes and changelog for learning about changes.
+We don't publish separate documentation for separate versions of Ops. The published docs at [documentation.ubuntu.com/ops](https://documentation.ubuntu.com/ops/latest/) are always for the in-development (main branch) of Ops, and do not include any notes indicating changes or additions across Ops versions. We encourage all charmers to promptly upgrade to the latest version of Ops, and to refer to the release notes and changelog for learning about changes.
 
 We do note when features behave differently when using different versions of Juju.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `ops` library is a Python framework for developing and testing Kubernetes an
 
 > - `ops` is  [available on PyPI](https://pypi.org/project/ops/).
 > - The latest version of `ops` requires Python 3.8 or above.
-> - Read our [docs](https://ops.readthedocs.io/en/latest/) for tutorials, how-to guides, the library reference, and more.
+> - Read our [docs](https://documentation.ubuntu.com/ops/latest/) for tutorials, how-to guides, the library reference, and more.
 
 ## Give it a try
 
@@ -73,7 +73,7 @@ class OpsExampleCharm(ops.CharmBase):
         environment configuration for your specific workload.
 
         Learn more about interacting with Pebble at
-            https://ops.readthedocs.io/en/latest/reference/pebble.html
+            https://documentation.ubuntu.com/ops/latest/reference/pebble.html
         """
         # Get a reference the container attribute on the PebbleReadyEvent
         container = event.workload
@@ -86,7 +86,7 @@ class OpsExampleCharm(ops.CharmBase):
         self.unit.status = ops.ActiveStatus()
 ```
 
-> See more: [`ops.PebbleReadyEvent`](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.PebbleReadyEvent)
+> See more: [`ops.PebbleReadyEvent`](https://documentation.ubuntu.com/ops/latest/reference/ops.html#ops.PebbleReadyEvent)
 
 - The `tests/unit/test_charm.py` file imports `ops.testing` and uses it to set up a unit test:
 
@@ -127,7 +127,7 @@ def test_httpbin_pebble_ready():
     assert state_out.unit_status == testing.ActiveStatus()
 ```
 
-> See more: [`ops.testing`](https://ops.readthedocs.io/en/latest/reference/ops-testing.html)
+> See more: [`ops.testing`](https://documentation.ubuntu.com/ops/latest/reference/ops-testing.html)
 
 
 Explore further, start editing the files, or skip ahead and pack the charm:
@@ -150,6 +150,6 @@ Congratulations, you’ve just built your first Kubernetes charm using `ops`!
 
 ## Next steps
 
-- Read the [docs](https://ops.readthedocs.io/en/latest/).
+- Read the [docs](https://documentation.ubuntu.com/ops/latest/).
 - Read our [Code of conduct](https://ubuntu.com/community/code-of-conduct) and join our [chat](https://matrix.to/#/#charmhub-ops:ubuntu.com) and [forum](https://discourse.charmhub.io/) or [open an issue](https://github.com/canonical/operator/issues).
 - Read our [CONTRIBUTING guide](https://github.com/canonical/operator/blob/main/HACKING.md) and contribute!

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -92,7 +92,7 @@ copyright = '%s, %s' % (datetime.date.today().year, author)  # noqa: A001
 # don't know yet)
 # NOTE: If no ogp_* variable is defined (e.g. if you remove this section) the
 # sphinxext.opengraph extension will be disabled.
-ogp_site_url = 'https://ops.readthedocs.io/en/latest/'
+ogp_site_url = 'https://documentation.ubuntu.com/ops/latest/'
 # The documentation website name (usually the same as the product name)
 ogp_site_name = project
 # The URL of an image or logo that is used in the preview

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -153,7 +153,7 @@ if os.environ.get('READTHEDOCS', '') == 'True':
 
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.
-slug = ''
+slug = 'ops'
 
 ############################################################
 ### Redirects

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -201,7 +201,7 @@ def _on_demo_server_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
     environment configuration for your specific workload.
 
     Learn more about interacting with Pebble at
-        https://ops.readthedocs.io/en/latest/reference/pebble.html
+        https://documentation.ubuntu.com/ops/latest/reference/pebble.html
     Learn more about Pebble layers at
         https://documentation.ubuntu.com/pebble/how-to/use-layers/
     """

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
@@ -80,7 +80,7 @@ def _on_get_db_info_action(self, event: ops.ActionEvent) -> None:
 
     If the PostgreSQL charm is not integrated, the output is set to "No database connected".
 
-    Learn more about actions at https://ops.readthedocs.io/en/latest/howto/manage-actions.html
+    Learn more about actions at https://documentation.ubuntu.com/ops/latest/howto/manage-actions.html
     """
     params = event.load_params(GetDbInfoAction, errors='fail')
     db_data = self.fetch_postgres_relation_data()

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -183,7 +183,7 @@ def _update_layer_and_restart(self) -> None:
     configuration for your specific workload. Tip: you can see the
     standard entrypoint of an existing container using docker inspect
     Learn more about interacting with Pebble at
-        https://ops.readthedocs.io/en/latest/reference/pebble.html
+        https://documentation.ubuntu.com/ops/latest/reference/pebble.html
     Learn more about Pebble layers at
         https://documentation.ubuntu.com/pebble/how-to/use-layers/
     """

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -102,7 +102,7 @@ def _update_layer_and_restart(self) -> None:
     configuration for your specific workload. Tip: you can see the
     standard entrypoint of an existing container using docker inspect
     Learn more about interacting with Pebble at
-        https://ops.readthedocs.io/en/latest/reference/pebble.html
+        https://documentation.ubuntu.com/ops/latest/reference/pebble.html
     Learn more about Pebble layers at
         https://documentation.ubuntu.com/pebble/how-to/use-layers/
     """

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,15 +2,15 @@ This directory contains charms that you can pack and deploy locally, to help lea
 
 ### Charms from the Kubernetes charm tutorial
 
-- **[k8s-1-minimal](k8s-1-minimal)** - From [Create a minimal Kubernetes charm](https://ops.readthedocs.io/en/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.html). This charm is a minimal Kubernetes charm for a demo web server.
+- **[k8s-1-minimal](k8s-1-minimal)** - From [Create a minimal Kubernetes charm](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.html). This charm is a minimal Kubernetes charm for a demo web server.
 
-- **[k8s-2-configurable](k8s-2-configurable)** - From [Make your charm configurable](https://ops.readthedocs.io/en/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.html). This charm has an option for configuring the web server's port.
+- **[k8s-2-configurable](k8s-2-configurable)** - From [Make your charm configurable](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.html). This charm has an option for configuring the web server's port.
 
-- **[k8s-3-postgresql](k8s-3-postgresql)** - From [Integrate your charm with PostgreSQL](https://ops.readthedocs.io/en/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.html). This charm can be integrated with a PostgreSQL charm, so that the web server can retrieve database credentials and connect to the database.
+- **[k8s-3-postgresql](k8s-3-postgresql)** - From [Integrate your charm with PostgreSQL](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.html). This charm can be integrated with a PostgreSQL charm, so that the web server can retrieve database credentials and connect to the database.
 
-- **[k8s-4-action](k8s-4-action)** - From [Expose operational tasks via actions](https://ops.readthedocs.io/en/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.html). This charm has an action for viewing the database credentials.
+- **[k8s-4-action](k8s-4-action)** - From [Expose operational tasks via actions](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.html). This charm has an action for viewing the database credentials.
 
-- **[k8s-5-observe](k8s-5-observe)** - From [Observe your charm with COS Lite](https://ops.readthedocs.io/en/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.html). This charm can be integrated with the [COS Lite](https://charmhub.io/cos-lite) observability stack.
+- **[k8s-5-observe](k8s-5-observe)** - From [Observe your charm with COS Lite](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.html). This charm can be integrated with the [COS Lite](https://charmhub.io/cos-lite) observability stack.
 
 ### Other demo charms
 

--- a/examples/k8s-1-minimal/src/charm.py
+++ b/examples/k8s-1-minimal/src/charm.py
@@ -41,7 +41,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         environment configuration for your specific workload.
 
         Learn more about interacting with Pebble at
-            https://ops.readthedocs.io/en/latest/reference/pebble.html
+            https://documentation.ubuntu.com/ops/latest/reference/pebble.html
         Learn more about Pebble layers at
             https://documentation.ubuntu.com/pebble/how-to/use-layers/
         """

--- a/examples/k8s-2-configurable/src/charm.py
+++ b/examples/k8s-2-configurable/src/charm.py
@@ -65,7 +65,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         configuration for your specific workload. Tip: you can see the
         standard entrypoint of an existing container using docker inspect
         Learn more about interacting with Pebble at
-            https://ops.readthedocs.io/en/latest/reference/pebble.html
+            https://documentation.ubuntu.com/ops/latest/reference/pebble.html
         Learn more about Pebble layers at
             https://documentation.ubuntu.com/pebble/how-to/use-layers/
         """

--- a/examples/k8s-3-postgresql/src/charm.py
+++ b/examples/k8s-3-postgresql/src/charm.py
@@ -103,7 +103,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         configuration for your specific workload. Tip: you can see the
         standard entrypoint of an existing container using docker inspect
         Learn more about interacting with Pebble at
-            https://ops.readthedocs.io/en/latest/reference/pebble.html
+            https://documentation.ubuntu.com/ops/latest/reference/pebble.html
         Learn more about Pebble layers at
             https://documentation.ubuntu.com/pebble/how-to/use-layers/
         """

--- a/examples/k8s-4-action/src/charm.py
+++ b/examples/k8s-4-action/src/charm.py
@@ -117,7 +117,7 @@ class FastAPIDemoCharm(ops.CharmBase):
 
         If the PostgreSQL charm is not integrated, the output is set to "No database connected".
 
-        Learn more about actions at https://ops.readthedocs.io/en/latest/howto/manage-actions.html
+        Learn more about actions at https://documentation.ubuntu.com/ops/latest/howto/manage-actions.html
         """
         params = event.load_params(GetDbInfoAction, errors='fail')
         db_data = self.fetch_postgres_relation_data()
@@ -142,7 +142,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         configuration for your specific workload. Tip: you can see the
         standard entrypoint of an existing container using docker inspect
         Learn more about interacting with Pebble at
-            https://ops.readthedocs.io/en/latest/reference/pebble.html
+            https://documentation.ubuntu.com/ops/latest/reference/pebble.html
         Learn more about Pebble layers at
             https://documentation.ubuntu.com/pebble/how-to/use-layers/
         """

--- a/examples/k8s-5-observe/src/charm.py
+++ b/examples/k8s-5-observe/src/charm.py
@@ -138,7 +138,7 @@ class FastAPIDemoCharm(ops.CharmBase):
 
         If the PostgreSQL charm is not integrated, the output is set to "No database connected".
 
-        Learn more about actions at https://ops.readthedocs.io/en/latest/howto/manage-actions.html
+        Learn more about actions at https://documentation.ubuntu.com/ops/latest/howto/manage-actions.html
         """
         params = event.load_params(GetDbInfoAction, errors='fail')
         db_data = self.fetch_postgres_relation_data()
@@ -163,7 +163,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         configuration for your specific workload. Tip: you can see the
         standard entrypoint of an existing container using docker inspect
         Learn more about interacting with Pebble at
-            https://ops.readthedocs.io/en/latest/reference/pebble.html
+            https://documentation.ubuntu.com/ops/latest/reference/pebble.html
         Learn more about Pebble layers at
             https://documentation.ubuntu.com/pebble/how-to/use-layers/
         """

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -323,7 +323,7 @@ class Harness(Generic[CharmType]):
 
         warnings.warn(
             'Harness is deprecated. For the recommended approach, see: '
-            'https://ops.readthedocs.io/en/latest/howto/write-unit-tests-for-a-charm.html',
+            'https://documentation.ubuntu.com/ops/latest/howto/write-unit-tests-for-a-charm.html',
             PendingDeprecationWarning,
             stacklevel=2,
         )

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -29,7 +29,7 @@ The module includes:
 
 .. note::
     Unit testing is only one aspect of a comprehensive testing strategy. For more
-    on testing charms, see `Testing <https://ops.readthedocs.io/en/latest/explanation/testing.html>`_.
+    on testing charms, see `Testing <https://documentation.ubuntu.com/ops/latest/explanation/testing.html>`_.
 """
 
 # ruff: noqa: F401 (unused import)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,10 +92,10 @@ release = [
 ]
 
 [project.urls]
-"Homepage" = "https://ops.readthedocs.io/en/latest/"
+"Homepage" = "https://documentation.ubuntu.com/ops/latest/"
 "Repository" = "https://github.com/canonical/operator"
 "Issues" = "https://github.com/canonical/operator/issues"
-"Documentation" = "https://ops.readthedocs.io"
+"Documentation" = "https://documentation.ubuntu.com/ops/latest/"
 "Changelog" = "https://github.com/canonical/operator/blob/main/CHANGES.md"
 
 [build-system]

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Learn more about testing at
-# https://documentation.ubuntu.com/ops/latest/explanation/testing.html
+
 
 from __future__ import annotations
 

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 # Learn more about testing at
-# https://ops.readthedocs.io/en/latest/explanation/testing.html
+# https://documentation.ubuntu.com/ops/latest/explanation/testing.html
 
 from __future__ import annotations
 

--- a/test/integration/test_tracing.py
+++ b/test/integration/test_tracing.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Learn more about testing at
-# https://documentation.ubuntu.com/ops/latest/explanation/testing.html
+
 
 from __future__ import annotations
 

--- a/test/integration/test_tracing.py
+++ b/test/integration/test_tracing.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 # Learn more about testing at
-# https://ops.readthedocs.io/en/latest/explanation/testing.html
+# https://documentation.ubuntu.com/ops/latest/explanation/testing.html
 
 from __future__ import annotations
 

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Learn more about testing at
-# https://documentation.ubuntu.com/ops/latest/explanation/testing.html
+
 
 from __future__ import annotations
 

--- a/test/smoke/test_smoke.py
+++ b/test/smoke/test_smoke.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 # Learn more about testing at
-# https://ops.readthedocs.io/en/latest/explanation/testing.html
+# https://documentation.ubuntu.com/ops/latest/explanation/testing.html
 
 from __future__ import annotations
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,7 +1,7 @@
 # ops-scenario, the unit testing framework for ops charms
 
 `ops-scenario` is a Python library that provides state-transition testing for
-[Ops](https://ops.readthedocs.io) charms. These tests are higher level than
+[Ops]("https://documentation.ubuntu.com/ops/latest/") charms. These tests are higher level than
 typical unit tests, but run at similar speeds and are the recommended approach
 for testing charms within requiring a full [Juju](https://juju.is) installation.
 
@@ -93,16 +93,16 @@ package.
 
 ## Documentation
 
- * To get started, work through our ['Write your first Kubernetes charm' tutorial](https://ops.readthedocs.io/en/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.html#write-unit-tests-for-your-charm), following the instructions for adding
+ * To get started, work through our ['Write your first Kubernetes charm' tutorial](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.html#write-unit-tests-for-your-charm), following the instructions for adding
    unit tests at the end of each chapter.
  * When you need to write a test that involves specific ops functionality,
-   refer to our [how-to guides](https://ops.readthedocs.io/en/latest/howto/index.html)
+   refer to our [how-to guides](https://documentation.ubuntu.com/ops/latest/howto/index.html)
    which all conclude with examples of tests of the ops functionality.
- * Use our extensive [reference documentation](https://ops.readthedocs.io/en/latest/reference/ops-testing.html#ops-testing) when you need to know how each `testing` object works. These
+ * Use our extensive [reference documentation](https://documentation.ubuntu.com/ops/latest/reference/ops-testing.html#ops-testing) when you need to know how each `testing` object works. These
    docs are also available via the standard Python `help()` functionality and in
    your IDE.
 
-[**Read the full documentation**](https://ops.readthedocs.io/)
+[**Read the full documentation**]("https://documentation.ubuntu.com/ops/latest/")
 
 ## Community
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,7 +1,7 @@
 # ops-scenario, the unit testing framework for ops charms
 
 `ops-scenario` is a Python library that provides state-transition testing for
-[Ops]("https://documentation.ubuntu.com/ops/latest/") charms. These tests are higher level than
+[Ops](https://documentation.ubuntu.com/ops/latest/) charms. These tests are higher level than
 typical unit tests, but run at similar speeds and are the recommended approach
 for testing charms within requiring a full [Juju](https://juju.is) installation.
 
@@ -102,7 +102,7 @@ package.
    docs are also available via the standard Python `help()` functionality and in
    your IDE.
 
-[**Read the full documentation**]("https://documentation.ubuntu.com/ops/latest/")
+[**Read the full documentation**](https://documentation.ubuntu.com/ops/latest/)
 
 ## Community
 

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -18,7 +18,7 @@ Please add `ops[tracing]` to your charm's dependencies, rather than this package
 ## Documentation
 
 Comprehensive documentation for the Ops library, including the tracing feature, is available at:
-[Ops documentation](https://ops.readthedocs.io/).
+[Ops documentation](https://documentation.ubuntu.com/ops/latest/).
 
 You’ll find setup instructions, usage examples, and best practices for leveraging the tracing functionality.
 

--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 [project.urls]
 "Repository" = "https://github.com/canonical/operator"
 "Issues" = "https://github.com/canonical/operator/issues"
-"Documentation" = "https://ops.readthedocs.io"
+"Documentation" = "https://documentation.ubuntu.com/ops/latest/"
 "Changelog" = "https://github.com/canonical/operator/blob/main/CHANGES.md"
 
 


### PR DESCRIPTION
This PR changes all hardcoded doc links to point to https://documentation.ubuntu.com/ops/latest/ instead of https://ops.readthedocs.io/en/latest/. In addition to switching to documentation.ubuntu.com, we're dropping `en` from URLs.

This PR also changes the Sphinx config to make sure that all styles can be loaded.

---

Related PR targeted at 2.23-maintenance: https://github.com/canonical/operator/pull/1942. As soon as both PRs have merged, I'll set up redirects from ops.readthedocs.io to documentation.ubuntu.com/ops.