### PR TITLE
ci: use Juju channel 4/stable in Ops smoke tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -50,7 +50,7 @@ jobs:
           - 3.6/stable
           - 4.0/stable
 
-    continue-on-error: ${{ matrix.juju-channel == '4.0/beta' }}
+    continue-on-error: ${{ matrix.juju-channel == '4.0/stable' }}
 
     steps:
       - run: |

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        juju-channel: ['2.9/stable', '3/stable', '4/beta']
+        juju-channel: ['2.9/stable', '3/stable', '4/stable']
         preset: ['machine', 'microk8s']
-    continue-on-error: ${{ matrix.juju-channel == '4/beta' && matrix.preset == 'microk8s' }}
+    continue-on-error: ${{ matrix.juju-channel == '4/stable' && matrix.preset == 'microk8s' }}
 
     steps:
       - run: sudo snap install --classic concierge


### PR DESCRIPTION
I've noticed that smoke tests failed in my fork of Ops.
This PR updates CI to use `4/stable` Juju channel.
And a fly-by where #2186 was incomplete.