### PR TITLE
ci: fix ops-tracing release for 2.23-maintenance

### DIFF
--- a/.github/workflows/publish-ops-tracing.yaml
+++ b/.github/workflows/publish-ops-tracing.yaml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - '2.*'
+  workflow_dispatch:
 
 permissions: {}
 
@@ -27,6 +28,6 @@ jobs:
       # is updated in the PYPI settings.
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: ./tracing/dist/
+          packages-dir: ./dist/
           skip-existing: true
           verbose: true


### PR DESCRIPTION
The `ops-tracing` release from this branch [failed](https://github.com/canonical/operator/actions/runs/21892179689/job/63200193863) when running `pypa/gh-action-pypi-publish@release/v1` with the following error:
```
Traceback (most recent call last):
  File "/app/print-pkg-names.py", line 30, in <module>
    pkg_name for file_path in packages_dir.iterdir() if
                              ~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/pathlib/_local.py", line 575, in iterdir
    with os.scandir(root_dir) as scandir_it:
         ~~~~~~~~~~^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/github/workspace/tracing/dist'
Warning:  It looks like there are no Python distribution packages to publish in the directory './tracing/dist/'. Please verify that they are in place should you face this problem.
ERROR    InvalidDistribution: Cannot find file (or expand pattern):             
         './tracing/dist/*'   
```
It looks like there were some shenanigans going on with where `uv build` was putting the built files, as we have a comment linking to https://github.com/astral-sh/uv/issues/13914 in the build step.

The built package ends up at `/home/runner/work/operator/operator/dist/ops_tracing-2.23.2.tar.gz`, so this PR adjusts where `gh-action-pypi-publish` should look for the files to publish, from `./tracing/dist/` to `./dist/`.

Because we need to publish just `ops-tracing` now, this PR also adds a `workflow_dispatch` trigger to the workflow. It can be removed in a follow up PR.