### PR TITLE
feat: bump default Juju version in ops.testing.Context

### DIFF
--- a/testing/src/scenario/context.py
+++ b/testing/src/scenario/context.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 logger = scenario_logger.getChild('runtime')
 
-_DEFAULT_JUJU_VERSION = '3.6.4'
+_DEFAULT_JUJU_VERSION = '3.6.14'
 
 
 class Manager(Generic[CharmType]):


### PR DESCRIPTION
As decided at the standup, bumping the default Juju version in Scenario Context to the version of the current Juju LTS, 3.6.14.