### PR TITLE
fix: credential-get is available on k8s in newer Juju

### DIFF
--- a/testing/src/scenario/_consistency_checker.py
+++ b/testing/src/scenario/_consistency_checker.py
@@ -724,16 +724,18 @@ def check_cloudspec_consistency(
     state: State,
     event: _Event,
     charm_spec: _CharmSpec[CharmType],
+    juju_version: tuple[int, ...],
     **_kwargs: Any,
 ) -> Results:
-    """Check that Kubernetes models don't have :attr:`scenario.State.cloud_spec` set."""
+    """Check the consistency of :attr:`scenario.State.cloud_spec` with the model type."""
     errors: list[str] = []
     warnings: list[str] = []
 
-    if state.model.type == 'kubernetes' and state.model.cloud_spec:
+    if state.model.type == 'kubernetes' and state.model.cloud_spec and juju_version < (3, 6, 10):
         errors.append(
-            'CloudSpec is only available for machine charms, not Kubernetes charms. '
-            "Simulate a machine substrate with: `State(..., model=Model(type='lxd'))`.",
+            'CloudSpec is not available for Kubernetes charms with Juju < 3.6.10. '
+            'Set the juju_version to 3.6.10+ or '
+            "simulate a machine substrate with: `State(..., model=Model(type='lxd'))`.",
         )
 
     return Results(errors, warnings)

--- a/testing/tests/test_consistency_checker.py
+++ b/testing/tests/test_consistency_checker.py
@@ -750,6 +750,7 @@ def test_cloudspec_consistency():
         ),
     )
 
+    # CloudSpec on k8s is inconsistent with Juju < 3.6.10.
     assert_inconsistent(
         State(model=Model(name='k8s-model', type='kubernetes', cloud_spec=cloud_spec)),
         _Event('start'),
@@ -757,6 +758,18 @@ def test_cloudspec_consistency():
             MyCharm,
             meta={'name': 'MyK8sCharm'},
         ),
+        juju_version='3.6.9',
+    )
+
+    # CloudSpec on k8s is consistent with Juju >= 3.6.10.
+    assert_consistent(
+        State(model=Model(name='k8s-model', type='kubernetes', cloud_spec=cloud_spec)),
+        _Event('start'),
+        _CharmSpec(
+            MyCharm,
+            meta={'name': 'MyK8sCharm'},
+        ),
+        juju_version='3.6.10',
     )
 
 


### PR DESCRIPTION
The Juju `credential-get` hook command is available for K8s models as of Juju 3.6.10, so adjust Scenario's consistency checker to match.

Fixes #2304