### PR TITLE
ci: sort the directory entries when updating the best practices list

### DIFF
--- a/.github/update-best-practice-table.py
+++ b/.github/update-best-practice-table.py
@@ -168,7 +168,7 @@ def main():
             '{external+charmcraft:ref}',
         ),
     ):
-        for file_path in directory.rglob('*'):
+        for file_path in sorted(directory.rglob('*')):
             if file_path.suffix not in ('.md', '.rst'):
                 continue
             text = file_path.read_text()


### PR DESCRIPTION
We currently get spurious PRs for updating the best practices list (like #2394) where the content has not changed, but the order has.

This PR sorts the directory listing, so that the output is consistently in the same order.