### PR TITLE
docs: match Charmcraft profiles in tox.ini example for integration testing

### DIFF
--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -99,6 +99,17 @@ commands =
         {posargs}
 ```
 
+Also check that `pyproject.toml` has an `integration` dependency group. Again, if you initialised the charm with `charmcraft init` it should already be there. For example:
+
+```toml
+[dependency-groups]
+...
+integration = [
+    "jubilant",
+    "pytest",
+]
+```
+
 ## Create a test file
 
 By convention, integration tests are kept in the charm’s source tree, in a directory called `tests/integration`.


### PR DESCRIPTION
This PR updates [How to write integration tests for a charm](https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/#prepare-the-tox-ini-configuration-file) to match how integration testing is set up in `tox.ini` (and `pyproject.toml`) in the latest machine and Kubernetes profiles.

**[Preview doc](https://canonical-ubuntu-documentation-library--2221.com.readthedocs.build/ops/2221/howto/write-integration-tests-for-a-charm/#prepare-the-tox-ini-configuration-file)**