### PR TITLE
docs: pin to 24.04 when launching VMs

### DIFF
--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -19,7 +19,7 @@ To run integration tests, you'll need a Juju controller and [tox](https://tox.wi
 Use [Multipass](https://canonical.com/multipass/install) to create a virtual machine:
 
 ```text
-multipass launch --cpus 4 --memory 8G --disk 50G --name juju-sandbox
+multipass launch --cpus 4 --memory 8G --disk 50G --name juju-sandbox 24.04
 multipass shell juju-sandbox  # Switch to your virtual machine.
 ```
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/set-up-your-development-environment.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/set-up-your-development-environment.md
@@ -14,7 +14,7 @@ First, install Multipass for managing virtual machines. See the [installation in
 Next, open a terminal, then run:
 
 ```text
-multipass launch --cpus 4 --memory 8G --disk 50G --name juju-sandbox-k8s
+multipass launch --cpus 4 --memory 8G --disk 50G --name juju-sandbox-k8s 24.04
 ```
 
 This creates a virtual machine called `juju-sandbox-k8s`.

--- a/docs/tutorial/write-your-first-machine-charm.md
+++ b/docs/tutorial/write-your-first-machine-charm.md
@@ -49,7 +49,7 @@ First, install Multipass for managing virtual machines. See the [installation in
 Next, open a terminal, then run:
 
 ```text
-multipass launch --cpus 4 --memory 8G --disk 50G --name juju-sandbox
+multipass launch --cpus 4 --memory 8G --disk 50G --name juju-sandbox 24.04
 ```
 
 This creates a virtual machine called `juju-sandbox`.


### PR DESCRIPTION
By default, Multipass now creates 26.04 VMs. But when packing on 26.04 I get an error:

```
charmcraft internal error: ValueError("'26.04' is not a valid BuilddBaseAlias")
```

This PR updates our docs to (hopefully temporarily) pin to 24.04 VMs.