### PR TITLE
docs: bump api_demo_server to 1.0.4 in docs and example charms

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -81,7 +81,7 @@ resources:
     # used by the 'canonical/charming-actions' GitHub action for automated releases.
     # The test_deploy function in tests/integration/test_charm.py reads upstream-source
     # to determine which OCI image to use when running the charm's integration tests.
-    upstream-source: ghcr.io/canonical/api_demo_server:1.0.3
+    upstream-source: ghcr.io/canonical/api_demo_server:1.0.4
 ```
 
 ### Define the charm class
@@ -229,7 +229,7 @@ Deploy the `.charm` file, as below. Juju will create a Kubernetes `StatefulSet` 
 
 ```text
 juju deploy ./fastapi-demo_amd64.charm --resource \
-     demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
+     demo-server-image=ghcr.io/canonical/api_demo_server:1.0.4
 ```
 
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -270,7 +270,7 @@ curl 10.1.157.73:8000/version
 You should see a JSON string with the version of the application:
 
 ```
-{"version":"1.0.3"}
+{"version":"1.0.4"}
 ```
 
 Congratulations, you've successfully created a minimal Kubernetes charm!

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
@@ -110,7 +110,7 @@ First, repack and refresh your charm:
 charmcraft pack
 juju refresh fastapi-demo --force-units \
   --path ./fastapi-demo_amd64.charm \
-  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
+  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.4
 ```
 
 Next, test that the basic action invocation works:

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -343,7 +343,7 @@ First, repack and refresh your charm:
 charmcraft pack
 juju refresh fastapi-demo --force-units \
   --path ./fastapi-demo_amd64.charm \
-  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
+  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.4
 ```
 
 Next, deploy the `postgresql-k8s` charm:

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -204,7 +204,7 @@ Now, let's validate that the app is actually running and reachable on the new po
 curl 10.1.157.74:5000/version
 ```
 
-You should see JSON string with the version of the application: `{"version":"1.0.3"}`
+You should see JSON string with the version of the application: `{"version":"1.0.4"}`
 
 Let's also verify that our invalid port number check works by setting the port to `22` and then running `juju status`:
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -179,7 +179,7 @@ First, repack and refresh your charm:
 charmcraft pack
 juju refresh fastapi-demo --force-units \
   --path ./fastapi-demo_amd64.charm \
-  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
+  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.4
 ```
 
 ```{tip}

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -231,7 +231,7 @@ First, repack and refresh your charm:
 charmcraft pack
 juju refresh fastapi-demo --force-units \
   --path ./fastapi-demo_amd64.charm \
-  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.3
+  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.4
 ```
 
 Next, test your charm's ability to integrate with Prometheus, Loki, and Grafana by following the steps below.

--- a/examples/k8s-1-minimal/charmcraft.yaml
+++ b/examples/k8s-1-minimal/charmcraft.yaml
@@ -57,4 +57,4 @@ resources:
     # used by the 'canonical/charming-actions' GitHub action for automated releases.
     # The test_deploy function in tests/integration/test_charm.py reads upstream-source
     # to determine which OCI image to use when running the charm's integration tests.
-    upstream-source: ghcr.io/canonical/api_demo_server:1.0.3
+    upstream-source: ghcr.io/canonical/api_demo_server:1.0.4

--- a/examples/k8s-2-configurable/charmcraft.yaml
+++ b/examples/k8s-2-configurable/charmcraft.yaml
@@ -46,4 +46,4 @@ resources:
     # used by the 'canonical/charming-actions' GitHub action for automated releases.
     # The test_deploy function in tests/integration/test_charm.py reads upstream-source
     # to determine which OCI image to use when running the charm's integration tests.
-    upstream-source: ghcr.io/canonical/api_demo_server:1.0.3
+    upstream-source: ghcr.io/canonical/api_demo_server:1.0.4

--- a/examples/k8s-3-postgresql/charmcraft.yaml
+++ b/examples/k8s-3-postgresql/charmcraft.yaml
@@ -56,4 +56,4 @@ resources:
     # used by the 'canonical/charming-actions' GitHub action for automated releases.
     # The test_deploy function in tests/integration/test_charm.py reads upstream-source
     # to determine which OCI image to use when running the charm's integration tests.
-    upstream-source: ghcr.io/canonical/api_demo_server:1.0.3
+    upstream-source: ghcr.io/canonical/api_demo_server:1.0.4

--- a/examples/k8s-4-action/charmcraft.yaml
+++ b/examples/k8s-4-action/charmcraft.yaml
@@ -66,4 +66,4 @@ resources:
     # used by the 'canonical/charming-actions' GitHub action for automated releases.
     # The test_deploy function in tests/integration/test_charm.py reads upstream-source
     # to determine which OCI image to use when running the charm's integration tests.
-    upstream-source: ghcr.io/canonical/api_demo_server:1.0.3
+    upstream-source: ghcr.io/canonical/api_demo_server:1.0.4

--- a/examples/k8s-5-observe/charmcraft.yaml
+++ b/examples/k8s-5-observe/charmcraft.yaml
@@ -85,4 +85,4 @@ resources:
     # used by the 'canonical/charming-actions' GitHub action for automated releases.
     # The test_deploy function in tests/integration/test_charm.py reads upstream-source
     # to determine which OCI image to use when running the charm's integration tests.
-    upstream-source: ghcr.io/canonical/api_demo_server:1.0.3
+    upstream-source: ghcr.io/canonical/api_demo_server:1.0.4


### PR DESCRIPTION
Version 1.0.4 only has dependency changes. See https://github.com/canonical/api_demo_server/pull/42