### PR TITLE
chore: add refactor, perf, and revert to the changelog/release note categories

### DIFF
--- a/release.py
+++ b/release.py
@@ -317,7 +317,7 @@ def commit_type_to_category(commit_type: str) -> str:
         'test': 'Tests',
         'ci': 'CI',
         'perf': 'Performance',
-        'refact': 'Refactor',
+        'refactor': 'Refactor',
         'revert': 'Revert',
     }
     return mapping.get(commit_type, commit_type.capitalize())

--- a/release.py
+++ b/release.py
@@ -170,7 +170,7 @@ def parse_release_notes(release_notes: str) -> tuple[dict[str, list[tuple[str, s
     """Parse auto-generated release notes into categories.
 
     The "New Contributors" section is removed.
-    The PRs are categorized into 'feat', 'fix', 'docs', 'test', and 'ci'.
+    The PRs are categorised by the conventional commit type.
     The full changelog line is returned separately.
 
     Returns:
@@ -188,6 +188,9 @@ def parse_release_notes(release_notes: str) -> tuple[dict[str, list[tuple[str, s
         'docs': [],
         'test': [],
         'ci': [],
+        'refactor': [],
+        'perf': [],
+        'revert': [],
     }
     full_changelog_line = None
 
@@ -313,6 +316,9 @@ def commit_type_to_category(commit_type: str) -> str:
         'docs': 'Documentation',
         'test': 'Tests',
         'ci': 'CI',
+        'perf': 'Performance',
+        'refact': 'Refactor',
+        'revert': 'Revert',
     }
     return mapping.get(commit_type, commit_type.capitalize())
 

--- a/release.py
+++ b/release.py
@@ -317,8 +317,8 @@ def commit_type_to_category(commit_type: str) -> str:
         'test': 'Tests',
         'ci': 'CI',
         'perf': 'Performance',
-        'refactor': 'Refactor',
-        'revert': 'Revert',
+        'refactor': 'Refactoring',
+        'revert': 'Reverted',
     }
     return mapping.get(commit_type, commit_type.capitalize())
 


### PR DESCRIPTION
The release notes and changelog currently ignore any commits that are `refactor`, `perf`, `revert`, or `chore`. We are deliberately ignoring 'chores', as those are deemed uninteresting and not relevant to consumers of the packages.

There are two cases for "revert". One is reverting a commit that is also in the same release; in this case we should remove both the original commit and the reverting commit to have a cleaner list of changes - doing this automatically is tricky, so having the revert listed in the changes makes it simpler to do this in the human review. The other case is reverting a change from a previous release: consumers of the packages should definitely be told about these.

Performance improvements are typically interesting to users, so it makes sense to mention those in the release notes and changelog. In extreme cases, the changes might make it possible to use a feature that wasn't feasible previously. Even in minor cases, it helps to show that we care about performance.

Refactoring is arguably not interesting to users, if there are no performance changes and no changes to the public interface of the packages. However, we decided as a team that we should include these as well, at least for now (and we have a very small number of `refactor` commits, so it doesn't make much difference in practice).