### PR TITLE
ci: update actions/checkout to v5

### DIFF
--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -26,14 +26,14 @@ jobs:
             commit: 177347ce779f8c86bc75fd62cdfaba0bdc1d427e  # rev266 rev265 rev264 2025-07-25T13:31:29Z
     steps:
       - name: Checkout the ${{ matrix.charm-repo }} repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ matrix.charm-repo }}
           persist-credentials: false
           ref: ${{ matrix.commit }}
 
       - name: Checkout the operator repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: myops
           persist-credentials: false

--- a/.github/workflows/example-charm-tests.yaml
+++ b/.github/workflows/example-charm-tests.yaml
@@ -26,7 +26,7 @@ jobs:
           - examples/k8s-5-observe
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Set up Python 3

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3
@@ -50,7 +50,7 @@ jobs:
         python-version: ["3.10", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3
@@ -73,7 +73,7 @@ jobs:
         python-version: ["3.10", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3
@@ -105,7 +105,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3

--- a/.github/workflows/hello-charm-tests.yaml
+++ b/.github/workflows/hello-charm-tests.yaml
@@ -27,7 +27,7 @@ jobs:
           python-version: '3.10'
 
       - name: Checkout the ${{ matrix.charm-repo }} repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ matrix.charm-repo }}
           persist-credentials: false

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -29,7 +29,7 @@ jobs:
           --juju-channel=3/stable
           --charmcraft-channel=3.x/stable
           -p "${{ matrix.preset }}"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3

--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -26,7 +26,7 @@ jobs:
             commit: 1ee19d9d5a782cf9f68e911aa02041bd7ee5e538  # 2025-07-28T15:06:48Z
     steps:
       - name: Checkout the ${{ matrix.charm-repo }} repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ matrix.charm-repo }}
           persist-credentials: false

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     environment: publish-pypi
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3

--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -65,7 +65,7 @@ jobs:
           - charm-repo: canonical/zookeeper-operator
     steps:
       - name: Checkout the ${{ matrix.charm-repo }} repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ matrix.charm-repo }}
           persist-credentials: false

--- a/.github/workflows/sbom-secscan.yaml
+++ b/.github/workflows/sbom-secscan.yaml
@@ -17,7 +17,7 @@ jobs:
         runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
         steps:
           - name: Checkout repository
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
             with:
               persist-credentials: false
           - name: Install dependencies
@@ -26,7 +26,7 @@ jobs:
               sudo apt-get install -y libapt-pkg-dev
               sudo apt install -y python3-apt
           - name: Checkout security scanner
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
             with:
               repository: canonical/sbomber
               path: scanner

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -25,7 +25,7 @@ jobs:
           --charmcraft-channel=3.x/stable
           -p "${{ matrix.preset }}"
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Build and publish to Test PYPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -11,7 +11,7 @@ jobs:
   TICS:
     runs-on: [self-hosted, reactive, amd64, tiobe, noble]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/update-charm-tests.yaml
+++ b/.github/workflows/update-charm-tests.yaml
@@ -13,7 +13,7 @@ jobs:
   update-pins:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.UPDATE_CHARM_PINS_ACCESS_TOKEN }}
           persist-credentials: true

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -15,7 +15,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 


### PR DESCRIPTION
The dependabot is making its rounds... (charming repos I track, etc.)

So I figure we can bump actions/checkout now rather than wait until the end of the month.