### PR TITLE
test: update new scenario test to fix linting error

### DIFF
--- a/testing/tests/test_context.py
+++ b/testing/tests/test_context.py
@@ -187,4 +187,4 @@ def test_run_env_cleared():
 def test_charm_spec_is_deprecated():
     ctx = Context(CharmBase, meta={'name': 'some-name'})
     with pytest.warns(DeprecationWarning):
-        ctx.charm_spec  # type: ignore  # noqa: B018
+        _ = ctx.charm_spec  # type: ignore


### PR DESCRIPTION
This PR adds a `noqa` directive to the test newly added in #2219, which is needed due to the linting updates in #2228.