### PR TITLE
ci: have cycle in the sbomber manifests use the default value

### DIFF
--- a/.sbomber-manifest-sdist.yaml
+++ b/.sbomber-manifest-sdist.yaml
@@ -15,7 +15,6 @@ artifacts:
         name: 'ops'
         version: ''
         channel: 'stable'
-        cycle: '26.04'
 
   - name: 'ops-scenario'
     type: 'sdist'
@@ -24,7 +23,6 @@ artifacts:
         name: 'ops-scenario'
         version: ''
         channel: 'stable'
-        cycle: '26.04'
 
   - name: 'ops-tracing'
     type: 'sdist'
@@ -34,4 +32,3 @@ artifacts:
         name: 'ops-tracing'
         version: ''
         channel: 'stable'
-        cycle: '26.04'

--- a/.sbomber-manifest-wheel.yaml
+++ b/.sbomber-manifest-wheel.yaml
@@ -14,7 +14,6 @@ artifacts:
         name: 'ops'
         version: ''
         channel: 'stable'
-        cycle: '26.04'
 
   - name: 'ops-scenario'
     type: 'wheel'
@@ -22,7 +21,6 @@ artifacts:
         name: 'ops-scenario'
         version: ''
         channel: 'stable'
-        cycle: '26.04'
 
   - name: 'ops-tracing'
     type: 'wheel'
@@ -30,4 +28,3 @@ artifacts:
         name: 'ops-tracing'
         version: ''
         channel: 'stable'
-        cycle: '26.04'


### PR DESCRIPTION
This information is passed to the secscan tool ("identification parameters" in the docs) to place the results in a long-term storage location. Removing the explicit value now means "use the next Ubuntu release", which is what we would be setting it to anyway.