### PR TITLE
docs: adopt latest Charmcraft profiles, incl juju_setup marker on integration tests

### DIFF
--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -51,7 +51,7 @@ Or for a machine charm:
 charmcraft init --name mega-calendar --profile machine
 ```
 
-<!-- Comment out this tip when the charmcraft stable version is up-to-date. Restore it and update the hash as needed. -->
+<!-- Remove this tip when the charmcraft stable version is up-to-date. -->
 ````{tip}
 The `charmcraft` version that you have installed may come with older versions of the profiles.
 

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -58,7 +58,7 @@ The `charmcraft` version that you have installed may come with older versions of
 To use the latest profile versions, initialise your charm using `charmcraft` directly from Github, like this:
 
 ```text
-uvx git+https://github.com/canonical/charmcraft@fae9862 init --name <name> --profile <profile>
+uvx git+https://github.com/canonical/charmcraft@74d12bc init --name <name> --profile <profile>
 ```
 ````
 

--- a/docs/howto/manage-the-workload-version.md
+++ b/docs/howto/manage-the-workload-version.md
@@ -85,6 +85,7 @@ that `charmcraft init` provides, and add a new test that verifies the workload
 version is set. For example:
 
 ```python
+@pytest.mark.juju_setup
 def test_deploy(charm: Path, juju: jubilant.Juju):
     """Deploy the charm under test."""
     juju.deploy(f'./{charm}')

--- a/docs/howto/manage-the-workload-version.md
+++ b/docs/howto/manage-the-workload-version.md
@@ -85,8 +85,14 @@ that `charmcraft init` provides, and add a new test that verifies the workload
 version is set. For example:
 
 ```python
+import pathlib
+
+import jubilant
+import pytest
+
+
 @pytest.mark.juju_setup
-def test_deploy(charm: Path, juju: jubilant.Juju):
+def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Deploy the charm under test."""
     juju.deploy(f'./{charm}')
     juju.wait(jubilant.all_active)

--- a/docs/howto/run-workloads-with-a-charm-machines.md
+++ b/docs/howto/run-workloads-with-a-charm-machines.md
@@ -385,7 +385,7 @@ import jubilant
 
 
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
-    juju.deploy(charm.resolve(), app="myworkload")
+    juju.deploy(charm, app="myworkload")
     juju.wait(jubilant.all_active, timeout=600)
 
 

--- a/docs/howto/run-workloads-with-a-charm-machines.md
+++ b/docs/howto/run-workloads-with-a-charm-machines.md
@@ -382,6 +382,7 @@ Integration tests deploy the packed charm to a real Juju model and check that th
 import pathlib
 
 import jubilant
+import pytest
 
 
 @pytest.mark.juju_setup

--- a/docs/howto/run-workloads-with-a-charm-machines.md
+++ b/docs/howto/run-workloads-with-a-charm-machines.md
@@ -384,6 +384,7 @@ import pathlib
 import jubilant
 
 
+@pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.deploy(charm, app="myworkload")
     juju.wait(jubilant.all_active, timeout=600)

--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -245,6 +245,7 @@ In `charmcraft.yaml`'s `resources` section, the `upstream-source` is, by convent
 import pathlib
 
 import jubilant
+import pytest
 import yaml
 
 

--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -197,7 +197,7 @@ For more examples of tests that deploy charms, see:
 
 Tests run sequentially in the order they are written in the file. It can be useful to put tests that deploy applications in the top of the file so the applications can be used by subsequent tests.
 
-We recommend that you mark such tests with `@pytest.mark.juju_setup`. If you later use `--no-juju-setup` to skip the deployment tests, the model must already exist. See {ref}`write-integration-tests-for-a-charm-run-your-tests`.
+Mark these tests with `@pytest.mark.juju_setup`. Then you can use `--no-juju-setup` with `--juju-model` to skip the deployment tests and run against an existing model. See {ref}`write-integration-tests-for-a-charm-run-your-tests`.
 
 Similarly, if you have tests that perform destructive actions (for example, removing relations or applications), mark them with `@pytest.mark.juju_teardown`. These tests will be skipped when `--no-juju-teardown` is passed.
 

--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -179,6 +179,7 @@ import pathlib
 import jubilant
 
 
+@pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Deploy the charm under test."""
     juju.deploy(charm)
@@ -196,7 +197,7 @@ For more examples of tests that deploy charms, see:
 
 Tests run sequentially in the order they are written in the file. It can be useful to put tests that deploy applications in the top of the file so the applications can be used by subsequent tests.
 
-You can mark such tests with `@pytest.mark.juju_setup`. If you later use `--no-juju-setup` to skip the deployment tests, the model must already exist. See {ref}`write-integration-tests-for-a-charm-run-your-tests`.
+We recommend that you mark such tests with `@pytest.mark.juju_setup`. If you later use `--no-juju-setup` to skip the deployment tests, the model must already exist. See {ref}`write-integration-tests-for-a-charm-run-your-tests`.
 
 Similarly, if you have tests that perform destructive actions (for example, removing relations or applications), mark them with `@pytest.mark.juju_teardown`. These tests will be skipped when `--no-juju-teardown` is passed.
 
@@ -250,6 +251,7 @@ import yaml
 METADATA = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text())
 
 
+@pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     resources = {
         name: res["upstream-source"]

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -31,7 +31,7 @@ In your virtual machine, go into your project directory and create the initial v
 
 ```text
 cd ~/fastapi-demo
-uvx git+https://github.com/canonical/charmcraft@fae9862 init --profile kubernetes
+uvx git+https://github.com/canonical/charmcraft@74d12bc init --profile kubernetes
 ```
 
 <!--

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -471,7 +471,7 @@ The result should be similar to the following output:
 `tox -e integration` doesn't pack your charm. If you modify the charm code and want to run the integration tests again, run `charmcraft pack` before `tox -e integration`.
 ```
 
-The Juju model is destroyed at the end of the test. If you want to run the test and keep the model for further exploration, see the example commands in [](#write-integration-tests-for-a-charm-run-your-tests). The `@pytest.mark.juju_setup` marker on `test_deploy` gives you the option of skipping this test on subsequent runs.
+The Juju model is destroyed at the end of the test. If you want to run the test and keep the model for further exploration, see the example commands in [](#write-integration-tests-for-a-charm-run-your-tests). The `@pytest.mark.juju_setup` marker on `test_deploy` gives you the option of skipping this test on subsequent runs, for iterative testing on a deployed application.
 
 ### Run tests with `charmcraft test`
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -431,6 +431,7 @@ METADATA = yaml.safe_load(pathlib.Path("charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
+@pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Deploy the charm under test."""
     resources = {
@@ -468,6 +469,8 @@ The result should be similar to the following output:
 ```{tip}
 `tox -e integration` doesn't pack your charm. If you modify the charm code and want to run the integration tests again, run `charmcraft pack` before `tox -e integration`.
 ```
+
+The Juju model is destroyed at the end of the test. If you want to run the test and keep the model for further exploration, see the example commands in [](#write-integration-tests-for-a-charm-run-your-tests). The `@pytest.mark.juju_setup` marker on `test_deploy` gives you the option of skipping this test on subsequent runs.
 
 ### Run tests with `charmcraft test`
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -35,8 +35,7 @@ uvx git+https://github.com/canonical/charmcraft@74d12bc init --profile kubernete
 ```
 
 <!--
-  When charmcraft stable is up-to-date, comment out this info and switch to 'charmcraft init --profile kubernetes' above.
-  If needed again later, restore the info and switch to 'uvx git+https://github.com/canonical/charmcraft@<hash> init --profile kubernetes'.
+  When charmcraft stable is up-to-date, remove this info and switch to 'charmcraft init --profile kubernetes' above.
 -->
 The `uvx ...` command runs Charmcraft directly from GitHub. We recommend doing this because the installed version of Charmcraft may come with an older version of the profile used in the tutorial. You should use the installed version of Charmcraft for everything else (as we'll do later in the tutorial).
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -423,6 +423,7 @@ import logging
 import pathlib
 
 import jubilant
+import pytest
 import yaml
 
 logger = logging.getLogger(__name__)

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -436,7 +436,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     resources = {
         "demo-server-image": METADATA["resources"]["demo-server-image"]["upstream-source"]
     }
-    juju.deploy(charm.resolve(), app=APP_NAME, resources=resources)
+    juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_active)
 ```
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -513,7 +513,7 @@ Then, let's add another test case to check the integration is successful. For th
 In your `tests/integration/test_charm.py` file add the following test case:
 
 ```python
-def test_database_integration(juju: jubilant.Juju):
+def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the charm integrates with the database.
 
     Assert that the charm is active if the integration is established.
@@ -523,23 +523,25 @@ def test_database_integration(juju: jubilant.Juju):
     juju.wait(jubilant.all_active)
 ```
 
-In your Multipass Ubuntu VM, run the test again:
+This test depends on the `charm` fixture so that the test fails immediately if a `.charm` file isn't available.
+
+In your Multipass Ubuntu VM, run the tests again:
 
 ```text
 ubuntu@juju-sandbox-k8s:~/fastapi-demo$ tox -e integration
 ```
 
-The test may take some time to run, depending on your computer and network.
+The tests may take some time to run, depending on your computer and network.
 
-If the test fails with a timeout error, override the default timeout in `test_database_integration`:
+If the tests fail with a timeout error, override the default timeout in `test_database_integration`:
 
 ```python
     juju.wait(jubilant.all_active, timeout=10 * 60)
 ```
 
-Then run `tox -e integration` again. If the test still fails, try [our example charm for this chapter](https://github.com/canonical/operator/tree/main/examples/k8s-3-postgresql) instead, in case there's a mistake in your code.
+Then run `tox -e integration` again. If the tests still fail, try [our example charm for this chapter](https://github.com/canonical/operator/tree/main/examples/k8s-3-postgresql) instead, in case there's a mistake in your code.
 
-When the test is done, the output should show two passing tests:
+When the tests are done, the output should show two passing tests:
 
 ```text
 tests/integration/test_charm.py::test_deploy

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -486,6 +486,7 @@ import logging
 import pathlib
 
 import jubilant
+import pytest
 import yaml
 
 logger = logging.getLogger(__name__)

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -494,6 +494,7 @@ METADATA = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
+@pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Deploy the charm under test.
 
@@ -513,6 +514,7 @@ Then, let's add another test case to check the integration is successful. For th
 In your `tests/integration/test_charm.py` file add the following test case:
 
 ```python
+@pytest.mark.juju_setup
 def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the charm integrates with the database.
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -512,12 +512,14 @@ We're now ready to write the tests.
 Add two test functions to `tests/integration/test_charm.py`:
 
 ```python
+@pytest.mark.juju_setup
 def test_deploy_cos(cos: jubilant.Juju):
     """Deploy COS Lite in a separate model."""
     cos.deploy("cos-lite", trust=True)
     cos.wait(jubilant.all_active, timeout=10 * 60)  # Allow time for the bundle to deploy.
 
 
+@pytest.mark.juju_setup
 def test_integrate_loki(juju: jubilant.Juju, cos: jubilant.Juju):
     """Integrate our app with Loki from COS Lite."""
     cos.offer("loki", endpoint="logging")

--- a/docs/tutorial/write-your-first-machine-charm.md
+++ b/docs/tutorial/write-your-first-machine-charm.md
@@ -171,8 +171,7 @@ uvx git+https://github.com/canonical/charmcraft@74d12bc init --profile machine
 ```
 
 <!--
-  When charmcraft stable is up-to-date, comment out this info and switch to 'charmcraft init --profile machine' above.
-  If needed again later, restore the info and switch to 'uvx git+https://github.com/canonical/charmcraft@<hash> init --profile machine'.
+  When charmcraft stable is up-to-date, remove this info and switch to 'charmcraft init --profile machine' above.
 -->
 The `uvx ...` command runs Charmcraft directly from GitHub. We recommend doing this because the installed version of Charmcraft may come with an older version of the profile used in the tutorial. You should use the installed version of Charmcraft for everything else (as we'll do later in the tutorial).
 

--- a/docs/tutorial/write-your-first-machine-charm.md
+++ b/docs/tutorial/write-your-first-machine-charm.md
@@ -167,7 +167,7 @@ In your virtual machine, go into your project directory and create the initial v
 
 ```text
 cd ~/tinyproxy
-uvx git+https://github.com/canonical/charmcraft@fae9862 init --profile machine
+uvx git+https://github.com/canonical/charmcraft@74d12bc init --profile machine
 ```
 
 <!--

--- a/examples/httpbin-demo/tests/integration/conftest.py
+++ b/examples/httpbin-demo/tests/integration/conftest.py
@@ -24,15 +24,13 @@ import pytest
 @pytest.fixture(scope="session")
 def charm():
     """Return the path of the charm under test."""
-    if "CHARM_PATH" in os.environ:
-        charm_path = pathlib.Path(os.environ["CHARM_PATH"])
-        if not charm_path.exists():
-            raise FileNotFoundError(f"Charm does not exist: {charm_path}")
-        return charm_path
-    charm_paths = list(pathlib.Path(".").glob("*.charm"))
-    if not charm_paths:
-        raise FileNotFoundError("No .charm file in current directory")
-    if len(charm_paths) > 1:
-        path_list = ", ".join(str(path) for path in charm_paths)
-        raise ValueError(f"More than one .charm file in current directory: {path_list}")
-    return charm_paths[0]
+    charm = os.environ.get("CHARM_PATH")
+    if not charm:
+        charm_dir = pathlib.Path()  # Assume the current working directory is the charm root.
+        charms = list(charm_dir.glob("*.charm"))
+        assert charms, f"No charms were found in {charm_dir.absolute()}"
+        assert len(charms) == 1, f"Found more than one charm {charms}"
+        charm = charms[0]
+    path = pathlib.Path(charm).resolve()
+    assert path.is_file(), f"{path} is not a file"
+    return path

--- a/examples/httpbin-demo/tests/integration/conftest.py
+++ b/examples/httpbin-demo/tests/integration/conftest.py
@@ -11,10 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# The integration tests use the Jubilant library. See https://documentation.ubuntu.com/jubilant/
-# The pytest-jubilant plugin (https://github.com/canonical/pytest-jubilant) provides a
-# module-scoped `juju` fixture that creates a temporary Juju model.
+#
+# The integration tests use the Jubilant library and the pytest-jubilant plugin.
+# See https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/
 
 import os
 import pathlib

--- a/examples/httpbin-demo/tests/integration/test_charm.py
+++ b/examples/httpbin-demo/tests/integration/test_charm.py
@@ -30,6 +30,7 @@ METADATA = yaml.safe_load(pathlib.Path("charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
+@pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Build the charm-under-test and deploy it together with related charms.
 

--- a/examples/httpbin-demo/tests/integration/test_charm.py
+++ b/examples/httpbin-demo/tests/integration/test_charm.py
@@ -38,7 +38,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     resources = {"httpbin-image": METADATA["resources"]["httpbin-image"]["upstream-source"]}
 
     # Deploy the charm and wait for active/idle status
-    juju.deploy(charm.resolve(), app=APP_NAME, resources=resources)
+    juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_active)
 
 

--- a/examples/httpbin-demo/tests/integration/test_charm.py
+++ b/examples/httpbin-demo/tests/integration/test_charm.py
@@ -22,6 +22,7 @@ import logging
 import pathlib
 
 import jubilant
+import pytest
 import yaml
 
 logger = logging.getLogger(__name__)

--- a/examples/httpbin-demo/tests/integration/test_charm.py
+++ b/examples/httpbin-demo/tests/integration/test_charm.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# The integration tests use the Jubilant library and the pytest-jubilant plugin.
+# See https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/
+#
+# pytest-jubilant provides a module-scoped `juju` fixture that creates a temporary Juju model.
+# The `charm` fixture is defined in conftest.py.
 
 import logging
 import pathlib

--- a/examples/k8s-1-minimal/tests/integration/conftest.py
+++ b/examples/k8s-1-minimal/tests/integration/conftest.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# The integration tests use the Jubilant library. See https://documentation.ubuntu.com/jubilant/
-# The pytest-jubilant plugin (https://github.com/canonical/pytest-jubilant) provides a
-# module-scoped `juju` fixture that creates a temporary Juju model.
-# To learn more about testing, see https://documentation.ubuntu.com/ops/latest/explanation/testing/
+# The integration tests use the Jubilant library and the pytest-jubilant plugin.
+# See https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/
 
 import os
 import pathlib

--- a/examples/k8s-1-minimal/tests/integration/test_charm.py
+++ b/examples/k8s-1-minimal/tests/integration/test_charm.py
@@ -30,6 +30,7 @@ METADATA = yaml.safe_load(pathlib.Path("charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
+@pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Deploy the charm under test."""
     resources = {

--- a/examples/k8s-1-minimal/tests/integration/test_charm.py
+++ b/examples/k8s-1-minimal/tests/integration/test_charm.py
@@ -35,5 +35,5 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     resources = {
         "demo-server-image": METADATA["resources"]["demo-server-image"]["upstream-source"]
     }
-    juju.deploy(charm.resolve(), app=APP_NAME, resources=resources)
+    juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_active)

--- a/examples/k8s-1-minimal/tests/integration/test_charm.py
+++ b/examples/k8s-1-minimal/tests/integration/test_charm.py
@@ -22,6 +22,7 @@ import logging
 import pathlib
 
 import jubilant
+import pytest
 import yaml
 
 logger = logging.getLogger(__name__)

--- a/examples/k8s-1-minimal/tests/integration/test_charm.py
+++ b/examples/k8s-1-minimal/tests/integration/test_charm.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# The integration tests use the Jubilant library. See https://documentation.ubuntu.com/jubilant/
-# To learn more about testing, see https://documentation.ubuntu.com/ops/latest/explanation/testing/
+# The integration tests use the Jubilant library and the pytest-jubilant plugin.
+# See https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/
+#
+# pytest-jubilant provides a module-scoped `juju` fixture that creates a temporary Juju model.
+# The `charm` fixture is defined in conftest.py.
 
 import logging
 import pathlib

--- a/examples/k8s-2-configurable/tests/integration/conftest.py
+++ b/examples/k8s-2-configurable/tests/integration/conftest.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# The integration tests use the Jubilant library. See https://documentation.ubuntu.com/jubilant/
-# The pytest-jubilant plugin (https://github.com/canonical/pytest-jubilant) provides a
-# module-scoped `juju` fixture that creates a temporary Juju model.
-# To learn more about testing, see https://documentation.ubuntu.com/ops/latest/explanation/testing/
+# The integration tests use the Jubilant library and the pytest-jubilant plugin.
+# See https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/
 
 import os
 import pathlib

--- a/examples/k8s-2-configurable/tests/integration/test_charm.py
+++ b/examples/k8s-2-configurable/tests/integration/test_charm.py
@@ -30,6 +30,7 @@ METADATA = yaml.safe_load(pathlib.Path("charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
+@pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Deploy the charm under test."""
     resources = {

--- a/examples/k8s-2-configurable/tests/integration/test_charm.py
+++ b/examples/k8s-2-configurable/tests/integration/test_charm.py
@@ -35,5 +35,5 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     resources = {
         "demo-server-image": METADATA["resources"]["demo-server-image"]["upstream-source"]
     }
-    juju.deploy(charm.resolve(), app=APP_NAME, resources=resources)
+    juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_active)

--- a/examples/k8s-2-configurable/tests/integration/test_charm.py
+++ b/examples/k8s-2-configurable/tests/integration/test_charm.py
@@ -22,6 +22,7 @@ import logging
 import pathlib
 
 import jubilant
+import pytest
 import yaml
 
 logger = logging.getLogger(__name__)

--- a/examples/k8s-2-configurable/tests/integration/test_charm.py
+++ b/examples/k8s-2-configurable/tests/integration/test_charm.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# The integration tests use the Jubilant library. See https://documentation.ubuntu.com/jubilant/
-# To learn more about testing, see https://documentation.ubuntu.com/ops/latest/explanation/testing/
+# The integration tests use the Jubilant library and the pytest-jubilant plugin.
+# See https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/
+#
+# pytest-jubilant provides a module-scoped `juju` fixture that creates a temporary Juju model.
+# The `charm` fixture is defined in conftest.py.
 
 import logging
 import pathlib

--- a/examples/k8s-3-postgresql/tests/integration/conftest.py
+++ b/examples/k8s-3-postgresql/tests/integration/conftest.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# The integration tests use the Jubilant library. See https://documentation.ubuntu.com/jubilant/
-# The pytest-jubilant plugin (https://github.com/canonical/pytest-jubilant) provides a
-# module-scoped `juju` fixture that creates a temporary Juju model.
-# To learn more about testing, see https://documentation.ubuntu.com/ops/latest/explanation/testing/
+# The integration tests use the Jubilant library and the pytest-jubilant plugin.
+# See https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/
 
 import os
 import pathlib

--- a/examples/k8s-3-postgresql/tests/integration/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/integration/test_charm.py
@@ -22,6 +22,7 @@ import logging
 import pathlib
 
 import jubilant
+import pytest
 import yaml
 
 logger = logging.getLogger(__name__)

--- a/examples/k8s-3-postgresql/tests/integration/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/integration/test_charm.py
@@ -44,7 +44,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_blocked)
 
 
-def test_database_integration(juju: jubilant.Juju):
+def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the charm integrates with the database.
 
     Assert that the charm is active if the integration is established.

--- a/examples/k8s-3-postgresql/tests/integration/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/integration/test_charm.py
@@ -30,6 +30,7 @@ METADATA = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
+@pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Deploy the charm under test.
 
@@ -44,6 +45,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_blocked)
 
 
+@pytest.mark.juju_setup
 def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the charm integrates with the database.
 

--- a/examples/k8s-3-postgresql/tests/integration/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/integration/test_charm.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# The integration tests use the Jubilant library. See https://documentation.ubuntu.com/jubilant/
-# To learn more about testing, see https://documentation.ubuntu.com/ops/latest/explanation/testing/
+# The integration tests use the Jubilant library and the pytest-jubilant plugin.
+# See https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/
+#
+# pytest-jubilant provides a module-scoped `juju` fixture that creates a temporary Juju model.
+# The `charm` fixture is defined in conftest.py.
 
 import logging
 import pathlib

--- a/examples/k8s-4-action/tests/integration/conftest.py
+++ b/examples/k8s-4-action/tests/integration/conftest.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# The integration tests use the Jubilant library. See https://documentation.ubuntu.com/jubilant/
-# The pytest-jubilant plugin (https://github.com/canonical/pytest-jubilant) provides a
-# module-scoped `juju` fixture that creates a temporary Juju model.
-# To learn more about testing, see https://documentation.ubuntu.com/ops/latest/explanation/testing/
+# The integration tests use the Jubilant library and the pytest-jubilant plugin.
+# See https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/
 
 import os
 import pathlib

--- a/examples/k8s-4-action/tests/integration/test_charm.py
+++ b/examples/k8s-4-action/tests/integration/test_charm.py
@@ -22,6 +22,7 @@ import logging
 import pathlib
 
 import jubilant
+import pytest
 import yaml
 
 logger = logging.getLogger(__name__)

--- a/examples/k8s-4-action/tests/integration/test_charm.py
+++ b/examples/k8s-4-action/tests/integration/test_charm.py
@@ -44,7 +44,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_blocked)
 
 
-def test_database_integration(juju: jubilant.Juju):
+def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the charm integrates with the database.
 
     Assert that the charm is active if the integration is established.

--- a/examples/k8s-4-action/tests/integration/test_charm.py
+++ b/examples/k8s-4-action/tests/integration/test_charm.py
@@ -30,6 +30,7 @@ METADATA = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
+@pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Deploy the charm under test.
 
@@ -44,6 +45,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_blocked)
 
 
+@pytest.mark.juju_setup
 def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the charm integrates with the database.
 

--- a/examples/k8s-4-action/tests/integration/test_charm.py
+++ b/examples/k8s-4-action/tests/integration/test_charm.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# The integration tests use the Jubilant library. See https://documentation.ubuntu.com/jubilant/
-# To learn more about testing, see https://documentation.ubuntu.com/ops/latest/explanation/testing/
+# The integration tests use the Jubilant library and the pytest-jubilant plugin.
+# See https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/
+#
+# pytest-jubilant provides a module-scoped `juju` fixture that creates a temporary Juju model.
+# The `charm` fixture is defined in conftest.py.
 
 import logging
 import pathlib

--- a/examples/k8s-5-observe/tests/integration/conftest.py
+++ b/examples/k8s-5-observe/tests/integration/conftest.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# The integration tests use the Jubilant library. See https://documentation.ubuntu.com/jubilant/
-# The pytest-jubilant plugin (https://github.com/canonical/pytest-jubilant) provides a
-# module-scoped `juju` fixture that creates a temporary Juju model.
-# To learn more about testing, see https://documentation.ubuntu.com/ops/latest/explanation/testing/
+# The integration tests use the Jubilant library and the pytest-jubilant plugin.
+# See https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/
 
 import os
 import pathlib

--- a/examples/k8s-5-observe/tests/integration/test_charm.py
+++ b/examples/k8s-5-observe/tests/integration/test_charm.py
@@ -35,6 +35,7 @@ METADATA = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
+@pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Deploy the charm under test.
 
@@ -49,6 +50,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_blocked)
 
 
+@pytest.mark.juju_setup
 def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the charm integrates with the database.
 
@@ -64,12 +66,14 @@ def cos(juju_factory: pytest_jubilant.JujuFactory):
     yield juju_factory.get_juju(suffix="cos")
 
 
+@pytest.mark.juju_setup
 def test_deploy_cos(charm: pathlib.Path, cos: jubilant.Juju):
     """Deploy COS Lite in a separate model."""
     cos.deploy("cos-lite", trust=True)
     cos.wait(jubilant.all_active, timeout=10 * 60)  # Allow time for the bundle to deploy.
 
 
+@pytest.mark.juju_setup
 def test_integrate_loki(charm: pathlib.Path, juju: jubilant.Juju, cos: jubilant.Juju):
     """Integrate our app with Loki from COS Lite."""
     cos.offer("loki", endpoint="logging")

--- a/examples/k8s-5-observe/tests/integration/test_charm.py
+++ b/examples/k8s-5-observe/tests/integration/test_charm.py
@@ -49,7 +49,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_blocked)
 
 
-def test_database_integration(juju: jubilant.Juju):
+def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the charm integrates with the database.
 
     Assert that the charm is active if the integration is established.
@@ -64,13 +64,13 @@ def cos(juju_factory: pytest_jubilant.JujuFactory):
     yield juju_factory.get_juju(suffix="cos")
 
 
-def test_deploy_cos(cos: jubilant.Juju):
+def test_deploy_cos(charm: pathlib.Path, cos: jubilant.Juju):
     """Deploy COS Lite in a separate model."""
     cos.deploy("cos-lite", trust=True)
     cos.wait(jubilant.all_active, timeout=10 * 60)  # Allow time for the bundle to deploy.
 
 
-def test_integrate_loki(juju: jubilant.Juju, cos: jubilant.Juju):
+def test_integrate_loki(charm: pathlib.Path, juju: jubilant.Juju, cos: jubilant.Juju):
     """Integrate our app with Loki from COS Lite."""
     cos.offer("loki", endpoint="logging")
     juju.integrate(APP_NAME, f"{cos.model}.loki")
@@ -78,7 +78,7 @@ def test_integrate_loki(juju: jubilant.Juju, cos: jubilant.Juju):
     cos.wait(jubilant.all_active)
 
 
-def test_loki_data(cos: jubilant.Juju):
+def test_loki_data(charm: pathlib.Path, cos: jubilant.Juju):
     """Use Loki's HTTP API to verify that Loki has a label for our app.
 
     COS Lite exposes Loki's API through the Traefik load balancer. Traefik comes with an action

--- a/examples/k8s-5-observe/tests/integration/test_charm.py
+++ b/examples/k8s-5-observe/tests/integration/test_charm.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# The integration tests use the Jubilant library. See https://documentation.ubuntu.com/jubilant/
-# To learn more about testing, see https://documentation.ubuntu.com/ops/latest/explanation/testing/
+# The integration tests use the Jubilant library and the pytest-jubilant plugin.
+# See https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/
+#
+# pytest-jubilant provides a module-scoped `juju` fixture that creates a temporary Juju model.
+# The `charm` fixture is defined in conftest.py.
 
 import json
 import logging

--- a/examples/machine-tinyproxy/tests/integration/conftest.py
+++ b/examples/machine-tinyproxy/tests/integration/conftest.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# The integration tests use the Jubilant library. See https://documentation.ubuntu.com/jubilant/
-# The pytest-jubilant plugin (https://github.com/canonical/pytest-jubilant) provides a
-# module-scoped `juju` fixture that creates a temporary Juju model.
-# To learn more about testing, see https://documentation.ubuntu.com/ops/latest/explanation/testing/
+# The integration tests use the Jubilant library and the pytest-jubilant plugin.
+# See https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/
 
 import os
 import pathlib

--- a/examples/machine-tinyproxy/tests/integration/test_charm.py
+++ b/examples/machine-tinyproxy/tests/integration/test_charm.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     """Deploy the charm under test."""
-    juju.deploy(charm.resolve(), app="tinyproxy")
+    juju.deploy(charm, app="tinyproxy")
     juju.wait(jubilant.all_active, timeout=600)
 
 

--- a/examples/machine-tinyproxy/tests/integration/test_charm.py
+++ b/examples/machine-tinyproxy/tests/integration/test_charm.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# The integration tests use the Jubilant library. See https://documentation.ubuntu.com/jubilant/
-# To learn more about testing, see https://documentation.ubuntu.com/ops/latest/explanation/testing/
+# The integration tests use the Jubilant library and the pytest-jubilant plugin.
+# See https://documentation.ubuntu.com/ops/latest/howto/write-integration-tests-for-a-charm/
+#
+# pytest-jubilant provides a module-scoped `juju` fixture that creates a temporary Juju model.
+# The `charm` fixture is defined in conftest.py.
 
 import logging
 import pathlib


### PR DESCRIPTION
This PR updates our example charms, docs, and tutorials about integration testing to match the latest Charmcraft profiles (https://github.com/canonical/charmcraft/pull/2695): add `@pytest.mark.juju_setup`, improve comments, fix double `resolve`.

To see which integration tests in the K8s tutorial now use `@pytest.mark.juju_setup`, see [test_charm.py](https://github.com/dwilding/operator/blob/juju-setup-etc/examples/k8s-5-observe/tests/integration/test_charm.py).

I'm also updating the Charmcraft commit hash in the docs so that readers get the latest profiles. This is the last time I expect to do this. We'll switch back to installed `charmcraft` after the next release is available on `latest/stable`.

Other notable changes:

- **[How to write integration tests for a charm](https://canonical-ubuntu-documentation-library--2497.com.readthedocs.build/ops/2497/howto/write-integration-tests-for-a-charm/#deploy-your-charm)** - Changed "you can" to a direct instruction when talking about `@pytest.mark.juju_setup`.

- **[Create a minimal Kubernetes charm](https://canonical-ubuntu-documentation-library--2497.com.readthedocs.build/ops/2497/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm/)** - Briefly explained `@pytest.mark.juju_setup` and linked to info about keeping models.

- **[Integrate your charm with PostgreSQL](https://canonical-ubuntu-documentation-library--2497.com.readthedocs.build/ops/2497/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql/#write-an-integration-test)** - Added the `charm` fixture to the second test so that it fails immediately if there's no `.charm` file. And similarly for subsequent chapters of the tutorial.