### PR TITLE
ci: test against 4.0/stable

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -47,11 +47,6 @@ jobs:
       fail-fast: false
       matrix:
         juju-channel:
-          - 3.1/stable
-          - 3.2/stable
-          - 3.3/stable
-          - 3.4/stable
-          - 3.5/stable
           - 3.6/stable
           - 4.0/stable
 


### PR DESCRIPTION
Since Juju 4.0-rc1 got promoted to stable on 14th Nov, let's test against stable rather than beta.

```
  4.0/stable:    4.0.0          2025-11-14 (33191) 106MB -
  4.0/candidate: ↑
  4.0/beta:      4.0-beta7      2025-10-07 (32795) 102MB -
  4.0/edge:      4.0.1-9922dc8  2025-11-19 (33266) 106MB -
```