### PR TITLE
fix: `get_deferred_events` breaks if `use_juju_for_storage=True`

### DIFF
--- a/testing/src/scenario/_ops_main_mock.py
+++ b/testing/src/scenario/_ops_main_mock.py
@@ -15,8 +15,7 @@ from typing import (
     Any,
     Generic,
     Sequence,
-    cast,
-    Union,
+    cast
 )
 
 import ops


### PR DESCRIPTION
I'm using `_ops_main_mock` in `jhack` and I found out that, if `use_juju_for_storage` is `True`, the `_db` attribute holds a variable of a different type.

This updates `_ops_main_mock` to support both types. 
I'd appreciate some pointers on: 
- how to (regression) test this
- how to fix the similar issue with `get_stored_states`, because `list_snapshots` is undefined on `JujuStorage`

This probably isn't a bug, because `_ops_main_mock` is only used when unittesting, and when unittesting we're never 'using juju for storage', that's simply not applicable. But it limits its usability by external scripts. But it's a private module so you could also say "meh". 
I can patch it on my side so it's not a blocker for me.