### PR TITLE
feat: log the total number of deferred events

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -973,7 +973,7 @@ class Framework(Object):
         last_event_path = None
         deferred = True
         notices = tuple(self._storage.notices(single_event_path))
-        for event_path, observer_path, method_name in notices:
+        for i, (event_path, observer_path, method_name) in enumerate(notices):
             event_handle = Handle.from_path(event_path)
 
             if last_event_path != event_path:
@@ -995,7 +995,10 @@ class Framework(Object):
             if observer:
                 if single_event_path is None:
                     logger.debug(
-                        'Re-emitting deferred event %s (%d in queue).', event, len(notices)
+                        'Re-emitting deferred event %s (%d of %d in queue).',
+                        event,
+                        i + 1,
+                        len(notices),
                     )
                 elif isinstance(event, LifecycleEvent):
                     # Ignore Lifecycle events: they are "private" and not interesting.


### PR DESCRIPTION
When logging that a deferred notice is being processed, also log the total number in the queue (as of the start of the hook). This allows anyone examining the debug-level Juju log to see that there is a large backlog, presumably indicating problems (see #2101 for an example).

There is a small cost here, in that we are collapsing a generator into a tuple, although we expect it to be small, and we're already getting it as a list from the storage.

Fixes #2101