### PR TITLE
chore: drop unused setuptools_scm build dependency

### DIFF
--- a/testing/pyproject.toml
+++ b/testing/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools >= 35.0.2",
-    "setuptools_scm >= 2.0.0, <3"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
This PR drops Scenario's build dependency on [setuptools_scm](https://pypi.org/project/setuptools-scm/), which we presumably don't need, as it's for versioning a package based on git tags. This appears to resolve the current build issue, example identified by David [here](https://github.com/canonical/operator/actions/runs/21809969678/job/62920050703#step:5:22). The build issue can be reproduced locally on `main` with `uv build --all`. I've verified that the build succeeds with `setuptools_scm` removed. The root cause of why builds started failing isn't clear though.