### PR TITLE
chore: remove the Concierge work-around

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '42 7 25 * *'
+  pull_request:
 
 permissions: {}
 
@@ -18,10 +19,6 @@ jobs:
         test: ['test_direct_connection', 'test_with_tls', 'test_relation_units']
 
     steps:
-      - run: |
-           # Work around https://github.com/jnsgruk/concierge/issues/30
-           sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
-           sudo rm -rf /run/containerd
       - run: sudo snap install --classic concierge
       - run: >
           sudo concierge prepare

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '42 7 25 * *'
-  pull_request:
 
 permissions: {}
 
@@ -19,6 +18,11 @@ jobs:
         test: ['test_direct_connection', 'test_with_tls', 'test_relation_units']
 
     steps:
+      - run: |
+           # Work around https://github.com/jnsgruk/concierge/issues/30
+           sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
+           sudo rm -rf /run/containerd
+        if: matrix.preset == 'k8s'
       - run: sudo snap install --classic concierge
       - run: >
           sudo concierge prepare


### PR DESCRIPTION
I noticed that Tempo charms don't seem to be using the same work-around as we do.

They are also on Concierge 1.0.4.

This is trial and error to see if the work-around can be removed.

Edit: instead of removing the work-around, I'm restricting it to Canonical K8s.

This works: https://github.com/canonical/operator/actions/runs/16896879217?pr=1976

