### PR TITLE
docs: add guidance about names of workload-less charms

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -4,6 +4,8 @@ balancer's
 breakpoint
 callables
 Canonical's
+configurator
+configurators
 cosl
 databag
 databags

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -5,7 +5,6 @@ breakpoint
 callables
 Canonical's
 configurator
-configurators
 cosl
 databag
 databags

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -25,13 +25,13 @@ To check that your preferred name isn't already in use, visit the (future) Charm
 https://charmhub.io/mega-calendar-k8s
 ```
 
-There also exists charms that do operate a workload, such as integrators and configurators charms. These two categories serve two different purposes:
+There also exist charms that do not operate a workload, such as integrators and configurators charms. These two categories serve two different purposes:
 
 * An integrator charm provides the possibility to integrate a service that is not managed via Juju into the Juju model. This can both apply to server side integrations (e.g. `s3-integrator`, that integrates an externally managed s3 object storage) or to client side integration (e.g. `data-integrator`, representing the integration of external client applications that needs a database).
 
 * A configurator charm provides better scalability and centralized logic to further configure for a particular charm or relation that is already in Juju. Examples for this could be `cos-configuration` when it applies to a single charm (e.g. providing more fine-grained configuration the prometheus scraping) or for relation/integration (e.g. `ingress-configurator` as to provide further configuration of ingresses requests)
 
-Since workload-less charms can equally work on machines and on Kubernetes, when naming integrator charms and configurator charms, avoid using the `k8s` suffix, unless the charm is only relevant for Kubernetes, e.g. managing K8s resources within the charm logic. Use the `integrator` and `configurator` suffix to signal the category of the charm, e.g. `foo-integrator` or `bar-configurator`.
+Since workload-less charms can work both on machines and on Kubernetes, when naming integrator charms and configurator charms, avoid using the `k8s` suffix, unless the charm is only relevant for Kubernetes, e.g. managing K8s resources within the charm logic using `lightkube`. When naming the charm, use the `integrator` and `configurator` suffix to signal the category of the charm, e.g. `foo-integrator` or `bar-configurator`.
 
 (create-a-repository)=
 ## Create a repository

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -35,6 +35,8 @@ Create a repository with your source control of choice.
 Name the repository using the pattern ``<charm name>-operator`` for a single
 charm, or ``<base charm name>-operators`` when the repository will hold
 multiple related charms. For the charm name, see [](#decide-your-charms-name).
+
+The suffix `-operator` applies only to charms that manage workloads and operate a particular software. Do not use "-operator" suffix for workless charm (e.g. integrator charms) that do not manage any workload for avoiding suffix stacking and favoring a leaner naming, such as `data-integrator` instead of `data-integrator-operator`. 
 ```
 
 For example, name the repository `mega-calendar-k8s-operator` if your charm will be called `mega-calendar-k8s`.

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -32,11 +32,7 @@ Create a repository with your source control of choice.
 ```{admonition} Best practice
 :class: hint
 
-Name the repository using the pattern ``<charm name>-operator`` for a single
-charm, or ``<base charm name>-operators`` when the repository will hold
-multiple related charms. For the charm name, see [](#decide-your-charms-name).
-
-The suffix `-operator` applies only to charms that manage workloads and operate a particular software. Do not use "-operator" suffix for workless charm (e.g. integrator charms) that do not manage any workload for avoiding suffix stacking and favoring a leaner naming, such as `data-integrator` instead of `data-integrator-operator`. 
+Name the repository using the pattern ``<charm name>-operator`` for a single charm managing a workload. Workloadless charms managing integration with another charm should use the suffix ``integrator`` instead. Charms managing configuration for another charm should use ``configurator``. Monorepos containing multiple related charms should instead use a plural suffix, like ``operators``. For the charm name, see [](#decide-your-charms-name).
 ```
 
 For example, name the repository `mega-calendar-k8s-operator` if your charm will be called `mega-calendar-k8s`.

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -25,13 +25,16 @@ To check that your preferred name isn't already in use, visit the (future) Charm
 https://charmhub.io/mega-calendar-k8s
 ```
 
-There also exist charms that do not operate a workload, such as integrators and configurators charms. These two categories serve two different purposes:
+Some charms do not operate a workload, such as integrator and configurator charms. These categories serve different purposes:
 
-* An integrator charm provides the possibility to integrate a service that is not managed via Juju into the Juju model. This can both apply to server side integrations (e.g. `s3-integrator`, that integrates an externally managed s3 object storage) or to client side integration (e.g. `data-integrator`, representing the integration of external client applications that needs a database).
+* An integrator charm allows integration with a service that is not managed through Juju. This can both apply to server side integrations (such as `s3-integrator`, which integrates an externally managed S3 object storage) or to client side integrations (such as `data-integrator`, representing the integration of external client applications that needs a database).
+* 
 
-* A configurator charm provides better scalability and centralized logic to further configure for a particular charm or relation that is already in Juju. Examples for this could be `cos-configuration` when it applies to a single charm (e.g. providing more fine-grained configuration the prometheus scraping) or for relation/integration (e.g. `ingress-configurator` as to provide further configuration of ingresses requests)
+* A configurator charm provides logic to configure a particular charm or relation that is already in Juju. Examples include `cos-configuration` when it applies to a single charm (such as providing more fine-grained configuration of the Prometheus scraping) or for a relation (such as `ingress-configurator` to provide additional configuration of ingress requests).
 
-Since workload-less charms can work both on machines and on Kubernetes, when naming integrator charms and configurator charms, avoid using the `k8s` suffix, unless the charm is only relevant for Kubernetes, e.g. managing K8s resources within the charm logic using `lightkube`. When naming the charm, use the `integrator` and `configurator` suffix to signal the category of the charm, e.g. `foo-integrator` or `bar-configurator`.
+Since workload-less charms can work both on machines and on Kubernetes, avoid using the `k8s` suffix when naming integrator charms and configurator charm , unless the charm is only relevant for Kubernetes (for example, managing K8s resources within the charm logic using `lightkube`).
+
+When naming the charm, use the `integrator` and `configurator` suffix to signal the category of the charm. For example, `foo-integrator` or `bar-configurator`.
 
 (create-a-repository)=
 ## Create a repository
@@ -41,7 +44,9 @@ Create a repository with your source control of choice.
 ```{admonition} Best practice
 :class: hint
 
-If your charm operates a workload, name the repository `<charm name>-operator`. If your charm doesn't operate a workload (as in the case of integrator charms and configurator charms), the `-operator` suffix is not needed and the repository can be named with the same name of the charm, e.g. `foo-integrator` and `bar-configurator`. Use the plural when `s` the repository contains multiple charms or artefacts (such as rocks).
+If your charm operates a workload, name the repository `<charm name>-operator`. For advice about the charm name, see [](#decide-your-charms-name). If your charm doesn't operate a workload (as in the case of integrator charms and configurator charms), the `-operator` suffix isn't needed. For example, `foo-integrator` and `bar-configurator`.
+
+Repositories that contain multiple charms or one or more charms and other artefacts (like Rocks) will need to use other naming patterns.
 ```
 
 Examples:
@@ -49,9 +54,9 @@ Examples:
 - [kafka-operator](https://github.com/canonical/kafka-operator) - Contains a single charm that operates a workload on machine.
 - [kafka-k8s-operator](https://github.com/canonical/kafka-k8s-operator) - Contains a single charm that operates a workload on K8s.
 - [katib-operators](https://github.com/canonical/katib-operators) - Contains multiple charms.
-- [data-integrator](https://github.com/canonical/data-integrator) - Contains a charm that integrates an externally managed service (e.g. client application).
-- [s3-integrator](https://github.com/canonical/object-storage-integrators) - Contains multiple charm that integrates externally managed service (e.g. different kind of object storage backends).
-- [request-authentication-configurator](https://github.com/canonical/request-authentication-configurator) - Contains a charm that configure Gateway to perform request authentication
+- [data-integrator](https://github.com/canonical/data-integrator) - Contains a charm that integrates an externally managed service (such as a client application).
+- [s3-integrator](https://github.com/canonical/object-storage-integrators) - Contains multiple charms that integrate an externally managed service (such as different kinds of object storage backends).
+- [request-authentication-configurator](https://github.com/canonical/request-authentication-configurator) - Contains a charm that configures Gateway to perform request authentication.
 
 (initialise-the-repository)=
 ## Initialise the repository

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -27,14 +27,13 @@ https://charmhub.io/mega-calendar-k8s
 
 Some charms do not operate a workload, such as integrator and configurator charms. These categories serve different purposes:
 
-* An integrator charm allows integration with a service that is not managed through Juju. This can both apply to server side integrations (such as `s3-integrator`, which integrates an externally managed S3 object storage) or to client side integrations (such as `data-integrator`, representing the integration of external client applications that needs a database).
-* 
+* An integrator charm allows integration with a service that is not managed through Juju. This can both apply to server side integrations (such as `s3-integrator`, which integrates an externally managed S3 object storage) or to client side integrations (such as `data-integrator`, representing the integration of external client application that needs a database).
 
 * A configurator charm provides logic to configure a particular charm or relation that is already in Juju. Examples include `cos-configuration` when it applies to a single charm (such as providing more fine-grained configuration of the Prometheus scraping) or for a relation (such as `ingress-configurator` to provide additional configuration of ingress requests).
 
-Since workload-less charms can work both on machines and on Kubernetes, avoid using the `k8s` suffix when naming integrator charms and configurator charm , unless the charm is only relevant for Kubernetes (for example, managing K8s resources within the charm logic using `lightkube`).
+Since workload-less charms can work both on machines and on Kubernetes, avoid using the `k8s` suffix when naming integrator charms and configurator charms, unless the charm is only relevant for Kubernetes (for example, managing K8s resources within the charm logic using `lightkube`).
 
-When naming the charm, use the `integrator` and `configurator` suffix to signal the category of the charm. For example, `foo-integrator` or `bar-configurator`.
+When naming the charm, use `-integrator` and `-configurator` to signal the category of the charm. For example, `foo-integrator` or `bar-configurator`.
 
 (create-a-repository)=
 ## Create a repository
@@ -46,13 +45,13 @@ Create a repository with your source control of choice.
 
 If your charm operates a workload, name the repository `<charm name>-operator`. For advice about the charm name, see [](#decide-your-charms-name). If your charm doesn't operate a workload (as in the case of integrator charms and configurator charms), the `-operator` suffix isn't needed. For example, `foo-integrator` and `bar-configurator`.
 
-Repositories that contain multiple charms or one or more charms and other artefacts (like Rocks) will need to use other naming patterns.
+Repositories that contain multiple charms or one or more charms and other artefacts (like rocks) will need to use other naming patterns.
 ```
 
 Examples:
 
-- [kafka-operator](https://github.com/canonical/kafka-operator) - Contains a single charm that operates a workload on machine.
-- [kafka-k8s-operator](https://github.com/canonical/kafka-k8s-operator) - Contains a single charm that operates a workload on K8s.
+- [kafka-operator](https://github.com/canonical/kafka-operator) - Contains a single charm that operates a machine workload.
+- [kafka-k8s-operator](https://github.com/canonical/kafka-k8s-operator) - Contains a single charm that operates a K8s workload.
 - [katib-operators](https://github.com/canonical/katib-operators) - Contains multiple charms.
 - [data-integrator](https://github.com/canonical/data-integrator) - Contains a charm that integrates an externally managed service (such as a client application).
 - [s3-integrator](https://github.com/canonical/object-storage-integrators) - Contains multiple charms that integrate an externally managed service (such as different kinds of object storage backends).

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -24,18 +24,37 @@ To check that your preferred name isn't already in use, visit the (future) Charm
 ```text
 https://charmhub.io/mega-calendar-k8s
 ```
-(create-a-repository-and-initialise-it)=
-## Create a repository and initialise it
+
+There also exists charms that do operate a workload, such as integrators and configurators charms. These two categories serve two different purposes:
+
+* An integrator charm provides the possibility to integrate a service that is not managed via Juju into the Juju model. This can both apply to server side integrations (e.g. `s3-integrator`, that integrates an externally managed s3 object storage) or to client side integration (e.g. `data-integrator`, representing the integration of external client applications that needs a database).
+
+* A configurator charm provides better scalability and centralized logic to further configure for a particular charm or relation that is already in Juju. Examples for this could be `cos-configuration` when it applies to a single charm (e.g. providing more fine-grained configuration the prometheus scraping) or for relation/integration (e.g. `ingress-configurator` as to provide futher configuration of ingresses requests)
+
+Since workload-less charms can equally work on machines and on Kubernetes, when naming integrator charms and configurator charms, avoid using the `k8s` suffix, unless the charm is only relevant for Kubernetes, e.g. managing K8s resources within the charm logic. Use the `integrator` and `configurator` suffix to signal the category of the charm, e.g. `foo-integrator` or `bar-configurator`.
+
+(create-a-repository)=
+## Create a repository
 
 Create a repository with your source control of choice.
 
 ```{admonition} Best practice
 :class: hint
 
-Name the repository using the pattern ``<charm name>-operator`` for a single charm managing a workload. Workloadless charms managing integration with another charm should use the suffix ``integrator`` instead. Charms managing configuration for another charm should use ``configurator``. Monorepos containing multiple related charms should instead use a plural suffix, like ``operators``. For the charm name, see [](#decide-your-charms-name).
+If your charm operates a workload, name the repository `<charm name>-operator`. If your charm doesn't operate a workload (as in the case of integrator charms and configurator charms), the `-operator` suffix is not needed and the repository can be named with the same name of the charm, e.g. `foo-integrator` and `bar-configurator`. Use the plural when `s` the repository contains multiple charms or artefacts (such as rocks).
 ```
 
-For example, name the repository `mega-calendar-k8s-operator` if your charm will be called `mega-calendar-k8s`.
+Examples:
+
+- [kafka-operator](https://github.com/canonical/kafka-operator) - Contains a single charm that operates a workload on machine.
+- [kafka-k8s-operator](https://github.com/canonical/kafka-k8s-operator) - Contains a single charm that operates a workload on K8s.
+- [katib-operators](https://github.com/canonical/katib-operators) - Contains multiple charms.
+- [data-integrator](https://github.com/canonical/data-integrator) - Contains a charm that integrates an externally managed service (e.g. client application).
+- [s3-integrator](https://github.com/canonical/object-storage-integrators) - Contains multiple charm that integrates externally managed service (e.g. different kind of object storage backends).
+- [request-authentication-configurator](https://github.com/canonical/request-authentication-configurator) - Contains a charm that configure Gateway to perform request authentication
+
+(initialise-the-repository)=
+## Initialise the repository
 
 Next, use {external+charmcraft:doc}`Charmcraft <index>` to generate the recommended project structure in the repository:
 

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -29,7 +29,7 @@ There also exists charms that do operate a workload, such as integrators and con
 
 * An integrator charm provides the possibility to integrate a service that is not managed via Juju into the Juju model. This can both apply to server side integrations (e.g. `s3-integrator`, that integrates an externally managed s3 object storage) or to client side integration (e.g. `data-integrator`, representing the integration of external client applications that needs a database).
 
-* A configurator charm provides better scalability and centralized logic to further configure for a particular charm or relation that is already in Juju. Examples for this could be `cos-configuration` when it applies to a single charm (e.g. providing more fine-grained configuration the prometheus scraping) or for relation/integration (e.g. `ingress-configurator` as to provide futher configuration of ingresses requests)
+* A configurator charm provides better scalability and centralized logic to further configure for a particular charm or relation that is already in Juju. Examples for this could be `cos-configuration` when it applies to a single charm (e.g. providing more fine-grained configuration the prometheus scraping) or for relation/integration (e.g. `ingress-configurator` as to provide further configuration of ingresses requests)
 
 Since workload-less charms can equally work on machines and on Kubernetes, when naming integrator charms and configurator charms, avoid using the `k8s` suffix, unless the charm is only relevant for Kubernetes, e.g. managing K8s resources within the charm logic. Use the `integrator` and `configurator` suffix to signal the category of the charm, e.g. `foo-integrator` or `bar-configurator`.
 

--- a/docs/reuse/best-practices.txt
+++ b/docs/reuse/best-practices.txt
@@ -1,5 +1,5 @@
 **[How to initialise your project](https://documentation.ubuntu.com/ops/latest/howto/initialise-your-project/)**
-- Name the repository using the pattern ``<charm name>-operator`` for a single charm, or ``<base charm name>-operators`` when the repository will hold multiple related charms. For the charm name, see [](#decide-your-charms-name). See [Create a repository and initialise it](#create-a-repository-and-initialise-it).
+- If your charm operates a workload, name the repository `<charm name>-operator`. For advice about the charm name, see [](#decide-your-charms-name). If your charm doesn't operate a workload (as in the case of integrator charms and configurator charms), the `-operator` suffix isn't needed. For example, `foo-integrator` and `bar-configurator`. Repositories that contain multiple charms or one or more charms and other artefacts (like Rocks) will need to use other naming patterns. See [Create a repository](#create-a-repository).
 
 **[How to log from your charm](https://documentation.ubuntu.com/ops/latest/howto/log-from-your-charm/)**
 - Capture output to `stdout` and `stderr` in your charm and use the logging and warning functionality to send messages to the charm user, rather than rely on Juju capturing output. In particular, you should avoid `print()` calls, and ensure that any subprocess calls capture output.


### PR DESCRIPTION
As discussed among Charm Engineering managers, we'd like to soften the guidance on using the `-operator` suffix for workless charm to favor a less verbose, convoluted naming using multiple suffix stacking.

[Preview](https://canonical-ubuntu-documentation-library--2496.com.readthedocs.build/ops/2496/howto/initialise-your-project/)