### PR TITLE
ci: adjust permissions block in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,15 +5,16 @@ name: Publish
     tags:
       - '[1-3].*'
 
-permissions:
-  id-token: write
-  attestations: write
-  contents: read
+permissions: {}
 
 jobs:
   build-and-publish:
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
     environment: publish-pypi
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This fixes the two open code scanning alerts. It's unclear how the failing workflow managed to get merged despite the failures (it doesn't appear to be due to a difference in Zizmor version, or an override, and the history in the scanning alerts does not seem correct).

This moves the permissions (particularly attestations:write and id-token:write) to the build-and-publish job, rather than applying to the entire workflow. In practice, this means that the secscan job doesn't have those permissions.