### PR TITLE
ci: add pytest.warns to note an expected warning

### DIFF
--- a/test/test_log.py
+++ b/test/test_log.py
@@ -51,7 +51,7 @@ def backend():
 @pytest.fixture()
 def logger():
     logger = logging.getLogger()
-    orig_showwarning = warnings.showwarning
+    orig_showwarning = warnings.showwarning  # Modified when setting up logging in ops.log.
     yield logger
     logging.getLogger().handlers.clear()
     sys.excepthook = sys.__excepthook__

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -87,6 +87,7 @@ def root_logging():
 class TestModel:
     @pytest.fixture
     def harness(self):
+        # Clear app ID cached when logging security events.
         _get_juju_log_and_app_id.cache_clear()
         harness = ops.testing.Harness(
             ops.CharmBase,
@@ -120,6 +121,7 @@ class TestModel:
         """,
         )
         yield harness
+        # Clear app ID cached when logging security events.
         _get_juju_log_and_app_id.cache_clear()
         harness.cleanup()
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -7137,7 +7137,7 @@ class TestChecks:
     def test_stop_checks(self, request: pytest.FixtureRequest):
         container = self._container_with_layer(request)
         # This generates a warning because there's a security event
-        # logged, but we haven't set up logging properly.
+        # logged, but we haven't set up logging for Harness in these tests.
         with pytest.warns(RuntimeWarning):
             changed = container.stop_checks('chk1', 'chk2', 'chk3')
         assert changed == ['chk1', 'chk2']

--- a/testing/src/scenario/_ops_main_mock.py
+++ b/testing/src/scenario/_ops_main_mock.py
@@ -279,6 +279,7 @@ class Ops(_Manager, Generic[CharmType]):
         for handler in logger.handlers[:]:
             if isinstance(handler, JujuLogHandler):
                 logger.removeHandler(handler)
+        # Clear app ID cached when logging security events.
         _get_juju_log_and_app_id.cache_clear()
 
 


### PR DESCRIPTION
Doing `stop_check` triggers a security event log, but in the Harness tests we haven't fully configured logging, which means that a `RuntimeWarning` is triggered. Use `pytest.warns` in the test to avoid this polluting the test output (and also to ensure that the warning does occur).

In addition, there's some extra cleanup of the logging. The most significant of these is in Scenario - when the manager finishes, it removes the JujuHandlers that were added when it was created. This seems generally cleaner (as well as avoiding the test inconsistency) and means that adding in the next test run is cleaner too.