### PR TITLE
docs: for 2.x, fix site title and unstyled error pages

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -150,7 +150,7 @@ if os.environ.get('READTHEDOCS', '') == 'True':
     html_context['github_user'] = 'canonical'
     html_context['github_repo'] = 'operator'
     html_context['github_version'] = '2.23-maintenance'
-    html_context['slug'] = 'operator'
+    html_context['slug'] = 'ops'
 
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.


### PR DESCRIPTION
After merging #1942, I noticed a couple of issues with the [2.x docs](https://documentation.ubuntu.com/ops/2.x/):

- The site title should be "Ops 2.x documentation" not "Ops 2.23 documentation"
- Error pages are still unstyled ([example](https://documentation.ubuntu.com/ops/2.x/foobar)). Unfortunately I can't test fixes without building the live RTD docs. But I think this PR should fix it - we'll find out after it merges