### PR TITLE
ci: remove the token for SBOM and secscan on publish

### DIFF
--- a/.github/workflows/sbom-secscan.yaml
+++ b/.github/workflows/sbom-secscan.yaml
@@ -30,7 +30,6 @@ jobs:
             with:
               repository: canonical/sbomber
               path: scanner
-              token: ${{ secrets.SBOMBER_TOKEN }}
               persist-credentials: false
           - name: Install uv
             uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3


### PR DESCRIPTION
The sbomber repository is now public, so we do not need a GitHub token to clone it in the workflow.