### PR TITLE
docs: provide examples in unit testing how-to, and other small improvements

### DIFF
--- a/docs/howto/write-unit-tests-for-a-charm.md
+++ b/docs/howto/write-unit-tests-for-a-charm.md
@@ -204,5 +204,5 @@ Machine charms:
 
 Kubernetes charms:
 
-- Our [k8s-3-postgresql](https://github.com/canonical/operator/tree/main/examples/k8s-3-postgresql/tests/unit) example charm, from the [](#integrate-your-charm-with-postgresql) chapter in our Kubernetes charm tutorial
+- Our [k8s-3-postgresql](https://github.com/canonical/operator/tree/main/examples/k8s-3-postgresql/tests/unit) example charm, from the [](#integrate-your-charm-with-postgresql) chapter in our Kubernetes charm tutorial (the charms from other chapters also have unit tests)
 - Our [httpbin-demo](https://github.com/canonical/operator/tree/main/examples/httpbin-demo/tests/unit) example charm


### PR DESCRIPTION
Fixes #2147. The main changes in this PR are:

- Added an Examples section with links to unit tests for machine and Kubernetes charms.
- Added a "Run your tests" section that mentions `tox -e unit`, making the unit testing how-to consistent with the [integration testing how-to](http://localhost:8080/_build/howto/write-integration-tests-for-a-charm/).

**[Preview doc](https://canonical-ubuntu-documentation-library--2251.com.readthedocs.build/ops/2251/howto/write-unit-tests-for-a-charm/)**