### PR TITLE
ci: nicer logging output in the release script using rich

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ integration = [
 ]
 release = [
     "pygithub~=2.6",
+    "rich~=14.1",
 ]
 
 [project.urls]

--- a/release.py
+++ b/release.py
@@ -28,14 +28,12 @@ import sys
 import github
 import github.GitRelease
 import github.Repository
+import rich.logging
 
-formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format='%(message)s', handlers=[rich.logging.RichHandler()]
+)
 logger = logging.getLogger('release')
-logger.setLevel(logging.INFO)
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-
 
 if 'GITHUB_TOKEN' not in os.environ:
     raise SystemExit('Environment variable GITHUB_TOKEN not set.')

--- a/uv.lock
+++ b/uv.lock
@@ -1097,6 +1097,7 @@ lint = [
 ]
 release = [
     { name = "pygithub" },
+    { name = "rich" },
 ]
 unit = [
     { name = "jsonpatch" },
@@ -1144,7 +1145,10 @@ lint = [
     { name = "ruff", specifier = "==0.11.2" },
     { name = "typing-extensions", specifier = "~=4.2" },
 ]
-release = [{ name = "pygithub", specifier = "~=2.6" }]
+release = [
+    { name = "pygithub", specifier = "~=2.6" },
+    { name = "rich", specifier = "~=14.1" },
+]
 unit = [
     { name = "jsonpatch", specifier = "~=1.33" },
     { name = "ops", extras = ["testing", "tracing"], editable = "." },
@@ -1669,6 +1673,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847 },
+]
+
+[[package]]
+name = "rich"
+version = "14.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds coloured output for the logging in the `release.py` script, using `rich.logging`. This will be especially nice for the draft release, as it will more clearly separate the logging output visually from the release notes being printed. I tested this change by generating the post-release PR using this version of the script. I also tested that it runs cleanly for the draft release, bailing out with a keyboard interrupt on user input.

Before:
<img width="876" height="71" alt="image" src="https://github.com/user-attachments/assets/fa6d4cdf-100e-4557-ac72-b28155e8bbc9" />

After:
<img width="876" height="69" alt="image" src="https://github.com/user-attachments/assets/aed3426c-f51f-4fd8-9394-bb3599f7eae8" />
