### PR TITLE
feat: Model.get_secret(..., validate=...) keyword argument; don't cache content on the Secret object

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -3848,30 +3848,6 @@ class TestSecretClass:
         assert secret.id is None
         assert secret.label == 'y'
 
-    def test_get_content_cached(self, model: ops.Model, fake_script: FakeScript):
-        fake_script.write('secret-get', """exit 1""")
-        return
-        # FIXME
-
-        secret = self.make_secret(model, id='x', label='y')
-        content = secret.get_content()  # will use cached content, not run secret-get
-        assert content == {'foo': 'bar'}
-
-        assert fake_script.calls(clear=True) == []
-
-    def test_get_content_refresh(self, model: ops.Model, fake_script: FakeScript):
-        fake_script.write('secret-get', """echo '{"foo": "refreshed"}'""")
-
-        return
-        # FIXME
-        secret = self.make_secret(model, id='y')
-        content = secret.get_content(refresh=True)
-        assert content == {'foo': 'refreshed'}
-
-        assert fake_script.calls(clear=True) == [
-            ['secret-get', '--format=json', f'secret://{model._backend.model_uuid}/y', '--refresh']
-        ]
-
     def test_get_content_uncached(self, model: ops.Model, fake_script: FakeScript):
         fake_script.write('secret-get', """echo '{"foo": "notcached"}'""")
 


### PR DESCRIPTION
User-facing API changes:

`Model.get_secret()` gains a new keyword argument, `validate: bool`, which is `True` by default.

With the default setting, `data = Model.get_secret(...).get_content()` makes invocations of the hook command and therefore two calls to the Juju secret backend.

Performance-sensitive applications should use `validate=False`, in which case, `Model.get_secret()` doesn't raise exceptions in simple cases, and only `Secret.get_content()` does.

Note that if both `id` and `label` parameters are supplied, the hook command is always invoked in order to set the secret consumer label.