### PR TITLE
docs: add a tip about AI help in the Jubilant migration guide

### DIFF
--- a/docs/howto/migrate/migrate-integration-tests-from-pytest-operator.md
+++ b/docs/howto/migrate/migrate-integration-tests-from-pytest-operator.md
@@ -3,6 +3,10 @@
 
 Many charm integration tests use [pytest-operator](https://github.com/charmed-kubernetes/pytest-operator) and [python-libjuju](https://github.com/juju/python-libjuju). This guide explains how to migrate your integration tests from those libraries to Jubilant.
 
+```{tip}
+Try bootstrapping your migration with an AI Agent (such as GitHub Copilot or Claude Code). Instruct the agent to clone the canonical/jubilant and canonical/pytest-jubilant repositories, study them, and then migrate the charm integration tests to Jubilant. You should end up with a great starting point to then continue as outlined in the rest of this guide.
+```
+
 To get help while you're migrating tests, please keep the {external+jubilant:doc}`Jubilant API Reference <reference/jubilant>` handy, and make use of your IDE's autocompletion -- Jubilant tries to provide good type annotations and docstrings.
 
 Migrating your tests can be broken into three steps:


### PR DESCRIPTION
As per the recent findings, a simple prompt that tells an agent to look over the repo (which, of course, includes the docs, handily in markdown/ReST rather than HTML) and then do the migration will go a long way. This PR adds a tip about this, without going into more detail on how you might use AI for this.

[Preview](https://canonical-ubuntu-documentation-library--2382.com.readthedocs.build/ops/2382/howto/migrate/migrate-integration-tests-from-pytest-operator/)