### PR TITLE
docs: change HACKING.md instructions for maintaining Charmcraft profiles

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -370,7 +370,7 @@ The Charmcraft `kubernetes` and `machine` profiles specify a minimum Ops version
 
     If you don't have [just](https://just.systems/man/en/) installed, use `uvx --from rust-just just` instead.
 
-4. Lock the dependencies the charms and generate `uv.lock.j2` files:
+4. Lock the dependencies of the charms and generate `uv.lock.j2` files:
 
     ```text
     just lock


### PR DESCRIPTION
This PR changes "Updating the Ops versions in the Charmcraft profiles" in HACKING.md to use [charmcraft-profile-tools](https://github.com/canonical/charmcraft-profile-tools) for initialising charms and generating lockfile templates.

_Why not keep the manual process too? Doesn't charmcraft-profile-tools make the steps less transparent?_ It does - but the manual process wasn't quite right any more. The lockfiles for the K8s and machine profiles aren't exactly the same, because the K8s profile has PyYAML as an integration dependency. So we can't say "repeat the full process for the machine profile" any more. Having tooling is more practical now.