### PR TITLE
ci: add scheduled workflow for packing and integration testing example charms

### DIFF
--- a/.github/workflows/example-charm-integration-tests.yaml
+++ b/.github/workflows/example-charm-integration-tests.yaml
@@ -3,7 +3,7 @@ name: Example Charm Integration Tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '50 15 * * *'  # 15:50 UTC daily
+    - cron: '50 15 * * 2'  # 15:50 UTC Tuesdays
 
 permissions: {}
 


### PR DESCRIPTION
As James suggested in #2229, this PR adds a scheduled workflow that packs and runs integration tests for our example charms. I've scheduled it to run each ~Tuesday~ Wednesday before NZ hours.

(We already have a workflow that lints and runs unit tests for the example charms. That workflow is fast and runs on PRs.)

I've organised the example charms into three jobs:
- The machine tutorial charm, based on a Charmcraft 4 profile.
- The httpbin-demo K8s charm, based on a Charmcraft 4 profile.
- The K8s tutorial charms, not based on a Charmcraft 4 profile. We're planning to refactor these later in the 26.04 cycle.

I tested the jobs by temporarily enabling them for this PR. All are passing after #2232 merged.