### PR TITLE
fix: Move the testing.Container compatibility import so that mypy style checkers understand it

### DIFF
--- a/ops/testing.py
+++ b/ops/testing.py
@@ -118,7 +118,6 @@ try:
         layer_from_rockcraft,
     )
 except ImportError:
-    # mypy requires the type: ignore, pyright complains about the type: ignore
     from .model import Container
 else:
     # The Scenario unit testing framework.


### PR DESCRIPTION
Test code, based on the code in the Matrix thread, but fixed:

```python
from typing import Iterable

import ops
import ops.testing
import pytest

execs: Iterable[ops.testing.Exec] = set()


@pytest.fixture()
def mediawiki_container():
    return ops.testing.Container(
        name="mediawiki",
        can_connect=True,
        execs=execs,
    )


class TestPebbleReadyEvent:
    def test_can_connect(self, ctx: ops.testing.Context[ops.CharmBase], mediawiki_container: ops.testing.Container) -> None:
        state_in = ops.testing.State(containers=[mediawiki_container], leader=True)
        ctx.run(ctx.on.update_status(), state_in)
```

With main:

```
tameyer@tam-canoncial-1:~/w/operator$ uvx --with=pytest --with=ops[testing] mypy --follow-imports=silent /tmp/mypy_example.py                                  
/tmp/mypy_example.py:21: error: List item 0 has incompatible type "ops.model.Container"; expected "scenario.state.Container"  [list-item]
Found 1 error in 1 file (checked 1 source file)
tameyer@tam-canoncial-1:~/w/operator$ uvx --with=pytest --with=ops[testing] pyright /tmp/mypy_example.py 
0 errors, 0 warnings, 0 informations
```

With this branch:

```
tameyer@tam-canoncial-1:~/w/fix-mypy-testing-container$ uvx --with=pytest --with=ops[testing] mypy --follow-imports=silent /tmp/mypy_example.py 
Success: no issues found in 1 source file
tameyer@tam-canoncial-1:~/w/fix-mypy-testing-container$ uvx --with=pytest --with=ops[testing] pyright /tmp/mypy_example.py 
0 errors, 0 warnings, 0 informations
```

By moving the import from `ops.model` to the `except` block, type checkers like mypy understand that it's one or the other. We also need a `type: ignore` there because mypy otherwise complains about incompatible imports.

This is an alternative to #2339.