### PR TITLE
docs: update chapter 2 to replace config in charmcraft.yaml

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -24,11 +24,11 @@ This can be done by defining a charm configuration in a file called `charmcraft.
 
 In this part of the tutorial you will update your charm to make it possible for a charm user to change the port on which the workload application is available.
 
-## Define the configuration options
+## Define the configuration option
 
-To begin with, let's define the options that will be available for configuration.
+To begin with, let's define the option that will be available for configuration.
 
-In the `charmcraft.yaml` file you created earlier, define a configuration option, as below. The name of your configurable option is going to be `server-port`.  The `default` value is `8000` -- this is the value you're trying to allow a charm user to configure.
+In `charmcraft.yaml`, replace the `config` block with:
 
 ```yaml
 config:
@@ -38,6 +38,8 @@ config:
       description: Default port on which FastAPI is available
       type: int
 ```
+
+This defines a configuration option called `server-port`. The `default` value is `8000` -- this is the value you're trying to allow a charm user to configure.
 
 ## Define a configuration class
 


### PR DESCRIPTION
This is an **intermediate PR** for switching the [Kubernetes charm tutorial](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/) to use uv and the latest Charmcraft profiles. Target branch is `k8s-tutorial-uv`

---

This PR modifies "Make your charm configurable" to replace the `config` block in `charmcraft.yaml` instead of adding the block.

The latest Charmcraft profile already has a placeholder `config` block. In `k8s-1-minimal`:

```yaml
# (Optional) Configuration options for the charm
# This config section defines charm config options, and populates the Configure
# tab on Charmhub.
# More information on this section at:
# https://documentation.ubuntu.com/charmcraft/stable/reference/files/charmcraft-yaml-file/#config
# General configuration documentation:
# https://documentation.ubuntu.com/juju/3.6/reference/configuration/#application-configuration
config:
  options:
    # An example config option to customise the log level of the workload
    log-level:
      description: |
        Configures the log level of gunicorn.

        Acceptable values are: "info", "debug", "warning", "error" and "critical"
      default: "info"
      type: string
```

After replacing the `config` block, per the updated doc, the block in `k8s-2-configurable` is:

```yaml
config:
  options:
    server-port:
      default: 8000
      description: Default port on which FastAPI is available
      type: int
```

**[Preview of updated doc](https://canonical-ubuntu-documentation-library--2279.com.readthedocs.build/ops/2279/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable/#define-the-configuration-option)**

This PR only touches the doc. I've already updated `k8s-2-configurable` to match the charm structure in `k8s-1-minimal`.