### PR TITLE
ci: update the list of published charms in the compatibility tests

### DIFF
--- a/.github/update-published-charms-tests-workflow.py
+++ b/.github/update-published-charms-tests-workflow.py
@@ -76,7 +76,9 @@ CHARM_ROOTS = {
     'argo-operators': ['charms/argo-controller'],
     'catalogue-k8s-operator': ['charm'],
     'jimm': ['charms/jimm'],
-    'k8s-operator': ['charms/worker/k8s'],
+    # k8s-operator has an odd structure where there is a charm in charms/worker, and
+    # also another separate charm not as a sibling, but inside a subfolder.
+    'k8s-operator': ['charms/worker', 'charms/worker/k8s'],
     'katib-operators': ['charms/katib-controller', 'charms/katib-db-manager', 'charms/katib-ui'],
     'kfp-operators': [
         'charms/kfp-api',

--- a/.github/workflows/published-charms-tests.yaml
+++ b/.github/workflows/published-charms-tests.yaml
@@ -67,6 +67,8 @@ jobs:
           - charm-repo: canonical/jimm
             charm-root: charms/jimm
           - charm-repo: canonical/k8s-operator
+            charm-root: charms/worker
+          - charm-repo: canonical/k8s-operator
             charm-root: charms/worker/k8s
           - charm-repo: canonical/kafka-k8s-operator
             charm-root: .


### PR DESCRIPTION
(These changes are broken ut of #2317, where they were more of a drive-by).

This PR updates the list of published charms. There are some newly published charms, and some fixes for where the charm is in a subdirectory.