### PR TITLE
docs: fix and clarify holistic example of handling storage

### DIFF
--- a/docs/howto/manage-storage.md
+++ b/docs/howto/manage-storage.md
@@ -162,7 +162,7 @@ To access the storage instance in charm code, use {external+charmlibs:ref}`patho
     (charm_cache_root / "processed-data").mkdir(exist_ok=True)
 ```
 
-Alternatively, use {external+charmlibs:class}`pathops.ContainerPath` to access `web_cache_path` in the workload container. This approach is more appropriate if you need to manipulate lots of data in the workload container.
+Alternatively, use {external+charmlibs:class}`pathops.ContainerPath` to access `web_cache_path` in the workload container. This approach is more appropriate if you need to reference additional data in the workload container.
 
 ## Handle storage detaching
 


### PR DESCRIPTION
This PR significantly reworks [How to manage storage](https://documentation.ubuntu.com/ops/latest/howto/manage-storage/). The current doc has several problems:

- It's not clear that `_update_configuration` is supposed to be an example of a holistic handler.

- The code incorrectly tries to access `self.model.storages["cache"]` as an object (it's a list).

- The doc mixes up machine and Kubernetes charms, which require different approaches because of (1) multiple vs singular storage and (2) how & whether to configure the workload with storage instance paths.

- The doc shows how to specify a location in a storage definition and explains the default location that Juju determines. This can mislead charmers into thinking that locations are predictable and could be hard-coded, when actually it's a better practice to transparently accept the locations that Juju determines.

Since this PR is substantial enough already, I've tried to leave the parts about detaching and tests largely unchanged.

**[Preview of updated doc](https://canonical-ubuntu-documentation-library--2098.com.readthedocs.build/ops/2098/howto/manage-storage/)**

See related discussion in https://github.com/canonical/operator/pull/2083