### PR TITLE
ci: configure dependabot for the example charms

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,3 +13,45 @@ updates:
     open-pull-requests-limit: 0  # Security updates only
     labels:
       - "dependencies"
+  - package-ecosystem: "uv"
+    directory: "/examples/httpbin-demo"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    labels:
+      - "dependencies"
+  - package-ecosystem: "uv"
+    directory: "/examples/k8s-5-observe"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "ops"
+      - dependency-name: "ruff"
+      - dependency-name: "codespell"
+      - dependency-name: "pyright"
+      - dependency-name: "coverage"
+      - dependency-name: "pytest"
+      - dependency-name: "jubilant"
+      - dependency-name: "PyYAML"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "uv"
+    directory: "/examples/machine-tinyproxy"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "ops"
+      - dependency-name: "ruff"
+      - dependency-name: "codespell"
+      - dependency-name: "pyright"
+      - dependency-name: "coverage"
+      - dependency-name: "pytest"
+      - dependency-name: "jubilant"
+      - dependency-name: "PyYAML"
+    labels:
+      - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,7 @@ updates:
       - dependency-name: "pyright"
       - dependency-name: "coverage"
       - dependency-name: "pytest"
+      - dependency-name: "pytest-jubilant"
       - dependency-name: "jubilant"
       - dependency-name: "PyYAML"
     labels:
@@ -54,7 +55,7 @@ updates:
       - dependency-name: "pyright"
       - dependency-name: "coverage"
       - dependency-name: "pytest"
+      - dependency-name: "pytest-jubilant"
       - dependency-name: "jubilant"
-      - dependency-name: "PyYAML"
     labels:
       - "dependencies"


### PR DESCRIPTION
This PR extends the dependabot configuration to also include the example charms, with the same settings (`uv`, monthly, 7-day cooldown) as the main dependencies.

For the two tutorial charms, which start off with a `charmcraft init`, the dependencies that `init` brings in are ignored, as those will be picked up in the `charmcraft` or `charmcraft-profile-tools` repositories.

For the K8s tutorial, only configure for the final chapter, to avoid noise. When reviewing those dependabot PRs, people should consider whether earlier chapters also need to be updated. For both tutorials, people should consider at the time whether any docs also need to be updated.