### PR TITLE
docs: add doc about subordinate charms

### DIFF
--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -55,6 +55,16 @@ The `defer()` mechanism in Ops is convenient, but has some limitations.
 defer-guidance
 ```
 
+## Subordinate charms
+
+A "subordinate" charm is a machine charm where each unit runs alongside a unit of another charm.
+
+```{toctree}
+:maxdepth: 1
+
+subordinate-charms
+```
+
 ## Security
 
 As you write your charm, follow good security practices and produce security documentation for your charm.

--- a/docs/explanation/subordinate-charms.md
+++ b/docs/explanation/subordinate-charms.md
@@ -9,8 +9,6 @@ myst:
 
 A "subordinate" charm is a machine charm where each unit runs alongside a unit of another charm, called the "principal" charm. In this setup, the principal unit and corresponding subordinate unit always run on the same machine.
 
-A subordinate charm typically communicates with the principal charm out of band. There isn't a dedicated Juju relation between a principal unit and the corresponding subordinate unit.
-
 Subordinate charms aren't always appropriate. If possible, instead of writing a subordinate charm, write a regular charm that communicates over relations.
 
 ## When to use a subordinate charm
@@ -29,18 +27,12 @@ A subordinate charm is declared in `charmcraft.yaml`:
 subordinate: true
 ```
 
-`charmcraft.yaml` doesn't specify a principal charm. A subordinate charm doesn't know which principal charm it will be deployed alongside. A Juju user is free to deploy a subordinate charm alongside any principal charm; your subordinate charm's code needs to decide whether it's running in the correct context.
+`charmcraft.yaml` doesn't specify a principal charm. A subordinate charm doesn't know which principal charm it will be deployed alongside. A Juju user is free to deploy a subordinate charm alongside any principal charm; your subordinate charm's code needs to determine whether it's running in the correct context.
 
 When you document a subordinate charm, clearly state the intended principal charm.
 
-```{important}
+## Runtime constraints
+
 A subordinate charm can't control the Ubuntu base that its units run on. If the principal charm supports multiple bases, consider publishing a separate revision of the subordinate charm for each base.
-```
 
-## After deployment
-
-TODO: What actually gets put on the machine? If I have two regular applications in my model, do I automatically get a unit of the subordinate for each unit of each regular application? So there isn't really a notion of "the" principal charm?
-
-TODO: Watch out - other subordinate charms might be configuring the same machine.
-
-TODO: What data can subordinate units see? Is there a peer relation with other units of the same subordinate charm? Review the relation how-to in Ops - "Note however that subordinate units cannot see each other's peer data".
+A subordinate unit shouldn't assume it's the only unit trying to configure the hardware or system. Subordinate units should minimise side effects when writing configuration and installing/uninstalling packages. For general advice, see {ref}`run-workloads-with-a-charm-machines`.

--- a/docs/explanation/subordinate-charms.md
+++ b/docs/explanation/subordinate-charms.md
@@ -1,0 +1,46 @@
+---
+myst:
+  html_meta:
+    description: A subordinate charm runs alongside another charm, typically for managing hardware or system interactions.
+---
+
+(subordinate-charms)=
+# Subordinate charms
+
+A "subordinate" charm is a machine charm where each unit runs alongside a unit of another charm, called the "principal" charm. In this setup, the principal unit and corresponding subordinate unit always run on the same machine.
+
+A subordinate charm typically communicates with the principal charm out of band. There isn't a dedicated Juju relation between a principal unit and the corresponding subordinate unit.
+
+Subordinate charms aren't always appropriate. If possible, instead of writing a subordinate charm, write a regular charm that communicates over relations.
+
+## When to use a subordinate charm
+
+A subordinate charm is appropriate if you need to monitor or configure the underlying hardware. For example, [`hardware-observer`](https://github.com/canonical/hardware-observer-operator).
+
+A subordinate charm is also appropriate if you need to manage how a particular workload interacts with the system. For example, how data is backed up or how connections are pooled. See [`pgbouncer`](https://github.com/canonical/pgbouncer-operator).
+
+In general, a subordinate charm should be lighter weight than its intended principal charm.
+
+## Declaring a subordinate charm
+
+A subordinate charm is declared in `charmcraft.yaml`:
+
+```yaml
+subordinate: true
+```
+
+`charmcraft.yaml` doesn't specify a principal charm. A subordinate charm doesn't know which principal charm it will be deployed alongside. A Juju user is free to deploy a subordinate charm alongside any principal charm; your subordinate charm's code needs to decide whether it's running in the correct context.
+
+When you document a subordinate charm, clearly state the intended principal charm.
+
+```{important}
+A subordinate charm can't control the Ubuntu base that its units run on. If the principal charm supports multiple bases, consider publishing a separate revision of the subordinate charm for each base.
+```
+
+## After deployment
+
+TODO: What actually gets put on the machine? If I have two regular applications in my model, do I automatically get a unit of the subordinate for each unit of each regular application? So there isn't really a notion of "the" principal charm?
+
+TODO: Watch out - other subordinate charms might be configuring the same machine.
+
+TODO: What data can subordinate units see? Is there a peer relation with other units of the same subordinate charm? Review the relation how-to in Ops - "Note however that subordinate units cannot see each other's peer data".

--- a/docs/explanation/subordinate-charms.md
+++ b/docs/explanation/subordinate-charms.md
@@ -30,7 +30,7 @@ subordinate: true
 Instead of specifying a principal charm, you define an endpoint with `scope: container`. The endpoint can use an application-specific interface or the generic `juju-info` interface.
 
 <!-- TODO when ref target is available (from https://github.com/juju/juju/pull/22373) -->
-<!-- See {external+juju:ref}`Juju | The implicit juju-info relation <the-implicit-juju-info-relation-endpoint>`. -->
+<!-- See {external+juju:ref}`Juju | The implicit juju-info relation endpoint <the-implicit-juju-info-relation-endpoint>`. -->
 
 The Juju user is free to integrate a subordinate charm with any principal charm that supports the container-scoped endpoint. If you define a `juju-info` endpoint instead of an application-specific endpoint, this means that the subordinate charm can be integrated with any other charm as principal. The subordinate charm's code needs to determine whether it's running in the correct context.
 

--- a/docs/explanation/subordinate-charms.md
+++ b/docs/explanation/subordinate-charms.md
@@ -9,7 +9,7 @@ myst:
 
 A "subordinate" charm is a machine charm where each unit runs alongside a unit of another charm, called the "principal" charm. In this setup, the principal unit and corresponding subordinate unit always run on the same machine.
 
-Subordinate charms aren't always appropriate. If possible, instead of writing a subordinate charm, write a regular charm that communicates over relations.
+When you deploy a subordinate charm, Juju doesn't create any units of the application. Instead, Juju creates subordinate units when you integrate with a principal charm. See {external+juju:ref}`Juju | Subordinate charm <subordinate-charm>` and {external+juju:ref}`Juju | Subordinate relation <subordinate-relation>`.
 
 ## When to use a subordinate charm
 

--- a/docs/explanation/subordinate-charms.md
+++ b/docs/explanation/subordinate-charms.md
@@ -17,8 +17,6 @@ A subordinate charm is appropriate if you need to monitor or configure the under
 
 A subordinate charm is also appropriate if you need to manage how a particular workload interacts with the system. For example, how data is backed up or how connections are pooled. See [`pgbouncer`](https://github.com/canonical/pgbouncer-operator).
 
-In general, a subordinate charm should be lighter weight than its intended principal charm.
-
 ## Declaring a subordinate charm
 
 A subordinate charm is declared in `charmcraft.yaml`:

--- a/docs/explanation/subordinate-charms.md
+++ b/docs/explanation/subordinate-charms.md
@@ -25,9 +25,13 @@ A subordinate charm is declared in `charmcraft.yaml`:
 subordinate: true
 ```
 
-`charmcraft.yaml` doesn't specify a principal charm. A subordinate charm doesn't know which principal charm it will be deployed alongside. A Juju user is free to deploy a subordinate charm alongside any principal charm; your subordinate charm's code needs to determine whether it's running in the correct context.
+`charmcraft.yaml` doesn't specify a principal charm. A subordinate charm doesn't know which principal charm it will be deployed alongside.
 
-When you document a subordinate charm, clearly state the intended principal charm.
+Instead of specifying a principal charm, you define an endpoint with `scope: container`. The endpoint can use an application-specific interface or the generic `juju-info` interface. See {external+juju:ref}`Juju | The implicit juju-info relation <the-implicit-juju-info-relation-endpoint>`.
+
+The Juju user is free to integrate a subordinate charm with any principal charm that supports the container-scoped endpoint. If you define a `juju-info` endpoint instead of an application-specific endpoint, this means that the subordinate charm can be integrated with any other charm as principal. The subordinate charm's code needs to determine whether it's running in the correct context.
+
+When you document a subordinate charm, clearly state which charms your subordinate charm is intended to be used with and how they should be integrated.
 
 ## Runtime constraints
 

--- a/docs/explanation/subordinate-charms.md
+++ b/docs/explanation/subordinate-charms.md
@@ -27,7 +27,10 @@ subordinate: true
 
 `charmcraft.yaml` doesn't specify a principal charm. A subordinate charm doesn't know which principal charm it will be deployed alongside.
 
-Instead of specifying a principal charm, you define an endpoint with `scope: container`. The endpoint can use an application-specific interface or the generic `juju-info` interface. See {external+juju:ref}`Juju | The implicit juju-info relation <the-implicit-juju-info-relation-endpoint>`.
+Instead of specifying a principal charm, you define an endpoint with `scope: container`. The endpoint can use an application-specific interface or the generic `juju-info` interface.
+
+<!-- TODO when ref target is available (from https://github.com/juju/juju/pull/22373) -->
+<!-- See {external+juju:ref}`Juju | The implicit juju-info relation <the-implicit-juju-info-relation-endpoint>`. -->
 
 The Juju user is free to integrate a subordinate charm with any principal charm that supports the container-scoped endpoint. If you define a `juju-info` endpoint instead of an application-specific endpoint, this means that the subordinate charm can be integrated with any other charm as principal. The subordinate charm's code needs to determine whether it's running in the correct context.
 

--- a/docs/explanation/subordinate-charms.md
+++ b/docs/explanation/subordinate-charms.md
@@ -27,10 +27,7 @@ subordinate: true
 
 `charmcraft.yaml` doesn't specify a principal charm. A subordinate charm doesn't know which principal charm it will be deployed alongside.
 
-Instead of specifying a principal charm, you define an endpoint with `scope: container`. The endpoint can use an application-specific interface or the generic `juju-info` interface.
-
-<!-- TODO when ref target is available (from https://github.com/juju/juju/pull/22373) -->
-<!-- See {external+juju:ref}`Juju | The implicit juju-info relation endpoint <the-implicit-juju-info-relation-endpoint>`. -->
+Instead of specifying a principal charm, you define an endpoint with `scope: container`. The endpoint can use an application-specific interface or the generic `juju-info` interface. See {external+juju:ref}`Juju | The implicit juju-info relation endpoint <the-implicit-juju-info-relation-endpoint>`.
 
 The Juju user is free to integrate a subordinate charm with any principal charm that supports the container-scoped endpoint. If you define a `juju-info` endpoint instead of an application-specific endpoint, this means that the subordinate charm can be integrated with any other charm as principal. The subordinate charm's code needs to determine whether it's running in the correct context.
 

--- a/docs/explanation/subordinate-charms.md
+++ b/docs/explanation/subordinate-charms.md
@@ -35,6 +35,6 @@ When you document a subordinate charm, clearly state which charms your subordina
 
 ## Runtime constraints
 
-A subordinate charm can't control the Ubuntu base that its units run on. If the principal charm supports multiple bases, consider publishing a separate revision of the subordinate charm for each base.
+A subordinate charm can't control the Ubuntu base that its units run on. When you document which charms your subordinate charm is intended to be used with, mention any differences in supported bases.
 
 A subordinate unit shouldn't assume it's the only unit trying to configure the hardware or system. Subordinate units should minimise side effects when writing configuration and installing/uninstalling packages. For general advice, see {ref}`run-workloads-with-a-charm-machines`.


### PR DESCRIPTION
This PR adds an explanation doc about subordinate charms. My intention is to give a summary of what a subordinate charm is, when it's appropriate to write a subordinate charm, and some of the considerations. This isn't meant to be a detailed guide on how to write a subordinate charm.

**[Preview doc](https://canonical-ubuntu-documentation-library--2455.com.readthedocs.build/ops/2455/explanation/subordinate-charms/)**