### PR TITLE
fix: detect categories with an explanation mark indicating breaking changes

### DIFF
--- a/release.py
+++ b/release.py
@@ -205,7 +205,10 @@ def parse_release_notes(release_notes: str) -> tuple[dict[str, list[tuple[str, s
                 description = description[0].upper() + description[1:]
                 pr_link = match.group('pr').strip()
                 if match.group('breaking') == '!':
-                    categories['breaking'].append((f'{category}: {description}', pr_link))
+                    categories['breaking'].append((
+                        f'{category.capitalize()}: {description}',
+                        pr_link,
+                    ))
                 else:
                     categories[category].append((description, pr_link))
 


### PR DESCRIPTION
Currently, the release script fails to recognise lines with the `!` breaking change indicator in the category, meaning they are not included in the change log or release notes (and yet, are probably the most important to include).

The PR:
* Changes the regular expression to use named groups for better readability.
* Changes the regular expression to capture the `!` if present.
* Puts any breaking changes into a separate category (keeping the main category in the description).
* In the changelog, puts the changes into a "Breaking Changes" group.
* In the release notes, adds a top-level section that calls out that there are breaking changes, and lists them, and notifies the user about this, because it's likely that some hand-crafted text will be required to cover these.

Also, to handle the upcoming release, adds support for alpha, beta, and release candidate numbers in the version (in a fairly minimal way - the tag, the title, and generally not crashing).

Fixes #2111