### PR TITLE
chore: add license and license-files fields in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ requires-python = ">=3.10"
 authors = [
     {name="The Charm Tech team at Canonical Ltd."},
 ]
+license = "Apache-2.0"
+license-files = ["LICENSE.txt"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ license = "Apache-2.0"
 license-files = ["LICENSE.txt"]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",


### PR DESCRIPTION
As per [the guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files) so that third-party tools can figure out the license in the modern way.