### PR TITLE
chore: include ops.hookcmds in Ops setuptools package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ ops-scenario = { workspace = true }
 ops-tracing = { workspace = true }
 
 [tool.setuptools.packages.find]
-include = ["ops", "ops._private", "ops.lib"]
+include = ["ops", "ops._private", "ops.hookcmds", "ops.lib"]
 
 [tool.setuptools.dynamic]
 version = {attr = "ops.version.version"}


### PR DESCRIPTION
Fixes #2312 

When `ops.hookcmds` has landed, we forgot to add the submodule to the setuptools config in pyproject.toml and now we get warnings. The PR addresses that.