### PR TITLE
docs: add k8s tutorial integration test examples

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
@@ -217,6 +217,12 @@ def test_get_db_info_action_show_password():
 
 Run `tox -e unit` to check that all tests pass.
 
+## Go further with integration tests
+
+Adding an integration test for this feature is left as an exercise for the reader. For guidance, see {ref}`How to write integration tests for a charm <write-integration-tests-for-a-charm>`.
+
+The example charm for this chapter includes an integration test that runs the `get-db-info` action against a deployed charm.
+
 ## Review the final code
 
 For the full code, see [our example charm for this chapter](https://github.com/canonical/operator/tree/main/examples/k8s-4-action).

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -279,6 +279,12 @@ def test_config_changed_invalid_port():
 
 Run `tox -e unit` to check that all tests pass.
 
+## Go further with integration tests
+
+Adding an integration test for this feature is left as an exercise for the reader. For guidance, see {ref}`How to write integration tests for a charm <write-integration-tests-for-a-charm>`.
+
+The example charm for this chapter includes an integration test that checks the charm's behaviour when `server-port` is set to an invalid value.
+
 ## Review the final code
 
 For the full code, see [our example charm for this chapter](https://github.com/canonical/operator/tree/main/examples/k8s-2-configurable).

--- a/examples/k8s-2-configurable/tests/integration/test_charm.py
+++ b/examples/k8s-2-configurable/tests/integration/test_charm.py
@@ -39,3 +39,16 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     }
     juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_active)
+
+
+@pytest.mark.juju_setup
+def test_invalid_server_port_blocks_unit(juju: jubilant.Juju):
+    """Verify that invalid config blocks the charm.
+
+    This integration test goes beyond the tutorial instructions.
+    """
+    juju.config(APP_NAME, {"server-port": "22"})
+    juju.wait(jubilant.all_blocked)
+
+    juju.config(APP_NAME, reset="server-port")
+    juju.wait(jubilant.all_active)

--- a/examples/k8s-2-configurable/tests/integration/test_charm.py
+++ b/examples/k8s-2-configurable/tests/integration/test_charm.py
@@ -41,12 +41,8 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_active)
 
 
-@pytest.mark.juju_setup
 def test_invalid_server_port_blocks_unit(juju: jubilant.Juju):
-    """Verify that invalid config blocks the charm.
-
-    This integration test goes beyond the tutorial instructions.
-    """
+    """Verify that invalid config blocks the charm."""
     juju.config(APP_NAME, {"server-port": "22"})
     juju.wait(jubilant.all_blocked)
 

--- a/examples/k8s-3-postgresql/tests/integration/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/integration/test_charm.py
@@ -43,7 +43,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
     # Deploy the charm and wait for it to report blocked, as it needs Postgres.
     juju.deploy(charm, app=APP_NAME, resources=resources)
-    juju.wait(jubilant.all_blocked)
+    juju.wait(lambda status: jubilant.all_blocked(status, APP_NAME))
 
 
 @pytest.mark.juju_setup
@@ -54,4 +54,13 @@ def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     """
     juju.deploy("postgresql-k8s", channel="14/stable", trust=True)
     juju.integrate(APP_NAME, "postgresql-k8s")
-    juju.wait(jubilant.all_active)
+    juju.wait(jubilant.all_active, timeout=10 * 60)
+
+
+def test_invalid_server_port_blocks_unit(juju: jubilant.Juju):
+    """Verify that invalid config blocks the charm."""
+    juju.config(APP_NAME, {"server-port": "22"})
+    juju.wait(lambda status: jubilant.all_blocked(status, APP_NAME))
+
+    juju.config(APP_NAME, reset="server-port")
+    juju.wait(jubilant.all_active, timeout=10 * 60)

--- a/examples/k8s-4-action/tests/integration/test_charm.py
+++ b/examples/k8s-4-action/tests/integration/test_charm.py
@@ -43,19 +43,31 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
     # Deploy the charm and wait for it to report blocked, as it needs Postgres.
     juju.deploy(charm, app=APP_NAME, resources=resources)
-    juju.wait(jubilant.all_blocked)
+    juju.wait(lambda status: jubilant.all_blocked(status, APP_NAME))
 
 
 @pytest.mark.juju_setup
-def test_database_integration_and_get_db_info_action(charm: pathlib.Path, juju: jubilant.Juju):
-    """Verify that the charm integrates with the database and exposes DB info.
+def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
+    """Verify that the charm integrates with the database.
 
-    The action check goes beyond the tutorial instructions.
+    Assert that the charm is active if the integration is established.
     """
     juju.deploy("postgresql-k8s", channel="14/stable", trust=True)
     juju.integrate(APP_NAME, "postgresql-k8s")
-    juju.wait(jubilant.all_active)
+    juju.wait(jubilant.all_active, timeout=10 * 60)
 
+
+def test_invalid_server_port_blocks_unit(juju: jubilant.Juju):
+    """Verify that invalid config blocks the charm."""
+    juju.config(APP_NAME, {"server-port": "22"})
+    juju.wait(lambda status: jubilant.all_blocked(status, APP_NAME))
+
+    juju.config(APP_NAME, reset="server-port")
+    juju.wait(jubilant.all_active, timeout=10 * 60)
+
+
+def test_get_db_info_action(juju: jubilant.Juju):
+    """Verify that the get-db-info action exposes database connection info."""
     task = juju.run(f"{APP_NAME}/0", "get-db-info", {"show-password": False})
 
     assert task.status == "completed"

--- a/examples/k8s-4-action/tests/integration/test_charm.py
+++ b/examples/k8s-4-action/tests/integration/test_charm.py
@@ -47,11 +47,17 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 
 @pytest.mark.juju_setup
-def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
-    """Verify that the charm integrates with the database.
+def test_database_integration_and_get_db_info_action(charm: pathlib.Path, juju: jubilant.Juju):
+    """Verify that the charm integrates with the database and exposes DB info.
 
-    Assert that the charm is active if the integration is established.
+    The action check goes beyond the tutorial instructions.
     """
     juju.deploy("postgresql-k8s", channel="14/stable", trust=True)
     juju.integrate(APP_NAME, "postgresql-k8s")
     juju.wait(jubilant.all_active)
+
+    task = juju.run(f"{APP_NAME}/0", "get-db-info", {"show-password": False})
+
+    assert task.status == "completed"
+    assert task.results["db-host"]
+    assert task.results["db-port"] == "5432"

--- a/examples/k8s-5-observe/tests/integration/test_charm.py
+++ b/examples/k8s-5-observe/tests/integration/test_charm.py
@@ -47,7 +47,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
     # Deploy the charm and wait for it to report blocked, as it needs Postgres.
     juju.deploy(charm, app=APP_NAME, resources=resources)
-    juju.wait(jubilant.all_blocked)
+    juju.wait(lambda status: jubilant.all_blocked(status, APP_NAME))
 
 
 @pytest.mark.juju_setup
@@ -58,7 +58,25 @@ def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     """
     juju.deploy("postgresql-k8s", channel="14/stable", trust=True)
     juju.integrate(APP_NAME, "postgresql-k8s")
-    juju.wait(jubilant.all_active)
+    juju.wait(jubilant.all_active, timeout=10 * 60)
+
+
+def test_invalid_server_port_blocks_unit(juju: jubilant.Juju):
+    """Verify that invalid config blocks the charm."""
+    juju.config(APP_NAME, {"server-port": "22"})
+    juju.wait(lambda status: jubilant.all_blocked(status, APP_NAME))
+
+    juju.config(APP_NAME, reset="server-port")
+    juju.wait(jubilant.all_active, timeout=10 * 60)
+
+
+def test_get_db_info_action(juju: jubilant.Juju):
+    """Verify that the get-db-info action exposes database connection info."""
+    task = juju.run(f"{APP_NAME}/0", "get-db-info", {"show-password": False})
+
+    assert task.status == "completed"
+    assert task.results["db-host"]
+    assert task.results["db-port"] == "5432"
 
 
 @pytest.fixture(scope="module")
@@ -78,7 +96,7 @@ def test_integrate_loki(charm: pathlib.Path, juju: jubilant.Juju, cos: jubilant.
     """Integrate our app with Loki from COS Lite."""
     cos.offer("loki", endpoint="logging")
     juju.integrate(APP_NAME, f"{cos.model}.loki")
-    juju.wait(jubilant.all_active)
+    juju.wait(jubilant.all_active, timeout=10 * 60)
     cos.wait(jubilant.all_active)
 
 


### PR DESCRIPTION
Fixes #2514.

## Summary

Add integration-test examples for the Kubernetes tutorial chapters that introduce configuration and actions.

This change:

- adds an integration test to `examples/k8s-2-configurable` that verifies invalid `server-port` config blocks the charm, then resets the config and waits for the unit to become active again
- extends the `examples/k8s-4-action` integration test to run the `get-db-info` action after the PostgreSQL integration is established
- updates both tutorial chapters to point readers toward integration testing as a follow-up exercise
- links readers to the integration testing guide

## Testing

```bash
ruff check \
  examples/k8s-2-configurable/tests/integration/test_charm.py \
  examples/k8s-4-action/tests/integration/test_charm.py

ruff format --check \
  examples/k8s-2-configurable/tests/integration/test_charm.py \
  examples/k8s-4-action/tests/integration/test_charm.py

git diff --check
```

The integration tests were updated but not run locally because they require a Juju/Kubernetes environment and packed charms.
