### PR TITLE
docs: add model-config best practice note

### DIFF
--- a/docs/howto/manage-configuration.md
+++ b/docs/howto/manage-configuration.md
@@ -12,11 +12,8 @@ In the `charmcraft.yaml` file of the charm, under `config.options`, add a config
 ```{admonition} Best practice
 :class: hint
 
-Don't duplicate model-level configuration options that are controlled by `juju model-config`.
+Don't duplicate model-level configuration options that are controlled by {external+juju:ref}`juju model-config <command-juju-model-config>`.
 ```
-
-> See more:
->  - {external+juju:ref}`Juju CLI | model-config <command-juju-model-config>`
 
 The example below shows how to define two configuration options, one called `name` of type `string` and default value `Wiki`, and one called `skin` with type `string` and default value `vector`:
 


### PR DESCRIPTION
This is copied from a new addition to the Juju Charm Maturity page. That page is in the process of being removed, but we'd like to retain this note.

The note is shorter than the one in the Juju docs. In the Juju docs there is a link to a library that handles this: I've instead opened a [PR in charmlibs](https://github.com/canonical/charmlibs/pull/113) to list the library there, as that seems more appropriate than advertising it in a best practice note or the how-to more broadly. I've also added a note about the Juju proxy settings to the public listing review notes, since we don't document those in ops currently.

[Preview](https://canonical-ubuntu-documentation-library--1990.com.readthedocs.build/ops/1990/howto/manage-configuration/)