### PR TITLE
chore: update the link to the Juju release notes

### DIFF
--- a/docs/howto/write-and-structure-charm-code.md
+++ b/docs/howto/write-and-structure-charm-code.md
@@ -63,7 +63,7 @@ my-charm-set-operators/
 Charms run using the Python version provided by the base Ubuntu version. Write
 charm code that will run with the Python version of the oldest base you support.
 
-> See also: {external+juju:ref}`Juju | Roadmap and releases <juju-roadmap-and-releases>`
+> See also: {external+juju:ref}`Juju | Roadmap and releases <releasenotes>`
 
 ```{admonition} Best practice
 :class: hint


### PR DESCRIPTION
The release notes were previously under `Reference | Juju`, and are now top level, and the inter-sphinx link has changed as a result.

[Preview link](https://canonical-ubuntu-documentation-library--2208.com.readthedocs.build/ops/2208/howto/write-and-structure-charm-code/#use-the-python-provided-by-the-base)