### PR TITLE
docs: explain how to remove errored apps in k8s tutorial

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
@@ -108,13 +108,10 @@ First, repack and refresh your charm:
 
 ```text
 charmcraft pack
-juju refresh \
-  --path="./fastapi-demo_amd64.charm" \
-  fastapi-demo --force-units --resource \
-  demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
+juju refresh fastapi-demo --force-units \
+  --path ./fastapi-demo_amd64.charm \
+  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
 ```
-
-If the app is in an `awaiting error resolution` state, `juju refresh` will not work. In this situation, `juju remove-application` may also fail; use `juju remove-application fastapi-demo --force` instead.
 
 Next, test that the basic action invocation works:
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
@@ -114,6 +114,8 @@ juju refresh \
   demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
 ```
 
+If the app is in an `awaiting error resolution` state, `juju refresh` will not work. In this situation, `juju remove-application` may also fail; use `juju remove-application fastapi-demo --force` instead.
+
 Next, test that the basic action invocation works:
 
 ```text

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -341,13 +341,10 @@ First, repack and refresh your charm:
 
 ```text
 charmcraft pack
-juju refresh \
-  --path="./fastapi-demo_amd64.charm" \
-  fastapi-demo --force-units --resource \
-  demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
+juju refresh fastapi-demo --force-units \
+  --path ./fastapi-demo_amd64.charm \
+  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
 ```
-
-If the app is in an `awaiting error resolution` state, `juju refresh` will not work. In this situation, `juju remove-application` may also fail; use `juju remove-application fastapi-demo --force` instead.
 
 Next, deploy the `postgresql-k8s` charm:
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -347,6 +347,8 @@ juju refresh \
   demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
 ```
 
+If the app is in an `awaiting error resolution` state, `juju refresh` will not work. In this situation, `juju remove-application` may also fail; use `juju remove-application fastapi-demo --force` instead.
+
 Next, deploy the `postgresql-k8s` charm:
 
 ```text

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -183,6 +183,8 @@ juju refresh \
   demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
 ```
 
+If the app is in an `awaiting error resolution` state, `juju refresh` will not work. In this situation, `juju remove-application` may also fail; use `juju remove-application fastapi-demo --force` instead.
+
 Now, check the available configuration options:
 
 ```text

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -177,13 +177,14 @@ First, repack and refresh your charm:
 
 ```text
 charmcraft pack
-juju refresh \
-  --path="./fastapi-demo_amd64.charm" \
-  fastapi-demo --force-units --resource \
-  demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
+juju refresh fastapi-demo --force-units \
+  --path ./fastapi-demo_amd64.charm \
+  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
 ```
 
-If the app is in an `awaiting error resolution` state, `juju refresh` will not work. In this situation, `juju remove-application` may also fail; use `juju remove-application fastapi-demo --force` instead.
+```{tip}
+`--force-units` ensures that the refresh succeeds even if the application is in an error state. This option is useful during development, when your charm code might be the cause of the error. You should avoid using `--force-units` when refreshing applications in production.
+```
 
 Now, check the available configuration options:
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -235,6 +235,8 @@ juju refresh \
   demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
 ```
 
+If the app is in an `awaiting error resolution` state, `juju refresh` will not work. In this situation, `juju remove-application` may also fail; use `juju remove-application fastapi-demo --force` instead.
+
 Next, test your charm's ability to integrate with Prometheus, Loki, and Grafana by following the steps below.
 
 ### Deploy COS Lite

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -229,13 +229,10 @@ First, repack and refresh your charm:
 
 ```text
 charmcraft pack
-juju refresh \
-  --path="./fastapi-demo_amd64.charm" \
-  fastapi-demo --force-units --resource \
-  demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
+juju refresh fastapi-demo --force-units \
+  --path ./fastapi-demo_amd64.charm \
+  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
 ```
-
-If the app is in an `awaiting error resolution` state, `juju refresh` will not work. In this situation, `juju remove-application` may also fail; use `juju remove-application fastapi-demo --force` instead.
 
 Next, test your charm's ability to integrate with Prometheus, Loki, and Grafana by following the steps below.
 


### PR DESCRIPTION
## Summary
- explain that `juju refresh` won't work when the app is in `awaiting error resolution`
- document using `juju remove-application fastapi-demo --force` in that situation
- add this guidance to the affected Kubernetes tutorial pages

## Issue
- closes #2442