### PR TITLE
chore: bump schedules to change owner

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -3,7 +3,7 @@ name: ops Integration Tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '42 7 25 * *'
+    - cron: '41 7 25 * *'
 
 permissions: {}
 

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -3,7 +3,7 @@ name: ops Smoke Tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 7 25 * *'
+    - cron: '1 7 25 * *'
 
 permissions: {}
 


### PR DESCRIPTION
This PR makes insignificant changes to two workload schedules that were last edited by Dima. This changes the notification recipient (when the workload fails) to me, which will suffice until we solve #2424.

Fixes #2481