### PR TITLE
docs: use classes from ops instead of ops.<submodule>

### DIFF
--- a/docs/howto/legacy/write-legacy-unit-tests-for-a-charm.md
+++ b/docs/howto/legacy/write-legacy-unit-tests-for-a-charm.md
@@ -66,7 +66,7 @@ When using `Harness.begin()` you are responsible for manually triggering events 
 ...
 # Add a relation and trigger relation-created.
 harness.add_relation('db', 'postgresql') # <relation-name>, <remote-app-name>
-# Add a peer relation and trigger relation-created 
+# Add a peer relation and trigger relation-created
 harness.add_relation('cluster', 'test-app') # <peer-relation-name>, <this-app-name>
 ```
 
@@ -92,7 +92,7 @@ harness.disable_hooks()
 harness.update_config({"foo": "quux"})
 # Re-enable hooks
 harness.enable_hooks()
-# Set the status of the active unit. We'd need "from ops.model import BlockedStatus".
+# Set the status of the active unit. We'd need "from ops import BlockedStatus".
 harness.charm.unit.status = BlockedStatus("Testing")
 ```
 
@@ -135,7 +135,7 @@ def test_logs(harness, caplog):
 
 In `ops` 1.4, functionality was added to the Harness to more accurately track connections to workload containers. As of `ops` 2.0, this behaviour is enabled and simulated by default (prior to 2.0, you had to enable it by setting `ops.testing.SIMULATE_CAN_CONNECT` to True before creating Harness instances).
 
-Containers normally start in a disconnected state, and any interaction with the remote container (push, pull, add_layer, and so on) will raise an `ops.pebble.ConnectionError`. 
+Containers normally start in a disconnected state, and any interaction with the remote container (push, pull, add_layer, and so on) will raise an `ops.pebble.ConnectionError`.
 
 To mark a container as connected,
 you can either call [`harness.set_can_connect(container, True)`](ops.testing.Harness.set_can_connect), or you can call [`harness.container_pebble_ready(container)`](ops.testing.Harness.container_pebble_ready) if you want to mark the container as connected *and* trigger its pebble-ready event.

--- a/docs/howto/legacy/write-legacy-unit-tests-for-a-charm.md
+++ b/docs/howto/legacy/write-legacy-unit-tests-for-a-charm.md
@@ -92,8 +92,8 @@ harness.disable_hooks()
 harness.update_config({"foo": "quux"})
 # Re-enable hooks
 harness.enable_hooks()
-# Set the status of the active unit. We'd need "from ops import BlockedStatus".
-harness.charm.unit.status = BlockedStatus("Testing")
+# Set the status of the active unit
+harness.charm.unit.status = ops.BlockedStatus("Testing")
 ```
 
 Any of your charm’s properties and methods (including event callbacks) can be accessed using

--- a/docs/howto/manage-libraries.md
+++ b/docs/howto/manage-libraries.md
@@ -79,7 +79,7 @@ class DatabaseReadyEvent(ops.EventBase):
 
 class DatabaseRequirerEvents(ops.ObjectEvents):
     """Container for Database Requirer events."""
-    ready = ops.charm.EventSource(DatabaseReadyEvent)
+    ready = ops.EventSource(DatabaseReadyEvent)
 
 
 class DatabaseRequirer(ops.Object):

--- a/ops/model.py
+++ b/ops/model.py
@@ -1710,7 +1710,7 @@ class Relation:
 
     This class should not be instantiated directly, instead use :meth:`Model.get_relation`,
     :attr:`Model.relations`, or :attr:`ops.RelationEvent.relation`. This is principally used by
-    :class:`ops.charm.RelationMeta` to represent the relationships between charms.
+    :class:`ops.RelationMeta` to represent the relationships between charms.
     """
 
     name: str


### PR DESCRIPTION
This PR finishes work on #1783. There are a few places in old docs where we're using classes from `ops.<submodule>` instead of directly from `ops`.

Drive-by: Pre-commit removed some whitespace. Best to hide whitespace when reviewing.