### PR TITLE
docs: improve intro to ops.testing reference

### DIFF
--- a/docs/howto/manage-relations.md
+++ b/docs/howto/manage-relations.md
@@ -280,6 +280,7 @@ def _on_db_relation_broken(self, event: ops.RelationBrokenEvent):
 
 > See more: [](ops.RelationBrokenEvent)
 
+(manage-relations-test-the-feature)=
 ## Test the feature
 
 ### Write unit tests

--- a/docs/reference/ops-testing.rst
+++ b/docs/reference/ops-testing.rst
@@ -14,10 +14,14 @@ See also:
 - :doc:`/howto/write-unit-tests-for-a-charm`
 - :doc:`/explanation/testing` - A summary of types of charm tests
 
-State-transition tests, also called 'unit' tests, expect you to define the
+State-transition tests expect you to define the
 Juju state all at once, define the Juju context against which to test the charm,
 and fire a single event on the charm to execute its logic. The tests can then
 assert that the Juju state has changed as expected.
+
+Unlike integration tests, state-transition tests do not deploy your charm with a real Juju
+controller and model. Instead, your charm code is run using the 'Scenario' testing framework.
+These are the primary form of unit tests that you should write for a charm.
 
 A very simple test, where the charm has no config, no relations, the unit
 is the leader, and has a `start` handler that sets the status to active might
@@ -38,8 +42,7 @@ how the state changes in reaction to events. They are not
 necessarily tests of individual methods or functions;
 they are testing the 'contract' of the charm: given
 a certain state, when a certain event happens, the charm should transition to
-another state. Unlike integration tests, they do not test using a real Juju
-controller and model, and focus on a single Juju unit.
+another state.
 
 Writing these tests should nudge you into thinking of a charm as a black-box
 'input to output' function. The inputs are:

--- a/docs/reference/ops-testing.rst
+++ b/docs/reference/ops-testing.rst
@@ -72,10 +72,6 @@ A test consists of three broad steps:
     - verify that the output state is what you expect it to be
     - verify that the charm has seen a certain sequence of statuses, events, and `juju-log` calls
 
-.. note::
-    Unit testing is only one aspect of a comprehensive testing strategy. For more
-    on testing charms, see :doc:`/explanation/testing`.
-
 
 ..
    _The list here is manually maintained, because the `automodule` directive

--- a/docs/reference/ops-testing.rst
+++ b/docs/reference/ops-testing.rst
@@ -14,7 +14,7 @@ See also:
 - :doc:`/howto/write-unit-tests-for-a-charm`
 - :doc:`/explanation/testing` - A summary of types of charm tests
 
-State-transition tests, previously known as 'Scenario', expect you to define the
+State-transition tests, also called 'unit' tests, expect you to define the
 Juju state all at once, define the Juju context against which to test the charm,
 and fire a single event on the charm to execute its logic. The tests can then
 assert that the Juju state has changed as expected.
@@ -40,7 +40,6 @@ they are testing the 'contract' of the charm: given
 a certain state, when a certain event happens, the charm should transition to
 another state. Unlike integration tests, they do not test using a real Juju
 controller and model, and focus on a single Juju unit.
-For simplicity, we refer to them as 'unit' tests.
 
 Writing these tests should nudge you into thinking of a charm as a black-box
 'input to output' function. The inputs are:
@@ -71,6 +70,8 @@ A test consists of three broad steps:
 - **Assert**:
     - verify that the output state is what you expect it to be
     - verify that the charm has seen a certain sequence of statuses, events, and `juju-log` calls
+
+This API for unit testing was previously called 'Scenario'.
 
 
 ..

--- a/docs/reference/ops-testing.rst
+++ b/docs/reference/ops-testing.rst
@@ -7,7 +7,7 @@ Install ops with the ``testing`` extra to use this API; for example:
 ``pip install ops[testing]``
 
 To learn how to test a particular feature, such as relations, see the relevant how-to guide.
-For example :doc:`/howto/manage-relations` > Test the feature.
+For example, How to manage relations > :ref:`manage-relations-test-the-feature`.
 
 See also:
 

--- a/docs/reference/ops-testing.rst
+++ b/docs/reference/ops-testing.rst
@@ -74,7 +74,7 @@ A test consists of three broad steps:
     - verify that the output state is what you expect it to be
     - verify that the charm has seen a certain sequence of statuses, events, and `juju-log` calls
 
-This API for unit testing was previously called 'Scenario'.
+This API for testing was previously called 'Scenario'.
 
 
 ..

--- a/docs/reference/ops-testing.rst
+++ b/docs/reference/ops-testing.rst
@@ -6,6 +6,14 @@
 Install ops with the ``testing`` extra to use this API; for example:
 ``pip install ops[testing]``
 
+To learn how to test a particular feature, such as relations, see the relevant how-to guide.
+For example :doc:`/howto/manage-relations` > Test the feature.
+
+See also:
+
+- :doc:`/howto/write-unit-tests-for-a-charm`
+- :doc:`/explanation/testing` - A summary of types of charm tests
+
 State-transition tests, previously known as 'Scenario', expect you to define the
 Juju state all at once, define the Juju context against which to test the charm,
 and fire a single event on the charm to execute its logic. The tests can then


### PR DESCRIPTION
Resolves #1826. This PR makes a few small improvements to the intro of the `ops.testing` reference:

- Mention that how-to guides have info about testing each feature
- Link to the unit testing how-to guide and the testing explanation (moved from the end of the intro)
- Mention the term "unit tests" much earlier
- Move the "previously known as 'Scenario'" part to the end of the intro, as Scenario is already mentioned in the title

**[Preview doc](https://canonical-ubuntu-documentation-library--2023.com.readthedocs.build/ops/2023/reference/ops-testing/)**

---

Not implemented:

- In [#1826](https://github.com/canonical/operator/issues/1826), I mentioned possibly adding a link from [`Relation`](https://documentation.ubuntu.com/ops/latest/reference/ops-testing/#ops.testing.Relation) to the how-to guide. But why only from `Relation`? I'm adding the new info right at the beginning of the intro, so let's first see how well that works.

- I also mentioned using full URLs for links, so that the links work in docstrings. We don't actually need to do that here. The docstring of `ops.testing` comes from `ops/testing.py` not the intro of `docs/reference/ops-testing.rst` - that intro is purely for the docs.