### PR TITLE
feat: log actual error traceback before raising UncaughtCharmError

### DIFF
--- a/testing/src/scenario/_runtime.py
+++ b/testing/src/scenario/_runtime.py
@@ -334,6 +334,7 @@ class Runtime:
             except (NoObserverError, ActionFailed):
                 raise  # propagate along
             except Exception as e:
+                logger.error('Logging traceback before raising UncaughtCharmError:', exc_info=True)
                 # The following is intentionally on one long line, so that the last line of pdb
                 # output shows the error message (pdb shows the "raise" line).
                 raise UncaughtCharmError(f'Uncaught {type(e).__name__} in charm, try "exceptions [n]" if using pdb on Python 3.13+. Details: {e!r}') from e  # fmt: skip


### PR DESCRIPTION
EDIT: Turns out the traceback info I was looking at logging is actually buried in the `pytest` output already, since we `raise UncaughtCharmError(...) from e`. There's not really any benefit to burying it in a second place too, so I'm closing this PR.

---

A common annoyance with the output of `scenario` test failures is that tracebacks for errors raised in charm or library code are obscured by the traceback for the `UncaughtCharmError` raised by `scenario`.

While it's currently possible to get back to the original traceback with `exceptions n` (where `n` is typically 0) when running with a debugger (e.g. with `pytest --pdb ...`) on Python 3.13+, a lot of the time these failures are encountered in CI where this option is not immediately available.

This PR improves the output available by default by adding a `logger.error(..., exc_info=True)` call before raising `UncaughtCharmError`. [exc_info=True](https://docs.python.org/3/library/logging.html#logging.Logger.debug) in an `except` block will log information about the current exception, including its traceback. This will make it possible to find the offending lines in charm and library code from the CI logs when tests fail.

<details>
<summary>Here's an example of the `logger.error` output:</summary>

```
ERROR    ops-scenario.runtime:_runtime.py:337 The charm raised an error:
Traceback (most recent call last):
  File "<REDACTED>/operator/25-10+feat+improved-scenario-logging-on-exceptions/testing/src/scenario/_runtime.py", line 327, in exec
    yield ops
  File "<REDACTED>/operator/25-10+feat+improved-scenario-logging-on-exceptions/testing/src/scenario/context.py", line 852, in _run
    yield ops
  File "<REDACTED>/operator/25-10+feat+improved-scenario-logging-on-exceptions/testing/src/scenario/context.py", line 825, in run
    ops.run()
    ~~~~~~~^^
  File "<REDACTED>/operator/25-10+feat+improved-scenario-logging-on-exceptions/ops/_main.py", line 488, in run
    self._emit()
    ~~~~~~~~~~^^
  File "<REDACTED>/operator/25-10+feat+improved-scenario-logging-on-exceptions/ops/_main.py", line 423, in _emit
    self._emit_charm_event(self.dispatcher.event_name)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<REDACTED>/operator/25-10+feat+improved-scenario-logging-on-exceptions/ops/_main.py", line 467, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "<REDACTED>/operator/25-10+feat+improved-scenario-logging-on-exceptions/ops/framework.py", line 351, in emit
    framework._emit(event)
    ~~~~~~~~~~~~~~~^^^^^^^
  File "<REDACTED>/operator/25-10+feat+improved-scenario-logging-on-exceptions/testing/src/scenario/_ops_main_mock.py", line 303, in _emit
    return super()._emit(event)
           ~~~~~~~~~~~~~^^^^^^^
  File "<REDACTED>/operator/25-10+feat+improved-scenario-logging-on-exceptions/ops/framework.py", line 924, in _emit
    self._reemit(event_path)
    ~~~~~~~~~~~~^^^^^^^^^^^^
  File "<REDACTED>/operator/25-10+feat+improved-scenario-logging-on-exceptions/testing/src/scenario/_ops_main_mock.py", line 307, in _reemit
    return super()._reemit(single_event_path)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "<REDACTED>/operator/25-10+feat+improved-scenario-logging-on-exceptions/ops/framework.py", line 1036, in _reemit
    custom_handler(event)
    ~~~~~~~~~~~~~~^^^^^^^
  File "<REDACTED>/.cache/uv/archive-v0/yEFss2tUIemyzyD69CQBl/lib/python3.13/site-packages/cosl/reconciler.py", line 143, in evt_handler
    handler()  # type: ignore
    ~~~~~~~^^
  File "<REDACTED>/.cache/uv/archive-v0/yEFss2tUIemyzyD69CQBl/lib/python3.13/site-packages/coordinated_workers/coordinator.py", line 413, in _reconcile
    self.nginx.reconcile(
    ~~~~~~~~~~~~~~~~~~~~^
        nginx_config=self._nginx_config.get_config(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
        tls_config=self.tls_config,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "<REDACTED>/.cache/uv/archive-v0/yEFss2tUIemyzyD69CQBl/lib/python3.13/site-packages/coordinated_workers/nginx.py", line 871, in reconcile
    self._reconcile_tls_config(tls_config)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "<REDACTED>/.cache/uv/archive-v0/yEFss2tUIemyzyD69CQBl/lib/python3.13/site-packages/coordinated_workers/nginx.py", line 882, in _reconcile_tls_config
    self._delete_certificates()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "<REDACTED>/.cache/uv/archive-v0/yEFss2tUIemyzyD69CQBl/lib/python3.13/site-packages/coordinated_workers/nginx.py", line 844, in _delete_certificates
    self._container.exec(["update-ca-certificates", "--fresh"]).wait()
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<REDACTED>/operator/25-10+feat+improved-scenario-logging-on-exceptions/ops/model.py", line 3318, in exec
    return self._pebble.exec(
           ~~~~~~~~~~~~~~~~~^
        command,
        ^^^^^^^^
    ...<12 lines>...
        combine_stderr=combine_stderr,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "<REDACTED>/operator/25-10+feat+improved-scenario-logging-on-exceptions/testing/src/scenario/mocking.py", line 944, in exec
    raise ExecError(
    ...<8 lines>...
    )
ops.pebble.ExecError: non-zero exit code 127 executing ['update-ca-certificates', '--fresh'], stdout='', stderr="mock for cmd ['update-ca-certificates', '--fresh'] not found. Please patch out whatever leads to the call, or pass to the Container nginx a scenario.Exec mock for the command your charm is attempting to run, such as 'Container(..., execs={scenario.Exec(['update-ca-certificates', '--fresh'], ...)})'"
```

</details>