### PR TITLE
docs: remove .html extensions from hardcoded links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ To help us review your changes, please rebase your pull request onto the `main` 
 
 # Tests
 
-Changes should include tests. Where reasonable, prefer to write 'Scenario' tests using [ops.testing](https://documentation.ubuntu.com/ops/latest/reference/ops-testing.html) instead of legacy [ops.testing.Harness](https://documentation.ubuntu.com/ops/latest/reference/ops-testing-harness.html) tests.
+Changes should include tests. Where reasonable, prefer to write 'Scenario' tests using [ops.testing](https://documentation.ubuntu.com/ops/latest/reference/ops-testing/) instead of legacy [ops.testing.Harness](https://documentation.ubuntu.com/ops/latest/reference/ops-testing-harness/) tests.
 
 Tests for Ops should go in the test module corresponding to the code. For example, a feature added in `ops/main.py` would go in `test/test_main.py`. However, when adding a large number of logically related tests, consider putting these in their own file, named accordingly. For example, if adding a feature `foo` in `ops/main.py`, the tests might go in `test/test_main_foo.py`.
 
@@ -43,7 +43,7 @@ Tests for [`ops-scenario`](https://github.com/canonical/operator/tree/main/testi
 
 # Coding style
 
-We have a team [Python style guide](./STYLE.md), most of which is enforced by CI checks. Please be complete with docstrings and keep them informative for _users_, as the [Ops library reference](https://documentation.ubuntu.com/ops/latest/reference/index.html) is automatically generated from Python docstrings.
+We have a team [Python style guide](./STYLE.md), most of which is enforced by CI checks. Please be complete with docstrings and keep them informative for _users_, as the [Ops library reference](https://documentation.ubuntu.com/ops/latest/reference/) is automatically generated from Python docstrings.
 
 # Documentation
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ class OpsExampleCharm(ops.CharmBase):
         environment configuration for your specific workload.
 
         Learn more about interacting with Pebble at
-            https://documentation.ubuntu.com/ops/latest/reference/pebble.html
+            https://documentation.ubuntu.com/ops/latest/reference/pebble/
         """
         # Get a reference the container attribute on the PebbleReadyEvent
         container = event.workload
@@ -86,7 +86,7 @@ class OpsExampleCharm(ops.CharmBase):
         self.unit.status = ops.ActiveStatus()
 ```
 
-> See more: [`ops.PebbleReadyEvent`](https://documentation.ubuntu.com/ops/latest/reference/ops.html#ops.PebbleReadyEvent)
+> See more: [`ops.PebbleReadyEvent`](https://documentation.ubuntu.com/ops/latest/reference/ops/#ops.PebbleReadyEvent)
 
 - The `tests/unit/test_charm.py` file imports `ops.testing` and uses it to set up a unit test:
 
@@ -127,7 +127,7 @@ def test_httpbin_pebble_ready():
     assert state_out.unit_status == testing.ActiveStatus()
 ```
 
-> See more: [`ops.testing`](https://documentation.ubuntu.com/ops/latest/reference/ops-testing.html)
+> See more: [`ops.testing`](https://documentation.ubuntu.com/ops/latest/reference/ops-testing/)
 
 
 Explore further, start editing the files, or skip ahead and pack the charm:

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -201,7 +201,7 @@ def _on_demo_server_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
     environment configuration for your specific workload.
 
     Learn more about interacting with Pebble at
-        https://documentation.ubuntu.com/ops/latest/reference/pebble.html
+        https://documentation.ubuntu.com/ops/latest/reference/pebble/
     Learn more about Pebble layers at
         https://documentation.ubuntu.com/pebble/how-to/use-layers/
     """

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
@@ -80,7 +80,7 @@ def _on_get_db_info_action(self, event: ops.ActionEvent) -> None:
 
     If the PostgreSQL charm is not integrated, the output is set to "No database connected".
 
-    Learn more about actions at https://documentation.ubuntu.com/ops/latest/howto/manage-actions.html
+    Learn more about actions at https://documentation.ubuntu.com/ops/latest/howto/manage-actions/
     """
     params = event.load_params(GetDbInfoAction, errors='fail')
     db_data = self.fetch_postgres_relation_data()

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -183,7 +183,7 @@ def _update_layer_and_restart(self) -> None:
     configuration for your specific workload. Tip: you can see the
     standard entrypoint of an existing container using docker inspect
     Learn more about interacting with Pebble at
-        https://documentation.ubuntu.com/ops/latest/reference/pebble.html
+        https://documentation.ubuntu.com/ops/latest/reference/pebble/
     Learn more about Pebble layers at
         https://documentation.ubuntu.com/pebble/how-to/use-layers/
     """

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -102,7 +102,7 @@ def _update_layer_and_restart(self) -> None:
     configuration for your specific workload. Tip: you can see the
     standard entrypoint of an existing container using docker inspect
     Learn more about interacting with Pebble at
-        https://documentation.ubuntu.com/ops/latest/reference/pebble.html
+        https://documentation.ubuntu.com/ops/latest/reference/pebble/
     Learn more about Pebble layers at
         https://documentation.ubuntu.com/pebble/how-to/use-layers/
     """

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,15 +2,15 @@ This directory contains charms that you can pack and deploy locally, to help lea
 
 ### Charms from the Kubernetes charm tutorial
 
-- **[k8s-1-minimal](k8s-1-minimal)** - From [Create a minimal Kubernetes charm](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.html). This charm is a minimal Kubernetes charm for a demo web server.
+- **[k8s-1-minimal](k8s-1-minimal)** - From [Create a minimal Kubernetes charm](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm/). This charm is a minimal Kubernetes charm for a demo web server.
 
-- **[k8s-2-configurable](k8s-2-configurable)** - From [Make your charm configurable](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.html). This charm has an option for configuring the web server's port.
+- **[k8s-2-configurable](k8s-2-configurable)** - From [Make your charm configurable](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable/). This charm has an option for configuring the web server's port.
 
-- **[k8s-3-postgresql](k8s-3-postgresql)** - From [Integrate your charm with PostgreSQL](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.html). This charm can be integrated with a PostgreSQL charm, so that the web server can retrieve database credentials and connect to the database.
+- **[k8s-3-postgresql](k8s-3-postgresql)** - From [Integrate your charm with PostgreSQL](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql/). This charm can be integrated with a PostgreSQL charm, so that the web server can retrieve database credentials and connect to the database.
 
-- **[k8s-4-action](k8s-4-action)** - From [Expose operational tasks via actions](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.html). This charm has an action for viewing the database credentials.
+- **[k8s-4-action](k8s-4-action)** - From [Expose operational tasks via actions](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions/). This charm has an action for viewing the database credentials.
 
-- **[k8s-5-observe](k8s-5-observe)** - From [Observe your charm with COS Lite](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.html). This charm can be integrated with the [COS Lite](https://charmhub.io/cos-lite) observability stack.
+- **[k8s-5-observe](k8s-5-observe)** - From [Observe your charm with COS Lite](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite/). This charm can be integrated with the [COS Lite](https://charmhub.io/cos-lite) observability stack.
 
 ### Other demo charms
 

--- a/examples/k8s-1-minimal/src/charm.py
+++ b/examples/k8s-1-minimal/src/charm.py
@@ -41,7 +41,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         environment configuration for your specific workload.
 
         Learn more about interacting with Pebble at
-            https://documentation.ubuntu.com/ops/latest/reference/pebble.html
+            https://documentation.ubuntu.com/ops/latest/reference/pebble/
         Learn more about Pebble layers at
             https://documentation.ubuntu.com/pebble/how-to/use-layers/
         """

--- a/examples/k8s-2-configurable/src/charm.py
+++ b/examples/k8s-2-configurable/src/charm.py
@@ -65,7 +65,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         configuration for your specific workload. Tip: you can see the
         standard entrypoint of an existing container using docker inspect
         Learn more about interacting with Pebble at
-            https://documentation.ubuntu.com/ops/latest/reference/pebble.html
+            https://documentation.ubuntu.com/ops/latest/reference/pebble/
         Learn more about Pebble layers at
             https://documentation.ubuntu.com/pebble/how-to/use-layers/
         """

--- a/examples/k8s-3-postgresql/src/charm.py
+++ b/examples/k8s-3-postgresql/src/charm.py
@@ -103,7 +103,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         configuration for your specific workload. Tip: you can see the
         standard entrypoint of an existing container using docker inspect
         Learn more about interacting with Pebble at
-            https://documentation.ubuntu.com/ops/latest/reference/pebble.html
+            https://documentation.ubuntu.com/ops/latest/reference/pebble/
         Learn more about Pebble layers at
             https://documentation.ubuntu.com/pebble/how-to/use-layers/
         """

--- a/examples/k8s-4-action/src/charm.py
+++ b/examples/k8s-4-action/src/charm.py
@@ -117,7 +117,7 @@ class FastAPIDemoCharm(ops.CharmBase):
 
         If the PostgreSQL charm is not integrated, the output is set to "No database connected".
 
-        Learn more about actions at https://documentation.ubuntu.com/ops/latest/howto/manage-actions.html
+        Learn more about actions at https://documentation.ubuntu.com/ops/latest/howto/manage-actions/
         """
         params = event.load_params(GetDbInfoAction, errors='fail')
         db_data = self.fetch_postgres_relation_data()
@@ -142,7 +142,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         configuration for your specific workload. Tip: you can see the
         standard entrypoint of an existing container using docker inspect
         Learn more about interacting with Pebble at
-            https://documentation.ubuntu.com/ops/latest/reference/pebble.html
+            https://documentation.ubuntu.com/ops/latest/reference/pebble/
         Learn more about Pebble layers at
             https://documentation.ubuntu.com/pebble/how-to/use-layers/
         """

--- a/examples/k8s-5-observe/src/charm.py
+++ b/examples/k8s-5-observe/src/charm.py
@@ -138,7 +138,7 @@ class FastAPIDemoCharm(ops.CharmBase):
 
         If the PostgreSQL charm is not integrated, the output is set to "No database connected".
 
-        Learn more about actions at https://documentation.ubuntu.com/ops/latest/howto/manage-actions.html
+        Learn more about actions at https://documentation.ubuntu.com/ops/latest/howto/manage-actions/
         """
         params = event.load_params(GetDbInfoAction, errors='fail')
         db_data = self.fetch_postgres_relation_data()
@@ -163,7 +163,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         configuration for your specific workload. Tip: you can see the
         standard entrypoint of an existing container using docker inspect
         Learn more about interacting with Pebble at
-            https://documentation.ubuntu.com/ops/latest/reference/pebble.html
+            https://documentation.ubuntu.com/ops/latest/reference/pebble/
         Learn more about Pebble layers at
             https://documentation.ubuntu.com/pebble/how-to/use-layers/
         """

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -323,7 +323,7 @@ class Harness(Generic[CharmType]):
 
         warnings.warn(
             'Harness is deprecated. For the recommended approach, see: '
-            'https://documentation.ubuntu.com/ops/latest/howto/write-unit-tests-for-a-charm.html',
+            'https://documentation.ubuntu.com/ops/latest/howto/write-unit-tests-for-a-charm/',
             PendingDeprecationWarning,
             stacklevel=2,
         )

--- a/ops/testing.py
+++ b/ops/testing.py
@@ -29,7 +29,7 @@ The module includes:
 
 .. note::
     Unit testing is only one aspect of a comprehensive testing strategy. For more
-    on testing charms, see `Testing <https://documentation.ubuntu.com/ops/latest/explanation/testing.html>`_.
+    on testing charms, see `Testing <https://documentation.ubuntu.com/ops/latest/explanation/testing/>`_.
 """
 
 # ruff: noqa: F401 (unused import)

--- a/testing/README.md
+++ b/testing/README.md
@@ -93,12 +93,12 @@ package.
 
 ## Documentation
 
- * To get started, work through our ['Write your first Kubernetes charm' tutorial](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.html#write-unit-tests-for-your-charm), following the instructions for adding
+ * To get started, work through our ['Write your first Kubernetes charm' tutorial](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm/#write-unit-tests-for-your-charm), following the instructions for adding
    unit tests at the end of each chapter.
  * When you need to write a test that involves specific ops functionality,
-   refer to our [how-to guides](https://documentation.ubuntu.com/ops/latest/howto/index.html)
+   refer to our [how-to guides](https://documentation.ubuntu.com/ops/latest/howto/)
    which all conclude with examples of tests of the ops functionality.
- * Use our extensive [reference documentation](https://documentation.ubuntu.com/ops/latest/reference/ops-testing.html#ops-testing) when you need to know how each `testing` object works. These
+ * Use our extensive [reference documentation](https://documentation.ubuntu.com/ops/latest/reference/ops-testing/#ops-testing) when you need to know how each `testing` object works. These
    docs are also available via the standard Python `help()` functionality and in
    your IDE.
 


### PR DESCRIPTION
After https://github.com/canonical/operator/pull/1951, the Ops docs have "clean" URLs (no .html extensions). I've set up redirects within RTD, so our hardcoded links still work. But to keep things tidy, this PR updates all the links.