### PR TITLE
docs: fix testing code in actions how-to guide

### DIFF
--- a/docs/howto/manage-actions.md
+++ b/docs/howto/manage-actions.md
@@ -144,7 +144,7 @@ success checks in every test where the action is successful.
 def test_backup_action_failed():
     ctx = testing.Context(MyCharm)
 
-    with pytest.raises(ops.testing.ActionFailed) as exc_info:
+    with pytest.raises(testing.ActionFailed) as exc_info:
         ctx.run(ctx.on.action('do_backup'), State())
     assert exc_info.value.message == 'sorry, couldn't do the backup'
     # The state is also available if that's required:

--- a/docs/howto/manage-actions.md
+++ b/docs/howto/manage-actions.md
@@ -146,7 +146,7 @@ def test_backup_action_failed():
 
     with pytest.raises(testing.ActionFailed) as exc_info:
         ctx.run(ctx.on.action('do_backup'), State())
-    assert exc_info.value.message == 'sorry, couldn't do the backup'
+    assert exc_info.value.message == "sorry, couldn't do the backup"
     # The state is also available if that's required:
     assert exc_info.value.state.get_container(...)
 

--- a/docs/howto/manage-actions.md
+++ b/docs/howto/manage-actions.md
@@ -144,7 +144,7 @@ success checks in every test where the action is successful.
 def test_backup_action_failed():
     ctx = testing.Context(MyCharm)
 
-    with pytest.raises(ops.ActionFailed) as exc_info:
+    with pytest.raises(ops.testing.ActionFailed) as exc_info:
         ctx.run(ctx.on.action('do_backup'), State())
     assert exc_info.value.message == 'sorry, couldn't do the backup'
     # The state is also available if that's required:


### PR DESCRIPTION
A tiny PR to fix the testing code in "How to manage actions":
* `ops.ActionFailed` should be `ops.testing.ActionFailed`. But since the sample code already imports `testing` from `ops`, I'm switching to `testing.ActionFailed`.
* Fix the quoting of a string

Preview: https://canonical-ubuntu-documentation-library--2054.com.readthedocs.build/ops/2054/howto/manage-actions/#write-unit-tests