### PR TITLE
docs: add integration test for invalid config in httpbin charm

### DIFF
--- a/examples/httpbin-demo/tests/integration/test_charm.py
+++ b/examples/httpbin-demo/tests/integration/test_charm.py
@@ -37,7 +37,7 @@ def test_build_and_deploy(charm: Path, juju: jubilant.Juju):
 
 
 def test_block_on_invalid_config(charm: Path, juju: jubilant):
-    """ "Check that the charm goes into blocked status if log-level is invalid."""
+    """Check that the charm goes into blocked status if log-level is invalid."""
     juju.config(
         APP_NAME,
         {

--- a/examples/httpbin-demo/tests/integration/test_charm.py
+++ b/examples/httpbin-demo/tests/integration/test_charm.py
@@ -38,11 +38,7 @@ def test_build_and_deploy(charm: Path, juju: jubilant.Juju):
 
 def test_block_on_invalid_config(charm: Path, juju: jubilant.Juju):
     """Check that the charm goes into blocked status if log-level is invalid."""
-    juju.config(
-        APP_NAME,
-        {
-            'log-level': 'foo'  # Should be one of info, debug, and so on.
-        },
-    )
+    # The value of log-level should be one of info, debug, and so on.
+    juju.config(APP_NAME, {'log-level': 'foo'})
     juju.wait(jubilant.all_blocked)
     juju.config(APP_NAME, reset='log-level')

--- a/examples/httpbin-demo/tests/integration/test_charm.py
+++ b/examples/httpbin-demo/tests/integration/test_charm.py
@@ -45,3 +45,4 @@ def test_block_on_invalid_config(charm: Path, juju: jubilant.Juju):
         },
     )
     juju.wait(jubilant.all_blocked)
+    juju.config(APP_NAME, reset='log-level')

--- a/examples/httpbin-demo/tests/integration/test_charm.py
+++ b/examples/httpbin-demo/tests/integration/test_charm.py
@@ -34,3 +34,14 @@ def test_build_and_deploy(charm: Path, juju: jubilant.Juju):
     # Deploy the charm and wait for active/idle status
     juju.deploy(f'./{charm}', app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_active)
+
+
+def test_block_on_invalid_config(charm: Path, juju: jubilant):
+    """ "Check that the charm goes into blocked status if log-level is invalid."""
+    juju.config(
+        APP_NAME,
+        {
+            'log-level': 'foo'  # Should be info, debug, etc.
+        },
+    )
+    juju.wait(jubilant.all_blocked)

--- a/examples/httpbin-demo/tests/integration/test_charm.py
+++ b/examples/httpbin-demo/tests/integration/test_charm.py
@@ -36,7 +36,7 @@ def test_build_and_deploy(charm: Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_active)
 
 
-def test_block_on_invalid_config(charm: Path, juju: jubilant):
+def test_block_on_invalid_config(charm: Path, juju: jubilant.Juju):
     """Check that the charm goes into blocked status if log-level is invalid."""
     juju.config(
         APP_NAME,

--- a/examples/httpbin-demo/tests/integration/test_charm.py
+++ b/examples/httpbin-demo/tests/integration/test_charm.py
@@ -41,7 +41,7 @@ def test_block_on_invalid_config(charm: Path, juju: jubilant.Juju):
     juju.config(
         APP_NAME,
         {
-            'log-level': 'foo'  # Should be info, debug, etc.
+            'log-level': 'foo'  # Should be one of info, debug, and so on.
         },
     )
     juju.wait(jubilant.all_blocked)


### PR DESCRIPTION
This PR expands the integration tests of the httpbin demo charm. The charm has a config option for specifying the log level, and the charm blocks if the configured log level is invalid. I'm adding an integration test for this behaviour.