### PR TITLE
ci: test if package versions match dependency versions before publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,17 +24,10 @@ jobs:
         with:
           enable-cache: false
       - run: uv build --all
-      - name: Create constraints file for test
-        shell: python
+      - name: Test if built package versions and dependency versions match
         run: |
-          import itertools, pathlib, tomllib
-          toml = tomllib.loads(pathlib.Path('pyproject.toml').read_text())
-          extras = toml['project']['optional-dependencies']
-          constraints = '\n'.join(itertools.chain(extras['testing'], extras['tracing']))
-          print(constraints)
-          pathlib.Path('constraints.txt').write_text(constraints)
-      - name: Test if package versions match dependency versions
-        run: uvx --with dist/ops-*.whl --with dist/ops_scenario-*.whl --with dist/ops_tracing-*.whl --constraints constraints.txt python -c 'print("OK")'
+          set -xueo pipefail
+          uvx --with "$(echo -n dist/ops-*.whl)[testing,tracing]" --with dist/ops_scenario-*.whl --with dist/ops_tracing-*.whl python -c 'import ops, scenario, ops_tracing; print("OK")'
       - uses: actions/attest-build-provenance@v3
         with:
           subject-path: 'dist/*'


### PR DESCRIPTION
This PR adds steps to the `build-n-publish` job of the `publish` workflow to validate that the versions of the packages are compatible with each others dependencies (on each other), including the extras specified by `ops`.

The new steps run after building and before attesting and publishing.
1. ~Use `python` to extract the extras to a `constraints.txt` file.~
2. Use `uvx` to install the three built packages together, respecting the `constraints.txt` file.

Fixes: #1875

## Testing

I've tested the steps locally, by running `uv build --all`, and then running the code from the two steps sequentially. The steps all pass.

I repeated the testing steps twice more:
1. Changed the `ops` version to `1`. The `uvx` step fails with:
```
  × No solution found when resolving tool dependencies:
  ╰─▶ Because there is no version of ops==3.4.0.dev0 and ops-scenario==8.4.0.dev0 depends on ops==3.4.0.dev0, we can conclude that ops-scenario==8.4.0.dev0 cannot be used.
      And because you require ops-scenario==8.4.0.dev0, we can conclude that your requirements are unsatisfiable.
```
2. Reverted (1) and changed the version in `testing/pyproject.toml` to `0.0`. The `uvx` step fails with:
```
  × No solution found when resolving tool dependencies:
  ╰─▶ Because there is no version of ops-scenario==8.4.0.dev0 and you require ops-scenario==8.4.0.dev0, we can conclude that your requirements are unsatisfiable.
```