### PR TITLE
docs: fix unstyled error pages

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,8 @@ passenv =
     # ReadTheDocs builder wants the output in a place of its choosing.
     # https://docs.readthedocs.com/platform/stable/build-customization.html#where-to-put-files
     READTHEDOCS_OUTPUT
+    # The canonical-sphinx extension uses READTHEDOCS_CANONICAL_URL to build URLs of static assets on error pages.
+    READTHEDOCS_CANONICAL_URL
     # The starter pack config uses READTHEDOCS_VERSION to build URLs for sitemap.xml.
     READTHEDOCS_VERSION
 commands =


### PR DESCRIPTION
Error pages in the docs are broken. For example:
https://documentation.ubuntu.com/ops/latest/foo

The problem is that the page is trying to load static assets from the wrong URLs:

```
# wrong
https://documentation.ubuntu.com/ops/_static/styles/furo.css

# right
https://documentation.ubuntu.com/ops/latest/_static/styles/furo.css
```

The URLs are wrong because the `READTHEDOCS_CANONICAL_URL` environment variable is not set at build time. The canonical-sphinx extension [needs the variable to be set](https://github.com/canonical/canonical-sphinx/blob/d63d89416434e213aefec84b8f09886dbf45597b/canonical_sphinx/config.py#L146-L148) to correctly build URLs of static assets.

This PR fixes ( :crossed_fingers: ) the issue by passing `READTHEDOCS_CANONICAL_URL` through to sphinx-build in our custom tox environment.