### PR TITLE
ci: ignore PERF401 (manual list comprehension) across the repo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,8 @@ ignore = [
     # Missing docstring in `__init__`
     "D107",
 
+    # Manual list comprehension.
+    "PERF401",
     # Manual dict comprehension.
     "PERF403",
 


### PR DESCRIPTION
Disables [PERF401](https://docs.astral.sh/ruff/rules/manual-list-comprehension/), which suggests using a list comprehension rather than for loops. We still want to do this in many cases, but would prefer to decided on a case-by-case basis, rather than have it enforced as a rule.

Examples of where this is suggested (all for using `list.extend` and all in testing, but that's what we currently have as exceptions):

```
testing/src/scenario/_consistency_checker.py:556:17: PERF401 Use `list.extend` to create a transformed list
    |
554 |           for relation in _get_relations(endpoint):
555 |               if not isinstance(relation, PeerRelation):
556 | /                 errors.append(
557 | |                     f'endpoint {endpoint} is a peer relation; '
558 | |                     f'expecting relation to be of type PeerRelation, got {type(relation)}',
559 | |                 )
    | |_________________^ PERF401
560 |
561 |       known_endpoints = [a[0] for a in all_relations_meta]
    |
    = help: Replace for loop with list.extend

testing/src/scenario/_consistency_checker.py:564:13: PERF401 Use `list.extend` to create a transformed list
    |
562 |     for relation in state.relations:
563 |         if (ep := relation.endpoint) not in known_endpoints:
564 |             errors.append(f'relation endpoint {ep} is not declared in metadata.')
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PERF401
565 |
566 |     seen_ids: set[int] = set()
    |
    = help: Replace for loop with list.extend

testing/src/scenario/_consistency_checker.py:714:21: PERF401 Use `list.extend` to create a transformed list
    |
712 |               for attr in ('level', 'startup', 'threshold'):
713 |                   if getattr(check, attr) != getattr(plan_check, attr):
714 | /                     errors.append(
715 | |                         f'container {container.name!r} has a check {check.name!r} with a '
716 | |                         f'different {attr!r} ({getattr(check, attr)}) '
717 | |                         f'than the plan ({getattr(plan_check, attr)}).',
718 | |                     )
    | |_____________________^ PERF401
719 |
720 |       return Results(errors, [])
    |
    = help: Replace for loop with list.extend
```