### PR TITLE
docs: explain K8s charms briefly at the start of the tutorial

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/index.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/index.md
@@ -3,8 +3,8 @@
 
 This tutorial will guide you through the steps of writing a Kubernetes charm for an application.
 
-Kubernetes charms manage their workload application from a separate 'sidecar' container, with Juju and Ops providing extra functionality to help with this.
-This contrasts with machine charms, which run in the same (possibly virtual) machine that their workload does.
+Kubernetes charms manage their workload application from a separate 'sidecar' container, with Juju and Ops providing functionality to help with this.
+This contrasts with machine charms, which run in the same machine as their workload.
 
 By the end of the tutorial, you'll have equipped the application with operational logic and used Juju to deploy the application to a local Kubernetes cluster.
 You'll also have learned how to implement typical functionality of a charm, including configuration, relations, and actions.


### PR DESCRIPTION
While looking at the flow of a new charmer going through the onboarding program, @dwilding and I realised that they're missing the context of what even is a Kubernetes charm and why is it different.

Rather than add this to the onboarding material, this PR adds a couple of sentences to make it clear at the start of the tutorial.

We already explain the details in more depth in [chapter 3](https://documentation.ubuntu.com/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm/).