### PR TITLE
docs: add workaround for symlink loop during packing

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -220,6 +220,10 @@ The first time you run `charmcraft pack`, Charmcraft takes several minutes to pa
 
 If you run into inexplicable issues when running `charmcraft pack`, this may be because some of the cached information is out of date. Run `charmcraft clean` to fix this.
 
+```{warning}
+If `charmcraft pack` fails with `Too many levels of symbolic links`, remove local virtual environment directories such as `.venv` and `.tox` from your project directory, then try again. If the problem persists, report it to the Charmcraft team, since the specific cause is still being investigated.
+```
+
 ```{important}
 
 **Did you know?** A `.charm` file is really just a zip file of your charm files and code dependencies that makes it more convenient to share, publish, and retrieve your charm contents.


### PR DESCRIPTION
## Summary

Add a warning to the Kubernetes tutorial pack step documenting a workaround for `Too many levels of symbolic links` failures during `charmcraft pack`.

The note suggests removing local virtual environment directories such as `.venv` and `.tox`, then retrying. It also suggests reporting persistent failures upstream, since the root cause is still under investigation.

## Testing

- `make -C docs html`
- `make -C docs vale TARGET='docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md'`
- `make -C docs spelling TARGET='docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md'`
