### PR TITLE
docs: make a `Layer` instead of a `LayerDict` in the httpbin charm

### DIFF
--- a/examples/httpbin-demo/src/charm.py
+++ b/examples/httpbin-demo/src/charm.py
@@ -129,6 +129,7 @@ class HttpbinDemoCharm(ops.CharmBase):
 
     def _make_pebble_layer(self, log_level: str) -> ops.pebble.Layer:
         """Return a Pebble layer that starts gunicorn with the specified log level."""
+        environment = {'GUNICORN_CMD_ARGS': f'--log-level {log_level}'}
         layer: ops.pebble.LayerDict = {  # Typing as a LayerDict hints the layer's keys.
             'services': {
                 SERVICE_NAME: {
@@ -136,7 +137,7 @@ class HttpbinDemoCharm(ops.CharmBase):
                     'summary': 'httpbin',
                     'command': 'gunicorn -b 0.0.0.0:80 httpbin:app -k gevent',
                     'startup': 'enabled',
-                    'environment': {'GUNICORN_CMD_ARGS': f'--log-level {log_level}'},
+                    'environment': environment,
                 }
             }
         }

--- a/examples/httpbin-demo/src/charm.py
+++ b/examples/httpbin-demo/src/charm.py
@@ -127,11 +127,9 @@ class HttpbinDemoCharm(ops.CharmBase):
             return
         logger.debug("Log level for gunicorn changed to '%s'", config.log_level)
 
-    def _make_pebble_layer(self, log_level: str) -> ops.pebble.LayerDict:
-        """Return a dictionary representing a Pebble layer."""
-        return {
-            'summary': 'httpbin layer',
-            'description': 'pebble config layer for httpbin',
+    def _make_pebble_layer(self, log_level: str) -> ops.pebble.Layer:
+        """Return a Pebble layer that starts gunicorn with the specified log level."""
+        layer: ops.pebble.LayerDict = {  # Typing as a LayerDict hints the layer's keys.
             'services': {
                 SERVICE_NAME: {
                     'override': 'replace',
@@ -140,8 +138,9 @@ class HttpbinDemoCharm(ops.CharmBase):
                     'startup': 'enabled',
                     'environment': {'GUNICORN_CMD_ARGS': f'--log-level {log_level}'},
                 }
-            },
+            }
         }
+        return ops.pebble.Layer(layer)
 
 
 if __name__ == '__main__':  # pragma: nocover


### PR DESCRIPTION
This PR resolves https://github.com/canonical/charmcraft/issues/1116 by changing the return type of the `_make_pebble_layer` function in the httpbin demo charm. Our preference is to pass around `Layer` objects rather than `LayerDict` objects. See the issue for detailed discussion.

Drive-by: extract the environment variables from the layer definition, into a separate variable.