### PR TITLE
fix: `_MockModelBackend.relation_get` will return a copy of the relation data

### DIFF
--- a/testing/src/scenario/mocking.py
+++ b/testing/src/scenario/mocking.py
@@ -253,7 +253,8 @@ class _MockModelBackend(_ModelBackend):  # type: ignore
 
     def relation_get(self, relation_id: int, member_name: str, is_app: bool):
         self._check_app_data_access(is_app)
-        return self._relation_get(relation_id, member_name=member_name, is_app=is_app).copy()
+        data = self._relation_get(relation_id, member_name=member_name, is_app=is_app)
+        return data.copy()
 
     def _relation_get(self, relation_id: int, member_name: str, is_app: bool):
         relation = self._get_relation_by_id(relation_id)

--- a/testing/src/scenario/mocking.py
+++ b/testing/src/scenario/mocking.py
@@ -253,6 +253,9 @@ class _MockModelBackend(_ModelBackend):  # type: ignore
 
     def relation_get(self, relation_id: int, member_name: str, is_app: bool):
         self._check_app_data_access(is_app)
+        return self._relation_get(relation_id, member_name=member_name, is_app=is_app).copy()
+
+    def _relation_get(self, relation_id: int, member_name: str, is_app: bool):
         relation = self._get_relation_by_id(relation_id)
         if is_app and member_name == self.app_name:
             return relation.local_app_data
@@ -405,7 +408,12 @@ class _MockModelBackend(_ModelBackend):  # type: ignore
         else:
             tgt = relation.local_unit_data
         for key, value in data.items():
-            tgt[key] = value
+            if value == '':
+                # Match the behavior of Juju, which is that setting the value to an
+                # empty string will remove the key entirely from the relation data.
+                tgt.pop(key, None)
+            else:
+                tgt[key] = value
 
     def secret_add(
         self,


### PR DESCRIPTION
Previously, `_MockModelBackend.relation_get` returned the same `dict` object associated with the `Relation` objects it managed, rather than a copy. This meant that when `ops.RelationDataContent` was instantiated, it was passed this `dict` to use as its local cached copy. This meant that our proxy for Juju's relation data store and the local cache were the same exact `dict` object in testing.

At runtime, when relation data is updated, first `relation_set` is called to update the Juju data, and then the local cached copy is updated to match. During testing, this hid a subtle bug in our mock `relation_set` logic -- entries were not deleted as expected, but this error was 'corrected' by `RelationDataContent`'s update of its local cached copy (the same `dict`) deleting the entries.

This PR updates `MockModelBackend.relation_get` to return a copy of the `dict` instead. This means that `_MockModelBackend.relation_set`'s logic is now exercised as expected (and has been corrected to handle removals as a result -- tests fail when we return a copy without making this change to the tests).

Resolves #1638.