### PR TITLE
docs: for 2.x, remove .html extensions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,13 +48,13 @@ passenv =
     # https://docs.readthedocs.com/platform/stable/build-customization.html#where-to-put-files
     READTHEDOCS_OUTPUT
 commands =
-    sphinx-build -W --keep-going docs/ {env:READTHEDOCS_OUTPUT:docs/_build}/html
+    sphinx-build -W --keep-going -b dirhtml docs/ {env:READTHEDOCS_OUTPUT:docs/_build}/html
 
 [testenv:docs-live]
 description = Live development: build the Sphinx docs with autoreloading enabled
 dependency_groups = docs
 commands =
-    sphinx-autobuild docs/ docs/_build/html --watch ops/ --port 8000 {posargs}
+    sphinx-autobuild -b dirhtml docs/ docs/_build/html --watch ops/ --port 8000 {posargs}
 
 [testenv:format]
 description = Apply coding style standards to code


### PR DESCRIPTION
In https://github.com/canonical/operator/pull/1951 we started updating the doc starter pack for the `latest` version of the Ops docs. That included switching to "clean" URLs (without .html).

This PR switches the `2.x` version of the docs to clean URLs too. I don't think it's worth doing further starter-pack related changes in 2.x, as we don't plan to update the 2.x docs frequently. But switching to clean URLs is helpful to avoid 404s when switching between doc versions.

Example of how to produce a 404:

1. Visit https://documentation.ubuntu.com/ops/latest/howto/manage-charms/
2. Use the version switcher to switch to the 2.x docs

The resulting page https://documentation.ubuntu.com/ops/2.x/howto/manage-charms/ is not found. I _might_ be able to work around this in the RTD redirect configuration, but it would be hacky. It's better to switch the 2.x docs to the `dirhtml` builder.
