### PR TITLE
ci: Use a consistent format for release notes and changelog lines

### DIFF
--- a/release.py
+++ b/release.py
@@ -292,7 +292,7 @@ def format_changes(categories: dict[str, list[tuple[str, str]]], tag: str) -> st
                 match = re.match(r'https?://[^ ]+/pull/(\d+)', pr_link)
                 if match:
                     pr_num = match.group(1)
-                lines.append(f'* {description} (#{pr_num})')
+                lines.append(f'* {description} in {pr_link}')
             lines.append('')
     return '\n'.join(lines) + '\n'
 

--- a/release.py
+++ b/release.py
@@ -288,10 +288,6 @@ def format_changes(categories: dict[str, list[tuple[str, str]]], tag: str) -> st
         if items:
             lines.append(f'## {commit_type_to_category(commit_type)}\n')
             for description, pr_link in items:
-                pr_num = '?'
-                match = re.match(r'https?://[^ ]+/pull/(\d+)', pr_link)
-                if match:
-                    pr_num = match.group(1)
                 lines.append(f'* {description} in {pr_link}')
             lines.append('')
     return '\n'.join(lines) + '\n'


### PR DESCRIPTION
This PR updates the release script to use the same format for changelog lines as the release notes. This will make it easy to copy improvements and corrections to the changelog from the release PR review to the published release notes. Presumably the script could actually be simplified a bit since we're using the same format in both places, but this PR currently optimises for simplicity in the change itself.