### PR TITLE
docs: add missing "How to" in page titles

### DIFF
--- a/docs/howto/make-your-charm-discoverable.md
+++ b/docs/howto/make-your-charm-discoverable.md
@@ -1,5 +1,5 @@
 (make-your-charm-discoverable)=
-# Make your charm discoverable
+# How to make your charm discoverable
 
 > See first: [Charm maturity](#charm-maturity)
 

--- a/docs/howto/manage-configuration.md
+++ b/docs/howto/manage-configuration.md
@@ -1,5 +1,5 @@
 (manage-configuration)=
-# Manage configuration
+# How to manage configuration
 > See first: {external+juju:ref}`Juju | <application-configuration>`, {external+juju:ref}`Juju | Manage applications > Configure <configure-an-application>`, {external+charmcraft:ref}`Charmcraft | Manage the app configuration <manage-the-app-configuration>`
 
 

--- a/docs/howto/manage-leadership-changes.md
+++ b/docs/howto/manage-leadership-changes.md
@@ -1,5 +1,5 @@
 (manage-leadership-changes)=
-# Manage leadership changes
+# How to manage leadership changes
 > See first: {external+juju:ref}`Juju | Leader unit <leader-unit>`
 
 ## Implement response to leadership changes

--- a/docs/howto/manage-libraries.md
+++ b/docs/howto/manage-libraries.md
@@ -1,5 +1,5 @@
 (manage-libraries)=
-# Manage libraries
+# How to manage libraries
 
 > See first: {external+charmcraft:ref}`Charmcraft | Manage libraries <manage-libraries>`
 


### PR DESCRIPTION
A tiny PR to add "How to" in the titles of a few how-to guides.