### PR TITLE
fix: allow shorthand action declaration in ops[testing]

### DIFF
--- a/testing/src/scenario/_consistency_checker.py
+++ b/testing/src/scenario/_consistency_checker.py
@@ -338,7 +338,7 @@ def _check_action_param_types(
         'object': dict,
     }
     expected_param_type: dict[str, Any] = {}
-    for par_name, par_spec in actions[action.name].get('params', {}).items():
+    for par_name, par_spec in (actions[action.name] or {}).get('params', {}).items():
         value = par_spec.get('type')
         if not value:
             errors.append(


### PR DESCRIPTION
Fixes #2089 

Juju allows actions to be declared using a shorthand.

Source `charmcraft.yaml`:
```
...
actions:
    add-secret:
```

Charmcraft pack produces this `actions.yaml` in the charm file:

```
add-secret: null
```

Juju is happy to deploy this charm, and call the action on the deployed unit (without action arguments, obv.)

`ops[testing]` didn't like this.
This PR fixes state transition testing to treat a shorthand action as an action without parameters.