### PR TITLE
ci: add ops-tracing as a dependency for the observability tests

### DIFF
--- a/.github/workflows/observability-charm-tests.yaml
+++ b/.github/workflows/observability-charm-tests.yaml
@@ -47,6 +47,7 @@ jobs:
             sed -i 's/requires-python = "~=3.8"/requires-python = "~=3.10"/g' pyproject.toml
             sed -i 's/pythonVersion = "3\.[89]"/pythonVersion = "3.10"/g' pyproject.toml
             uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#subdirectory=testing --optional dev --raw-sources --prerelease=if-necessary-or-explicit
+            uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA#subdirectory=tracing --raw-sources --prerelease=if-necessary-or-explicit
             uv add git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA --raw-sources --prerelease=if-necessary-or-explicit
           else
             echo "Error: no uv.lock file found"


### PR DESCRIPTION
The workflow removes `ops` as a dependency (so that it can add it back from main@HEAD), which also removes `ops[tracing]`. However, `grafana-k8s` now relies on that dependency, so that breaks the tests.

This PR always adds `ops-tracing` as a dependency. `alertmanager-k8s` and `prometheus-k8s` don't currently need that, but they have other dependencies (like pedantic) that mean that packaging the charm should still work.

We need a cleaner system than this, but I think #1843 may end up solving this, and this will mean that the tests on main can pass again, so it seems a reasonable workaround.

[Run in my fork](https://github.com/tonyandrewmeyer/operator/actions/runs/20250813274) - note that the failure is because of a different problem, and the grafana-k8s tests passing is the important piece.