### PR TITLE
fix: preserve hyphens in Juju hook names in ops.testing

### DIFF
--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -2245,12 +2245,41 @@ class _Event:  # type: ignore
 
     _owner_path: list[str] = dataclasses.field(default_factory=list)
 
+    # The event name as Juju provides it. Set in __post_init__ via
+    # object.__setattr__ (frozen dataclass), so it's excluded from init.
+    _juju_name: str = dataclasses.field(init=False)
+
     def __post_init__(self):
+        # The original (un-normalised) name, so that we can recover the exact
+        # spelling of the entity the event refers to (see _juju_name below).
+        original_name = str(self.path).split('.')[-1]
         path = _EventPath(self.path)
         # bypass frozen dataclass
         object.__setattr__(self, 'path', path)
-        # This is the event name as Juju provides it, with dashes not underscores.
-        object.__setattr__(self, '_juju_name', path.name.replace('_', '-'))
+        # This is the event name as Juju provides it. Juju keeps the entity
+        # name (a relation endpoint, storage name, or container name) exactly
+        # as it is declared in the charm metadata -- which may contain dashes
+        # *or* underscores -- and only ever uses dashes in the event-type
+        # suffix. For events that are not tied to such an entity, the whole
+        # name uses dashes. See #2511.
+        object.__setattr__(self, '_juju_name', self._build_juju_name(original_name, path))
+
+    @staticmethod
+    def _build_juju_name(original_name: str, path: _EventPath) -> str:
+        suffix = path.suffix
+        if suffix and path.type in (
+            _EventType.RELATION,
+            _EventType.STORAGE,
+            _EventType.WORKLOAD,
+        ):
+            # Preserve the entity name (the prefix) verbatim; only the suffix
+            # is normalised to dashes. ``original_name`` and the normalised
+            # ``path.name`` have the same length (``_normalise_name`` only
+            # swaps dashes for underscores), so the suffix can be stripped by
+            # length to recover the original prefix spelling.
+            prefix = original_name[: len(original_name) - len(suffix)]
+            return f'{prefix}{suffix.replace("_", "-")}'
+        return path.name.replace('_', '-')
 
     @property
     def _path(self) -> _EventPath:

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -2250,7 +2250,7 @@ class _Event:  # type: ignore
         # bypass frozen dataclass
         object.__setattr__(self, 'path', path)
         # This is the event name as Juju provides it, with dashes not underscores.
-        object.__setattr__(self, '_juju_name', f'{path.prefix}{path.suffix.replace("_", "-")}')
+        object.__setattr__(self, '_juju_name', path.name.replace('_', '-'))
 
     @property
     def _path(self) -> _EventPath:

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -2140,10 +2140,12 @@ class _EventPath(str):
         owner_path: list[str]
         suffix: str
         prefix: str
+        _original_prefix: str
         is_custom: bool
         type: _EventType
 
     def __new__(cls, string: str):
+        original_string = string
         string = _normalise_name(string)
         instance = super().__new__(cls, string)
 
@@ -2152,6 +2154,7 @@ class _EventPath(str):
 
         instance.suffix, instance.type = _EventPath._get_suffix_and_type(name)
         instance.prefix = string.removesuffix(instance.suffix)
+        instance._original_prefix = original_string[: len(instance.prefix)]
         instance._is_custom = instance.suffix == ''
 
         return instance
@@ -2250,9 +2253,6 @@ class _Event:  # type: ignore
     _juju_name: str = dataclasses.field(init=False)
 
     def __post_init__(self):
-        # The original (un-normalised) name, so that we can recover the exact
-        # spelling of the entity the event refers to (see _juju_name below).
-        original_name = str(self.path).split('.')[-1]
         path = _EventPath(self.path)
         # bypass frozen dataclass
         object.__setattr__(self, 'path', path)
@@ -2262,10 +2262,10 @@ class _Event:  # type: ignore
         # *or* underscores -- and only ever uses dashes in the event-type
         # suffix. For events that are not tied to such an entity, the whole
         # name uses dashes. See #2511.
-        object.__setattr__(self, '_juju_name', self._build_juju_name(original_name, path))
+        object.__setattr__(self, '_juju_name', self._build_juju_name(path))
 
     @staticmethod
-    def _build_juju_name(original_name: str, path: _EventPath) -> str:
+    def _build_juju_name(path: _EventPath) -> str:
         suffix = path.suffix
         if suffix and path.type in (
             _EventType.RELATION,
@@ -2273,12 +2273,8 @@ class _Event:  # type: ignore
             _EventType.WORKLOAD,
         ):
             # Preserve the entity name (the prefix) verbatim; only the suffix
-            # is normalised to dashes. ``original_name`` and the normalised
-            # ``path.name`` have the same length (``_normalise_name`` only
-            # swaps dashes for underscores), so the suffix can be stripped by
-            # length to recover the original prefix spelling.
-            prefix = original_name[: len(original_name) - len(suffix)]
-            return f'{prefix}{suffix.replace("_", "-")}'
+            # is normalised to dashes.
+            return f'{path._original_prefix}{suffix.replace("_", "-")}'
         return path.name.replace('_', '-')
 
     @property

--- a/testing/tests/test_e2e/test_event.py
+++ b/testing/tests/test_e2e/test_event.py
@@ -62,6 +62,35 @@ def test_event_type(evt: str, expected_type: _EventType):
     assert event._is_builtin_event(spec) is (expected_type is not _EventType.CUSTOM)
 
 
+@pytest.mark.parametrize(
+    'evt, expected_juju_name',
+    (
+        # For events tied to a named entity (a relation endpoint, storage, or
+        # container), Juju keeps the entity name -- the prefix -- exactly as it
+        # is declared in the charm metadata, and only uses dashes in the
+        # event-type suffix. So an entity declared with dashes keeps its
+        # dashes, and one declared with underscores keeps its underscores.
+        ('foo_relation_changed', 'foo-relation-changed'),
+        ('receive-ca-cert_relation_changed', 'receive-ca-cert-relation-changed'),
+        ('receive_ca_cert_relation_changed', 'receive_ca_cert-relation-changed'),
+        ('my-storage_storage_attached', 'my-storage-storage-attached'),
+        ('my_storage_storage_detaching', 'my_storage-storage-detaching'),
+        ('my-container_pebble_ready', 'my-container-pebble-ready'),
+        ('my_container_pebble_ready', 'my_container-pebble-ready'),
+        # Events that are not tied to such an entity use dashes throughout.
+        ('config_changed', 'config-changed'),
+        ('update_status', 'update-status'),
+        ('pre_series_upgrade', 'pre-series-upgrade'),
+        ('secret_changed', 'secret-changed'),
+        ('start', 'start'),
+    ),
+)
+def test_event_juju_name(evt: str, expected_juju_name: str):
+    # See #2511.
+    event = _Event(evt)
+    assert event._juju_name == expected_juju_name
+
+
 def test_emitted_framework():
     ctx = Context(ops.CharmBase, meta={'name': 'joop'}, capture_framework_events=True)
     ctx.run(ctx.on.update_status(), State())

--- a/testing/tests/test_runtime.py
+++ b/testing/tests/test_runtime.py
@@ -140,10 +140,24 @@ def test_env_clean_on_charm_error(monkeypatch: pytest.MonkeyPatch):
     assert os.getenv('JUJU_REMOTE_APP', None) is None
 
 
-def test_relation_event_juju_hook_name_uses_hyphens_for_endpoint():
+@pytest.mark.parametrize(
+    'endpoint, expected_hook_name',
+    (
+        # Juju keeps the endpoint name exactly as declared in the metadata and
+        # only uses dashes in the event-type suffix, so an endpoint declared
+        # with dashes produces an all-dashes hook name, while one declared with
+        # underscores keeps those underscores in the prefix. See #2511.
+        ('receive-ca-cert', 'receive-ca-cert-relation-changed'),
+        ('receive_ca_cert', 'receive_ca_cert-relation-changed'),
+    ),
+)
+def test_relation_event_juju_hook_name_preserves_endpoint_spelling(
+    endpoint: str,
+    expected_hook_name: str,
+):
     meta: dict[str, Any] = {
         'name': 'foo',
-        'requires': {'receive-ca-cert': {'interface': 'certificates'}},
+        'requires': {endpoint: {'interface': 'certificates'}},
     }
 
     my_charm_type = charm_type()
@@ -156,15 +170,17 @@ def test_relation_event_juju_hook_name_uses_hyphens_for_endpoint():
         charm_spec,
     )
 
-    rel = Relation('receive-ca-cert')
+    rel = Relation(endpoint)
     ctx: Context[ops.CharmBase] = Context(my_charm_type, meta=meta)
     with runtime.exec(
         state=State(relations={rel}),
-        event=_Event('receive-ca-cert_relation_changed', relation=rel),
+        event=_Event(f'{endpoint}_relation_changed', relation=rel),
         context=ctx,
     ):
-        assert os.environ['JUJU_HOOK_NAME'] == 'receive-ca-cert-relation-changed'
-        assert os.environ['JUJU_DISPATCH_PATH'] == 'hooks/receive-ca-cert-relation-changed'
+        assert os.environ['JUJU_HOOK_NAME'] == expected_hook_name
+        assert os.environ['JUJU_DISPATCH_PATH'] == f'hooks/{expected_hook_name}'
+        # Juju echoes the endpoint name verbatim in JUJU_RELATION.
+        assert os.environ['JUJU_RELATION'] == endpoint
 
 
 def test_juju_version_is_set_in_environ():

--- a/testing/tests/test_runtime.py
+++ b/testing/tests/test_runtime.py
@@ -140,6 +140,33 @@ def test_env_clean_on_charm_error(monkeypatch: pytest.MonkeyPatch):
     assert os.getenv('JUJU_REMOTE_APP', None) is None
 
 
+def test_relation_event_juju_hook_name_uses_hyphens_for_endpoint():
+    meta: dict[str, Any] = {
+        'name': 'foo',
+        'requires': {'receive-ca-cert': {'interface': 'certificates'}},
+    }
+
+    my_charm_type = charm_type()
+    charm_spec: _CharmSpec[ops.CharmBase] = _CharmSpec(
+        my_charm_type,
+        meta=meta,
+    )
+    runtime = Runtime(
+        'foo',
+        charm_spec,
+    )
+
+    rel = Relation('receive-ca-cert')
+    ctx: Context[ops.CharmBase] = Context(my_charm_type, meta=meta)
+    with runtime.exec(
+        state=State(relations={rel}),
+        event=_Event('receive-ca-cert_relation_changed', relation=rel),
+        context=ctx,
+    ):
+        assert os.environ['JUJU_HOOK_NAME'] == 'receive-ca-cert-relation-changed'
+        assert os.environ['JUJU_DISPATCH_PATH'] == 'hooks/receive-ca-cert-relation-changed'
+
+
 def test_juju_version_is_set_in_environ():
     version = '2.9'
 


### PR DESCRIPTION
Fixes #2511.

## Summary

Preserve Juju hook-name spelling in `ops.testing` for events whose entity names contain dashes or underscores.

Juju keeps the entity name portion of a hook name exactly as declared in charm metadata, for example relation endpoints, storage names, or workload/container names. The event-type suffix uses dashes.

For example:

- endpoint `receive-ca-cert` + relation changed -> `receive-ca-cert-relation-changed`
- endpoint `foo_bar` + relation changed -> `foo_bar-relation-changed`

Previously, Scenario normalised the full event path to underscores and then converted only the event suffix back to dashes. For endpoints such as `receive-ca-cert`, this produced mixed hook names like:

`receive_ca_cert-relation-changed`

This change preserves the original entity prefix for relation, storage, and workload events, while still rendering the event suffix in Juju's dash-separated form.

## Testing

```bash
uv tool run --with tox-uv tox -e unit -- testing/tests/test_runtime.py -k 'juju_hook_name or env_clean' -rs -vv --tb=short

uv tool run --with tox-uv tox -e unit -- \
  testing/tests/test_runtime.py \
  testing/tests/test_context_on.py \
  testing/tests/test_consistency_checker.py \
  -k 'juju_hook_name or relation_complex_name or relation_unit_events or relation_changed' \
  -rs -vv --tb=short

ruff check testing/src/scenario/state.py testing/tests/test_runtime.py testing/tests/test_e2e/test_event.py
ruff format --check testing/src/scenario/state.py testing/tests/test_runtime.py testing/tests/test_e2e/test_event.py
git diff --check
```
