### PR TITLE
docs: fix charm name in httpbin deploy command

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,5 +22,5 @@ This directory contains charms that you can pack and deploy locally, to help lea
 
     ```
     charmcraft pack
-    juju deploy ./httpbin-demo_ubuntu-22.04-amd64.charm --resource httpbin-image=kennethreitz/httpbin
+    juju deploy ./httpbin-demo_amd64.charm --resource httpbin-image=kennethreitz/httpbin
     ```


### PR DESCRIPTION
Our httpbin demo charm packs to a file called `httpbin-demo_amd64.charm` not `httpbin-demo_ubuntu-22.04-amd64.charm` (depending on the architecture). That's because the charm's `charmcraft.yaml` has

```yaml
base: ubuntu@24.04
platforms:
  amd64:
  arm64:
```

instead of

```yaml
bases:
  - build-on:
    - name: ubuntu
      channel: "22.04"
    run-on:
    - name: ubuntu
      channel: "22.04"
```

[Related discussion](https://github.com/canonical/operator/pull/2259#discussion_r2688923293)