### PR TITLE
fix: treat remote unit zero as explicit

### DIFF
--- a/testing/src/scenario/_consistency_checker.py
+++ b/testing/src/scenario/_consistency_checker.py
@@ -614,7 +614,7 @@ def check_relation_consistency(
     # with data.
     if (
         event.name.endswith(('_relation_joined', '_relation_changed', '_relation_departed'))
-        and not event.relation_remote_unit_id
+        and event.relation_remote_unit_id is None
         and event.relation is not None  # Another check will have complained if it is None.
     ):
         try:

--- a/testing/tests/test_consistency_checker.py
+++ b/testing/tests/test_consistency_checker.py
@@ -219,19 +219,17 @@ def test_evt_bad_container_name():
     ],
 )
 def test_checkinfo_matches_layer(check: CheckInfo, consistent: bool):
-    layer = ops.pebble.Layer(
-        {
-            'checks': {
-                'chk1': {
-                    'override': 'replace',
-                    'level': 'ready',
-                    'startup': 'disabled',
-                    'threshold': 42,
-                    'http': {'url': 'http://localhost:5000/version'},
-                }
+    layer = ops.pebble.Layer({
+        'checks': {
+            'chk1': {
+                'override': 'replace',
+                'level': 'ready',
+                'startup': 'disabled',
+                'threshold': 42,
+                'http': {'url': 'http://localhost:5000/version'},
             }
         }
-    )
+    })
     state = State(containers={Container('foo', check_infos={check}, layers={'base': layer})})
     asserter = assert_consistent if consistent else assert_inconsistent
     asserter(

--- a/testing/tests/test_consistency_checker.py
+++ b/testing/tests/test_consistency_checker.py
@@ -488,6 +488,15 @@ def test_relation_changed_remote_unit_zero_is_explicit():
     )
 
 
+def test_relation_changed_without_available_remote_unit_is_inconsistent():
+    relation = Relation('foo', remote_units_data={})
+    assert_inconsistent(
+        State(relations={relation}),
+        _Event('foo_relation_changed', relation=relation),
+        _CharmSpec(MyCharm, {'requires': {'foo': {'interface': 'bar'}}}),
+    )
+
+
 def test_action_not_in_meta_inconsistent():
     ctx = Context(MyCharm, meta={'name': 'foo'}, actions={'foo': {}})
     assert_inconsistent(

--- a/testing/tests/test_consistency_checker.py
+++ b/testing/tests/test_consistency_checker.py
@@ -219,17 +219,19 @@ def test_evt_bad_container_name():
     ],
 )
 def test_checkinfo_matches_layer(check: CheckInfo, consistent: bool):
-    layer = ops.pebble.Layer({
-        'checks': {
-            'chk1': {
-                'override': 'replace',
-                'level': 'ready',
-                'startup': 'disabled',
-                'threshold': 42,
-                'http': {'url': 'http://localhost:5000/version'},
+    layer = ops.pebble.Layer(
+        {
+            'checks': {
+                'chk1': {
+                    'override': 'replace',
+                    'level': 'ready',
+                    'startup': 'disabled',
+                    'threshold': 42,
+                    'http': {'url': 'http://localhost:5000/version'},
+                }
             }
         }
-    })
+    )
     state = State(containers={Container('foo', check_infos={check}, layers={'base': layer})})
     asserter = assert_consistent if consistent else assert_inconsistent
     asserter(
@@ -475,6 +477,15 @@ def test_relation_not_in_state():
     assert_consistent(
         State(relations={relation}),
         _Event('foo_relation_changed', relation=relation),
+        _CharmSpec(MyCharm, {'requires': {'foo': {'interface': 'bar'}}}),
+    )
+
+
+def test_relation_changed_remote_unit_zero_is_explicit():
+    relation = Relation('foo', remote_units_data={0: {}})
+    assert_consistent(
+        State(relations={relation}),
+        _Event('foo_relation_changed', relation=relation, relation_remote_unit_id=0),
         _CharmSpec(MyCharm, {'requires': {'foo': {'interface': 'bar'}}}),
     )
 


### PR DESCRIPTION
Fixes #2341.

This updates the Scenario consistency checker to distinguish between a missing remote unit id and an explicit remote unit id of `0`.

`0` is a valid Juju unit id, so the checker should not treat it as falsy/absent.

Changes:
- check `relation_remote_unit_id is None` instead of relying on truthiness
- add a regression test for `relation_remote_unit_id=0`

Validation:
- `uv tool run --with tox-uv tox -e unit -- testing/tests/test_consistency_checker.py -k "relation_not_in_state or remote_unit_zero" -rs -vv --tb=short`
- `uv tool run --with tox-uv tox -e unit -- testing/tests/test_consistency_checker.py -rs`
- `ruff check testing/src/scenario/_consistency_checker.py testing/tests/test_consistency_checker.py`