### PR TITLE
docs: rename hook tools to hook commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -583,7 +583,7 @@ The minimum version of Python for Ops 3.x is 3.10.
 
 ## Features
 
-* Added `Model.get_cloud_spec` which uses the `credential-get` hook tool to get details of the cloud where the model is deployed (#1152)
+* Added `Model.get_cloud_spec` which uses the `credential-get` hook command to get details of the cloud where the model is deployed (#1152)
 
 ## Fixes
 

--- a/docs/explanation/state-transition-testing.md
+++ b/docs/explanation/state-transition-testing.md
@@ -62,7 +62,7 @@ Comparing these tests with `Harness` tests:
   time. This ensures that the execution environment is as clean as possible
   (for a unit test).
 - Harness maintains a model of the Juju Model, which is a maintenance burden and
-  adds complexity. These tests mock at the level of hook tools and store all
+  adds complexity. These tests mock at the level of hook commands and store all
   mocking data in a monolithic data structure (the `State`), which makes it more
   lightweight and portable.
 

--- a/docs/explanation/tracing.md
+++ b/docs/explanation/tracing.md
@@ -49,7 +49,7 @@ For the `receive-ca-cert` relation, the supported `certificate_transfer` interfa
 **Ops** contains its own instrumentation, as well as unit and integration tests for it:
 
 - Ops creates the root span and a separate span when calling each observer, which provide context for your instrumentation and can be used to scope trace data assertions in your unit tests.
-- Ops creates spans for every Juju hook tool invocation and every Pebble operation, so you typically don't have to.
+- Ops creates spans for every Juju hook command invocation and every Pebble operation, so you typically don't have to.
 - The [ops.tracing.Tracing](ops_tracing.Tracing) first-party charm library validates its arguments during object construction, and would trip on misconfiguration in a unit or integration test.
 - Buffering and export logic is already tested as part of Ops, and charms need not write integration
 tests to cover these.

--- a/docs/howto/trace-your-charm.md
+++ b/docs/howto/trace-your-charm.md
@@ -52,7 +52,7 @@ At this point, Ops will trace:
 - The `ops.main()` call
 - Observer invocations for the Juju event
 - Observer invocations for custom and life-cycle events
-- Ops calls that inspect and update Juju (also called "hook tools")
+- Ops calls that inspect and update Juju (also called "hook commands")
 - Pebble API access
 
 This provides coarse-grained tracing, focused on the boundaries between the

--- a/ops/_main.py
+++ b/ops/_main.py
@@ -254,7 +254,7 @@ class _Manager:
 
     Running _Manager consists of three main steps:
     - setup: initialise the following from JUJU_* environment variables:
-      - the Framework (hook tool wrappers)
+      - the Framework (hook command wrappers)
       - the storage backend
       - the event that Juju is emitting on us
       - the charm instance (user-facing)
@@ -414,7 +414,7 @@ class _Manager:
         #       EventBase.defer().
         #
         # Skip reemission of deferred events for collect-metrics events because
-        # they do not have the full access to all hook tools.
+        # they do not have the full access to all hook commands.
         if not self.dispatcher.is_restricted_context():
             # Re-emit any deferred events from the previous run.
             self.framework.reemit()

--- a/ops/hookcmds/_action.py
+++ b/ops/hookcmds/_action.py
@@ -145,7 +145,7 @@ def action_set(results: Mapping[str, Any]):
     Args:
         results: The results map of the action, provided to the Juju user.
     """
-    # The Juju action-set hook tool cannot interpret nested dicts, so we use a
+    # The Juju action-set hook command cannot interpret nested dicts, so we use a
     # helper to flatten out any nested dict structures into a dotted notation.
     flat_results = format_result_dict(results)
     run('action-set', *[f'{k}={v}' for k, v in flat_results.items()])

--- a/ops/jujuversion.py
+++ b/ops/jujuversion.py
@@ -133,7 +133,7 @@ class JujuVersion:
         """Report whether this Juju version supports the "secrets" feature."""
         # Juju version 3.0.0 had an initial version of secrets, but:
         # * In 3.0.2, secret-get "--update" was renamed to "--refresh", and
-        #   secret-get-info was separated into its own hook tool
+        #   secret-get-info was separated into its own hook command
         # * In 3.0.3, a bug with observer labels was fixed (juju/juju#14916)
         return (self.major, self.minor, self.patch) >= (3, 0, 3)
 

--- a/ops/model.py
+++ b/ops/model.py
@@ -1822,7 +1822,7 @@ class Relation:
 
         Raises:
             ModelError: if on a version of Juju that doesn't support the
-                "relation-model-get" hook tool.
+                "relation-model-get" hook command.
         """
         if self._remote_model is None:
             d = self._backend.relation_model_get(self.id)
@@ -2492,7 +2492,7 @@ class StorageMapping(Mapping[str, List['Storage']]):
     def request(self, storage_name: str, count: int = 1):
         """Requests new storage instances of a given name.
 
-        Uses storage-add tool to request additional storage. Juju will notify the unit
+        Uses storage-add hook command to request additional storage. Juju will notify the unit
         via ``<storage-name>-storage-attached`` events when it becomes available.
 
         Raises:
@@ -3524,7 +3524,7 @@ def _format_action_result_dict(
     """Turn a nested dictionary into a flattened dictionary, using '.' as a key separator.
 
     This is used to allow nested dictionaries to be translated into the dotted format required by
-    the Juju `action-set` hook tool in order to set nested data on an action.
+    the Juju `action-set` hook command in order to set nested data on an action.
 
     Additionally, this method performs some validation on keys to ensure they only use permitted
     characters.
@@ -3631,7 +3631,7 @@ class _ModelBackend:
         input_stream: str | None = None,
     ) -> str | Any | None:
         if self._is_recursive.get():
-            # Either `juju-log` hook tool failed or there's a bug in ops.
+            # Either `juju-log` hook command failed or there's a bug in ops.
             return
         # Logs are collected via log integration, omit the subprocess calls that push
         # the same content to juju from telemetry.
@@ -3657,7 +3657,7 @@ class _ModelBackend:
                 args += ('--format=json',)
             if span:
                 span.set_attribute('call', 'subprocess.run')
-                # Some hook tool command line arguments may include sensitive data.
+                # The command-line arguments for some hook commands may include sensitive data.
                 truncate = args[0] in ['action-set']
                 span.set_attribute('argv', [args[0], '...'] if truncate else args)
             # TODO(benhoyt): all the "type: ignore"s below kinda suck, but I've
@@ -3948,7 +3948,7 @@ class _ModelBackend:
         return typing.cast('dict[str, Any]', out)
 
     def action_set(self, results: dict[str, Any]) -> None:
-        # The Juju action-set hook tool cannot interpret nested dicts, so we use a helper to
+        # The Juju action-set hook command cannot interpret nested dicts, so we use a helper to
         # flatten out any nested dict structures into a dotted notation, and validate keys.
         flat_results = _format_action_result_dict(results)
         self._run('action-set', *[f'{k}={v}' for k, v in flat_results.items()])
@@ -4032,9 +4032,9 @@ class _ModelBackend:
         of being started, but will not include units that are being shut down.
 
         """
-        # The goal-state tool will return the information that we need. Goal state as a general
-        # concept is being deprecated, however, in favor of approaches such as the one that we use
-        # here.
+        # The goal-state hook command will return the information that we need. Goal state as a
+        # general concept is being deprecated, however, in favor of approaches such as the one
+        # that we use here.
         app_state = self._run('goal-state', return_output=True, use_json=True)
         app_state = typing.cast('dict[str, dict[str, Any]]', app_state)
 
@@ -4234,7 +4234,7 @@ class _ModelBackend:
             self._run('juju-reboot')
 
     def credential_get(self) -> CloudSpec:
-        """Access cloud credentials by running the credential-get hook tool.
+        """Access cloud credentials by running the credential-get hook command.
 
         Returns the cloud specification used by the model.
         """

--- a/test/charms/test_secrets/src/charm.py
+++ b/test/charms/test_secrets/src/charm.py
@@ -82,7 +82,7 @@ class SecretsCharm(ops.CharmBase):
 
     def _snapshot(self, secret_id: str) -> SecretSnapshot:
         secret = self.model.get_secret(id=secret_id)
-        # The `expires` and `rotates` fields are coerced to strings by hook tool invocation.
+        # The `expires` and `rotates` fields are coerced to strings by hook command invocation.
         info = cast('InfoSnapshot', secret.get_info().__dict__) if self.unit.is_leader() else None
         return {
             'info': info,

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1230,7 +1230,7 @@ class TestModel:
         remote_model = rel.remote_model
         assert remote_model.uuid == 'UUID'
 
-        # Multiple accesses to remote_model are cached (shouldn't call hook tool again).
+        # Multiple accesses to remote_model are cached (shouldn't call the hook command again).
         remote_model = rel.remote_model
         assert remote_model.uuid == 'UUID'
 
@@ -2844,7 +2844,9 @@ class TestModelBackend:
         backend._leader_check_time = None
         assert model.unit.is_leader()
 
-    def test_relation_tool_errors(self, fake_script: FakeScript, monkeypatch: pytest.MonkeyPatch):
+    def test_relation_hook_command_errors(
+        self, fake_script: FakeScript, monkeypatch: pytest.MonkeyPatch
+    ):
         monkeypatch.setenv('JUJU_VERSION', '2.8.0')
         backend = _ModelBackend('myapp/0')
         err_msg = 'ERROR invalid value "$2" for option -r: relation not found'
@@ -3094,7 +3096,7 @@ class TestModelBackend:
                     message=message,  # type: ignore[assignment]
                 )
 
-    def test_storage_tool_errors(self, fake_script: FakeScript, backend: _ModelBackend):
+    def test_storage_hook_command_errors(self, fake_script: FakeScript, backend: _ModelBackend):
         fake_script.write('storage-list', 'echo fooerror >&2 ; exit 1')
         with pytest.raises(ops.ModelError):
             backend.storage_list('foobar')

--- a/testing/src/scenario/context.py
+++ b/testing/src/scenario/context.py
@@ -765,8 +765,8 @@ class Context(Generic[CharmType]):
 
         :arg event: the event that the charm will respond to. Use the :attr:`on` attribute to
             specify the event; for example: ``ctx.on.start()``.
-        :arg state: the :class:`State` instance to use as data source for the hook tool calls that
-            the charm will invoke when handling the event.
+        :arg state: the :class:`State` instance to use as data source for the hook command
+            calls that the charm will invoke when handling the event.
         """
         # Help people transition from Scenario 6:
         if isinstance(event, str):

--- a/testing/src/scenario/errors.py
+++ b/testing/src/scenario/errors.py
@@ -43,7 +43,7 @@ class MetadataNotFoundError(RuntimeError):
 
 
 class ActionMissingFromContextError(Exception):
-    """Raised when the user attempts to invoke action hook tools outside an action context."""
+    """Raised when the user attempts to invoke action hook commands outside an action context."""
 
     # This is not an ops error: in ops, you'd have to go exceptionally out of
     # your way to trigger this flow.

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -465,7 +465,7 @@ class BindAddress(_max_posargs(1)):
         _deepcopy_mutable_fields(self)
 
     def _hook_tool_output_fmt(self):
-        """Dumps itself to dict in the same format the hook tool would."""
+        """Dumps itself to dict in the same format the hook command would."""
         dct = {
             'interface-name': self.interface_name,
             'addresses': [dataclasses.asdict(addr) for addr in self.addresses],
@@ -518,7 +518,7 @@ class Network(_max_posargs(2)):
         _deepcopy_mutable_fields(self)
 
     def _hook_tool_output_fmt(self):
-        # dumps itself to dict in the same format the hook tool would
+        # dumps itself to dict in the same format the hook command would
         return {
             'bind-addresses': [ba._hook_tool_output_fmt() for ba in self.bind_addresses],
             'egress-subnets': self.egress_subnets,


### PR DESCRIPTION
The Juju nomenclature has changed.
Hook tools are hook commands now.

Fixes #2113 