### PR TITLE
test: treat warnings as errors when running unit tests

### DIFF
--- a/ops/_main.py
+++ b/ops/_main.py
@@ -315,8 +315,15 @@ class _Manager:
         self.dispatcher.run_any_legacy_hook()
 
         self.framework = self._make_framework(self.dispatcher)
-        with self.framework._event_context('__init__'):
-            self.charm = self._charm_class(self.framework)
+        try:
+            with self.framework._event_context('__init__'):
+                self.charm = self._charm_class(self.framework)
+        except BaseException:
+            # If charm construction fails, close the framework so that the
+            # underlying storage (SQLite) is released; main() only reaches
+            # the run()/destroy() path when __init__ completes successfully.
+            self.framework.close()
+            raise
 
     def _load_charm_meta(self):
         return _charm.CharmMeta.from_charm_root(self._charm_root)

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -939,6 +939,7 @@ class Framework(Object):
             >>> with harness._event_context(''):
             ...     # Harness thinks it is not running an event hook.
             ...     pass
+            >>> harness.cleanup()
         """
         backend: _ModelBackend | None = self.model._backend if self.model else None
         if not backend:

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -2237,15 +2237,16 @@ class Client:
         try:
             response = self.opener.open(request, timeout=self.timeout)
         except urllib.error.HTTPError as e:
-            code = e.code
-            status = e.reason
-            try:
-                body: dict[str, Any] = json.loads(e.read())
-                message: str = body['result']['message']
-            except (OSError, ValueError, KeyError) as e2:
-                # Will only happen on read error or if Pebble sends invalid JSON.
-                body: dict[str, Any] = {}
-                message = f'{type(e2).__name__} - {e2}'
+            with e:  # close the underlying tempfile so it doesn't leak
+                code = e.code
+                status = e.reason
+                try:
+                    body: dict[str, Any] = json.loads(e.read())
+                    message: str = body['result']['message']
+                except (OSError, ValueError, KeyError) as e2:
+                    # Will only happen on read error or if Pebble sends invalid JSON.
+                    body: dict[str, Any] = {}
+                    message = f'{type(e2).__name__} - {e2}'
             raise APIError(body, code, status, message) from None
         except urllib.error.URLError as e:
             if e.args and isinstance(e.args[0], FileNotFoundError):

--- a/ops/storage.py
+++ b/ops/storage.py
@@ -74,7 +74,15 @@ class SQLiteStorage:
         self._db = sqlite3.connect(
             str(filename), isolation_level=None, timeout=self.DB_LOCK_TIMEOUT.total_seconds()
         )
-        self._setup()
+        try:
+            self._setup()
+        except BaseException:
+            # _setup acquires the exclusive lock; if it fails (e.g. the DB
+            # is already held by another connection) the connection must
+            # still be closed so it doesn't leak as an unraisable
+            # ResourceWarning.
+            self._db.close()
+            raise
 
     def _ensure_db_permissions(self, filename: str):
         """Make sure that the DB file has appropriately secure permissions."""

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -110,10 +110,17 @@ class TestFramework:
                 None,  # type: ignore
                 juju_debug_at=set(),
             )
-        assert 'WARNING:ops.framework:deprecated: Framework now takes a Storage not a path' in [
-            f'{record.levelname}:{record.name}:{record.message}' for record in caplog.records
-        ]
-        assert isinstance(framework._storage, SQLiteStorage)
+        try:
+            assert (
+                'WARNING:ops.framework:deprecated: Framework now takes a Storage not a path'
+                in [
+                    f'{record.levelname}:{record.name}:{record.message}'
+                    for record in caplog.records
+                ]
+            )
+            assert isinstance(framework._storage, SQLiteStorage)
+        finally:
+            framework.close()
 
     def test_handle_path(self):
         cases = [

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1215,7 +1215,12 @@ class TestModel:
 
     @mock.patch('grp.getgrgid')
     @mock.patch('pwd.getpwuid')
-    def test_push_path_unnamed(self, getpwuid: mock.MagicMock, getgrgid: mock.MagicMock):
+    def test_push_path_unnamed(
+        self,
+        getpwuid: mock.MagicMock,
+        getgrgid: mock.MagicMock,
+        request: pytest.FixtureRequest,
+    ):
         getpwuid.side_effect = KeyError
         getgrgid.side_effect = KeyError
         harness = ops.testing.Harness(
@@ -1227,6 +1232,7 @@ class TestModel:
                 resource: foo-image
             """,
         )
+        request.addfinalizer(harness.cleanup)
         harness.begin()
         harness.set_can_connect('foo', True)
         container = harness.model.unit.containers['foo']
@@ -1478,7 +1484,7 @@ recursive_push_pull_cases = [
 
 
 @pytest.mark.parametrize('case', recursive_push_pull_cases)
-def test_recursive_push_and_pull(case: PushPullCase):
+def test_recursive_push_and_pull(case: PushPullCase, request: pytest.FixtureRequest):
     # full "integration" test of push+pull
     harness = ops.testing.Harness(
         ops.CharmBase,
@@ -1489,77 +1495,78 @@ def test_recursive_push_and_pull(case: PushPullCase):
             resource: foo-image
         """,
     )
+    request.addfinalizer(harness.cleanup)
     harness.begin()
     harness.set_can_connect('foo', True)
     c = harness.model.unit.containers['foo']
 
-    # create push test case filesystem structure
-    push_src = tempfile.TemporaryDirectory()
-    for file in case.files:
-        fpath = os.path.join(push_src.name, file[1:])
-        os.makedirs(os.path.dirname(fpath), exist_ok=True)
-        with open(fpath, 'wb') as f:
-            f.write(b'push \xc3\x28')  # invalid UTF-8 to ensure binary works
-    if case.dirs:
-        for directory in case.dirs:
-            fpath = os.path.join(push_src.name, directory[1:])
-            os.makedirs(fpath, exist_ok=True)
+    with tempfile.TemporaryDirectory() as push_src, tempfile.TemporaryDirectory() as pull_dst:
+        # create push test case filesystem structure
+        for file in case.files:
+            fpath = os.path.join(push_src, file[1:])
+            os.makedirs(os.path.dirname(fpath), exist_ok=True)
+            with open(fpath, 'wb') as f:
+                f.write(b'push \xc3\x28')  # invalid UTF-8 to ensure binary works
+        if case.dirs:
+            for directory in case.dirs:
+                fpath = os.path.join(push_src, directory[1:])
+                os.makedirs(fpath, exist_ok=True)
 
-    # test push
-    if isinstance(case.path, list):
-        # swap slash for dummy dir on root dir so Path.parent doesn't return tmpdir path component
-        # otherwise remove leading slash so we can do the path join properly.
-        push_path = [
-            os.path.join(push_src.name, p[1:] if len(p) > 1 else 'foo') for p in case.path
-        ]
-    else:
-        # swap slash for dummy dir on root dir so Path.parent doesn't return tmpdir path component
-        # otherwise remove leading slash so we can do the path join properly.
-        push_path = os.path.join(push_src.name, case.path[1:] if len(case.path) > 1 else 'foo')
+        # test push
+        if isinstance(case.path, list):
+            # swap slash for dummy dir on root dir so Path.parent doesn't
+            # return tmpdir path component; otherwise remove leading slash
+            # so we can do the path join properly.
+            push_path = [os.path.join(push_src, p[1:] if len(p) > 1 else 'foo') for p in case.path]
+        else:
+            # swap slash for dummy dir on root dir so Path.parent doesn't
+            # return tmpdir path component; otherwise remove leading slash
+            # so we can do the path join properly.
+            push_path = os.path.join(push_src, case.path[1:] if len(case.path) > 1 else 'foo')
 
-    errors: set[str] = set()
-    assert case.dst is not None
-    try:
-        c.push_path(push_path, case.dst)
-    except ops.MultiPushPullError as err:
-        if not case.errors:
-            raise
-        errors = {src[len(push_src.name) :] for src, _ in err.errors}
+        errors: set[str] = set()
+        assert case.dst is not None
+        try:
+            c.push_path(push_path, case.dst)
+        except ops.MultiPushPullError as err:
+            if not case.errors:
+                raise
+            errors = {src[len(push_src) :] for src, _ in err.errors}
 
-    assert case.errors == errors, (
-        f'push_path gave wrong expected errors: want {case.errors}, got {errors}'
-    )
-    for fpath in case.want:
-        assert c.exists(fpath), f'push_path failed: file {fpath} missing at destination'
-        content = c.pull(fpath, encoding=None).read()
-        assert content == b'push \xc3\x28'
-    for fdir in case.want_dirs:
-        assert c.isdir(fdir), f'push_path failed: dir {fdir} missing at destination'
+        assert case.errors == errors, (
+            f'push_path gave wrong expected errors: want {case.errors}, got {errors}'
+        )
+        for fpath in case.want:
+            assert c.exists(fpath), f'push_path failed: file {fpath} missing at destination'
+            with c.pull(fpath, encoding=None) as f:
+                content = f.read()
+            assert content == b'push \xc3\x28'
+        for fdir in case.want_dirs:
+            assert c.isdir(fdir), f'push_path failed: dir {fdir} missing at destination'
 
-    # create pull test case filesystem structure
-    pull_dst = tempfile.TemporaryDirectory()
-    for fpath in case.files:
-        c.push(fpath, 'hello', make_dirs=True)
-    if case.dirs:
-        for directory in case.dirs:
-            c.make_dir(directory, make_parents=True)
+        # create pull test case filesystem structure
+        for fpath in case.files:
+            c.push(fpath, 'hello', make_dirs=True)
+        if case.dirs:
+            for directory in case.dirs:
+                c.make_dir(directory, make_parents=True)
 
-    # test pull
-    errors: set[str] = set()
-    try:
-        c.pull_path(case.path, os.path.join(pull_dst.name, case.dst[1:]))
-    except ops.MultiPushPullError as err:
-        if not case.errors:
-            raise
-        errors = {src for src, _ in err.errors}
+        # test pull
+        errors = set()
+        try:
+            c.pull_path(case.path, os.path.join(pull_dst, case.dst[1:]))
+        except ops.MultiPushPullError as err:
+            if not case.errors:
+                raise
+            errors = {src for src, _ in err.errors}
 
-    assert case.errors == errors, (
-        f'pull_path gave wrong expected errors: want {case.errors}, got {errors}'
-    )
-    for fpath in case.want:
-        assert c.exists(fpath), f'pull_path failed: file {fpath} missing at destination'
-    for fdir in case.want_dirs:
-        assert c.isdir(fdir), f'pull_path failed: dir {fdir} missing at destination'
+        assert case.errors == errors, (
+            f'pull_path gave wrong expected errors: want {case.errors}, got {errors}'
+        )
+        for fpath in case.want:
+            assert c.exists(fpath), f'pull_path failed: file {fpath} missing at destination'
+        for fdir in case.want_dirs:
+            assert c.isdir(fdir), f'pull_path failed: dir {fdir} missing at destination'
 
 
 @pytest.mark.parametrize(
@@ -1588,7 +1595,7 @@ def test_recursive_push_and_pull(case: PushPullCase):
         ),
     ],
 )
-def test_push_path_relative(case: PushPullCase):
+def test_push_path_relative(case: PushPullCase, request: pytest.FixtureRequest):
     harness = ops.testing.Harness(
         ops.CharmBase,
         meta="""
@@ -1598,6 +1605,7 @@ def test_push_path_relative(case: PushPullCase):
             resource: foo-image
         """,
     )
+    request.addfinalizer(harness.cleanup)
     harness.begin()
     harness.set_can_connect('foo', True)
     container = harness.model.unit.containers['foo']
@@ -1621,7 +1629,8 @@ def test_push_path_relative(case: PushPullCase):
 
             # test
             for want_path in case.want:
-                content = container.pull(want_path).read()
+                with container.pull(want_path) as f:
+                    content = f.read()
                 assert content == 'test'
         finally:
             os.chdir(cwd)

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -51,13 +51,15 @@ class StoragePermutations(abc.ABC):
     ) -> ops.Framework:
         """Create a Framework that we can use to test the backend storage."""
         storage = self.create_storage(request, fake_script)
-        return ops.Framework(
+        framework = ops.Framework(
             storage,
             None,  # type: ignore
             None,  # type: ignore
             None,  # type: ignore
             juju_debug_at=set(),
         )
+        request.addfinalizer(framework.close)
+        return framework
 
     @abc.abstractmethod
     def create_storage(
@@ -266,7 +268,9 @@ class StoragePermutations(abc.ABC):
 
 class TestSQLiteStorage(StoragePermutations):
     def create_storage(self, request: pytest.FixtureRequest, fake_script: FakeScript):
-        return ops.storage.SQLiteStorage(':memory:')
+        storage = ops.storage.SQLiteStorage(':memory:')
+        request.addfinalizer(storage.close)
+        return storage
 
     def test_permissions_new(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import collections
 import datetime
+import gc
 import grp
 import importlib
 import inspect
@@ -34,6 +35,7 @@ import time
 import typing
 import unittest
 import uuid
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1214,17 +1216,24 @@ class TestHarness:
         harness.update_config(key_values={'a': False})
 
     def test_bad_config_option_type(self):
-        with pytest.raises(RuntimeError):
-            ops.testing.Harness(
-                RecordingCharm,
-                config="""
-                options:
-                    a:
-                        description: a config option
-                        type: gibberish
-                        default: False
-                """,
-            )
+        # Harness.__init__ allocates a tempdir before config validation, so
+        # when validation raises the half-built backend becomes unreachable
+        # and its tempdir is finalised by GC. Force the collection inside an
+        # ignore filter to suppress the ResourceWarning under -Werror.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', ResourceWarning)
+            with pytest.raises(RuntimeError):
+                ops.testing.Harness(
+                    RecordingCharm,
+                    config="""
+                    options:
+                        a:
+                            description: a config option
+                            type: gibberish
+                            default: False
+                    """,
+                )
+            gc.collect()
 
     def test_config_secret_option(self, request: pytest.FixtureRequest):
         harness = ops.testing.Harness(
@@ -1256,17 +1265,21 @@ class TestHarness:
             )
 
     def test_uncastable_config_option_type(self):
-        with pytest.raises(RuntimeError):
-            ops.testing.Harness(
-                RecordingCharm,
-                config="""
-                options:
-                    a:
-                        description: a config option
-                        type: boolean
-                        default: peek-a-bool!
-                """,
-            )
+        # See test_bad_config_option_type for why the GC + filter is needed.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', ResourceWarning)
+            with pytest.raises(RuntimeError):
+                ops.testing.Harness(
+                    RecordingCharm,
+                    config="""
+                    options:
+                        a:
+                            description: a config option
+                            type: boolean
+                            default: peek-a-bool!
+                    """,
+                )
+            gc.collect()
 
     def test_update_config_unset_boolean(self, request: pytest.FixtureRequest):
         harness = ops.testing.Harness(
@@ -2139,7 +2152,7 @@ class TestHarness:
         request.addfinalizer(harness.cleanup)
         assert list(harness.framework.meta.actions) == ['test-action']
 
-    def test_event_context(self):
+    def test_event_context(self, request: pytest.FixtureRequest):
         class MyCharm(ops.CharmBase):
             def event_handler(self, evt: ops.RelationEvent):
                 rel = evt.relation
@@ -2155,6 +2168,7 @@ class TestHarness:
                     interface: pgsql
             """,
         )
+        request.addfinalizer(harness.cleanup)
         harness.begin()
         rel_id = harness.add_relation('db', 'postgresql')
         rel = harness.charm.model.get_relation('db', rel_id)
@@ -2166,7 +2180,7 @@ class TestHarness:
             with pytest.raises(ops.RelationDataError):
                 harness.charm.event_handler(event)
 
-    def test_event_context_inverse(self):
+    def test_event_context_inverse(self, request: pytest.FixtureRequest):
         class MyCharm(ops.CharmBase):
             def __init__(self, framework: ops.Framework):
                 super().__init__(framework)
@@ -2185,6 +2199,7 @@ class TestHarness:
                     interface: pgsql
             """,
         )
+        request.addfinalizer(harness.cleanup)
         harness.begin()
 
         def mock_join_db(event: ops.EventBase):
@@ -3180,7 +3195,7 @@ class TestHarness:
         harness_plan = harness.get_container_pebble_plan('foo')
         assert harness_plan.to_yaml() == plan.to_yaml()
 
-    def test_add_layer_with_log_targets_to_plan(self):
+    def test_add_layer_with_log_targets_to_plan(self, request: pytest.FixtureRequest):
         layer_yaml = """\
         services:
          foo:
@@ -3205,6 +3220,7 @@ class TestHarness:
                 'containers': {'consumer': {'type': 'oci-image'}},
             }),
         )
+        request.addfinalizer(harness.cleanup)
         harness.begin()
         harness.set_can_connect('consumer', True)
 
@@ -3259,7 +3275,7 @@ class TestHarness:
             },
         ]
 
-    def test_get_filesystem_root(self):
+    def test_get_filesystem_root(self, request: pytest.FixtureRequest):
         harness = ops.testing.Harness(
             ops.CharmBase,
             meta="""
@@ -3269,6 +3285,7 @@ class TestHarness:
                 resource: foo-image
         """,
         )
+        request.addfinalizer(harness.cleanup)
         foo_root = harness.get_filesystem_root('foo')
         assert foo_root.exists()
         assert foo_root.is_dir()
@@ -3276,7 +3293,7 @@ class TestHarness:
         container = harness.charm.unit.get_container('foo')
         assert foo_root == harness.get_filesystem_root(container)
 
-    def test_evaluate_status(self):
+    def test_evaluate_status(self, request: pytest.FixtureRequest):
         class TestCharm(ops.CharmBase):
             app_status_to_add: ops.StatusBase
             unit_status_to_add: ops.StatusBase
@@ -3295,6 +3312,7 @@ class TestHarness:
                 event.add_status(self.unit_status_to_add)
 
         harness = ops.testing.Harness(TestCharm)
+        request.addfinalizer(harness.cleanup)
         harness.set_leader(True)
         harness.begin()
         # Tests for the behaviour of status evaluation are in test_charm.py
@@ -3308,8 +3326,9 @@ class TestHarness:
         assert harness.model.app.status == ops.ActiveStatus('active app')
         assert harness.model.unit.status == ops.ActiveStatus('active unit')
 
-    def test_invalid_status_set(self):
+    def test_invalid_status_set(self, request: pytest.FixtureRequest):
         harness = ops.testing.Harness(ops.CharmBase)
+        request.addfinalizer(harness.cleanup)
         harness.set_leader(True)
         harness.begin()
 
@@ -5650,7 +5669,8 @@ class TestFilesystem:
 
     def test_pull(self, container: ops.Container, container_fs_root: pathlib.Path):
         (container_fs_root / 'foo').write_text('foo')
-        assert container.pull('/foo').read() == 'foo'
+        with container.pull('/foo') as f:
+            assert f.read() == 'foo'
 
     def test_pull_path(self, container: ops.Container, container_fs_root: pathlib.Path):
         (container_fs_root / 'foo').mkdir()
@@ -5693,7 +5713,8 @@ class TestFilesystem:
         storage_id = harness.add_storage('test-storage', 1, attach=True)[0]
         assert (container_fs_root / 'mounts/foo').exists()
         (container_fs_root / 'mounts/foo/bar').write_text('foobar')
-        assert container.pull('/mounts/foo/bar').read() == 'foobar'
+        with container.pull('/mounts/foo/bar') as f:
+            assert f.read() == 'foobar'
         harness.detach_storage(storage_id)
         assert not (container_fs_root / 'mounts/foo/bar').is_file()
         harness.attach_storage(storage_id)
@@ -6717,13 +6738,14 @@ class TestActions:
         yield harness
         harness.cleanup()
 
-    def test_before_begin(self):
+    def test_before_begin(self, request: pytest.FixtureRequest):
         harness = ops.testing.Harness(
             ops.CharmBase,
             meta="""
             name: test
             """,
         )
+        request.addfinalizer(harness.cleanup)
         with pytest.raises(RuntimeError):
             harness.run_action('fail')
 

--- a/testing/src/scenario/_ops_main_mock.py
+++ b/testing/src/scenario/_ops_main_mock.py
@@ -269,6 +269,13 @@ class Ops(_Manager, Generic[CharmType]):
     def destroy(self):
         # Must be run first, so that ops._main trace span is finished and can be read back.
         super().destroy()
+        # _Manager.run() closes the framework in its finally block, but tests
+        # often use `with runtime.exec(...) as mgr:` without calling
+        # `mgr.run()`. Close defensively so the SQLite storage is released;
+        # framework.close() is idempotent.
+        framework = getattr(self, 'framework', None)
+        if framework is not None:
+            framework.close()
         if self._tracing_mock:
             assert self._tracing_exporter
             self.trace_data = self._tracing_exporter.get_finished_spans()

--- a/tox.ini
+++ b/tox.ini
@@ -79,6 +79,7 @@ commands =
         --ignore={[vars]examples_path} \
         --ignore={[vars]tst_path}charms \
         -v --tb native \
+        -W error \
         -W 'ignore:Harness is deprecated:PendingDeprecationWarning' {posargs}
 
 [testenv:coverage]

--- a/tracing/ops_tracing/_buffer.py
+++ b/tracing/ops_tracing/_buffer.py
@@ -150,7 +150,13 @@ class Buffer:
     @contextlib.contextmanager
     def tx(self, *, timeout: float = DB_TIMEOUT, readonly: bool = False):
         """Thread-safe transaction context manager."""
-        with sqlite3.connect(self.path, isolation_level=None, timeout=timeout) as conn:
+        # sqlite3.Connection as a context manager only commits/rolls back —
+        # it does not close. Use contextlib.closing so the connection is
+        # released; with isolation_level=None we manage BEGIN/COMMIT/ROLLBACK
+        # explicitly below.
+        with contextlib.closing(
+            sqlite3.connect(self.path, isolation_level=None, timeout=timeout)
+        ) as conn:
             mode = 'DEFERRED' if readonly else 'IMMEDIATE'
             conn.execute(f'BEGIN {mode}')
             try:

--- a/tracing/ops_tracing/_export.py
+++ b/tracing/ops_tracing/_export.py
@@ -143,7 +143,8 @@ class BufferingSpanExporter(SpanExporter):
             ):
                 pass
         except urllib.error.HTTPError as e:
-            resp = e.fp.read()[:1000]
+            with e.fp:
+                resp = e.fp.read()[:1000]
             logger.exception(f'Tracing collector rejected our data, {e.code=} {resp=}')
         except OSError:
             # URLError, TimeoutError, SSLError, socket.error


### PR DESCRIPTION
The key line here is the `-W error` in `tox.ini`. That raises all warnings (the most common are deprecation and resource) to errors, when running the unit tests. The bulk of the rest of the PR is cleaning up tests (and one docstring, because we test those too, via doctest) to properly clean up resources.

The changes not in the tests (or docs) need more careful examination:
* in `ops.storage` we wrap setup so that if opening the database fails, we properly clean up. Should never happen in practice (no other process should be touching the db) and even if it did, we would close on the crash, but better to tidily manage it, and this also fixes test cases.
* in `ops._main` when instantiating the charm if something goes wrong (like the charm `__init__` raising) cleanly close the framework. Definitely could happen in practice, but we would close everyone on the crash. Doing it explicitly is cleaner in general, and helps when running tests.
* in `ops.pebble` when handling garage coming back from Pebble, the `urllib.error.HTTPError` is also a response object and carries the open HTTP response body in e.fp (we use it already with `.read()` and so on). Under Python 3.14 there's a tempfile (https://github.com/python/cpython/pull/15002, which looks unrelated but look at the code) so we get a warning on exit for failing to clean up. This could happen in production with a broken Pebble, although again  no real consequence, but nice to clean up for the tests and correctness.