### PR TITLE
docs: fix integration tests of K8s tutorial charms

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -504,7 +504,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     }
 
     # Deploy the charm and wait for it to report blocked, as it needs Postgres.
-    juju.deploy(f"./{charm}", app=APP_NAME, resources=resources)
+    juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_blocked)
 ```
 

--- a/examples/k8s-3-postgresql/tests/integration/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/integration/test_charm.py
@@ -37,7 +37,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     }
 
     # Deploy the charm and wait for it to report blocked, as it needs Postgres.
-    juju.deploy(f"./{charm}", app=APP_NAME, resources=resources)
+    juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_blocked)
 
 

--- a/examples/k8s-4-action/tests/integration/test_charm.py
+++ b/examples/k8s-4-action/tests/integration/test_charm.py
@@ -37,7 +37,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     }
 
     # Deploy the charm and wait for it to report blocked, as it needs Postgres.
-    juju.deploy(f"./{charm}", app=APP_NAME, resources=resources)
+    juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_blocked)
 
 

--- a/examples/k8s-5-observe/tests/integration/test_charm.py
+++ b/examples/k8s-5-observe/tests/integration/test_charm.py
@@ -42,7 +42,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     }
 
     # Deploy the charm and wait for it to report blocked, as it needs Postgres.
-    juju.deploy(f"./{charm}", app=APP_NAME, resources=resources)
+    juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_blocked)
 
 


### PR DESCRIPTION
The integration tests are failing for some of our example charms from the K8s tutorial. See https://github.com/canonical/operator/actions/runs/25410405824.

Cause: We're trying to deploy from `f"./{charm}"`, but `charm` is already a resolved path (from `conftest.py`) so the file can't be found.

---

BTW, the `k8s-1` and `k8s-2` charms don't have this issue. They use `juju.deploy(charm.resolve(), ...` from the Charmcraft profile. This does mean there's a double resolve. I'll open a PR to Charmcraft to switch to `juju.deploy(charm, ...)`, then we can update our charms.