### PR TITLE
chore: make integration tests slightly faster

### DIFF
--- a/test/charms/test_relation/charmcraft.yaml
+++ b/test/charms/test_relation/charmcraft.yaml
@@ -14,6 +14,8 @@ parts:
     test-relation:
         plugin: charm
         source: .
+        charm-binary-python-packages:
+            - PyYAML
 
 requires:
     db:

--- a/test/charms/test_tracing/charmcraft.yaml
+++ b/test/charms/test_tracing/charmcraft.yaml
@@ -14,10 +14,9 @@ parts:
     test-tracing:
         plugin: charm
         source: .
-        build-packages:
-            - cargo
-        charm-binary-python-packages: 
+        charm-binary-python-packages:
             - pydantic
+            - PyYAML
 
 requires:
     charm-tracing:
@@ -30,15 +29,15 @@ requires:
         optional: true
 
 actions:
-  one:
-    params:
-      arg:
-        type: string
-  two:
-    params:
-      arg:
-        type: string
-  three:
-    params:
-      arg:
-        type: string
+    one:
+        params:
+            arg:
+                type: string
+    two:
+        params:
+            arg:
+                type: string
+    three:
+        params:
+            arg:
+                type: string


### PR DESCRIPTION
PyYAML is a compiled dependency, this change makes the tests faster:

11m5s --> 8m41s
13m46s --> 8m50s

Runs:
- old: https://github.com/canonical/operator/actions/runs/18183586135/job/51763852983
- new: https://github.com/dimaqq/operator/actions/runs/18183591438/job/51763867160

Fly-by: fix yaml indentation and dangling space