### PR TITLE
chore: fix release note parsing in release script

### DIFF
--- a/release.py
+++ b/release.py
@@ -193,7 +193,7 @@ def parse_release_notes(release_notes: str) -> tuple[dict[str, list[tuple[str, s
     full_changelog_line = None
 
     for line in release_notes.splitlines():
-        if match := re.match(r'^\* (\w+): (.*) by @\w+ in (.*)', line.strip()):
+        if match := re.match(r'^\* (\w+): (.*) by [^ ]+ in (.*)', line.strip()):
             category = match.group(1)
             if category in categories:
                 description = match.group(2).strip()


### PR DESCRIPTION
I noticed that the release script missed some items when parsing the release notes generated by GitHub. The username matching was too strict. E.g., it didn't match usernames containing `-`. I've loosened the matching.