### PR TITLE
chore: update tox-uv advice to include explicit Python version

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -14,7 +14,7 @@ sudo snap install astral-uv --classic
 Then install `tox` with extensions, as well as a range of Python versions:
 
 ```sh
-uv tool install tox --with tox-uv
+uv tool install tox --python 3.12 --with tox-uv
 uv tool update-shell
 ```
 

--- a/docs/explanation/testing.md
+++ b/docs/explanation/testing.md
@@ -148,7 +148,7 @@ on:
       - name: Set up uv
         uses: astral-sh/setup-uv@7
       - name: Set up tox and tox-uv
-        run: uv tool install tox --with tox-uv
+        run: uv tool install tox --python 3.12 --with tox-uv
       - name: Run tests
         run: tox -e unit
 ```

--- a/docs/howto/manage-charms.md
+++ b/docs/howto/manage-charms.md
@@ -9,7 +9,7 @@ You'll need the following tools:
 
 - **Charmcraft** - For initialising and packing your charm. See {external+charmcraft:ref}`Charmcraft | Manage Charmcraft <manage-charmcraft>`.
 - **uv** - For managing your charm's dependencies, including Ops. See [Installing uv](https://docs.astral.sh/uv/getting-started/installation/).
-- **tox** - For running checks and tests. To install tox: `uv tool install tox --with tox-uv`.
+- **tox** - For running checks and tests. To install tox: `uv tool install tox --python 3.12 --with tox-uv`.
 
 To deploy your charm locally and to run integration tests, you'll also need a Juju controller.
 

--- a/docs/howto/write-and-structure-charm-code.md
+++ b/docs/howto/write-and-structure-charm-code.md
@@ -401,7 +401,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@7
       - name: Set up tox and tox-uv
-        run: uv tool install tox --with tox-uv
+        run: uv tool install tox --python 3.12 --with tox-uv
       - name: Run linters
         run: tox -e lint
 ```
@@ -418,7 +418,7 @@ Other `tox` environments can be run similarly; for example unit tests:
       - name: Set up uv
         uses: astral-sh/setup-uv@7
       - name: Set up tox and tox-uv
-        run: uv tool install tox --with tox-uv
+        run: uv tool install tox --python 3.12 --with tox-uv
       - name: Run tests
         run: tox -e unit
 ```
@@ -444,7 +444,7 @@ a cloud in which to deploy it, is required. This example uses [Concierge](https:
       - name: Set up uv
         uses: astral-sh/setup-uv@7
       - name: Set up tox and tox-uv
-        run: uv tool install tox --with tox-uv
+        run: uv tool install tox --python 3.12 --with tox-uv
       - name: Run integration tests
         # Set a predictable model name so it can be consumed by charm-logdump-action
         run: tox -e integration -- --model testing

--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -41,7 +41,7 @@ Where `<preset>` is `machine`, `kubernetes`, or another of Concierge's presets. 
 Next, use uv to install tox:
 
 ```text
-uv tool install tox --with tox-uv
+uv tool install tox --python 3.12 --with tox-uv
 ```
 
 Your virtual machine is now ready. Before using your virtual machine, we recommend that you do a couple more setup steps.

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/set-up-your-development-environment.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/set-up-your-development-environment.md
@@ -69,7 +69,7 @@ msg="Bootstrapped Juju" provider=k8s
 To install tox, run:
 
 ```text
-uv tool install tox --with tox-uv
+uv tool install tox --python 3.12 --with tox-uv
 ```
 
 When tox has been installed, you'll see a confirmation and a warning:

--- a/docs/tutorial/write-your-first-machine-charm.md
+++ b/docs/tutorial/write-your-first-machine-charm.md
@@ -104,7 +104,7 @@ msg="Bootstrapped Juju" provider=lxd
 To install tox, run:
 
 ```text
-uv tool install tox --with tox-uv
+uv tool install tox --python 3.12 --with tox-uv
 ```
 
 When tox has been installed, you'll see a confirmation and a warning:


### PR DESCRIPTION
Our current advice is to install tox with tox-uv as follows:
```
uv tool install tox --with tox-uv
```

I've tried this today, and the result was `tox` that could not run unit tests.

The cause was that the tool was installed with Python 3.8.
(which I think pulls in ancient version of tox-uv).

Setting Python version explicitly works:
```
uv tool install tox --python 3.12 --with tox-uv
```

I'm a little unsure how far we should go with this advice... is this a problem only for me? my machine? any charmer? only charmers that have Py 3.8 available?