### PR TITLE
feat(testing): don't inject UncaughtCharmError exception

### DIFF
--- a/testing/src/scenario/_runtime.py
+++ b/testing/src/scenario/_runtime.py
@@ -331,13 +331,6 @@ class Runtime:
                     if e.exit_code != 0:
                         raise
 
-            except (NoObserverError, ActionFailed):
-                raise  # propagate along
-            except Exception as e:
-                # The following is intentionally on one long line, so that the last line of pdb
-                # output shows the error message (pdb shows the "raise" line).
-                raise UncaughtCharmError(f'Uncaught {type(e).__name__} in charm, try "exceptions [n]" if using pdb on Python 3.13+. Details: {e!r}') from e  # fmt: skip
-
             finally:
                 if ops:
                     ops.destroy()


### PR DESCRIPTION
this exception provides no additional value, instead it just creates a intermediate exception referencing the original one.

to simplify debug output, just propagate all exceptions - so we have a single backtrace instead of two.

why is this useful? when running test with `pytest --pdb` you can directly inspect the real problem, instead of being dropped to the point where `raise UncaughtCharmError()` is called.