### PR TITLE
chore: update the list of published charms

### DIFF
--- a/.github/update-published-charms-tests-workflow.py
+++ b/.github/update-published-charms-tests-workflow.py
@@ -67,6 +67,8 @@ SKIP = {
     'charm-sysconfig',
     # A bundle, not a charm.
     'cos-lite-bundle',
+    # Source is not public.
+    'charm-weebl',
 }
 CHARM_ROOTS = {
     'argo-operators': ['charms/argo-controller'],

--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -32,8 +32,6 @@ jobs:
             charm-root: .
           - charm-repo: canonical/charm-ubuntu
             charm-root: .
-          - charm-repo: canonical/charm-weebl
-            charm-root: .
           - charm-repo: canonical/conserver-charm
             charm-root: .
           - charm-repo: canonical/content-cache-k8s-operator


### PR DESCRIPTION
Update after running the update script, adjusting the monorepo additions.

[Run in my fork](https://github.com/tonyandrewmeyer/operator/actions/runs/20121233031).

There are an increasing number of failures due to Python 3.8 / Ops 2.x requirements, but it's better that we have the known failing list rather than wait to add the extra ones.