### PR TITLE
docs: update integration testing how-to guide

### DIFF
--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -193,10 +193,10 @@ After `test_deploy`, add more tests to check that your charm operates correctly.
 ```python
 def test_integrate(charm: pathlib.Path, juju: jubilant.Juju):
     # Deploy some other charm from Charmhub:
-    juju.deploy("ubuntu")
+    juju.deploy("other-app")
 
     # Integrate the charms:
-    juju.integrate("your-app:endpoint1", "ubuntu:endpoint2")
+    juju.integrate("your-app:endpoint1", "other-app:endpoint2")
 
     # Ensure that both applications and all units reach a good state:
     juju.wait(jubilant.all_active)


### PR DESCRIPTION
This PR makes several improvements to the [how-to guide for integration testing](https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/).

Main improvements:

- Reduce the introduction, especially the number of outgoing links. Currently, it's easy to get confused about what to read first. There's especially no need to go and read about Jubilant first. I'm making sure that Jubilant is linked from several places throughout the doc.

- Add extra info about fixtures and `juju.deploy()`. Mostly this is adapted from the Jubilant tutorial, which I'm pruning in [jubilant#280](https://github.com/canonical/jubilant/pull/280).

- Reorganise the flow of examples. The current flow shows a deploy, then defines fixtures, then shows a deploy again (in a better way).

**[Preview of updated doc](https://canonical-ubuntu-documentation-library--2390.com.readthedocs.build/ops/2390/howto/write-integration-tests-for-a-charm/)**