### PR TITLE
docs: add a short umask note

### DIFF
--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -76,7 +76,7 @@ Otherwise, Ops doesn't introduce any new security risks. Ops does expand the imp
 * Use {external+juju:ref}`Juju secrets <secret>` for storing and sharing sensitive data.
 * Juju users that integrate a charm with a tracing receiver should also integrate with a certificate authority provider, to ensure all traces are sent via HTTPS.
 * Charms should follow best practices for writing secure Python code.
-* Charms should manage Unix permissions, including [`umask(2)`](https://manpages.ubuntu.com/manpages/noble/man2/umask.2.html) to respect the [principle of least authority](https://en.wikipedia.org/wiki/Principle_of_least_privilege).
+* Machine charms are responsible for setting appropriate ownership and permissions on the files and directories they create, for example using {py:func}`os.umask`.
 * Charms should have workflows that statically check for security issues (such as [ruff](https://docs.astral.sh/ruff/linter/) and [zizmor](https://docs.zizmor.sh/)).
 * Charm authors should exercise caution when considering adding dependencies to their charms.
 * Write the exact dependencies of the charm into a lock file (using `uv lock`, `poetry lock`, or similar tool) and commit that lock file to source control.


### PR DESCRIPTION
Charm authors are responsible for their umask(2) setting. https://github.com/canonical/operator/issues/2181