### PR TITLE
docs: remove mention of the `simple` Charmcraft profile

### DIFF
--- a/docs/howto/write-and-structure-charm-code.md
+++ b/docs/howto/write-and-structure-charm-code.md
@@ -21,7 +21,7 @@ In your new repository, run `charmcraft init` to generate the recommended
 structure for building a charm.
 
 ```{note}
-In most cases, you'll want to use `--profile=machine` or `profile=kubernetes`.
+In most cases, you'll want to use `--profile=machine` or `--profile=kubernetes`.
 If you are charming an application built with a popular framework, check if
 charmcraft has a {external+charmcraft:ref}`specific profile <tutorial>` for it.
 ```


### PR DESCRIPTION
Resolves #1803. The `simple` profile won't exist in Charmcraft 4. Since Charmcraft 4 has almost released (it's available on latest/candidate), I figure we're safe to remove the sentence in Ops that warns against using the `simple` profile.

**[Preview doc](https://canonical-ubuntu-documentation-library--2138.com.readthedocs.build/ops/2138/howto/write-and-structure-charm-code/)**