### PR TITLE
chore: clean up build settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ ops-scenario = { workspace = true }
 ops-tracing = { workspace = true }
 
 [tool.setuptools.packages.find]
-include = ["ops"]
+include = ["ops", "ops._private", "ops.lib"]
 
 [tool.setuptools.dynamic]
 version = {attr = "ops.version.version"}

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -18,7 +18,6 @@ maintainers = [
 ]
 description = "Python library providing a state-transition testing API for Operator Framework charms."
 license = "Apache-2.0"
-license-files = ["../LICENSE.txt"]
 keywords = ["juju", "test"]
 
 dependencies = [

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -17,7 +17,8 @@ maintainers = [
     { name = "The Charm Tech team at Canonical Ltd." }
 ]
 description = "Python library providing a state-transition testing API for Operator Framework charms."
-license.text = "Apache-2.0"
+license = "Apache-2.0"
+license-files = ["../LICENSE.txt"]
 keywords = ["juju", "test"]
 
 dependencies = [
@@ -29,7 +30,6 @@ requires-python = ">=3.10"
 
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: Apache Software License",
     'Framework :: Pytest',
     'Intended Audience :: Developers',
     'Topic :: Software Development :: Quality Assurance',

--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -4,6 +4,8 @@ version = "3.2.0.dev0"
 description = "The tracing facility for the Ops library."
 requires-python = ">=3.10"
 readme = "README.md"
+license = "Apache-2.0"
+license-files = ["../LICENSE.txt"]
 authors = [
     {name="The Charm Tech team at Canonical Ltd."},
 ]
@@ -11,7 +13,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX :: Linux",

--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -5,7 +5,6 @@ description = "The tracing facility for the Ops library."
 requires-python = ">=3.10"
 readme = "README.md"
 license = "Apache-2.0"
-license-files = ["../LICENSE.txt"]
 authors = [
     {name="The Charm Tech team at Canonical Ltd."},
 ]


### PR DESCRIPTION
In #1949 the license metadata was updated for ops, but not ops-tracing or ops-scenario; this PR completes.

`uv build` also warns about the `ops._private` and `ops.lib` packages inclusion being ambiguous, so the PR makes that explicit.

Fixes #1965