### PR TITLE
docs: update get_cloud_spec doc now that credential-get works on K8s

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -335,8 +335,9 @@ class Model:
     def get_cloud_spec(self) -> CloudSpec:
         """Get details of the cloud in which the model is deployed.
 
-        Note: This information is only available for machine charms,
-        not Kubernetes sidecar charms.
+        Since Juju 3.6.10, this information is available on both machine
+        charms and Kubernetes charms. With earlier Juju versions, it was only
+        available on machine charms.
 
         Returns:
             a specification for the cloud in which the model is deployed,


### PR DESCRIPTION
Update the docstring for `Model.get_cloud_spec` now that the Juju fix for credential-get to work on K8s is merged (https://github.com/juju/juju/pull/20428).