### PR TITLE
chore: secure permission bits on the tracing database file

### DIFF
--- a/tracing/ops_tracing/_buffer.py
+++ b/tracing/ops_tracing/_buffer.py
@@ -109,7 +109,7 @@ class Buffer:
     def _set_db_schema(self) -> None:
         mode = stat.S_IRUSR | stat.S_IWUSR
         try:
-            os.close(os.open(self.path, os.O_CREAT| os.O_EXCL, mode))
+            os.close(os.open(self.path, os.O_CREAT | os.O_EXCL, mode))
         except FileExistsError:
             if stat.S_IMODE(self.path.stat().st_mode) != mode:
                 self.path.chmod(mode)

--- a/tracing/ops_tracing/_export.py
+++ b/tracing/ops_tracing/_export.py
@@ -56,7 +56,7 @@ class BufferingSpanExporter(SpanExporter):
 
     cache: dict[str | None, ssl.SSLContext]
 
-    def __init__(self, buffer_path: pathlib.Path | str):
+    def __init__(self, buffer_path: pathlib.Path):
         self.buffer = Buffer(buffer_path)
         self.lock = threading.Lock()
         self.cache = {}


### PR DESCRIPTION
This change ensures that the tracing data file has same minimal permissions as the unit state file.

fly-by: `path|str --> path` type change in the private api

not included: custom exceptions, I figured if sqlite can connect to the path, then chmod should work as well.

note that we don't care about `:memory:` paths because tracing is mocked out at a different level in `ops[testing]` and is disabled completely in legacy unit testing framework.

Fixes #1950