### PR TITLE
ci: remove outdated custom signature generation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -510,7 +510,6 @@ nitpick_ignore = [
     ('py:class', 'scenario.state.CharmType'),
     ('py:class', 'scenario.state._EntityStatus'),
     ('py:class', 'scenario.state._Event'),
-    ('py:class', 'scenario.state._max_posargs.<locals>._MaxPositionalArgs'),
 ]
 
 # Pull in fix from https://github.com/sphinx-doc/sphinx/pull/11222/files to fix


### PR DESCRIPTION
In Ops 2.x, the Scenario state classes had a custom `__new__` that provided keyword-only argument support for the data classes, since we had to support Python 3.8, which didn't have them.

Sphinx wasn't able to figure out the signature to display using our custom code, so we also had a custom Sphinx processor to do that.

When we removed the custom `__new__` system, we missed removing the customisation in the docs. This PR does that.

[Preview](https://canonical-ubuntu-documentation-library--2280.com.readthedocs.build/ops/2280/reference/ops-testing/) (should look unchanged from main).