### PR TITLE
ci: bump Tempo to compatible with Juju 3.6.9 in integration tests

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -218,7 +218,7 @@ def deploy_tempo(tracing_juju: jubilant.Juju):
     tracing_juju.deploy(
         'tempo-coordinator-k8s',
         app='tempo',
-        channel='edge',
+        channel='2/edge',
         trust=True,
         resources={
             'nginx-image': 'ubuntu/nginx:1.24-24.04_beta',
@@ -231,7 +231,7 @@ def deploy_tempo_worker(tracing_juju: jubilant.Juju):
     tracing_juju.deploy(
         'tempo-worker-k8s',
         app='tempo-worker',
-        channel='edge',
+        channel='2/edge',
         config={'role-all': True},
         trust=True,
         resources={'tempo-image': 'docker.io/ubuntu/tempo:2-22.04'},


### PR DESCRIPTION
Integration tests are failing for `ops[tracing]`: https://matrix.to/#/!aEDlwVgqmZMLeZIcUP:ubuntu.com/$bC7jUzDOoMXI7_H5h2A0MeSchP-F6e2TO1G13ZESn4M?via=ubuntu.com

CK8s: message='running PreBind plugin "VolumeBinding": binding volumes: provisioning failed for PVC "minio-data-e47d58a6-minio-0"'

microk8s: message='Kubernetes resources patch failed: Apply failed with 1 conflict: conflict with "juju" using apps/v1: .spec.template.spec.containers[name="charm"].resources.requests.memory',

This PR bumps Tempo from 1/edged to 2/edge, the latter actually having been updated after Juju 3.6.9 got released, which configures k8s differently and Tempo can no longer patch things willy-nilly.

