### PR TITLE
chore: pass SSH_AUTH_SOCK to release script

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -202,8 +202,7 @@ description = Make a draft release
 dependency_groups = release
 passenv =
     GITHUB_TOKEN
-    # Without this, on some systems SSH connections to github.com fail.
-    SSH_AUTH_SOCK
+    SSH_AUTH_SOCK  # Without this, on some systems SSH connections to github.com fail.
 commands = python release.py {posargs}
 
 [testenv:post-release]
@@ -211,5 +210,5 @@ description = Perform post-release actions
 dependency_groups = release
 passenv =
     GITHUB_TOKEN
-    SSH_AUTH_SOCK
+    SSH_AUTH_SOCK  # Without this, on some systems SSH connections to github.com fail.
 commands = python release.py --post-release {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -199,12 +199,14 @@ commands = pytest -vvv --tb native {toxinidir}/test/integration/ {posargs}
 
 [testenv:draft-release]
 description = Make a draft release
+passenv = SSH_AUTH_SOCK  # Without this, on some systems SSH connections to github.com fail.
 dependency_groups = release
 passenv = GITHUB_TOKEN
 commands = python release.py {posargs}
 
 [testenv:post-release]
 description = Perform post-release actions
+passenv = SSH_AUTH_SOCK
 dependency_groups = release
 passenv = GITHUB_TOKEN
 commands = python release.py --post-release {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -199,14 +199,17 @@ commands = pytest -vvv --tb native {toxinidir}/test/integration/ {posargs}
 
 [testenv:draft-release]
 description = Make a draft release
-passenv = SSH_AUTH_SOCK  # Without this, on some systems SSH connections to github.com fail.
 dependency_groups = release
-passenv = GITHUB_TOKEN
+passenv =
+    GITHUB_TOKEN
+    # Without this, on some systems SSH connections to github.com fail.
+    SSH_AUTH_SOCK
 commands = python release.py {posargs}
 
 [testenv:post-release]
 description = Perform post-release actions
-passenv = SSH_AUTH_SOCK
 dependency_groups = release
-passenv = GITHUB_TOKEN
+passenv =
+    GITHUB_TOKEN
+    SSH_AUTH_SOCK
 commands = python release.py --post-release {posargs}


### PR DESCRIPTION
This PR should fix https://github.com/canonical/operator/issues/2015, which was causing the release script to fail for James.