### PR TITLE
docs: note that arbitrary_types_allowed is required when ops.Secret is used in a Pydantic class

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -1524,6 +1524,10 @@ class CharmBase(Object):
                 data = self.load_config(Config, errors='blocked')
                 # `data.workload_class` has the value of the Juju option `class`
 
+        Note that Pydantic classes that have fields that are not simple or
+        Pydantic types, such as :class:`ops.Secret`, require setting
+        ``arbitrary_types_allowed`` in the Pydantic model config.
+
         Any additional positional or keyword arguments to this method will be
         passed through to the config class ``__init__``.
 


### PR DESCRIPTION
Add a note in `load_config` that explains that `arbitrary_types_allowed` is required in the Pydantic model config if using types like `ops.Secret`.

Fixes #2030