### PR TITLE
docs: use cosl binary in K8s tutorial charm to work around error

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -211,19 +211,21 @@ Now, in your `src` directory, create a subdirectory called `grafana_dashboards` 
 
 ```
 
-## Specify packages required to build
+## Specify binary packages required to build
 
-When packing a charm, charmcraft uses source distributions for the dependencies. When a charm has a dependency that includes a binary package charmcraft will build the package, but may require additional packages to be installed.
+When packing a charm, Charmcraft builds the charm's dependencies from source.
 
-The `cos-lite` packages include a dependency that has Rust code, and the default charmcraft build environment does not have a Rust compiler, so you need to instruct charmcraft to install one for the build. In your `charmcraft.yaml` file, add a new `parts` section:
+Charmcraft currently encounters an error when building the `cos-lite` packages from source. As a workaround, add a new `parts` section in your `charmcraft.yaml` file:
 
 ```yaml
+# Workaround for a build error.
 parts:
   charm:
-    build-packages:
-      # Required for the cos-lite packages, which have a Rust dependency.
-      - cargo
+    charm-binary-python-packages:
+      - cosl
 ```
+
+You wouldn't usually need to use this workaround in a charm. We're planning to update this tutorial to modernise the charm and remove the workaround.
 
 ## Validate your charm
 

--- a/examples/k8s-5-observe/charmcraft.yaml
+++ b/examples/k8s-5-observe/charmcraft.yaml
@@ -19,11 +19,11 @@ assumes:
   - juju >= 3.1
   - k8s-api
 
+# Workaround for a build error.
 parts:
   charm:
-    build-packages:
-      # Required for the cos-lite packages, which have a Rust dependency.
-      - cargo
+    charm-binary-python-packages:
+      - cosl
 
 config:
   options:


### PR DESCRIPTION
This PR temporarily fixes #2229. As a more permanent fix, we should switch the K8s tutorial to use the latest uv-based Charmcraft profiles. We're planning to do that later in the 26.04 cycle.