### PR TITLE
docs: add metadata descriptions to the debug and public listing how-to guides

### DIFF
--- a/docs/howto/debug-your-charm.md
+++ b/docs/howto/debug-your-charm.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: Debug Juju charms with SSH, Pebble, debug-log, debug-hooks, debug-code breakpoints, jhack utilities, and VS Code remote debugging via debugpy.
+---
+
 (debug-your-charm)=
 # How to debug your charm
 

--- a/docs/howto/debug-your-charm.md
+++ b/docs/howto/debug-your-charm.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: Debug Juju charms with SSH, Pebble, debug-log, debug-hooks, debug-code breakpoints, jhack utilities, and VS Code remote debugging via debugpy.
+    description: Debug Juju charms with SSH, Pebble, debug-log, debug-hooks, debug-code breakpoints, jhack utilities, and debugpy for remote debugging in VS Code.
 ---
 
 (debug-your-charm)=

--- a/docs/howto/make-your-charm-discoverable.md
+++ b/docs/howto/make-your-charm-discoverable.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: Get your charm publicly listed on Charmhub by checking it against the listing criteria, requesting a review, and addressing reviewer feedback.
+---
+
 (make-your-charm-discoverable)=
 # How to make your charm discoverable
 


### PR DESCRIPTION
Follows the guidelines:

* [x] Length up to 200 chars, most important in first 150: 142 chars (both, coincidentally)
* [x] Simple language without unnecessary adverbs or adjectives
* [x] Product name and focus keyword: I don't have "ops", maybe I should? I have "Juju" for one and "Charmhub" for the other, as the product names. I have "debug" and "publicly listed" as the focus keywords.
* [x] Where possible, summarise the content.
* [x] Avoids excessive repetition.  "debug" does appear a lot in one of them, but that's because it's part of `debug-code`, `debug-hooks`, `debug-log`, etc.