### PR TITLE
chore: bump versions after release

### DIFF
--- a/ops/version.py
+++ b/ops/version.py
@@ -19,4 +19,4 @@ This module is NOT to be used when developing charms using ops.
 
 from __future__ import annotations
 
-version: str = '3.4.0b1'
+version: str = '3.4.0.dev0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,10 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 testing = [
-    "ops-scenario==8.4.0b1",
+    "ops-scenario==8.4.0.dev0",
 ]
 tracing = [
-    "ops-tracing==3.4.0b1",
+    "ops-tracing==3.4.0.dev0",
 ]
 # Empty for now, because Harness is bundled with the base install, but allow
 # specifying the extra to ease transition later.

--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ops-scenario"
 
-version = "8.4.0b1"
+version = "8.4.0.dev0"
 
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
@@ -21,7 +21,7 @@ license = "Apache-2.0"
 keywords = ["juju", "test"]
 
 dependencies = [
-    "ops==3.4.0b1",
+    "ops==3.4.0.dev0",
     "PyYAML>=6.0.1",
 ]
 readme = "README.md"

--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ops-tracing"
-version = "3.4.0b1"
+version = "3.4.0.dev0"
 description = "The tracing facility for the Ops library."
 requires-python = ">=3.10"
 readme = "README.md"
@@ -31,7 +31,7 @@ classifiers = [
 dependencies = [
     "opentelemetry-api~=1.0",
     "opentelemetry-sdk~=1.30",
-    "ops==3.4.0b1",
+    "ops==3.4.0.dev0",
     "pydantic",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -744,7 +744,7 @@ xdist = [{ name = "pytest-xdist", specifier = "~=3.6" }]
 
 [[package]]
 name = "ops-scenario"
-version = "8.4.0b1"
+version = "8.4.0.dev0"
 source = { editable = "testing" }
 dependencies = [
     { name = "ops" },
@@ -759,7 +759,7 @@ requires-dist = [
 
 [[package]]
 name = "ops-tracing"
-version = "3.4.0b1"
+version = "3.4.0.dev0"
 source = { editable = "tracing" }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION
The release script can't yet handle moving on from a beta release, so I've done this by hand.