### PR TITLE
docs: clarify Secret manage-permission error in testing.State

### DIFF
--- a/testing/src/scenario/mocking.py
+++ b/testing/src/scenario/mocking.py
@@ -478,9 +478,12 @@ class _MockModelBackend(_ModelBackend):  # type: ignore
         secret: Secret,
     ):
         if secret.owner is None:
+            # The secret is in State.secrets (otherwise _get_secret would have
+            # raised already), so the charm has read access; it just doesn't
+            # own the secret and so cannot manage it. Set `Secret.owner` to
+            # 'unit' or 'app' in the test setup if the charm is meant to own it.
             raise SecretNotFoundError(
-                'this secret is not owned by this unit/app or granted to it. '
-                'Did you forget passing it to State.secrets?',
+                f'You must own secret {secret.id!r} to perform this operation',
             )
         if secret.owner == 'app' and not self.is_leader():
             understandable_error = SecretNotFoundError(

--- a/testing/tests/test_e2e/test_secrets.py
+++ b/testing/tests/test_e2e/test_secrets.py
@@ -332,10 +332,18 @@ def test_secret_permission_model(leader: bool, owner: Literal['app', 'unit'] | N
         else:  # cannot manage
             # nothing else to do directly if you can't get a hold of the Secret instance
             # but we can try some raw backend calls
-            with pytest.raises(ops.ModelError):
+            if owner is None:
+                # The secret has been granted to this charm but it is not the
+                # owner, so management operations should explain that.
+                expected_message = f'You must own secret {secret_id!r}'
+            else:
+                # app-owned secret + non-leader: ops surfaces Juju's
+                # "permission denied" message.
+                expected_message = 'permission denied'
+            with pytest.raises(ops.ModelError, match=expected_message):
                 secret_obj.get_info()
 
-            with pytest.raises(ops.ModelError):
+            with pytest.raises(ops.ModelError, match=expected_message):
                 secret_obj.set_content(content={'boo': 'foo'})
 
 


### PR DESCRIPTION
The error raised by `_check_can_manage_secret` when `secret.owner` is `None` is currently 'this secret is not owned by this unit/app or granted to it. Did you forget passing it to State.secrets?', but by the time that branch runs, the secret *is* in `State.secrets` (`_get_secret` would have raised otherwise) and `owner=None` is a valid state (meaning read access has been granted to this unit). The message contradicted the docs on `Secret.owner` (which are correct) and `State.secrets` and pointed users at a fix that wasn't the real problem.

This PR replaces it with 'You must own secret {id!r} to perform this operation', matching the equivalent error raised by Harness's `secret_info_get`. It also adds a code comment explaining the precondition, since there was confusion around this in an earlier attempt to fix the issue. It also tightens the existing `test_secret_permission_model` parametrized test to match on the message form so the fix can't regress silently.

Fixes #2077