### PR TITLE
docs: clarify that secret labels are not names

### DIFF
--- a/docs/howto/manage-secrets.md
+++ b/docs/howto/manage-secrets.md
@@ -253,7 +253,7 @@ Note that:
 ### Label the secrets you're observing
 
 Sometimes a charm will observe multiple secrets. In the `secret-changed` event handler above, you might ask yourself: How do I know which secret has changed?
-The answer lies with **secret labels**: a label is a charm-local name that you can assign to a secret. Let's go through the following code:
+The answer lies with **secret labels**: you can assign a charm-local label to a secret. Let's go through the following code:
 
 ```python
 class MyWebserverCharm(ops.CharmBase):
@@ -313,7 +313,7 @@ So, having labelled the secret on creation, the database charm could add a new r
 
 #### When to use labels
 
-When should you use labels? A label is basically the secret's *name* (local to the charm), so whenever a charm has, or is observing, multiple secrets you should label them. This allows you to distinguish between secrets, for example, in the `SecretChangedEvent` shown above.
+When should you use labels? Juju lets you attach a label (local to the charm) to a secret, so whenever a charm owns, or is observing, multiple secrets you should label them. This allows you to distinguish between secrets, for example, in the `SecretChangedEvent` shown above.
 
 Most charms that use secrets have a fixed number of secrets each with a specific meaning, so the charm author should give them meaningful labels like `database-credential`, `tls-cert`, and so on. Think of these as "pets" with names.
 


### PR DESCRIPTION
Don't confuse secret labels with names.
Fixes #2284 

I went for smallest possible change, not going into "charm" vs "deployed app" distinction or whether charmers "should" or are "recommended to" label secrets or what to do with unbounded number of secrets, etc.