### PR TITLE
fix: normalise Secret.owner to 'app' for ops[testing] output state

### DIFF
--- a/testing/src/scenario/mocking.py
+++ b/testing/src/scenario/mocking.py
@@ -424,7 +424,7 @@ class _MockModelBackend(_ModelBackend):  # type: ignore
         description: str | None = None,
         expire: datetime.datetime | None = None,
         rotate: SecretRotate | None = None,
-        owner: Literal['unit', 'app'] | None = None,
+        owner: Literal['unit', 'application'] | None = None,
     ) -> str:
         from .state import Secret
 
@@ -434,7 +434,8 @@ class _MockModelBackend(_ModelBackend):  # type: ignore
             description=description,
             expire=expire,
             rotate=rotate,
-            owner=owner,
+            # It's called 'application' in Ops, but 'app' in Scenario.
+            owner='app' if owner == 'application' else owner,
         )
         secrets = set(self._state.secrets)
         secrets.add(secret)

--- a/testing/tests/test_e2e/test_secrets.py
+++ b/testing/tests/test_e2e/test_secrets.py
@@ -663,7 +663,7 @@ def test_add_secret_with_metadata(secrets_context: Context[SecretsCharm], fields
 
 def common_assertions(scenario_secret: Secret | None, result: Result):
     if scenario_secret:
-        assert scenario_secret.owner == 'application'
+        assert scenario_secret.owner == 'app'
         assert not scenario_secret.remote_grants
 
         assert result.get('after')


### PR DESCRIPTION
`ops.Model.add_secret()` currently sets `owner='application'`, while Scenario’s declared type for `Secret.owner` is `Literal['unit', 'app', None]`, causing an inconsistency in test (resulting state) output.

This PR implements option 1a: translate 'application' → 'app' in the Scenario backend when constructing the output state, with no public API changes and no changes to the model or hookcmd call path.

- keeps Ops (runtime path) as-is
- preserves Juju-like semantics in hookcmds
- aligns Scenario with its documented 'app' literal

The API stays the same, and most or majority of unit tests don't get broken.
Output state secret owner string could be validated in tests, but so far I didn't find a test like this across GitHub or the charms that we track the source code for.