### PR TITLE
ci: add integration and state transition tests for the secrets API

### DIFF
--- a/test/charms/test_secrets/.gitignore
+++ b/test/charms/test_secrets/.gitignore
@@ -1,0 +1,3 @@
+requirements.txt
+*.tar.gz
+*.charm

--- a/test/charms/test_secrets/charmcraft.yaml
+++ b/test/charms/test_secrets/charmcraft.yaml
@@ -1,0 +1,24 @@
+---
+name: test-secrets
+type: charm
+title: Test secrets
+summary: Test secrets
+description: A charm to test the fidelity of Ops API for Juju secrets.
+
+base: ubuntu@24.04
+platforms:
+    amd64:
+
+parts:
+    test-secrets:
+        plugin: charm
+        source: .
+
+actions:
+    exec:
+        description: Execute arbitrary Python code in an event handler.
+        required: [code]
+        params:
+            code:
+                type: string
+                description: The Python code to run.

--- a/test/charms/test_secrets/src/charm.py
+++ b/test/charms/test_secrets/src/charm.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+
+import ops
+
+
+class TestSecretsCharm(ops.CharmBase):
+    _stored = ops.StoredState()
+
+    def __init__(self, framework: ops.Framework):
+        super().__init__(framework)
+        self._stored.set_default(secret_id=None)
+        framework.observe(self.on['exec'].action, self._on_exec)
+
+    def _on_exec(self, event: ops.ActionEvent):
+        """Action to execute arbitrary Python code in specific context."""
+        assert event.params['code']
+        rv = {}
+
+        rv['_before'] = self._snapshot()
+
+        exec(event.params['code'], globals(), locals())  # noqa
+
+        rv['_after'] = self._snapshot()
+
+        event.set_results({'rv': json.dumps(rv)})
+
+    def _snapshot(self):
+        secret_id = self._stored.secret_id
+        if not secret_id:
+            return None
+        secret = self.model.get_secret(id=secret_id)
+        return {
+            'info': _to_dict(secret_info=secret.get_info()),
+            'tracked': secret.get_content(),
+            'latest': secret.peek_content(),
+        }
+
+
+def _to_dict(secret_info: ops.SecretInfo):
+    return {
+        'id': secret_info.id,
+        'label': secret_info.label,
+        'revision': secret_info.revision,
+        'expires': secret_info.expires,
+        'rotation': secret_info.rotation,
+        'rotates': secret_info.rotates,
+        'description': secret_info.description,
+    }
+
+
+if __name__ == '__main__':
+    ops.main(TestSecretsCharm)

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -86,11 +86,10 @@ def tracing_juju(juju: jubilant.Juju) -> Generator[jubilant.Juju]:
 def tracing_charm_dir(pytestconfig: pytest.Config) -> Generator[pathlib.Path]:
     """Prepare and return the test_tracing charm directory.
 
-    Builds and injects `ops` and `ops-tracing` from the local checkout in to the
+    Builds and injects `ops` and `ops-tracing` from the local checkout into the
     charm's dependencies. Cleans up afterwards.
     """
-    charm_dir = pytestconfig.rootpath / 'test/charms/test_tracing'  # type: ignore
-    assert isinstance(charm_dir, pathlib.Path)
+    charm_dir = pytestconfig.rootpath / 'test/charms/test_tracing'
     yield from _prepare_generic_charm_dir(root_path=pytestconfig.rootpath, charm_dir=charm_dir)
 
 
@@ -98,11 +97,23 @@ def tracing_charm_dir(pytestconfig: pytest.Config) -> Generator[pathlib.Path]:
 def relation_charm_dir(pytestconfig: pytest.Config) -> Generator[pathlib.Path]:
     """Prepare and return the test_relation charm directory.
 
-    Builds and injects `ops` from the local checkout in to the charm's
+    Builds and injects `ops` from the local checkout into the charm's
     dependencies. Cleans up afterwards.
     """
-    charm_dir = pytestconfig.rootpath / 'test/charms/test_relation'  # type: ignore
-    assert isinstance(charm_dir, pathlib.Path)
+    charm_dir = pytestconfig.rootpath / 'test/charms/test_relation'
+    yield from _prepare_generic_charm_dir(
+        root_path=pytestconfig.rootpath, charm_dir=charm_dir, build_tracing=False
+    )
+
+
+@pytest.fixture(scope='session')
+def secrets_charm_dir(pytestconfig: pytest.Config) -> Generator[pathlib.Path]:
+    """Prepare and return the test_secrets charm directory.
+
+    Builds and injects `ops` from the local checkout into the charm's
+    dependencies. Cleans up afterwards.
+    """
+    charm_dir = pytestconfig.rootpath / 'test/charms/test_secrets'
     yield from _prepare_generic_charm_dir(
         root_path=pytestconfig.rootpath, charm_dir=charm_dir, build_tracing=False
     )
@@ -186,6 +197,16 @@ def build_relation_charm(relation_charm_dir: pathlib.Path) -> Generator[Callable
     Call the fixture value to get the built charm file path.
     """
     yield from _build_charm(relation_charm_dir, 'test-relation_amd64.charm')
+
+
+@pytest.fixture(scope='session')
+def build_secrets_charm(secrets_charm_dir: pathlib.Path) -> Generator[Callable[[], str]]:
+    """Build the test_secrets charm and provide the artefact path.
+
+    Starts building the test-relation charm early.
+    Call the fixture value to get the built charm file path.
+    """
+    yield from _build_charm(secrets_charm_dir, 'test-secrets_amd64.charm')
 
 
 def _build_charm(charm_dir: pathlib.Path, expected_artifact: str) -> Generator[Callable[[], str]]:

--- a/test/integration/test_secrets.py
+++ b/test/integration/test_secrets.py
@@ -1,0 +1,31 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Callable
+
+import jubilant
+
+
+def test_foo(build_secret_charm: Callable[[], str], juju: jubilant.Juju):
+    charm_path = build_secret_charm()
+    juju.deploy(charm_path)
+    status = juju.wait(jubilant.all_active)
+
+    unit, unit_obj = next(iter(status.apps['test-secrets'].units.items()))
+    assert unit_obj.leader
+
+    rv = juju.run(unit, 'foo', params={'a': 42})
+    assert rv.results['foo'] == 'bar'

--- a/testing/tests/test_e2e/conftest.py
+++ b/testing/tests/test_e2e/conftest.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sys
+from typing import Any, Generator
+
+import pytest
+import yaml
+
+from ops.charm import CharmBase
+from scenario import Context
+
+
+@pytest.fixture
+def secrets_context(secrets_charm: CharmBase, secrets_charm_meta: dict[str, Any]):
+    return Context(secrets_charm, meta=secrets_charm_meta, actions=secrets_charm_meta['actions'])
+
+
+@pytest.fixture
+def secrets_charm(pytestconfig: pytest.Config) -> Generator[type[CharmBase]]:
+    """A reference to the secret test charm class."""
+    # FIXME: consider which is better:
+    # a. fixture that provides the charm class, or
+    # b. fixture that provides a Context with a charm class
+    extra = str(pytestconfig.rootpath / 'test/charms/test_secrets/src')
+    sys.path.append(extra)
+    from charm import TestSecretsCharm  # type: ignore
+
+    yield TestSecretsCharm
+    sys.path.remove(extra)
+    del sys.modules['charm']
+
+
+@pytest.fixture
+def secrets_charm_meta(pytestconfig: pytest.Config) -> Generator[dict[str, Any]]:
+    """Metadata for the secret test charm."""
+    return yaml.safe_load(
+        (pytestconfig.rootpath / 'test/charms/test_secrets/charmcraft.yaml').read_text()
+    )

--- a/tracing/test/conftest.py
+++ b/tracing/test/conftest.py
@@ -96,7 +96,7 @@ def setup_tracing(juju_context: ops.JujuContext):
 
 
 @pytest.fixture
-def sample_charm() -> Generator[ops.CharmBase, None, None]:
+def sample_charm() -> Generator[type[ops.CharmBase]]:
     extra = str(pathlib.Path(__file__).parent / 'sample_charm/src')
     sys.path.append(extra)
     from charm import SampleCharm  # type: ignore


### PR DESCRIPTION
### High level idea

Run the same series of Ops API calls in unit and integration tests.

- Scaffolding
- A set of test cases
- Run each against Scenario
- Run each against Juju (several versions) with Jubilant

### This PR

- Enough scaffolding to get Scenario to work
- One sample test case
- [wip] Juju/Jubilant