### PR TITLE
docs: be consistent with recommending self.config

### DIFF
--- a/docs/explanation/storedstate-guidance.md
+++ b/docs/explanation/storedstate-guidance.md
@@ -19,7 +19,7 @@ Here's a simplified charm code snippet that will allow us to toggle the state of
 
 ```python
 def _on_config_changed(self, event: ops.ConfigChangedEvent):
-    mode = self.model.config['mode']
+    mode = self.config['mode']
     if mode not in ('production', 'test'):
         self.unit.status = ops.BlockedStatus(f'Invalid mode: {mode!r})
         return
@@ -43,7 +43,7 @@ def __init__(self, framework: ops.Framework):
     self._stored.set_default(current_mode='test')
 
 def _on_config_changed(self, event):
-    mode = self.model.config['mode']
+    mode = self.config['mode']
     if self._stored.current_mode == mode:
         return
     if mode not in ('production', 'test'):
@@ -76,7 +76,7 @@ In our example code, for instance, we might think about the fact that `config_ch
 
 ```python
 def _on_config_changed(self, event: ops.ConfigChangedEvent):
-    mode = self.model.config['mode']
+    mode = self.config['mode']
     if mode not in ('production', 'test'):
         self.unit.status = ops.BlockedStatus(f'Invalid mode: {mode!r})
         return

--- a/docs/howto/manage-relations.md
+++ b/docs/howto/manage-relations.md
@@ -199,7 +199,7 @@ To add data to the relation databag, use the [`.data` attribute](ops.Relation.da
 ```python
 def _on_config_changed(self, event: ops.ConfigChangedEvent):
     if relation := self.model.get_relation('ingress'):
-        relation.data[self.app]["domain"] = self.model.config["domain"]
+        relation.data[self.app]["domain"] = self.config["domain"]
 ```
 
 To read data from the relation databag, again use the `.data` attribute, selecting the appropriate databag, and then using it as if it were a regular dictionary.

--- a/ops/model.py
+++ b/ops/model.py
@@ -2222,7 +2222,8 @@ class RelationDataContent(LazyMapping, MutableMapping[str, str]):
 class ConfigData(_GenericLazyMapping['bool | int | float | str']):
     """Configuration data.
 
-    This class should not be instantiated directly. It should be accessed via :attr:`Model.config`.
+    Don't instantiate ConfigData objects directly. To get configuration data for the application
+    that this unit is part of, use :meth:`CharmBase.load_config` or :attr:`CharmBase.config`.
     """
 
     def __init__(self, backend: _ModelBackend):


### PR DESCRIPTION
This PR changes `self.model.config` to `self.config` in the docs. I'm also updating the description of ConfigData to be consistent with [Application](https://documentation.ubuntu.com/ops/latest/reference/ops.html#ops.Application).