### PR TITLE
docs: Update the required Python version and note the 2.x documentation site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,9 @@ tox -e docs-live
 
 ## How to document version dependencies
 
-We don't publish separate documentation for separate versions of Ops. The published docs at [documentation.ubuntu.com/ops](https://documentation.ubuntu.com/ops/latest/) are always for the in-development (main branch) of Ops, and do not include any notes indicating changes or additions across Ops versions. We encourage all charmers to promptly upgrade to the latest version of Ops, and to refer to the release notes and changelog for learning about changes.
+We publish separate documentation for each major version of Ops. We generally only make improvements to the latest version of the docs, and only backport changes that are applicable only to the older version, or are critical for charming.
+
+The published docs at [documentation.ubuntu.com/ops](https://documentation.ubuntu.com/ops/latest/) are always for the in-development (main branch) of Ops, and do not include any notes indicating changes or additions across Ops versions. We encourage all charmers to promptly upgrade to the latest version of Ops, and to refer to the release notes and changelog for learning about changes.
 
 We do note when features behave differently when using different versions of Juju.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ tox -e docs-live
 
 ## How to document version dependencies
 
-We publish separate documentation for each major version of Ops. We generally only make improvements to the latest version of the docs, and only backport changes that are applicable only to the older version, or are critical for charming.
+We publish separate documentation for each major version of Ops. We generally only make improvements to the latest version of the docs. If an older version of Ops changes in a way that's only applicable to that version, we update the older version of the docs. We also update the older version of the docs if there's an improvement that's critical for charming.
 
 The published docs at [documentation.ubuntu.com/ops](https://documentation.ubuntu.com/ops/latest/) are always for the in-development (main branch) of Ops, and do not include any notes indicating changes or additions across Ops versions. We encourage all charmers to promptly upgrade to the latest version of Ops, and to refer to the release notes and changelog for learning about changes.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 The `ops` library is a Python framework for developing and testing Kubernetes and machine [charms](https://charmhub.io/). While charms can be written in any language, `ops` defines the latest standard, and charmers are encouraged to use Python with `ops` for all charms. The library is an official component of the Charm SDK, itself a part of [the Juju universe](https://juju.is/).
 
 > - `ops` is  [available on PyPI](https://pypi.org/project/ops/).
-> - The latest version of `ops` requires Python 3.8 or above.
+> - The latest version of `ops` requires Python 3.10 or above.
 > - Read our [docs](https://documentation.ubuntu.com/ops/latest/) for tutorials, how-to guides, the library reference, and more.
 
 ## Give it a try


### PR DESCRIPTION
Two minor doc changes following on from the 3.0 release:

* Update the minimum Python version in the README.
* We do publish separate docs for separate versions of Ops now, but only major versions, and we don't generally backport doc changes.

Fixes #1941, #1943