### PR TITLE
docs: remove Charmcraft channel specifier from machine charm tutorial

### DIFF
--- a/docs/tutorial/write-your-first-machine-charm.md
+++ b/docs/tutorial/write-your-first-machine-charm.md
@@ -83,7 +83,7 @@ In your virtual machine, run:
 
 ```text
 sudo snap install --classic concierge
-sudo concierge prepare -p machine --extra-snaps astral-uv --charmcraft-channel latest/candidate
+sudo concierge prepare -p machine --extra-snaps astral-uv
 ```
 
 This first installs Concierge, then uses Concierge to install and configure the other tools (except tox). The option `-p machine` tells Concierge that we want tools for developing machine charms.


### PR DESCRIPTION
**Don't merge until Charmcraft 4 is available on latest/stable**
See https://snapcraft.io/charmcraft

The [updated machine charm tutorial](https://documentation.ubuntu.com/ops/latest/tutorial/write-your-first-machine-charm/) requires Charmcraft 4. When we published the tutorial, Charmcraft 4 was available on latest/candidate but not latest/stable. This PR switches the tutorial to use Charmcraft from latest/stable.