### PR TITLE
docs: add 26.04 to the versions page and mark 2.23 as LTS

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Security updates will be released for all major versions that have had releases in the last year.
 
-Long Term Support (LTS) releases receive 5 years of normal support and up to 10 additional years of extended support.
+Long Term Support (LTS) releases receive 5 years of support and up to 10 additional years of [extended support](https://ubuntu.com/security/esm).
 
 - Ops 1.x is no longer supported.
 - Ops 2.23 is the current LTS release.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,12 @@
 
 Security updates will be released for all major versions that have had releases in the last year.
 
+Long Term Support (LTS) releases receive 5 years of normal support and up to 10 additional years of extended support.
+
+- Ops 1.x is no longer supported.
+- Ops 2.23 is the current LTS release.
+- Ops 3.x is the current release line and is under active development.
+
 ## Reporting a vulnerability
 
 Please provide a description of the issue, the steps you took to

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -51,7 +51,7 @@ When testing an event with [](ops.testing.Context), the mocked unit state databa
 
 ## Security updates
 
-We strongly recommend restricting the version of `ops` (and `ops[harness,testing,tracing]` in your `dev` dependencies) in `pyproject.toml` in a way that allows picking up new compatible releases every time that you re-lock. If your charm needs to support Ubuntu 20.04 (with Python 3.8), then this looks like `ops~=2.23`. Otherwise, this looks like `ops~=3.0`. Set a minor version that includes all the features that the charm uses.
+We strongly recommend restricting the version of `ops` (and `ops[harness,testing,tracing]` in your `dev` dependencies) in `pyproject.toml` in a way that allows picking up new compatible releases every time that you re-lock. If your charm needs to support Ubuntu 20.04 (with Python 3.8), then this looks like `ops~=2.23`, which is a Long Term Support (LTS) release. Otherwise, this looks like `ops~=3.0`. Set a minor version that includes all the features that the charm uses.
 
 Your charm repository should have tooling configured so that any dependencies with security updates are detected automatically (such as [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates) or [Renovate](https://www.mend.io/renovate/)), prompting to you re-lock so that the charm will be built with the latest version.
 

--- a/docs/explanation/versions.md
+++ b/docs/explanation/versions.md
@@ -10,8 +10,13 @@ When you're deciding which version of tools to use within the charming ecosystem
 |------|----------------|---------------|--------------|-------------------|
 | 18.04 (Bionic Beaver) | [3.6](https://docs.python.org/3/whatsnew/3.6.html) | [2.9](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_2.9.x/) | 1.x | 2.x |
 | 20.04 (Focal Fossa) | [3.8](https://docs.python.org/3/whatsnew/3.8.html) | [2.9](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_2.9.x/), [3.6](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_3.6.x/), [4.0](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/) | [2.x](https://documentation.ubuntu.com/ops/2.x/) | 2.x |
-| 22.04 (Jammy Jellyfish) | [3.10](https://docs.python.org/3/whatsnew/3.10.html) | [2.9](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_2.9.x/), [3.6](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_3.6.x/), [4.0](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/) | [2.x](https://documentation.ubuntu.com/ops/2.x/), [3.x](https://documentation.ubuntu.com/ops/latest/) | [3.x](https://documentation.ubuntu.com/charmcraft/3.5.3/), [4.x](https://documentation.ubuntu.com/charmcraft/4.0.1/) |
-| 24.04 (Noble Numbat) | [3.12](https://docs.python.org/3/whatsnew/3.12.html) | [2.9](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_2.9.x/), [3.6](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_3.6.x/), [4.0](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/) | [2.x](https://documentation.ubuntu.com/ops/2.x/), [3.x](https://documentation.ubuntu.com/ops/latest/) | [3.x](https://documentation.ubuntu.com/charmcraft/3.5.3/), [4.x](https://documentation.ubuntu.com/charmcraft/4.0.1/) |
+| 22.04 (Jammy Jellyfish) | [3.10](https://docs.python.org/3/whatsnew/3.10.html) | [2.9](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_2.9.x/), [3.6](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_3.6.x/), [4.0](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/) | [2.x](https://documentation.ubuntu.com/ops/2.x/), [3.x](https://documentation.ubuntu.com/ops/latest/) | [3.x](https://documentation.ubuntu.com/charmcraft/3.5.3/), [4.x](https://documentation.ubuntu.com/charmcraft/4.2.1/) |
+| 24.04 (Noble Numbat) | [3.12](https://docs.python.org/3/whatsnew/3.12.html) | [2.9](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_2.9.x/), [3.6](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_3.6.x/), [4.0](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/) | [2.x](https://documentation.ubuntu.com/ops/2.x/), [3.x](https://documentation.ubuntu.com/ops/latest/) | [3.x](https://documentation.ubuntu.com/charmcraft/3.5.3/), [4.x](https://documentation.ubuntu.com/charmcraft/4.2.1/) |
+| 26.04 (Resolute Raccoon) | [3.14](https://docs.python.org/3/whatsnew/3.14.html) | [3.6](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_3.6.x/), [4.0](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/)¹ | [3.x](https://documentation.ubuntu.com/ops/latest/) | [4.x](https://documentation.ubuntu.com/charmcraft/4.2.1/)² |
+
+¹ On 26.04, Juju 4.0 support requires Juju >= 4.0.6. Juju 3.6 already supports 26.04.
+
+² On 26.04, Charmcraft supports `base: ubuntu@26.04` as a stable base from Charmcraft >= 4.3. On Charmcraft 4.2.x, build with `build-base: ubuntu@devel`.
 
 ## Pebble provided by Juju
 
@@ -50,7 +55,7 @@ Ops releases new minor versions approximately once per month. Major versions are
 | [Juju 3.4](https://documentation.ubuntu.com/juju/latest/releasenotes/unsupported/juju_3.x.x/) | <span style="color:red">✗</span> EOL | 2024-02-15 | 2024-06-15 | 2024-08-15 |
 | [Juju 3.5](https://documentation.ubuntu.com/juju/latest/releasenotes/unsupported/juju_3.x.x/) | <span style="color:red">✗</span> EOL | 2024-05-07 | 2024-09-07 | 2024-11-07 |
 | [Juju 3.6 (LTS)](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_3.6.x/) | <span style="color:green">●</span> Active | 2024-12-11 |  | 2039-04-11 |
-| [Juju 4.0](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/) | <span style="color:green">●</span> Active | 2025-11-14 | 2026-03-14 | 2026-05-14 |
+| [Juju 4.0](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/) | <span style="color:green">●</span> Active | 2025-11-14 |  |  |
 
 ### Ops
 
@@ -58,7 +63,7 @@ Ops releases new minor versions approximately once per month. Major versions are
 |---------|--------|--------------|-------------|
 | Ops 1.5 | <span style="color:red">✗</span> EOL | 2020-10-31 | 2024-04-26 |
 | Ops 2.23 | <span style="color:orange">⚠</span> Upgrade soon | 2023-01-25 | 2027-02-11 |
-| Ops 3.7 | <span style="color:green">●</span> Active | 2026-03-30 | 2027-03-30 |
+| Ops 3.7 | <span style="color:green">●</span> Active | 2026-03-30 | 2027-05-28 |
 
 **Legend:**
 - <span style="color:green">●</span> Active: Currently supported

--- a/docs/explanation/versions.md
+++ b/docs/explanation/versions.md
@@ -14,7 +14,7 @@ When you're deciding which version of tools to use within the charming ecosystem
 | 24.04 (Noble Numbat) | [3.12](https://docs.python.org/3/whatsnew/3.12.html) | [2.9](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_2.9.x/), [3.6](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_3.6.x/), [4.0](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/) | [2.x](https://documentation.ubuntu.com/ops/2.x/), [3.x](https://documentation.ubuntu.com/ops/latest/) | [3.x](https://documentation.ubuntu.com/charmcraft/3.5.3/), [4.x](https://documentation.ubuntu.com/charmcraft/4.2.1/) |
 | 26.04 (Resolute Raccoon) | [3.14](https://docs.python.org/3/whatsnew/3.14.html) | [3.6](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_3.6.x/), [4.0](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/) | [3.x](https://documentation.ubuntu.com/ops/latest/) | [4.x](https://documentation.ubuntu.com/charmcraft/4.2.1/)¹ |
 
-¹ On 26.04, current stable Charmcraft (4.2.x) supports `base: ubuntu@26.04` but requires `build-base: ubuntu@devel`.
+¹ `base: ubuntu@26.04` is supported by Charmcraft >= 4.3. On Charmcraft 4.2.x, build with `build-base: ubuntu@devel` instead (unstable).
 
 ## Pebble provided by Juju
 
@@ -37,7 +37,7 @@ Juju releases new minor versions approximately every 3 months, which are support
 
 > See more: {external+juju:ref}`Juju support timeframes <releasenotes>`
 
-Ops releases new minor versions approximately once per month. Major versions are supported with security fixes for one year from the latest release. To receive bug and security fixes within a major version, charms must update to the latest minor release within that major version. Long Term Support (LTS) releases receive 5 years of normal support and up to 10 additional years of extended support.
+Ops releases new minor versions approximately once per month. Major versions are supported with security fixes for one year from the latest release. To receive bug and security fixes within a major version, charms must update to the latest minor release within that major version. Long Term Support (LTS) releases receive 5 years of support and up to 10 additional years of [extended support](https://ubuntu.com/security/esm).
 
 > See more: [Ops support timeframes](https://github.com/canonical/operator/blob/main/SECURITY.md)
 

--- a/docs/explanation/versions.md
+++ b/docs/explanation/versions.md
@@ -39,7 +39,7 @@ Juju releases new minor versions approximately every 3 months, which are support
 
 > See more: {external+juju:ref}`Juju support timeframes <releasenotes>`
 
-Ops releases new minor versions approximately once per month. Major versions are supported with security fixes for one year from the latest release. To receive bug and security fixes within a major version, charms must update to the latest minor release within that major version.
+Ops releases new minor versions approximately once per month. Major versions are supported with security fixes for one year from the latest release. To receive bug and security fixes within a major version, charms must update to the latest minor release within that major version. Long Term Support (LTS) releases are supported for 15 years from their initial release: 5 years of regular support, followed by 5 years of critical bug fixes, and a further 5 years of security fixes.
 
 > See more: [Ops support timeframes](https://github.com/canonical/operator/blob/main/SECURITY.md)
 
@@ -62,7 +62,7 @@ Ops releases new minor versions approximately once per month. Major versions are
 | Version | Status | Release Date | End of Life |
 |---------|--------|--------------|-------------|
 | Ops 1.5 | <span style="color:red">✗</span> EOL | 2020-10-31 | 2024-04-26 |
-| Ops 2.23 | <span style="color:orange">⚠</span> Upgrade soon | 2023-01-25 | 2027-02-11 |
+| Ops 2.23 (LTS) | <span style="color:green">●</span> Active | 2023-01-25 | 2038-01-25 |
 | Ops 3.7 | <span style="color:green">●</span> Active | 2026-03-30 | 2027-05-28 |
 
 **Legend:**

--- a/docs/explanation/versions.md
+++ b/docs/explanation/versions.md
@@ -12,11 +12,9 @@ When you're deciding which version of tools to use within the charming ecosystem
 | 20.04 (Focal Fossa) | [3.8](https://docs.python.org/3/whatsnew/3.8.html) | [2.9](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_2.9.x/), [3.6](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_3.6.x/), [4.0](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/) | [2.x](https://documentation.ubuntu.com/ops/2.x/) | 2.x |
 | 22.04 (Jammy Jellyfish) | [3.10](https://docs.python.org/3/whatsnew/3.10.html) | [2.9](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_2.9.x/), [3.6](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_3.6.x/), [4.0](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/) | [2.x](https://documentation.ubuntu.com/ops/2.x/), [3.x](https://documentation.ubuntu.com/ops/latest/) | [3.x](https://documentation.ubuntu.com/charmcraft/3.5.3/), [4.x](https://documentation.ubuntu.com/charmcraft/4.2.1/) |
 | 24.04 (Noble Numbat) | [3.12](https://docs.python.org/3/whatsnew/3.12.html) | [2.9](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_2.9.x/), [3.6](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_3.6.x/), [4.0](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/) | [2.x](https://documentation.ubuntu.com/ops/2.x/), [3.x](https://documentation.ubuntu.com/ops/latest/) | [3.x](https://documentation.ubuntu.com/charmcraft/3.5.3/), [4.x](https://documentation.ubuntu.com/charmcraft/4.2.1/) |
-| 26.04 (Resolute Raccoon) | [3.14](https://docs.python.org/3/whatsnew/3.14.html) | [3.6](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_3.6.x/), [4.0](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/)¹ | [3.x](https://documentation.ubuntu.com/ops/latest/) | [4.x](https://documentation.ubuntu.com/charmcraft/4.2.1/)² |
+| 26.04 (Resolute Raccoon) | [3.14](https://docs.python.org/3/whatsnew/3.14.html) | [3.6](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_3.6.x/), [4.0](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/juju_4.0.0/) | [3.x](https://documentation.ubuntu.com/ops/latest/) | [4.x](https://documentation.ubuntu.com/charmcraft/4.2.1/)¹ |
 
-¹ On 26.04, Juju 4.0 support requires Juju >= 4.0.6. Juju 3.6 already supports 26.04.
-
-² On 26.04, Charmcraft supports `base: ubuntu@26.04` as a stable base from Charmcraft >= 4.3. On Charmcraft 4.2.x, build with `build-base: ubuntu@devel`.
+¹ On 26.04, current stable Charmcraft (4.2.x) supports `base: ubuntu@26.04` but requires `build-base: ubuntu@devel`.
 
 ## Pebble provided by Juju
 

--- a/docs/explanation/versions.md
+++ b/docs/explanation/versions.md
@@ -39,7 +39,7 @@ Juju releases new minor versions approximately every 3 months, which are support
 
 > See more: {external+juju:ref}`Juju support timeframes <releasenotes>`
 
-Ops releases new minor versions approximately once per month. Major versions are supported with security fixes for one year from the latest release. To receive bug and security fixes within a major version, charms must update to the latest minor release within that major version. Long Term Support (LTS) releases are supported for 15 years from their initial release: 5 years of regular support, followed by 5 years of critical bug fixes, and a further 5 years of security fixes.
+Ops releases new minor versions approximately once per month. Major versions are supported with security fixes for one year from the latest release. To receive bug and security fixes within a major version, charms must update to the latest minor release within that major version. Long Term Support (LTS) releases receive 5 years of normal support and up to 10 additional years of extended support.
 
 > See more: [Ops support timeframes](https://github.com/canonical/operator/blob/main/SECURITY.md)
 


### PR DESCRIPTION
A few updates to the versions page:

* Drop the support dates for Juju 4.0, since the published dates have come and gone but there's no new 4.1 yet. When 4.1 releases we can update again, until then it seems like speculation.
* Add 26.04. Charmcraft still has this as a devel base so include that as a note and when there is a charmcraft release to stable that properly supports it (presumably next month, as the change has landed just not released) we can update. Juju 3 and 4.0 support 26.04 nicely. I verified this all manually, looking at the code to see whether changes are merged yet or not, running test charms to validate. I didn't include Ops 2 for 26.04 as our CI doesn't test Python 3.14. We could add that, but I think we're ok with people getting a nudge to Ops 3.
* Note that we're treating Ops 2.x as a LTS now, putting in a 15-year support period from its release. Going forward we might tie these to Ubuntu release dates, like a 3.x to 26.04+15 maybe, but this seems what we want for now.

Also corresponding updates to the security pages.

[Preview of versions page](https://canonical-ubuntu-documentation-library--2517.com.readthedocs.build/ops/2517/explanation/versions/), [preview of security explanation page](https://canonical-ubuntu-documentation-library--2517.com.readthedocs.build/ops/2517/explanation/security/#security-updates).

Fixes #2461