### PR TITLE
docs: update CI examples to use uv and tox-uv

### DIFF
--- a/docs/explanation/testing.md
+++ b/docs/explanation/testing.md
@@ -145,8 +145,6 @@ on:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v6
       - name: Set up uv
         uses: astral-sh/setup-uv@7
       - name: Set up tox and tox-uv

--- a/docs/howto/write-and-structure-charm-code.md
+++ b/docs/howto/write-and-structure-charm-code.md
@@ -409,8 +409,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v6
       - name: Set up uv
         uses: astral-sh/setup-uv@7
       - name: Set up tox and tox-uv
@@ -428,8 +426,6 @@ Other `tox` environments can be run similarly; for example unit tests:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v6
       - name: Set up uv
         uses: astral-sh/setup-uv@7
       - name: Set up tox and tox-uv
@@ -456,8 +452,6 @@ a cloud in which to deploy it, is required. This example uses a `concierge` in o
         run: sudo concierge prepare -p k8s
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v6
       - name: Set up uv
         uses: astral-sh/setup-uv@7
       - name: Set up tox and tox-uv


### PR DESCRIPTION
This PR updates how tox is installed in the GitHub CI examples in our docs. The latest machine and Kubernetes Charmcraft profiles expect uv, tox, and tox-uv, so I figure it's good for our docs to show that too.

Unlike in our own CI, I've not pinned the uv action to a specific commit. Should we mention something about this in the docs?