### PR TITLE
ci: test both Charmcraft 3 and Charmcraft 4 profiles

### DIFF
--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -75,6 +75,7 @@ jobs:
 
       - name: Update 'ops' and 'ops-scenario' dependencies in test charm to latest
         run: |
+          set -xueo pipefail
           if [ -e "test-requirements.txt" ]; then
             sed -i -e "/^ops[ ><=]/d" -e "/canonical\/operator/d" -e "/#egg=ops/d" test-requirements.txt
             echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#egg=ops" >> test-requirements.txt
@@ -118,6 +119,7 @@ jobs:
         id: has-static
         if: ${{ !cancelled() && steps.deps.outcome == 'success' }}
         run: |
+          set -xueo pipefail
           if tox list --no-desc | grep '^static$'; then
             echo 'static=true' >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
Add support for Charmcraft 4 in preparation for it becoming "latest/stable".

* The "simple" profile is not present in Charmcraft 3, so we shouldn't try to run tests against it.
* The "static" tox environment has been combined with the "lint" environment in the Charmcraft 4 profiles.

It seems like for a while it's worth testing both Charmcraft 3 and Charmcraft 4, so rather than replacing 3, add 4 into a matrix.

[Example run in my fork](https://github.com/tonyandrewmeyer/operator/actions/runs/18576943297/job/52964083743).