### PR TITLE
docs: clean up Resources.fetch docstring, add ModelError exception

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -2419,7 +2419,7 @@ class Resources:
 
         Raises:
             NameError: if the resource name is not in the charm metadata.
-            ModelError: if the controller is unable to fetch the resource, for
+            ModelError: if the controller is unable to fetch the resource; for
                 example, if you ``juju deploy`` from a local charm file and
                 forget the appropriate ``--resource``.
         """


### PR DESCRIPTION
This adds the `ModelError` to the docstring, and adjust the docstring to use "Returns" properly.

[**Docs preview**](https://canonical-ubuntu-documentation-library--2039.com.readthedocs.build/ops/2039/reference/ops/#ops.Resources.fetch)

Fixes #2036.