### PR TITLE
chore: drop the unused importlib-metadata dependency declaration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "websocket-client==1.*",
     # Wide version range to preempt conflicts when charms pin a version.
     "opentelemetry-api~=1.0",
-    "importlib-metadata",
 ]
 dynamic = ["version"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1939,8 +1939,6 @@ wheels = [
 name = "ops"
 source = { editable = "." }
 dependencies = [
-    { name = "importlib-metadata", version = "8.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "importlib-metadata", version = "8.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "opentelemetry-api", version = "1.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "opentelemetry-api", version = "1.34.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pyyaml" },
@@ -2020,7 +2018,6 @@ xdist = [
 
 [package.metadata]
 requires-dist = [
-    { name = "importlib-metadata" },
     { name = "opentelemetry-api", specifier = "~=1.0" },
     { name = "ops-scenario", marker = "extra == 'testing'", editable = "testing" },
     { name = "ops-tracing", marker = "extra == 'tracing'", editable = "tracing" },


### PR DESCRIPTION
ops uses the stdlib importlib.metadata module (in ops/testing.py for the ops-scenario version check), not the PyPI importlib-metadata backport package. The two APIs we use, `.version()` and `PackageNotFoundError`, have been in stdlib since Python 3.8, which is the minimum supported version, so the backport is not required at any supported Python.

It remains a transitive dependency of opentelemetry-api on Python < 3.10.2, so the resolved install set on those Pythons is functionally unchanged; on newer Pythons it is no longer present in the resolved tree.

This aligns 2.23-maintenance with main, where #1980 dropped the direct declaration as part of a broader cleanup. More importantly, it makes it clearer what dependencies are actually required for building ops.