### PR TITLE
docs: in the tutorials, recommend initing from GitHub

### DIFF
--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -58,7 +58,7 @@ The `charmcraft` version that you have installed may come with older versions of
 To use the latest profile versions, initialise your charm using `charmcraft` directly from Github, like this:
 
 ```text
-uvx git+https://github.com/canonical/charmcraft@460e8df init --name <name> --profile <profile>
+uvx git+https://github.com/canonical/charmcraft@fae9862 init --name <name> --profile <profile>
 ```
 ````
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -31,18 +31,15 @@ In your virtual machine, go into your project directory and create the initial v
 
 ```text
 cd ~/fastapi-demo
-charmcraft init --profile kubernetes
-```
-
-<!-- Comment out this tip when the charmcraft stable version is up-to-date. Restore it and update the hash as needed. -->
-````{tip}
-The `charmcraft` version that you have installed may come with older versions of the profiles than we use in this tutorial.
-
-To use the profile versions used in the tutorial, initialise a charm using `charmcraft` directly from Github, like this:
-```
 uvx git+https://github.com/canonical/charmcraft@fae9862 init --profile kubernetes
 ```
-````
+
+<!--
+  When charmcraft stable is up-to-date, comment out this info and switch to 'charmcraft init --profile kubernetes' above.
+  If needed again later, restore the info and switch to 'uvx git+https://github.com/canonical/charmcraft@<hash> init --profile kubernetes'.
+-->
+The `uvx ...` command runs Charmcraft directly from GitHub. We recommend doing this because the installed version of Charmcraft may come with an older version of the profile used in the tutorial. You should use the installed version of Charmcraft for everything else (as we'll do later in the tutorial).
+
 
 Charmcraft created several files, including:
 

--- a/docs/tutorial/write-your-first-machine-charm.md
+++ b/docs/tutorial/write-your-first-machine-charm.md
@@ -167,18 +167,14 @@ In your virtual machine, go into your project directory and create the initial v
 
 ```text
 cd ~/tinyproxy
-charmcraft init --profile machine
-```
-
-<!-- Comment out this tip when the charmcraft stable version is up-to-date. Restore it and update the hash as needed. -->
-````{tip}
-The `charmcraft` version that you have installed may come with older versions of the profiles than we use in this tutorial.
-
-To use the profile versions used in the tutorial, initialise a charm using `charmcraft` directly from Github, like this:
-```
 uvx git+https://github.com/canonical/charmcraft@fae9862 init --profile machine
 ```
-````
+
+<!--
+  When charmcraft stable is up-to-date, comment out this info and switch to 'charmcraft init --profile machine' above.
+  If needed again later, restore the info and switch to 'uvx git+https://github.com/canonical/charmcraft@<hash> init --profile machine'.
+-->
+The `uvx ...` command runs Charmcraft directly from GitHub. We recommend doing this because the installed version of Charmcraft may come with an older version of the profile used in the tutorial. You should use the installed version of Charmcraft for everything else (as we'll do later in the tutorial).
 
 Charmcraft created several files, including:
 


### PR DESCRIPTION
This PR removes the tips in the tutorials about running `charmhub init` from GitHub. Instead, I'm making the GitHub approach the expected approach (and only approach) in the tutorials. While conducting a UX test of the machine charm tutorial, I observed that it's easy for the reader to miss the GitHub approach, causing a downstream problem with an out-of-date base in their charm.

- **[Preview of machine tutorial](https://canonical-ubuntu-documentation-library--2459.com.readthedocs.build/ops/2459/tutorial/write-your-first-machine-charm/#create-a-charm-project)**
- **[Preview of K8s tutorial](https://canonical-ubuntu-documentation-library--2459.com.readthedocs.build/ops/2459/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm/#create-a-charm-project)**

I'm also fixing the commit hash in [How to initialise your project](https://documentation.ubuntu.com/ops/latest/howto/initialise-your-project/). (I forgot to rebase before copying the commit hash into my draft of that doc)