### PR TITLE
ci: add workflow_dispatch trigger to workflows where it is useful

### DIFF
--- a/.github/workflows/charmcraft-pack.yaml
+++ b/.github/workflows/charmcraft-pack.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/db-charm-tests.yaml
+++ b/.github/workflows/db-charm-tests.yaml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
   workflow_call:
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
   workflow_call:
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/example-charm-tests.yaml
+++ b/.github/workflows/example-charm-tests.yaml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
   workflow_call:
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
   workflow_call:
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/hello-charm-tests.yaml
+++ b/.github/workflows/hello-charm-tests.yaml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
   workflow_call:
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["**"]
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
We already have `workflow_dispatch` triggers on many workflows, which is very useful when something goes wrong (especially externally), and we want to validate how the workflow currently runs on `main`. This PR adds `workflow_dispatch` triggers to workflows that didn't have this trigger, where this would also be useful. This excludes workflows like publishing (which runs on pushing tags), and workflows that are only called by others.

---

This PR is motivated by the [db test failure](https://github.com/canonical/operator/actions/runs/25240130398/job/74014364316?pr=2466) in a seemingly unrelated PR. The last run on `main` was a success, but that was a few days ago, so I would have liked to run the tests on `main`  manually as a quick sanity check.