### PR TITLE
fix: hold only copies of user provided meta/config/actions in testing.Context

### DIFF
--- a/testing/src/scenario/context.py
+++ b/testing/src/scenario/context.py
@@ -689,10 +689,7 @@ class Context(Generic[CharmType]):
                 ) from e
 
         else:
-            if meta:
-                meta = copy.deepcopy(meta)
-            else:
-                meta = {'name': str(charm_type.__name__)}
+            meta = copy.deepcopy(meta) if meta else {'name': str(charm_type.__name__)}
             spec = _CharmSpec(
                 charm_type=charm_type,
                 meta=meta,


### PR DESCRIPTION
Currently, `ops.testing.Context` holds onto the `dict` objects that users pass in for `meta`, `config`, and/or `actions`, storing them in an instance of the private `_CharmSpec` class. When the user later calls `Context.run`, the stored dictionaries are used to write the appropriate YAML files to temporary charm directories, check the `State` for consistency, and so on. This PR updates `Context.__init__` to make copies of this data instead.

## Rationale

Holding onto the actual objects provided by the user is problematic for two reasons:
1. If we were to ever mutate these dictionaries (e.g. as proposed in #2296), this would be a new and unexpected side effect for the caller.
2. If the user mutates their dictionaries after passing them to `ops.testing.Context`, this would unexpectedly be reflected in the context.

```py
meta = {'name': 'foo'}  # etc
ctx1 = testing.Context(FooCharm, meta)
meta['name'] = 'bar'
ctx2 = testing.Context(BarCharm, meta)
# Now ctx1 and ctx2 have the same stored name.
```

## Impact

Charms typically don't provide meta/config/actions, instead having these automatically derived from their `charmcraft.yaml` file, so the potential for users to be surprised by the changes introduced in this PR is low. However, charm libraries use meta/config/actions when constructing contexts for example charms, which will likely become more common going forward with the `charmlibs` monorepo recommending this approach in its tutorial etc., so it would be nice to clean this behaviour up now.

## Performance

`State` already makes deep copies of all mutable arguments on construction, and copying is used extensively internally when running. Additionally, if `meta`/`config`/`actions` are provided, they are written to the disk on `Context.run`. Comparatively, making deep copies of these three (typically) small dictionaries on `Context` construction should not be a performance bottleneck.