### PR TITLE
ci: remove obsolete containerd workaround from integration workflow

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -22,11 +22,6 @@ jobs:
           - test_relation_units
 
     steps:
-      - run: |
-           # Work around https://github.com/jnsgruk/concierge/issues/30
-           sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
-           sudo rm -rf /run/containerd
-        if: matrix.preset == 'k8s'
       - run: sudo snap install --classic concierge
       - run: >
           sudo concierge prepare
@@ -53,11 +48,6 @@ jobs:
     continue-on-error: ${{ matrix.juju-channel == '4.0/stable' }}
 
     steps:
-      - run: |
-           # Work around https://github.com/jnsgruk/concierge/issues/30
-           sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
-           sudo rm -rf /run/containerd
-        if: matrix.preset == 'k8s'
       - run: sudo snap install --classic concierge
       - run: >
           sudo concierge prepare


### PR DESCRIPTION
Removes the pre-step that uninstalled `docker-ce`/`containerd.io` and deleted `/run/containerd` from both jobs in `integration.yaml`.

```yaml
- run: |
     # Work around https://github.com/jnsgruk/concierge/issues/30
     sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
     sudo rm -rf /run/containerd
  if: matrix.preset == 'k8s'
```

Modern concierge handles a pre-existing containerd/Docker install itself, so the workaround for [jnsgruk/concierge#30](https://github.com/jnsgruk/concierge/issues/30) is no longer needed.

While removing it, note the `secrets` job's copy of this step was also dead in a second way: it was guarded by `if: matrix.preset == 'k8s'`, but the `secrets` job's matrix has no `preset` dimension (it only varies `juju-channel` and always uses `microk8s`), so the condition never evaluated true. Removing the step resolves both.