### PR TITLE
ci: ignore juju/4 timeouts

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         juju-channel: ['2.9/stable', '3/stable', '4/beta']
         preset: ['machine', 'microk8s']
+      continue-on-error: ${{ matrix.juju-channel == '4/beta' && matrix.preset == 'microk8s' }}
 
     steps:
       - run: sudo snap install --classic concierge

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         juju-channel: ['2.9/stable', '3/stable', '4/beta']
         preset: ['machine', 'microk8s']
-      continue-on-error: ${{ matrix.juju-channel == '4/beta' && matrix.preset == 'microk8s' }}
+    continue-on-error: ${{ matrix.juju-channel == '4/beta' && matrix.preset == 'microk8s' }}
 
     steps:
       - run: sudo snap install --classic concierge


### PR DESCRIPTION
Ignore Juju 4/beta timeouts on microk8s, as those seem to happen all the time.