### PR TITLE
docs: add a note to our tutorials about the confusing concierge output

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/set-up-your-development-environment.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/set-up-your-development-environment.md
@@ -60,7 +60,7 @@ sudo concierge prepare -p k8s --extra-snaps astral-uv
 
 This first installs Concierge, then uses Concierge to install and configure the other tools (except tox). The option `-p k8s` tells Concierge that we want tools for developing Kubernetes charms, with a local cloud managed by Canonical Kubernetes.
 
-This step should take less than 15 minutes, but the time depends on your computer and network. When the tools have been installed, you'll see a message that ends with:
+This step should take less than 15 minutes, but the time depends on your computer and network. As `concierge` runs, you may see a number of messages that appear to be errors, like `ERROR controller ... not found`. Don't worry about these, they're because of how `concierge` currently exposes the output of the commands it runs internally. You only need to worry if your `concierge prepare` call fails -- then you should investigate the output, and reach out to us if you can't solve the problem yourself. When the tools have been installed, you'll see a message that ends with:
 
 ```text
 msg="Bootstrapped Juju" provider=k8s

--- a/docs/tutorial/write-your-first-machine-charm.md
+++ b/docs/tutorial/write-your-first-machine-charm.md
@@ -95,7 +95,7 @@ sudo concierge prepare -p machine --extra-snaps astral-uv
 
 This first installs Concierge, then uses Concierge to install and configure the other tools (except tox). The option `-p machine` tells Concierge that we want tools for developing machine charms.
 
-This step should take less than 15 minutes, but the time depends on your computer and network. When the tools have been installed, you'll see a message that ends with:
+This step should take less than 15 minutes, but the time depends on your computer and network. As `concierge` runs, you may see a number of messages that appear to be errors, like `ERROR controller ... not found`. Don't worry about these, they're because of how `concierge` currently exposes the output of the commands it runs internally. You only need to worry if your `concierge prepare` call fails -- then you should investigate the output, and reach out to us if you can't solve the problem yourself. When the tools have been installed, you'll see a message that ends with:
 
 ```text
 msg="Bootstrapped Juju" provider=lxd


### PR DESCRIPTION
We plan to improve `concierge` output in future, but right now it confuses users who follow our tutorial. This PR adds a note about the "error" messages to setup step. This can be reverted when we address this in `concierge`.

- https://github.com/canonical/concierge/issues/102
- https://github.com/canonical/concierge/issues/171