### PR TITLE
fix: correct type annotation for StorageMeta.properties

### DIFF
--- a/ops/charm.py
+++ b/ops/charm.py
@@ -2079,7 +2079,7 @@ class StorageMeta:
     multiple_range: tuple[int, int | None] | None
     """Range of numeric qualifiers when multiple storage units are used."""
 
-    properties = list[str]
+    properties: list[str]
     """List of additional characteristics of the storage."""
 
     def __init__(self, name: str, raw: _StorageMetaDict):


### PR DESCRIPTION
I'm pretty sure this is supposed to be a type annotation, not initializing the attribute to `list[str]`

It's assigned with a list in the constructor on L2103