### PR TITLE
Security: Potential GitHub token exfiltration via unvalidated repository path in API requests

### DIFF
--- a/.github/actions/update-charm-pins/main.py
+++ b/.github/actions/update-charm-pins/main.py
@@ -4,6 +4,7 @@
 
 import logging
 import os
+import re
 import sys
 
 from httpx import Client
@@ -20,6 +21,8 @@ github = Client(
     },
 )
 
+charm_repo_pattern = re.compile(r'^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')
+
 
 def update_charm_pins(workflow):
     """Update pinned versions of charms in the given GitHub Actions workflow."""
@@ -31,6 +34,8 @@ def update_charm_pins(workflow):
 
     for idx, item in enumerate(doc['jobs'][job_name]['strategy']['matrix']['include']):
         charm_repo = item['charm-repo']
+        if not charm_repo_pattern.fullmatch(charm_repo):
+            raise ValueError(f'Invalid charm-repo: {charm_repo!r}')
         commit = github.get(f'{charm_repo}/commits').raise_for_status().json()[0]
         data = github.get(f'{charm_repo}/tags').raise_for_status().json()
         comment = ' '.join(


### PR DESCRIPTION
## Summary

Security: Potential GitHub token exfiltration via unvalidated repository path in API requests

## Problem

**Severity**: `High` | **File**: `.github/actions/update-charm-pins/main.py:L31`

The workflow updater reads `charm-repo` values from YAML and interpolates them directly into `github.get(f'{charm_repo}/commits')` and `github.get(f'{charm_repo}/tags')`. If `charm-repo` is attacker-controlled (for example via a modified workflow in a PR), an absolute URL may bypass the intended `base_url` and cause requests to be sent to an attacker-controlled host with the configured `Authorization` header, leaking `GITHUB_TOKEN`.

## Solution

Validate `charm-repo` against a strict pattern such as `^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$` before use, reject absolute URLs, and construct URLs via safe path joining. Optionally instantiate a separate unauthenticated client for untrusted input or only add `Authorization` per-request after validation.

## Changes

- `.github/actions/update-charm-pins/main.py` (modified)