### PR TITLE
docs: replace links to juju.is by canonical.com/juju

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI Status](https://github.com/canonical/operator/actions/workflows/framework-tests.yaml/badge.svg)
 
-The `ops` library is a Python framework for developing and testing Kubernetes and machine [charms](https://charmhub.io/). While charms can be written in any language, `ops` defines the latest standard, and charmers are encouraged to use Python with `ops` for all charms. The library is an official component of the Charm SDK, itself a part of [the Juju universe](https://juju.is/).
+The `ops` library is a Python framework for developing and testing Kubernetes and machine [charms](https://charmhub.io/). While charms can be written in any language, `ops` defines the latest standard, and charmers are encouraged to use Python with `ops` for all charms. The library is an official component of the Charm SDK, itself a part of [the Juju universe](https://canonical.com/juju).
 
 > - `ops` is  [available on PyPI](https://pypi.org/project/ops/).
 > - The latest version of `ops` requires Python 3.10 or above.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,7 +129,7 @@ html_context = {
     # TODO: If there's no such website,
     #       remove the {{ product_page }} link from the page header template
     #       (usually .sphinx/_templates/header.html; also, see README.rst).
-    "product_page": "juju.is",
+    "product_page": "canonical.com/juju/docs",
     # Product tag image; the orange part of your logo, shown in the page header
     #
     # TODO: To add a tag image, uncomment and update as needed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ reference/index
 explanation/index
 ```
 
-Ops is a Python framework for writing and testing [Juju](https://juju.is/) charms.
+Ops is a Python framework for writing and testing [Juju](https://canonical.com/juju) charms.
 
 The core `ops` package provides an API to respond to Juju events and manage the charm's application. Ops also includes extra packages for testing and tracing charms.
 
@@ -84,4 +84,4 @@ If you're new to charm development, the {external+charmcraft:ref}`Charmcraft tut
 
 To follow along with updates and tips about charm development, join our [Discourse forum](https://discourse.charmhub.io/).
 
-[Learn more about the Juju ecosystem](https://juju.is/docs)
+[Learn more about the Juju ecosystem](https://canonical.com/juju/docs)

--- a/testing/README.md
+++ b/testing/README.md
@@ -3,7 +3,7 @@
 `ops-scenario` is a Python library that provides state-transition testing for
 [Ops](https://documentation.ubuntu.com/ops/latest/) charms. These tests are higher level than
 typical unit tests, but run at similar speeds and are the recommended approach
-for testing charms within requiring a full [Juju](https://juju.is) installation.
+for testing charms within requiring a full [Juju](https://canonical.com/juju) installation.
 
 Test are written in the arrange/act/assert pattern, arranging an object
 representing the current Juju state, acting by emulating an event from Juju, and


### PR DESCRIPTION
[juju.is](https://juju.is) now redirects to [canonical.com/juju](https://canonical.com/juju). No links are broken - this PR updates the links to keep things tidy.

I'm adjusting the documentation header to point to [canonical.com/juju/docs](https://canonical.com/juju/docs) instead of canonical.com/juju, matching the Juju RTD docs.