### PR TITLE
ci: temporarily disable tracing integration tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -15,7 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         preset: ['k8s', 'microk8s']
-        test: ['test_direct_connection', 'test_with_tls', 'test_relation_units']
+        test:
+          # https://github.com/canonical/observability-stack/issues/110
+          # - test_direct_connection
+          # - test_with_tls
+          - test_relation_units
 
     steps:
       - run: |


### PR DESCRIPTION
Current status is that:
- we can't force specific version of Juju (like 3.6.8), only select a track (which yields 3.6.9)
- Tempo 1/ track is broken on Juju 3.6.9
- Tempo 2/ track is only available as 2/edge

Ref: https://github.com/canonical/observability-stack/issues/110

This PR disables the tracing integration tests until a fix is released on 1/ channel of Tempo.

Discussion: https://matrix.to/#/!nHXpRkcSNJHlHdUGbQ:ubuntu.com/$Nhj8XxLNQXENt7I72FdB2IiVhUtRGGL6UQ0qNttRsOk?via=ubuntu.com&via=matrix.org&via=laquadrature.net