### PR TITLE
docs: use base 24.04 for httpbin-demo charm

### DIFF
--- a/examples/httpbin-demo/charmcraft.yaml
+++ b/examples/httpbin-demo/charmcraft.yaml
@@ -1,5 +1,8 @@
 type: charm
 base: ubuntu@24.04
+platforms:
+  amd64:
+  arm64:
 
 name: httpbin-demo
 title: |


### PR DESCRIPTION
This PR bumps the base of the [httpbin-demo](https://github.com/canonical/operator/tree/main/examples/httpbin-demo) charm from 22.04 to 24.04. (I'm classifying this as docs, as I consider our example charms loosely part of the docs)

I've opened https://github.com/canonical/charmcraft/pull/2522 to make the same change in the `kubernetes` and `machine` profiles. So I'll leave bumping our other example charms to 24.04 until that has been released.