### PR TITLE
ci: run ruff check --fix in tox -e format

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,9 @@ passenv =
 [testenv:format]
 description = Apply coding style standards to code
 dependency_groups = lint
-commands = ruff format --preview
+commands =
+    ruff format --preview
+    ruff check --preview --fix
 
 [testenv:lint]
 description = Check code style and type correctness


### PR DESCRIPTION
This PR updates `tox -e format` to run `ruff check --preview --fix` after running `ruff format --preview`.

Why? `tox -e lint` will complain about errors that are fixable with `ruff check --preview --fix`, but we don't provide a way to fix them with `tox`. This is especially painful for import sorting errors. It's nice if `tox -e format` takes care of the automated changes that satisfy `tox -e lint`.

This doesn't introduce new checks -- we already enforce `ruff check --preview` on `main` via `tox -e lint`. It just adds developer convenience.