### PR TITLE
ci: clean up PYTHONPATH in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 [tox]
-skipsdist=True
+skipsdist = True
 skip_missing_interpreters = True
 envlist = lint, unit
 
@@ -31,10 +31,8 @@ examples_path = examples/
 [testenv]
 runner = uv-venv-lock-runner
 setenv =
-  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
   PY_COLORS=1
 passenv =
-  PYTHONPATH
   HOME
   PATH
   MODEL_SETTINGS


### PR DESCRIPTION
Per #1825, we can simplify the PYTHONPATH here. In fact, it seems like we don't need it at all, so just drop it entirely.

I've skimmed over the rest of tox.ini as well, and it doesn't look like there's anything else egregious.

Fixes #1825