### PR TITLE
[do not merge] preview sphinx-config-options fix when building the docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,7 @@ sphinxcontrib-jquery
 sphinxext-opengraph
 
 # Extra extensions, previously bundled as canonical-sphinx-extensions
-sphinx-config-options>=0.1.0
+sphinx-config-options @ git+https://github.com/dwilding/sphinx-config-options.git@restrict-expand-all-options
 sphinx-contributor-listing>=0.1.0
 sphinx-filtered-toctree>=0.1.0
 sphinx-related-links>=0.1.1


### PR DESCRIPTION
This is a testing PR to make RTD build the docs with the "Expand all options" fix from https://github.com/canonical/sphinx-config-options/pull/14. Based on Tony's investigation, "Expand all options" is only displayed with Safari and hosted docs (not a local build).