### PR TITLE
docs: add how-to guide for naming and initialising a charm

### DIFF
--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -19,7 +19,15 @@ Once your charm is ready for wide production use, your next goal should be to ge
 
 ## Writing charm code and tests
 
-Your charm is Python code that depends on Ops, with standard structures for handling events, status, and errors. As you write your charm, make sure to follow best practices.
+Your charm is a Python project, with Juju-specific metadata in a file called `charmcraft.yaml`. After creating a repository for your charm, use {external+charmcraft:doc}`Charmcraft <index>` to generate the recommended project structure.
+
+```{toctree}
+:maxdepth: 1
+
+Initialise your project <initialise-your-project>
+```
+
+Your charm depends on Ops, with standard structures for handling events, status, and errors. As you write your charm, make sure to follow best practices.
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -62,14 +62,7 @@ Important files to be aware of:
 - `pyproject.toml` - Python project configuration, including the dependencies of your charm.
 - `src/charm.py` - The Python file that will contain the main logic of your charm.
 
-(alternative-project-structures)=
-## Alternative project structures
-
-If your repository will hold multiple charms, or a charm and source for another artifact, such as a [rock](https://ubuntu.com/containers/docs), create a `charms` directory at the repository root. Then create a subdirectory for each charm and run `charmcraft init` in each subdirectory.
-
 If your charm's workload was built with a web framework such as Django or FastAPI, consider using one of Charmcraft's 12-factor app profiles instead of `kubernetes` or `machine`. These profiles accelerate development by generating charms that are ready to deploy. {external+charmcraft:ref}`Write your first 12-factor app charm <tutorial>`.
-
-<!-- Can we link to a real example of a charm monorepo? -->
 
 ## Next steps
 

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -69,7 +69,7 @@ If your repository will hold multiple charms, or a charm and source for another 
 
 If your charm's workload was built with a web framework such as Django or FastAPI, consider using one of Charmcraft's 12-factor app profiles instead of `kubernetes` or `machine`. These profiles accelerate development by generating charms that are ready to deploy. {external+charmcraft:ref}`Write your first 12-factor app charm <tutorial>`.
 
-<!-- TODO: Can we link to a real example of a charm monorepo? -->
+<!-- Can we link to a real example of a charm monorepo? -->
 
 ## Next steps
 

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -1,0 +1,77 @@
+---
+myst:
+  html_meta:
+    description: Decide your charm's name and use Charmcraft to generate the recommended project structure.
+---
+
+(init-charm)=
+# How to initialise your project
+
+Before you initialise your project, install charm development tools. See {ref}`prepare-your-environment`.
+
+This guide demonstrates how to name your charm and generate the recommended project structure. You should decide your charm's name before you create a repository for your charm.
+
+(decide-your-charms-name)=
+## Decide your charm's name
+
+Your charm's name should be based on the name of the workload and should be short and memorable. Examples:
+
+- `mega-calendar` for a machine charm that operates a workload called Mega Calendar
+- `mega-calendar-k8s` for a Kubernetes charm that operates the same workload
+
+To check that your preferred name isn't already in use, visit the (future) Charmhub URL, which should be an error page:
+
+```text
+https://charmhub.io/mega-calendar-k8s
+```
+(create-a-repository-and-initialise-it)=
+## Create a repository and initialise it
+
+Create a repository with your source control of choice.
+
+```{admonition} Best practice
+:class: hint
+
+Name the repository using the pattern ``<charm name>-operator`` for a single
+charm, or ``<base charm name>-operators`` when the repository will hold
+multiple related charms. For the charm name, see [](#decide-your-charms-name).
+```
+
+For example, name the repository `mega-calendar-k8s-operator` if your charm will be called `mega-calendar-k8s`.
+
+Next, use {external+charmcraft:doc}`Charmcraft <index>` to generate the recommended project structure in the repository:
+
+```text
+charmcraft init --name mega-calendar-k8s --profile kubernetes
+```
+
+Or for a machine charm:
+
+```text
+charmcraft init --name mega-calendar --profile machine
+```
+
+<!-- Mention that --name is optional? (Omitting it can cause confusion) -->
+
+Charmcraft's `kubernetes` and `machine` profiles are minimal charms that contain placeholder code and configuration.
+These profiles also give you starting points for unit tests and integration tests.
+
+Important files to be aware of:
+
+- `charmcraft.yaml` - Metadata about your charm.
+- `pyproject.toml` - Python project configuration, including the dependencies of your charm.
+- `src/charm.py` - The Python file that will contain the main logic of your charm.
+
+(alternative-project-structures)=
+## Alternative project structures
+
+If your repository will hold multiple charms, or a charm and source for another artifact, such as a [rock](https://ubuntu.com/containers/docs), create a `charms` directory at the repository root. Then create a subdirectory for each charm and run `charmcraft init` in each subdirectory.
+
+If your charm's workload was built with a web framework such as Django or FastAPI, consider using one of Charmcraft's 12-factor app profiles instead of `kubernetes` or `machine`. These profiles accelerate development by generating charms that are ready to deploy. {external+charmcraft:ref}`Write your first 12-factor app charm <tutorial>`.
+
+<!-- TODO: Can we link to a real example of a charm monorepo? -->
+
+## Next steps
+
+- Start writing your charm code. See {ref}`write-and-structure-charm-code` and our other guides.
+- Provide metadata in `charmcraft.yaml`. See {external+charmcraft:ref}`Charmcraft | Configure package information <configure-package-information>`.

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -7,7 +7,7 @@ myst:
 (init-charm)=
 # How to initialise your project
 
-Before you initialise your project, install charm development tools. See {ref}`prepare-your-environment`.
+Before you initialise your project, install charm development tools. See [](#prepare-your-environment).
 
 This guide demonstrates how to name your charm and generate the recommended project structure. You should decide your charm's name before you create a repository for your charm.
 

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -51,7 +51,20 @@ Or for a machine charm:
 charmcraft init --name mega-calendar --profile machine
 ```
 
+<!-- Comment out this tip when the charmcraft stable version is up-to-date. Restore it and update the hash as needed. -->
+````{tip}
+The `charmcraft` version that you have installed may come with older versions of the profiles.
+
+To use the latest profile versions, initialise your charm using `charmcraft` directly from Github, like this:
+
+```text
+uvx git+https://github.com/canonical/charmcraft@460e8df init --name <name> --profile <profile>
+```
+````
+
 If you don't specify `--name` when running `charmcraft init`, Charmcraft uses the parent directory name for your charm. For example, `mega-calendar-k8s-operator`, from the name of the repository. So we recommend specifying `--name` to ensure that your charm's name doesn't end with `-operator`.
+
+## Inspect your charm
 
 Charmcraft's `kubernetes` and `machine` profiles are minimal charms that contain placeholder code and configuration.
 These profiles also give you starting points for unit tests and integration tests.
@@ -62,9 +75,9 @@ Important files to be aware of:
 - `pyproject.toml` - Python project configuration, including the dependencies of your charm.
 - `src/charm.py` - The Python file that will contain the main logic of your charm.
 
-If your charm's workload was built with a web framework such as Django or FastAPI, consider using one of Charmcraft's 12-factor app profiles instead of `kubernetes` or `machine`. These profiles accelerate development by generating charms that are ready to deploy. {external+charmcraft:ref}`Write your first 12-factor app charm <tutorial>`.
-
 ## Next steps
 
 - Start writing your charm code. See {ref}`write-and-structure-charm-code` and our other guides.
 - Provide metadata in `charmcraft.yaml`. See {external+charmcraft:ref}`Charmcraft | Configure package information <configure-package-information>`.
+
+If your charm's workload was built with a web framework such as Django or FastAPI, consider using one of Charmcraft's 12-factor app profiles instead of `kubernetes` or `machine`. These profiles accelerate development by generating charms that are ready to deploy. {external+charmcraft:ref}`Write your first 12-factor app charm <tutorial>`.

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -51,7 +51,7 @@ Or for a machine charm:
 charmcraft init --name mega-calendar --profile machine
 ```
 
-<!-- Mention that --name is optional? (Omitting it can cause confusion) -->
+If you don't specify `--name` when running `charmcraft init`, Charmcraft uses the parent directory name for your charm. For example, `mega-calendar-k8s-operator`, from the name of the repository. So we recommend specifying `--name` to ensure that your charm's name doesn't end with `-operator`.
 
 Charmcraft's `kubernetes` and `machine` profiles are minimal charms that contain placeholder code and configuration.
 These profiles also give you starting points for unit tests and integration tests.

--- a/docs/howto/manage-charms.md
+++ b/docs/howto/manage-charms.md
@@ -3,6 +3,7 @@
 
 > See first: {external+juju:ref}`Juju | Build a charm <build-a-charm>`, {external+charmcraft:ref}`Charmcraft | Manage charms <manage-charms>`
 
+(prepare-your-environment)=
 ## Prepare your environment
 
 You'll need the following tools:
@@ -29,12 +30,7 @@ configures development tooling.
 
 > See more:
 >
-> * {external+charmcraft:ref}`Charmcraft | Manage charms > Initialize a charm <initialise-a-charm>` (see also the best practice note on setting up a repository and considering your CI)
-> * [Charmcraft | Manage charms > Add charm project metadata, an icon, docs](https://canonical-charmcraft.readthedocs-hosted.com/en/latest/howto/manage-charms/#add-charm-project-metadata-an-icon-docs)
-
-<!--
-TODO: Add a reference link in charmcraft for the link above and the 'runtime details' one below, and switch over to external refs.
--->
+> - {ref}`init-charm`
 
 (develop-your-charm)=
 ## Develop your charm
@@ -95,7 +91,7 @@ do it well.
 >   - {ref}`manage-resources`
 >   - {ref}`manage-secrets`
 > * Add functionality
->   - [Charmcraft | Add runtime details to a charm](https://canonical-charmcraft.readthedocs-hosted.com/en/latest/howto/manage-charms/#add-runtime-details-to-a-charm)
+>   - {external+charmcraft:ref}`Charmcraft | Add runtime details to a charm <add-runtime-details-to-a-charm>`
 >   - {ref}`manage-actions`
 >   - {ref}`manage-configuration`
 >   - {ref}`manage-opened-ports`

--- a/docs/howto/write-and-structure-charm-code.md
+++ b/docs/howto/write-and-structure-charm-code.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: Define your charm's dependencies and Python modules, handle status and errors in a standard way, and follow best practices for charm development.
+---
+
 (write-and-structure-charm-code)=
 # How to write and structure charm code
 

--- a/docs/howto/write-and-structure-charm-code.md
+++ b/docs/howto/write-and-structure-charm-code.md
@@ -1,60 +1,11 @@
 (write-and-structure-charm-code)=
 # How to write and structure charm code
 
-(create-a-repository-and-initialise-it)=
-## Create a repository and initialise it
+Before you write your charm code, create a repository and use Charmcraft to generate your charm's project structure. See [](#init-charm).
 
-Create a repository with your source control of choice. Commit the code you have
-added and changed after every significant change, so that you have a record of
-your work and can revert to an earlier version if required.
+This guide demonstrates how to use standard structures in your charm code and summarises best practices for charm development.
 
-```{admonition} Best practice
-:class: hint
-
-Name the repository using the pattern ``<charm name>-operator`` for a single
-charm, or ``<base charm name>-operators`` when the repository will hold
-multiple related charms. For the charm name, see
-{external+charmcraft:ref}`Charmcraft | Specify a name <specify-a-name>`.
-```
-
-In your new repository, run `charmcraft init` to generate the recommended
-structure for building a charm.
-
-```{note}
-In most cases, you'll want to use `--profile=machine` or `--profile=kubernetes`.
-If you are charming an application built with a popular framework, check if
-charmcraft has a {external+charmcraft:ref}`specific profile <tutorial>` for it.
-```
-
-If your repository will hold multiple charms, or a charm and source for other
-artifacts, such as a Rock, create a `charms` folder at the top level, then a folder
-for each charm inside of that one, and run `charmcraft init` in each charm
-folder. You'll end up with a structure similar to:
-
-```
-my-charm-set-operators/
-├── charms
-│   ├── my-charm-core
-│   │   ├── charmcraft.yaml
-│   │   ├── pyproject.toml
-│   │   ├── README.md
-│   │   ├── src
-│   │   │   ├── charm.py
-│   │   │   └── core.py
-│   │   ├── tests
-|   |   |   └── ...
-│   │   ├── tox.ini
-│   │   └── uv.lock
-│   ├── my-charm-dashboard
-|   |   └── ...
-│   └── my-charm-helper
-|   |   └── ...
-├── CONTRIBUTING.md
-├── LICENSE
-├── README.md
-└── rock
-    └── ...
-```
+As you work on your charm, commit your changes after every significant change. You'll then have a record of your work and can revert to an earlier version if required.
 
 (define-the-required-dependencies)=
 ## Define the required dependencies

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ For a hands-on introduction to charm development with Ops, try our tutorials:
 :class: top-aligned
 
 * - **Starting a project**
-  - [Manage charms](howto/manage-charms) • [Write and structure charm code](howto/write-and-structure-charm-code)
+  - [Manage charms](howto/manage-charms) • [Initialise your project](howto/initialise-your-project) • [Write and structure charm code](howto/write-and-structure-charm-code)
 * - **Running workloads**
   - [Manage packages on machines](howto/run-workloads-with-a-charm-machines) • [Manage Kubernetes workloads](howto/manage-containers/index)
 * - **Adding functionality**


### PR DESCRIPTION
This PR adds a new how-to guide called "How to initialise your project". I'm doing this for two reasons:

1. Our [current guidance](https://documentation.ubuntu.com/ops/latest/howto/write-and-structure-charm-code/#create-a-repository-and-initialise-it) is not so easy to find. This topic deserves to be discoverable from the Ops homepage and the list of how-to guides.

2. In the charming docs generally, it could be clearer how developers are supposed to name their repos and charms. See [charmcraft#2582](https://github.com/canonical/charmcraft/issues/2582). I'm taking this opportunity to improve our naming guidelines.

**[Preview of new how-to guide](https://canonical-ubuntu-documentation-library--2449.com.readthedocs.build/ops/2449/howto/initialise-your-project/)**

Also updated:

- [How to manage charms > Initialise your charm project](https://canonical-ubuntu-documentation-library--2449.com.readthedocs.build/ops/2449/howto/manage-charms/#initialise-your-charm-project)
- [How to write and structure charm code](https://canonical-ubuntu-documentation-library--2449.com.readthedocs.build/ops/2449/howto/write-and-structure-charm-code/) - Removed the current guidance and rewrote the intro