### PR TITLE
docs: add related doc links to homepage

### DIFF
--- a/docs/_static/project_specific.css
+++ b/docs/_static/project_specific.css
@@ -8,3 +8,13 @@ body {
     -webkit-mask-image: var(--icon-star);
     mask-image: var(--icon-star);
 }
+
+/* For the "related links" block, use the same spacing & sizing as the "contents" block */
+.relatedlinks-title-container {
+    padding: var(--toc-title-padding);
+    padding-top: var(--toc-spacing-vertical);
+}
+.relatedlinks {
+    font-size: var(--toc-font-size);
+    line-height: 1.3;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+relatedlinks: "[Charmcraft](https://documentation.ubuntu.com/charmcraft/stable/), [Charmlibs](https://canonical-charmlibs.readthedocs-hosted.com/), [Concierge](https://github.com/canonical/concierge), [Jubilant](https://documentation.ubuntu.com/jubilant/), [Juju](https://documentation.ubuntu.com/juju/3.6/), [Pebble](https://documentation.ubuntu.com/pebble/)"
+---
+
 # Ops documentation
 
 ```{toctree}


### PR DESCRIPTION
Inspired by https://github.com/juju/juju/pull/20358, this PR adds a "related links" block to the docs homepage, with links to related docs in the charming ecosystem.