### PR TITLE
docs: add COS Lite integration tests to K8s tutorial

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -4,6 +4,7 @@ balancer's
 breakpoint
 callables
 Canonical's
+cosl
 databag
 databags
 dataclasses

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -529,9 +529,17 @@ In your Multipass Ubuntu VM, run the test again:
 ubuntu@juju-sandbox-k8s:~/fastapi-demo$ tox -e integration
 ```
 
-The test may again take some time to run.
+The test may take some time to run, depending on your computer and network.
 
-When it's done, the output should show two passing tests:
+If the test fails with a timeout error, override the default timeout in `test_database_integration`:
+
+```python
+    juju.wait(jubilant.all_active, timeout=10 * 60)
+```
+
+Then run `tox -e integration` again.
+
+When the test is done, the output should show two passing tests:
 
 ```text
 tests/integration/test_charm.py::test_deploy

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -537,7 +537,7 @@ If the test fails with a timeout error, override the default timeout in `test_da
     juju.wait(jubilant.all_active, timeout=10 * 60)
 ```
 
-Then run `tox -e integration` again.
+Then run `tox -e integration` again. If the test still fails, try [our example charm for this chapter](https://github.com/canonical/operator/tree/main/examples/k8s-3-postgresql) instead, in case there's a mistake in your code.
 
 When the test is done, the output should show two passing tests:
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -539,18 +539,22 @@ def test_loki_data(cos: jubilant.Juju):
     results = json.loads(task.results["proxied-endpoints"])
     loki_url = results["loki/0"]["url"]
     loki_api_url = f"{loki_url}/loki/api/v1/label/juju_application/values"
+    juju_applications = _get_loki_logs(loki_api_url)
+    assert juju_applications is not None, "No logs available from Loki"
+    assert APP_NAME in juju_applications
 
-    # Wait for logs to be available from Loki, then check for our app.
-    for _ in range(2 * 60):
+
+def _get_loki_logs(loki_api_url: str) -> list[str] | None:
+    """Wait for logs to be available from Loki and return them."""
+    for attempt in range(60):
+        if attempt:  # If not the first attempt, wait before retrying.
+            time.sleep(1)
         response = requests.get(loki_api_url)
         if response.status_code == 200:
             response_decoded = response.json()
             if "data" in response_decoded:
-                juju_applications: list[str] = response_decoded["data"]
-                assert APP_NAME in juju_applications
-                return
-        time.sleep(1)
-    pytest.fail("No logs available from Loki")
+                return response_decoded["data"]
+    return None
 ```
 
 ### Run the tests

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -511,6 +511,8 @@ We're now ready to write the tests.
 
 ### Deploy COS Lite and integrate with Loki
 
+Add two test functions to `tests/integration/test_charm.py`:
+
 ```python
 def test_deploy_cos(cos: jubilant.Juju):
     """Deploy COS Lite in a separate model."""
@@ -527,6 +529,8 @@ def test_integrate_loki(juju: jubilant.Juju, cos: jubilant.Juju):
 ```
 
 ### Request logs from Loki
+
+Add a test function to `tests/integration/test_charm.py`:
 
 ```python
 def test_loki_data(cos: jubilant.Juju):
@@ -557,9 +561,20 @@ def _get_loki_logs(loki_api_url: str) -> list[str] | None:
     return None
 ```
 
+For more information, see:
+
+- [Traefik actions](https://charmhub.io/traefik-k8s/actions)
+- [Loki HTTP API](https://grafana.com/docs/loki/latest/reference/loki-http-api/#query-label-values)
+
 ### Run the tests
 
-TODO
+Run the following command from anywhere in the `~/fastapi-demo` directory:
+
+```text
+tox -e integration
+```
+
+The tests take 10-15 minutes to run, depending on your computer and network.
 
 ## Review the final code
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -85,7 +85,7 @@ If you open `lib/charms/grafana_k8s/v0/grafana_dashboard.py` and the other libra
 - `loki_push_api.py` specifies `PYDEPS = ["cosl"]`
 - `prometheus_scrape.py` specifies `PYDEPS = ["cosl>=0.0.53"]`
 
-This means that you need to add `cosl>=1.9.1` to your charm's dependencies.
+You should add the latest version of the [cosl package](https://pypi.org/project/cosl/) to your charm's dependencies.
 
 To update your charm's dependencies in `pyproject.toml`, run:
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -468,6 +468,97 @@ The search result should look like:
 
 Which means that `/names` has received 150 requests so far.
 
+## Write integration tests
+
+Let's write some integration tests to check that our application works correctly with COS Lite:
+
+1. Deploy COS Lite in a separate Juju model.
+2. Integrate our application with Loki from the COS Lite model.
+3. Ask Loki for logs related to our application.
+
+### Create a model for COS Lite
+
+The existing integration tests use a model that is created by the `juju` fixture. We'll define a similar fixture that creates a separate model for COS Lite.
+
+First, update the imports at the beginning of `tests/integration/test_charm.py`:
+
+```python
+import json
+import logging
+import pathlib
+import time
+
+import jubilant
+import pytest
+import pytest_jubilant
+import requests
+import yaml
+```
+
+We need `pytest` and `pytest_jubilant` for the new fixture. We'll use the other additions (`json`, `time`, and `requests`) when we write the tests.
+
+Next, still in `tests/integration/test_charm.py`, define the new fixture:
+
+```python
+@pytest.fixture(scope="module")
+def cos(juju_factory: pytest_jubilant.JujuFactory):
+    yield juju_factory.get_juju(suffix="cos")
+```
+
+`get_juju` creates a model called `jubilant-<randomhex>-cos`.
+
+We're now ready to write the tests.
+
+### Deploy COS Lite and integrate with Loki
+
+```python
+@pytest.mark.juju_setup
+def test_deploy_cos(cos: jubilant.Juju):
+    """Deploy COS Lite in a separate model."""
+    cos.deploy("cos-lite", trust=True)
+    cos.wait(jubilant.all_active, timeout=10 * 60)  # Allow time for the bundle to deploy.
+
+
+@pytest.mark.juju_setup
+def test_integrate_loki(juju: jubilant.Juju, cos: jubilant.Juju):
+    """Integrate our app with Loki from COS Lite."""
+    cos.offer("loki", endpoint="logging")
+    juju.integrate(APP_NAME, f"{cos.model}.loki")
+    juju.wait(jubilant.all_active)
+    cos.wait(jubilant.all_active)
+```
+
+### Request logs from Loki
+
+```python
+def test_loki_data(cos: jubilant.Juju):
+    """Use Loki's HTTP API to verify that Loki has a label for our app.
+
+    COS Lite exposes Loki's API through the Traefik load balancer. Traefik comes with an action
+    that tells us the base URL of Loki's API.
+    """
+    task = cos.run("traefik/0", "show-proxied-endpoints")
+    results = json.loads(task.results["proxied-endpoints"])
+    loki_url = results["loki/0"]["url"]
+    loki_api_url = f"{loki_url}/loki/api/v1/label/juju_application/values"
+
+    # Wait for logs to be available from Loki, then check for our app.
+    for _ in range(2 * 60):
+        response = requests.get(loki_api_url)
+        if response.status_code == 200:
+            response_decoded = response.json()
+            if "data" in response_decoded:
+                juju_applications: list[str] = response_decoded["data"]
+                assert APP_NAME in juju_applications
+                return
+        time.sleep(1)
+    pytest.fail("No logs available from Loki")
+```
+
+### Run the tests
+
+TODO
+
 ## Review the final code
 
 For the full code, see [our example charm for this chapter](https://github.com/canonical/operator/tree/main/examples/k8s-5-observe).

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -90,7 +90,7 @@ You should add the latest version of the [cosl package](https://pypi.org/project
 To update your charm's dependencies in `pyproject.toml`, run:
 
 ```text
-uv add 'cosl>=1.9.1'
+uv add 'cosl>=1.9.1,<2'
 ```
 
 ## Integrate with Prometheus

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -470,7 +470,7 @@ Which means that `/names` has received 150 requests so far.
 
 ## Write integration tests
 
-Let's write some integration tests to check that our application works correctly with COS Lite:
+Let's write some integration tests to check that our application works correctly with COS Lite. The tests will:
 
 1. Deploy COS Lite in a separate Juju model.
 2. Integrate our application with Loki from the COS Lite model.
@@ -480,7 +480,7 @@ Let's write some integration tests to check that our application works correctly
 
 The existing integration tests use a model that is created by the `juju` fixture. We'll define a similar fixture that creates a separate model for COS Lite.
 
-First, update the imports at the beginning of `tests/integration/test_charm.py`:
+First, in `tests/integration/test_charm.py`, import `json` and `time` from the standard library. Then import `pytest`, `pytest_jubilant`, and `requests`. Your imports should now look like this:
 
 ```python
 import json
@@ -494,8 +494,6 @@ import pytest_jubilant
 import requests
 import yaml
 ```
-
-We need `pytest` and `pytest_jubilant` for the new fixture. We'll use the other additions (`json`, `time`, and `requests`) when we write the tests.
 
 Next, still in `tests/integration/test_charm.py`, define the new fixture:
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -512,14 +512,12 @@ We're now ready to write the tests.
 ### Deploy COS Lite and integrate with Loki
 
 ```python
-@pytest.mark.juju_setup
 def test_deploy_cos(cos: jubilant.Juju):
     """Deploy COS Lite in a separate model."""
     cos.deploy("cos-lite", trust=True)
     cos.wait(jubilant.all_active, timeout=10 * 60)  # Allow time for the bundle to deploy.
 
 
-@pytest.mark.juju_setup
 def test_integrate_loki(juju: jubilant.Juju, cos: jubilant.Juju):
     """Integrate our app with Loki from COS Lite."""
     cos.offer("loki", endpoint="logging")


### PR DESCRIPTION
This PR follows on from https://github.com/canonical/operator/pull/2411 and resolves https://github.com/canonical/operator/issues/1838.

I'm adding a new section [Write integration tests (preview)](https://canonical-ubuntu-documentation-library--2478.com.readthedocs.build/ops/2478/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite/#write-integration-tests) to the last chapter of the K8s tutorial. The tests in this section match what was added to the example charm in the previous PR.

Other changes:

- Adjusted the part where we talk about adding `cosl` to dependencies. It wasn't clear why 1.9.1 should be added based on the versions required by libs, so I'm explicitly saying to add the latest version of the package. [Preview](https://canonical-ubuntu-documentation-library--2478.com.readthedocs.build/ops/2478/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite/#add-dependencies-from-libraries)

- During earlier testing, I found that the postgres deployment can cause the integration tests to time out. We don't want to specify a timeout in that test, so I've added some info to the tutorial chapter ([Preview](https://canonical-ubuntu-documentation-library--2478.com.readthedocs.build/ops/2478/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql/#write-an-integration-test)):

    > If the test fails with a timeout error, override the default timeout in test_database_integration:
    > ...