### PR TITLE
chore: run TIOBE weekly

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -3,7 +3,7 @@ name: TIOBE Quality Checks
 on:
   workflow_dispatch:
   schedule:
-    - cron:  '0 7 1 * *'
+    - cron:  '0 7 * * 0'
 
 permissions: {}
 


### PR DESCRIPTION
We've been asked to [run the TIOBE workflow weekly](https://discourse.canonical.com/t/tiobe-tics-news-maas-ui-go-1-24-ci-integration-tics-gh-self-hosted-runner/6038?u=tony-meyer). This changes from monthly on the first of the month to weekly on Sundays.