### PR TITLE
docs: note that the peer databag isn't usable during the install event

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1736,6 +1736,9 @@ class Relation:
     """Holds the data buckets for each entity of a relation.
 
     This is accessed using, for example, ``Relation.data[unit]['foo']``.
+
+    Note that peer relation data is not readable or writable during the Juju ``install``
+    event, even though the relation exists.
     """
 
     active: bool

--- a/ops/model.py
+++ b/ops/model.py
@@ -1738,7 +1738,7 @@ class Relation:
     This is accessed using, for example, ``Relation.data[unit]['foo']``.
 
     Note that peer relation data is not readable or writable during the Juju ``install``
-    event, even though the relation exists.
+    event, even though the relation exists. :class:`ModelError` will be raised in that case.
     """
 
     active: bool


### PR DESCRIPTION
Add a note to the `Relation.data` docs that points out that peer relation data cannot be used during the `install` event.

Fixes #1452