### PR TITLE
ci: store charmcraft logs if smoke tests fail

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -37,3 +37,10 @@ jobs:
       - name: Run smoke tests
         run: tox -e smoke
         timeout-minutes: 20  # Juju 4 gets stuck while destroying the test model
+
+      - name: Archive charmcraft logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: charmcraft-logs
+          path: /home/runner/.local/state/charmcraft/log/*.log


### PR DESCRIPTION
Sometimes the smoke test fails not in the interaction between the charm and Juju, but before that when the charm is being packed. The charmcraft output is almost always useless in this case, with the actual failure buried in the charmcraft log file.

This PR updates the smoke workflow to upload the charmcraft log files if the smoke tests fails, so that it's easier to investigate in such situations.