### PR TITLE
docs: remove 2.19 version in docs, tweak ops.testing title

### DIFF
--- a/docs/howto/write-unit-tests-for-a-charm.md
+++ b/docs/howto/write-unit-tests-for-a-charm.md
@@ -11,18 +11,12 @@ First of all, install the Ops testing framework. To do this in a virtual environ
 pip install ops[testing]
 ```
 
-When we want to run repeatable unit tests, we'll normally pin `ops[testing]` to the latest minor version in the dependency group for our unit tests. For example, in a `test-requirements.txt` file:
-
-```text
-ops[testing] ~= 2.19
-```
-
-Or in `pyproject.toml`:
+Or using `pyproject.toml`:
 
 ```toml
 [dependency-groups]
 test = [
-  "ops[testing] ~= 2.19",
+  "ops[testing]",
 ]
 ```
 

--- a/docs/reference/ops-testing.rst
+++ b/docs/reference/ops-testing.rst
@@ -1,7 +1,7 @@
 .. _ops_testing:
 
-`ops.testing` (was: Scenario)
-=============================
+`ops.testing`
+=============
 
 Install ops with the ``testing`` extra to use this API; for example:
 ``pip install ops[testing]``
@@ -14,7 +14,7 @@ See also:
 - :doc:`/howto/write-unit-tests-for-a-charm`
 - :doc:`/explanation/testing` - A summary of types of charm tests
 
-State-transition tests expect you to define the
+State-transition tests (previously called 'Scenario' tests) expect you to define the
 Juju state all at once, define the Juju context against which to test the charm,
 and fire a single event on the charm to execute its logic. The tests can then
 assert that the Juju state has changed as expected.


### PR DESCRIPTION
This removes the note about pinning `ops[testing]` from the "write unit tests for a charm" how-to, primarily because it's old (2.19), but also [now that we pin ops-scenario](https://github.com/canonical/operator/blob/3df8ae9c665256d36f60e835ece4b4ac4ae22cef/pyproject.toml#L29) in ops's pyproject.toml, I don't think we need this anymore.

In addition, remove the (to me) confusing "was: Scenario" mention in the ops.testing reference page's title, and say that elsewhere instead.

[See Matrix thread.](https://matrix.to/#/!EfnrLPl1aPaEUQlLDDgKHtOfvsx6xGDUkel5gim8l0U/$CFCBH7ZqdaxaKjgLt1RLYX28fxxTDIsS2Zf89gQh_SA?via=ubuntu.com&via=matrix.org&via=matrix.debian.social)