### PR TITLE
docs: change some best practices to tips

### DIFF
--- a/docs/howto/log-from-your-charm.md
+++ b/docs/howto/log-from-your-charm.md
@@ -54,9 +54,7 @@ In particular, you should avoid `print()` calls, and ensure that any subprocess
 calls capture output.
 ```
 
-````{admonition} Best practice
-:class: hint
-
+````{tip}
 Do not build log strings yourself: allow the logger to do this for you as
 required. That is:
 
@@ -78,5 +76,6 @@ Ensure that log messages are clear, meaningful, and provide enough information f
 
 ```{admonition} Best practice
 :class: hint
+
 Never log credentials or other sensitive information.
 ```

--- a/docs/howto/manage-stored-state.md
+++ b/docs/howto/manage-stored-state.md
@@ -12,7 +12,6 @@ have the same lifetime as the machine or container, and storing state in a Juju
 peer relation - for state that should have the same lifetime as the application.
 
 ```{tip}
-
 Write your charm to be stateless, where possible.
 ```
 

--- a/docs/howto/run-workloads-with-a-charm-machines.md
+++ b/docs/howto/run-workloads-with-a-charm-machines.md
@@ -78,7 +78,6 @@ Use absolute paths in subprocesses to prevent security issues.
 ```
 
 ```{tip}
-
 Execute processes directly rather than via the shell.
 ```
 

--- a/docs/howto/run-workloads-with-a-charm-machines.md
+++ b/docs/howto/run-workloads-with-a-charm-machines.md
@@ -69,19 +69,15 @@ class MachineCharm(ops.CharmBase):
 ```
 
 ```{tip}
-
 When running subprocesses, log the return (exit) code as well as `stderr` when
 errors occur.
 ```
 
-```{admonition} Best practice
-:class: hint
-
+```{tip}
 Use absolute paths in subprocesses to prevent security issues.
 ```
 
-```{admonition} Best practice
-:class: hint
+```{tip}
 
 Execute processes directly rather than via the shell.
 ```


### PR DESCRIPTION
We're using "best practice" blocks to mean "required for public listing on charmhub". That implies that they should be items that are reasonable to review & resolve at that time, rather than earlier in the charm development process. We're generally using "tip" blocks for suggestions that occur earlier.

This PR changes some "best practice" blocks to tips:

* `logger.info(f"foo {bar}")` rather than `logger.info("foo %s", bar)` (in practice this also doesn't tend to make a lot of difference in the charming case, although it is more correct)
* Absolute paths in `subprocess` calls (this is also less relevant in the charming context than in general Python code)
* Avoid running subprocesses via the shell.

[More context](https://github.com/tonyandrewmeyer/charmhub-listing-review/issues/3).