### PR TITLE
docs: clarify parts of the machine charm tutorial

### DIFF
--- a/docs/tutorial/write-your-first-machine-charm.md
+++ b/docs/tutorial/write-your-first-machine-charm.md
@@ -342,10 +342,10 @@ In `src/charm.py`, replace the `_on_install` method of the charm class with:
 
 When your charm receives the "install" event from Juju, Ops runs this method and tells Juju the version of tinyproxy that's installed on the machine. Juju shows the version in its status output.
 
-As you write your charm, keep in mind that the charm code only runs when there's an event to handle. Behind the scenes, Juju runs `charm.py` with event data in the environment. Ops reads the event data, instantiates the charm class, then runs the appropriate method.
+As you write your charm, keep in mind that the charm code only runs when there's an event to handle.
 
 ```{important}
-The charm class will be newly instantiated on every event. In general, when you write a charm, you can't persist data between events by storing the data in the charm class.
+Juju executes `charm.py` on every event, with event data in the environment. Your call to `ops.main` creates a fresh instance of the charm class, then Ops runs the appropriate method on the charm class. You can't persist data between Juju events by storing it in memory.
 ```
 
 ### Define a configuration option


### PR DESCRIPTION
Based on feedback we received about the new [machine charm tutorial](https://documentation.ubuntu.com/ops/latest/tutorial/write-your-first-machine-charm/), I'm making a few clarifications:

- Add a link for context about what a charm is
- Emphasise that the code is on GitHub, and mention this in a couple more places
- Emphasise that the charm class is newly instantiated on every event, and what that means for storing data in the charm class. I'm less sure this addition is needed - happy to revise

**[Preview doc](https://canonical-ubuntu-documentation-library--2223.com.readthedocs.build/ops/2223/tutorial/write-your-first-machine-charm/)**