### PR TITLE
docs: remove unnecessary pages from sitemap

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -205,6 +205,16 @@ else:
 
 sitemap_show_lastmod = True
 
+# Exclude generated pages from the sitemap:
+
+sitemap_excludes = [
+    '404/',
+    'genindex/',
+    'py-modindex/',
+    '_modules/*',
+    'search/',
+]
+
 #######################
 # Template and asset locations
 #######################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ docs = [
     "packaging",
     "sphinxcontrib-svg2pdfconverter[CairoSVG]",
     "sphinx-last-updated-by-git",
-    "sphinx-sitemap",
+    "sphinx-sitemap~=2.8",
 ]
 static = [
     "ops[testing,tracing]",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -573,7 +573,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1127,7 +1127,7 @@ docs = [
     { name = "ops", extras = ["testing", "tracing"], editable = "." },
     { name = "packaging" },
     { name = "sphinx-last-updated-by-git" },
-    { name = "sphinx-sitemap" },
+    { name = "sphinx-sitemap", specifier = "~=2.8" },
     { name = "sphinxcontrib-svg2pdfconverter", extras = ["cairosvg"] },
 ]
 integration = [
@@ -1932,14 +1932,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-sitemap"
-version = "2.7.2"
+version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx-last-updated-by-git" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/a7/60e6cce670fcc21d95215bf2e3f3f6455b7bce0ecc8423ce8ffbd044587e/sphinx_sitemap-2.7.2.tar.gz", hash = "sha256:819e028e27579b47efa0e2f863b87136b711c45f13e84730610e80316f6883da", size = 6387, upload-time = "2025-06-27T00:32:31.332Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/0e/e249fdd17c0530c8260191f0020556862b243fa718cf0e6b28d956eafb2c/sphinx_sitemap-2.8.0.tar.gz", hash = "sha256:749d7184a0c7b73d486a232b54b5c1b38a0e2d6f18cf19fb1b033b8162b44a82", size = 6829, upload-time = "2025-08-12T04:54:24.51Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/2f/ae76e120797b42a7e96ed3cccc93bd7b1feb583008f6686fc85d90c774da/sphinx_sitemap-2.7.2-py3-none-any.whl", hash = "sha256:1a6a8dcecb0ffb85fd37678f785cfcc40adfe3eebafb05e678971e5260b117e4", size = 6018, upload-time = "2025-06-27T00:32:30.161Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ab/3bc6f9ee09b5fd5ae2e5ae1febf41a2ed2bdde452a41c06e78fec0296b5c/sphinx_sitemap-2.8.0-py3-none-any.whl", hash = "sha256:332042cd5b9385f61ec2861dfd550d9bccbdfcff86f6b68c7072cf40c9f16363", size = 6167, upload-time = "2025-08-12T04:54:23.479Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The [sitemap](https://documentation.ubuntu.com/ops/latest/sitemap.xml) for Ops contains pages that are generated by Sphinx or our automodule setup:

- 404/
- genindex/
- py-modindex/
- _modules/ops/main/, etc
- search/

These pages aren't discoverable through the site, so they also shouldn't appear in the sitemap. This PR removes the pages from the sitemap.

**[Preview of updated sitemap](https://canonical-ubuntu-documentation-library--1979.com.readthedocs.build/ops/1979/sitemap.xml)**

To exclude everything under `_modules/`, I'm using the new wildcard support in sphinx-sitemap version 2.8. See https://github.com/jdillard/sphinx-sitemap/pull/113 and https://github.com/jdillard/sphinx-sitemap/releases/tag/v2.8.0. I've updated our dependencies to require a compatible version of sphinx-sitemap.