### PR TITLE
test: Re-enable scenario consistency checks after disabling them

### DIFF
--- a/testing/tests/test_e2e/test_rubbish_events.py
+++ b/testing/tests/test_e2e/test_rubbish_events.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 import pytest
 from ops.charm import CharmBase, CharmEvents
 from ops.framework import EventBase, EventSource, Framework, Object
@@ -45,18 +43,18 @@ def mycharm():
     return MyCharm
 
 
-@pytest.mark.parametrize('evt_name', ('rubbish', 'foo', 'bar', 'kazoo_pebble_ready'))
-def test_rubbish_event_raises(mycharm, evt_name):
+@pytest.mark.parametrize('evt_name', ('rubbish', 'foo', 'bar'))
+def test_rubbish_event_raises(mycharm: CharmBase, evt_name: str):
     with pytest.raises(AttributeError):
-        if evt_name.startswith('kazoo'):
-            os.environ['SCENARIO_SKIP_CONSISTENCY_CHECKS'] = 'true'
-            # else it will whine about the container not being in state and meta;
-            # but if we put the container in meta, it will actually register an event!
-        try:
-            trigger(State(), evt_name, mycharm, meta={'name': 'foo'})
-        finally:
-            if evt_name.startswith('kazoo'):
-                del os.environ['SCENARIO_SKIP_CONSISTENCY_CHECKS']
+        trigger(State(), evt_name, mycharm, meta={'name': 'foo'})
+
+
+def test_rubbish_pebble_ready_event_raises(mycharm: CharmBase, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('SCENARIO_SKIP_CONSISTENCY_CHECKS', '1')
+    # else it will whine about the container not being in state and meta;
+    # but if we put the container in meta, it will actually register an event!
+    with pytest.raises(AttributeError):
+        trigger(State(), 'kazoo_pebble_ready', mycharm, meta={'name': 'foo'})
 
 
 @pytest.mark.parametrize('evt_name', ('qux',))


### PR DESCRIPTION
This PR corrects one of the `testing` tests to correctly re-enable consistency checks after turning them off. They default to on, and we run our own tests with them on.

Before this PR, they would be turned off, as we check `if os.getenv(...)`, which will be `True` when the variable is set to the string `'false'`.