### PR TITLE
docs: in httpbin charm integration tests, add env var for charm file to deploy

### DIFF
--- a/examples/httpbin-demo/tests/integration/conftest.py
+++ b/examples/httpbin-demo/tests/integration/conftest.py
@@ -34,9 +34,9 @@ def juju(request: pytest.FixtureRequest):
 def charm():
     charm_path = os.getenv("CHARM_PATH")
     if charm_path is not None:
+        if not pathlib.Path(charm_path).exists():
+            raise FileNotFoundError(f"Charm does not exist: {charm_path}")
         return pathlib.Path(charm_path)
-        # TODO: Raise an error if the charm doesn't exist?
-        #       Will juju.deploy() raise for us?
 
     subprocess.check_call(["charmcraft", "pack"])
     return next(pathlib.Path(".").glob("*.charm"))

--- a/examples/httpbin-demo/tests/integration/conftest.py
+++ b/examples/httpbin-demo/tests/integration/conftest.py
@@ -40,5 +40,6 @@ def charm():
     if not charm_paths:
         raise FileNotFoundError("No .charm file in current directory")
     if len(charm_paths) > 1:
-        raise ValueError("More than one .charm file in current directory")
+        path_list = ", ".join(str(path) for path in charm_paths)
+        raise ValueError(f"More than one .charm file in current directory: {path_list}")
     return charm_paths[0]

--- a/examples/httpbin-demo/tests/integration/conftest.py
+++ b/examples/httpbin-demo/tests/integration/conftest.py
@@ -32,5 +32,11 @@ def juju(request: pytest.FixtureRequest):
 
 @pytest.fixture(scope="session")
 def charm():
+    charm_path = os.getenv("CHARM_PATH")
+    if charm_path is not None:
+        return pathlib.Path(charm_path)
+        # TODO: Raise an error if the charm doesn't exist?
+        #       Will juju.deploy() raise for us?
+
     subprocess.check_call(["charmcraft", "pack"])
     return next(pathlib.Path(".").glob("*.charm"))

--- a/examples/httpbin-demo/tests/integration/conftest.py
+++ b/examples/httpbin-demo/tests/integration/conftest.py
@@ -14,7 +14,6 @@
 
 import os
 import pathlib
-import subprocess
 
 import jubilant
 import pytest
@@ -32,11 +31,14 @@ def juju(request: pytest.FixtureRequest):
 
 @pytest.fixture(scope="session")
 def charm():
-    charm_path = os.getenv("CHARM_PATH")
-    if charm_path is not None:
-        if not pathlib.Path(charm_path).exists():
+    if "CHARM_PATH" in os.environ:
+        charm_path = pathlib.Path(os.environ["CHARM_PATH"])
+        if not charm_path.exists():
             raise FileNotFoundError(f"Charm does not exist: {charm_path}")
-        return pathlib.Path(charm_path)
-
-    subprocess.check_call(["charmcraft", "pack"])
-    return next(pathlib.Path(".").glob("*.charm"))
+        return charm_path
+    charm_paths = list(pathlib.Path(".").glob("*.charm"))
+    if not charm_paths:
+        raise FileNotFoundError("No .charm files in current directory")
+    if len(charm_paths) > 1:
+        raise ValueError("More than one .charm file in current directory")
+    return charm_paths[0]

--- a/examples/httpbin-demo/tests/integration/conftest.py
+++ b/examples/httpbin-demo/tests/integration/conftest.py
@@ -38,7 +38,7 @@ def charm():
         return charm_path
     charm_paths = list(pathlib.Path(".").glob("*.charm"))
     if not charm_paths:
-        raise FileNotFoundError("No .charm files in current directory")
+        raise FileNotFoundError("No .charm file in current directory")
     if len(charm_paths) > 1:
         raise ValueError("More than one .charm file in current directory")
     return charm_paths[0]

--- a/examples/httpbin-demo/tests/integration/conftest.py
+++ b/examples/httpbin-demo/tests/integration/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import pathlib
 import subprocess
 
@@ -31,5 +32,5 @@ def juju(request: pytest.FixtureRequest):
 
 @pytest.fixture(scope="session")
 def charm():
-    subprocess.check_call(["charmcraft", "pack"])  # noqa
+    subprocess.check_call(["charmcraft", "pack"])
     return next(pathlib.Path(".").glob("*.charm"))

--- a/examples/httpbin-demo/tests/integration/test_charm.py
+++ b/examples/httpbin-demo/tests/integration/test_charm.py
@@ -32,7 +32,7 @@ def test_deploy(charm: Path, juju: jubilant.Juju):
     resources = {"httpbin-image": METADATA["resources"]["httpbin-image"]["upstream-source"]}
 
     # Deploy the charm and wait for active/idle status
-    juju.deploy(f"./{charm}", app=APP_NAME, resources=resources)
+    juju.deploy(charm.resolve(), app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_active)
 
 

--- a/examples/httpbin-demo/tests/integration/test_charm.py
+++ b/examples/httpbin-demo/tests/integration/test_charm.py
@@ -20,7 +20,7 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+METADATA = yaml.safe_load(Path("charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 

--- a/examples/httpbin-demo/tests/integration/test_charm.py
+++ b/examples/httpbin-demo/tests/integration/test_charm.py
@@ -13,18 +13,18 @@
 # limitations under the License.
 
 import logging
-from pathlib import Path
+import pathlib
 
 import jubilant
 import yaml
 
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(Path("charmcraft.yaml").read_text())
+METADATA = yaml.safe_load(pathlib.Path("charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
-def test_deploy(charm: Path, juju: jubilant.Juju):
+def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Build the charm-under-test and deploy it together with related charms.
 
     Assert on the unit status before any relations/configurations take place.
@@ -36,7 +36,7 @@ def test_deploy(charm: Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_active)
 
 
-def test_block_on_invalid_config(charm: Path, juju: jubilant.Juju):
+def test_block_on_invalid_config(charm: pathlib.Path, juju: jubilant.Juju):
     """Check that the charm goes into blocked status if log-level is invalid."""
     # The value of log-level should be one of info, debug, and so on.
     juju.config(APP_NAME, {"log-level": "foo"})

--- a/examples/httpbin-demo/tox.ini
+++ b/examples/httpbin-demo/tox.ini
@@ -74,8 +74,8 @@ runner = uv-venv-lock-runner
 dependency_groups =
     integration
 pass_env =
-    # The integration tests pack the charm before deploying it.
-    # To skip the packing step, set CHARM_PATH to the location of a .charm file.
+    # The integration tests don't pack the charm. If CHARM_PATH is set, the tests deploy the
+    # specified .charm file. Otherwise, the tests look for a .charm file in the project dir.
     CHARM_PATH
 commands =
     pytest \

--- a/examples/httpbin-demo/tox.ini
+++ b/examples/httpbin-demo/tox.ini
@@ -79,6 +79,8 @@ deps =
     pytest
     jubilant
     -r {tox_root}/requirements.txt
+passenv =
+    CHARM_PATH
 commands =
     pytest \
         -v \

--- a/examples/httpbin-demo/tox.ini
+++ b/examples/httpbin-demo/tox.ini
@@ -80,6 +80,8 @@ deps =
     jubilant
     -r {tox_root}/requirements.txt
 pass_env =
+    # The integration tests pack the charm before deploying it.
+    # To skip the packing step, set CHARM_PATH to the location of a .charm file.
     CHARM_PATH
 commands =
     pytest \

--- a/examples/httpbin-demo/tox.ini
+++ b/examples/httpbin-demo/tox.ini
@@ -79,7 +79,7 @@ deps =
     pytest
     jubilant
     -r {tox_root}/requirements.txt
-passenv =
+pass_env =
     CHARM_PATH
 commands =
     pytest \


### PR DESCRIPTION
This PR updates the integration tests of the httpbin charm to include an environment variable `CHARM_PATH`:

- If `CHARM_PATH` is not set, `tox -e integration` looks for a `.charm` file, deploys that charm, then runs the tests.

- If `CHARM_PATH` is set, `tox -e integration` deploys the specified charm file then runs the tests. For example:

    ```
    CHARM_PATH=mycharm.charm tox -e integration
    ```

In either case, `charmcraft pack` needs to have been run before `tox -e integration`.