### PR TITLE
fix: return copy of relation data from Harness backend

### DIFF
--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -2455,7 +2455,7 @@ class _TestingModelBackend:
             member_name = member_name.split('/')[0]
         if relation_id not in self._relation_data_raw:
             raise model.RelationNotFoundError()
-        return self._relation_data_raw[relation_id][member_name]
+        return self._relation_data_raw[relation_id][member_name].copy()
 
     def update_relation_data(
         self,

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3782,6 +3782,30 @@ class TestTestingModelBackend:
         with pytest.raises(ops.RelationNotFoundError):
             backend.relation_get(1234, 'unit/0', False)
 
+    def test_relation_get_returns_copy(self, request: pytest.FixtureRequest):
+        harness = ops.testing.Harness(
+            ops.CharmBase,
+            meta="""
+            name: test-charm
+            requires:
+              db:
+                interface: pgsql
+            """,
+        )
+        request.addfinalizer(harness.cleanup)
+        rel_id = harness.add_relation('db', 'postgresql')
+        harness.add_relation_unit(rel_id, 'postgresql/0')
+        harness.update_relation_data(rel_id, 'postgresql/0', {'key': 'value'})
+        backend = harness._backend
+
+        data1 = backend.relation_get(rel_id, 'postgresql/0', False)
+        data1['key'] = 'mutated'
+        data1['extra'] = 'injected'
+
+        data2 = backend.relation_get(rel_id, 'postgresql/0', False)
+        assert data2['key'] == 'value'
+        assert 'extra' not in data2
+
     def test_relation_list_unknown_relation_id(self, request: pytest.FixtureRequest):
         harness = ops.testing.Harness(
             ops.CharmBase,


### PR DESCRIPTION
## Summary

- `relation_get()` in the Harness backend (`ops/_private/harness.py`) returned a direct reference to the internal `_relation_data_raw` dict rather than a copy. This meant any mutation of the returned dict by charm code would silently corrupt the Harness's internal state, leading to subtle and hard-to-diagnose test failures.
- The Scenario mock backend already fixed this same issue (see `testing/src/scenario/mocking.py:257` which returns `data.copy()`), creating an inconsistency where tests behaved differently depending on which backend was used.
- This change aligns the Harness backend with the Scenario backend by returning `.copy()`, and adds a regression test to verify the copy semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code) but owned by me.