### PR TITLE
docs: for 2.23, update links and config for switch to documentation.ubuntu.com/ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 The `ops` library is a Python framework for developing and testing Kubernetes and machine [charms](https://charmhub.io/). While charms can be written in any language, `ops` defines the latest standard, and charmers are encouraged to use Python with `ops` for all charms. The library is an official component of the Charm SDK, itself a part of [the Juju universe](https://juju.is/).
 
 > - `ops` is  [available on PyPI](https://pypi.org/project/ops/).
-> - Version 2.23 of `ops` requires Python 3.8 or above.
+> - Version 2 of `ops` requires Python 3.8 or above.
 > - Read our [docs](https://documentation.ubuntu.com/ops/2.x/) for tutorials, how-to guides, the library reference, and more.
 
 ## Give it a try

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 The `ops` library is a Python framework for developing and testing Kubernetes and machine [charms](https://charmhub.io/). While charms can be written in any language, `ops` defines the latest standard, and charmers are encouraged to use Python with `ops` for all charms. The library is an official component of the Charm SDK, itself a part of [the Juju universe](https://juju.is/).
 
 > - `ops` is  [available on PyPI](https://pypi.org/project/ops/).
-> - The latest version of `ops` requires Python 3.8 or above.
-> - Read our [docs](https://ops.readthedocs.io/en/latest/) for tutorials, how-to guides, the library reference, and more.
+> - Version 2.23 of `ops` requires Python 3.8 or above.
+> - Read our [docs](https://documentation.ubuntu.com/ops/2.23/) for tutorials, how-to guides, the library reference, and more.
 
 ## Give it a try
 
@@ -150,6 +150,6 @@ Congratulations, you’ve just built your first Kubernetes charm using `ops`!
 
 ## Next steps
 
-- Read the [docs](https://ops.readthedocs.io/en/latest/).
+- Read the [docs](https://documentation.ubuntu.com/ops/2.23/).
 - Read our [Code of conduct](https://ubuntu.com/community/code-of-conduct) and join our [chat](https://matrix.to/#/#charmhub-ops:ubuntu.com) and [forum](https://discourse.charmhub.io/) or [open an issue](https://github.com/canonical/operator/issues).
 - Read our [CONTRIBUTING guide](https://github.com/canonical/operator/blob/main/HACKING.md) and contribute!

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `ops` library is a Python framework for developing and testing Kubernetes an
 
 > - `ops` is  [available on PyPI](https://pypi.org/project/ops/).
 > - Version 2.23 of `ops` requires Python 3.8 or above.
-> - Read our [docs](https://documentation.ubuntu.com/ops/2.23/) for tutorials, how-to guides, the library reference, and more.
+> - Read our [docs](https://documentation.ubuntu.com/ops/2.x/) for tutorials, how-to guides, the library reference, and more.
 
 ## Give it a try
 
@@ -150,6 +150,6 @@ Congratulations, you’ve just built your first Kubernetes charm using `ops`!
 
 ## Next steps
 
-- Read the [docs](https://documentation.ubuntu.com/ops/2.23/).
+- Read the [docs](https://documentation.ubuntu.com/ops/2.x/).
 - Read our [Code of conduct](https://ubuntu.com/community/code-of-conduct) and join our [chat](https://matrix.to/#/#charmhub-ops:ubuntu.com) and [forum](https://discourse.charmhub.io/) or [open an issue](https://github.com/canonical/operator/issues).
 - Read our [CONTRIBUTING guide](https://github.com/canonical/operator/blob/main/HACKING.md) and contribute!

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 The `ops` library is a Python framework for developing and testing Kubernetes and machine [charms](https://charmhub.io/). While charms can be written in any language, `ops` defines the latest standard, and charmers are encouraged to use Python with `ops` for all charms. The library is an official component of the Charm SDK, itself a part of [the Juju universe](https://juju.is/).
 
 > - `ops` is  [available on PyPI](https://pypi.org/project/ops/).
-> - Version 2 of `ops` requires Python 3.8 or above.
+> - Version 2.x of `ops` requires Python 3.8 or above.
 > - Read our [docs](https://documentation.ubuntu.com/ops/2.x/) for tutorials, how-to guides, the library reference, and more.
 
 ## Give it a try

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -154,7 +154,7 @@ if os.environ.get('READTHEDOCS', '') == 'True':
 
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.
-slug = ''
+slug = 'ops'
 
 ############################################################
 ### Redirects

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -93,7 +93,7 @@ copyright = '%s, %s' % (datetime.date.today().year, author)  # noqa: A001
 # don't know yet)
 # NOTE: If no ogp_* variable is defined (e.g. if you remove this section) the
 # sphinxext.opengraph extension will be disabled.
-ogp_site_url = 'https://documentation.ubuntu.com/ops/2.23/'
+ogp_site_url = 'https://documentation.ubuntu.com/ops/2.x/'
 # The documentation website name (usually the same as the product name)
 ogp_site_name = project
 # The URL of an image or logo that is used in the preview

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -93,7 +93,7 @@ copyright = '%s, %s' % (datetime.date.today().year, author)  # noqa: A001
 # don't know yet)
 # NOTE: If no ogp_* variable is defined (e.g. if you remove this section) the
 # sphinxext.opengraph extension will be disabled.
-ogp_site_url = 'https://ops.readthedocs.io/en/latest/'
+ogp_site_url = 'https://documentation.ubuntu.com/ops/2.23/'
 # The documentation website name (usually the same as the product name)
 ogp_site_name = project
 # The URL of an image or logo that is used in the preview

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,12 +11,12 @@ explanation/index
 ```
 
 ```{important}
-This is the documentation for version 2 of Ops, which stopped being actively developed in June 2025. Ops 2 will continue to receive security and critical bug fixes.
+This is the documentation for version 2.x of Ops, which stopped being actively developed in June 2025. Ops 2.x will continue to receive security and critical bug fixes.
 
-- If your charm needs to support Python 3.8 (Ubuntu 20.04), use Ops 2.
+- If your charm needs to support Python 3.8 (Ubuntu 20.04), use Ops 2.x.
 - Otherwise, use Ops 3.
 
-Ops 3 removed support for Python 3.8, but is otherwise compatible with Ops 2. See the [latest documentation](https://documentation.ubuntu.com/ops/latest/).
+Ops 3 removed support for Python 3.8, but is otherwise compatible with Ops 2.x. See the [latest documentation](https://documentation.ubuntu.com/ops/latest/).
 ```
 
 The Ops library (`ops`) is a Python framework for writing and testing Juju charms.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,9 +14,9 @@ explanation/index
 This is the documentation for version 2.x of Ops, which stopped being actively developed in June 2025. Ops 2.x will continue to receive security and critical bug fixes.
 
 - If your charm needs to support Python 3.8 (Ubuntu 20.04), use Ops 2.x.
-- Otherwise, use Ops 3.
+- Otherwise, use Ops 3.x.
 
-Ops 3 removed support for Python 3.8, but is otherwise compatible with Ops 2.x. See the [latest documentation](https://documentation.ubuntu.com/ops/latest/).
+Ops 3.x removed support for Python 3.8, but is otherwise compatible with Ops 2.x. See the [latest documentation](https://documentation.ubuntu.com/ops/latest/).
 ```
 
 The Ops library (`ops`) is a Python framework for writing and testing Juju charms.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ This is the documentation for version 2 of Ops, which stopped being actively dev
 - If your charm needs to support Python 3.8 (Ubuntu 20.04), use Ops 2.
 - Otherwise, use Ops 3.
 
-Ops 3 removed support for Python 3.8, but is otherwise compatible with Ops 2. See the [latest documentation](https://ops.readthedocs.io).
+Ops 3 removed support for Python 3.8, but is otherwise compatible with Ops 2. See the [latest documentation](https://documentation.ubuntu.com/ops/latest/).
 ```
 
 The Ops library (`ops`) is a Python framework for writing and testing Juju charms.

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -323,7 +323,7 @@ class Harness(Generic[CharmType]):
 
         warnings.warn(
             'Harness is deprecated. For the recommended approach, see: '
-            'https://ops.readthedocs.io/en/latest/howto/write-unit-tests-for-a-charm.html',
+            'https://documentation.ubuntu.com/ops/2.x/howto/write-unit-tests-for-a-charm.html',
             PendingDeprecationWarning,
             stacklevel=2,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,10 +89,10 @@ integration = [
 ]
 
 [project.urls]
-"Homepage" = "https://ops.readthedocs.io/en/latest/"
+"Homepage" = "https://documentation.ubuntu.com/ops/2.23/"
 "Repository" = "https://github.com/canonical/operator"
 "Issues" = "https://github.com/canonical/operator/issues"
-"Documentation" = "https://ops.readthedocs.io"
+"Documentation" = "https://documentation.ubuntu.com/ops/2.23/"
 "Changelog" = "https://github.com/canonical/operator/blob/main/CHANGES.md"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,10 +89,10 @@ integration = [
 ]
 
 [project.urls]
-"Homepage" = "https://documentation.ubuntu.com/ops/2.23/"
+"Homepage" = "https://documentation.ubuntu.com/ops/2.x/"
 "Repository" = "https://github.com/canonical/operator"
 "Issues" = "https://github.com/canonical/operator/issues"
-"Documentation" = "https://documentation.ubuntu.com/ops/2.23/"
+"Documentation" = "https://documentation.ubuntu.com/ops/2.x/"
 "Changelog" = "https://github.com/canonical/operator/blob/main/CHANGES.md"
 
 [build-system]

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,7 +1,7 @@
 # ops-scenario, the unit testing framework for ops charms
 
 `ops-scenario` is a Python library that provides state-transition testing for
-[Ops](https://ops.readthedocs.io) charms. These tests are higher level than
+[Ops](https://documentation.ubuntu.com/ops/2.x/) charms. These tests are higher level than
 typical unit tests, but run at similar speeds and are the recommended approach
 for testing charms within requiring a full [Juju](https://juju.is) installation.
 
@@ -102,7 +102,7 @@ package.
    docs are also available via the standard Python `help()` functionality and in
    your IDE.
 
-[**Read the full documentation**](https://ops.readthedocs.io/)
+[**Read the full documentation**](https://documentation.ubuntu.com/ops/2.x/)
 
 ## Community
 

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -18,7 +18,7 @@ Please add `ops[tracing]` to your charm's dependencies, rather than this package
 ## Documentation
 
 Comprehensive documentation for the Ops library, including the tracing feature, is available at:
-[Ops documentation](https://ops.readthedocs.io/).
+[Ops documentation](https://documentation.ubuntu.com/ops/2.x/).
 
 You’ll find setup instructions, usage examples, and best practices for leveraging the tracing functionality.
 

--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 [project.urls]
 "Repository" = "https://github.com/canonical/operator"
 "Issues" = "https://github.com/canonical/operator/issues"
-"Documentation" = "https://documentation.ubuntu.com/ops/2.23/"
+"Documentation" = "https://documentation.ubuntu.com/ops/2.x/"
 "Changelog" = "https://github.com/canonical/operator/blob/main/CHANGES.md"
 
 

--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 [project.urls]
 "Repository" = "https://github.com/canonical/operator"
 "Issues" = "https://github.com/canonical/operator/issues"
-"Documentation" = "https://ops.readthedocs.io"
+"Documentation" = "https://documentation.ubuntu.com/ops/2.23/"
 "Changelog" = "https://github.com/canonical/operator/blob/main/CHANGES.md"
 
 


### PR DESCRIPTION
This PR changes _selected_ hardcoded doc links to point to https://documentation.ubuntu.com/ops/2.23/ or https://documentation.ubuntu.com/ops/latest/ (as appropriate) instead of https://ops.readthedocs.io/en/latest/.

Since the changes are targeted at 2.23-maintenance, I wanted to avoid unnecessary doc and code changes. So I'm only adjusting the links that people would first encounter in the README/PyPI/docs.

This PR also changes the Sphinx config to make sure that all styles can be loaded.

---

Related PR targeted at main: https://github.com/canonical/operator/pull/1940. As soon as both PRs have merged, I'll set up redirects from ops.readthedocs.io to documentation.ubuntu.com/ops.