### PR TITLE
chore: reenable one assert in harness tests

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2293,8 +2293,7 @@ class TestHarness:
 
         # add_relation_unit resets the relation_list, but doesn't trigger backend calls
         harness.add_relation_unit(rel_id, 'postgresql/0')
-        # This rest has started failing recently, https://github.com/canonical/operator/issues/1822
-        # assert harness._get_backend_calls(reset=False) == []
+        assert harness._get_backend_calls(reset=False) == []
         # however, update_relation_data does, because we are preparing relation-changed
         harness.update_relation_data(rel_id, 'postgresql/0', {'foo': 'bar'})
         pgql_unit = harness.model.get_unit('postgresql/0')


### PR DESCRIPTION
Fixes #1822 

I've re-tested with `-n` from `1` to `16`.
Confirming Tony's comment that the bug was fixed in #1701.