### PR TITLE
ci: use the sys.monitoring coverage core

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -84,6 +84,11 @@ commands =
 [testenv:coverage]
 description = Run unit tests with coverage
 allowlist_externals = mv
+setenv =
+    # Use the sys.monitoring core (PEP 669): much lower overhead than the
+    # default C trace core, especially with branch coverage. No-op on Python
+    # < 3.12, where it falls back to the C trace core.
+    COVERAGE_CORE=sysmon
 passenv =
     RUN_REAL_PEBBLE_TESTS
     PEBBLE
@@ -107,6 +112,9 @@ commands =
 [testenv:coverage-tracing]
 description = Run tracing unit tests with coverage
 allowlist_externals = mv
+setenv =
+    # See the note in [testenv:coverage].
+    COVERAGE_CORE=sysmon
 dependency_groups = unit, coverage
 changedir = ./tracing/
 commands =


### PR DESCRIPTION
Set COVERAGE_CORE=sysmon for the coverage and coverage-tracing tox environments. The sys.monitoring core has much lower overhead than the default C trace core, especially with branch coverage. For me, with Python 3.14, this cut the coverage run from ~64s to ~40s on the unit suite, with identical results. It is a no-op on Python < 3.12, where coverage falls back to the C trace core.

See https://nedbatchelder.com/blog/202312/coveragepy_with_sysmonitoring for more background.