### PR TITLE
docs: fix broken URLs in sitemap

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,8 @@ passenv =
     # ReadTheDocs builder wants the output in a place of its choosing.
     # https://docs.readthedocs.com/platform/stable/build-customization.html#where-to-put-files
     READTHEDOCS_OUTPUT
+    # The starter pack config uses READTHEDOCS_VERSION to build URLs for sitemap.xml.
+    READTHEDOCS_VERSION
 commands =
     sphinx-build -W --keep-going -b dirhtml docs/ {env:READTHEDOCS_OUTPUT:docs/_build}/html -d docs/.sphinx/.doctrees
 


### PR DESCRIPTION
Contrary to [my claim in #1951](https://github.com/canonical/operator/pull/1951#discussion_r2253104136), the [published sitemap](https://documentation.ubuntu.com/ops/latest/sitemap.xml) still has URLs containing `MANUAL`. The starter pack config expects `READTHEDOCS_VERSION` to be set, but we're not passing that env variable through to sphinx-build. This PR fixes the issue.