### PR TITLE
docs: move 2.x docs to canonical.com/juju/docs/ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `ops` library is a Python framework for developing and testing Kubernetes an
 
 > - `ops` is  [available on PyPI](https://pypi.org/project/ops/).
 > - Version 2.x of `ops` requires Python 3.8 or above.
-> - Read our [docs](https://documentation.ubuntu.com/ops/2.x/) for tutorials, how-to guides, the library reference, and more.
+> - Read our [docs](https://canonical.com/juju/docs/ops/2.x/) for tutorials, how-to guides, the library reference, and more.
 
 ## Give it a try
 
@@ -150,6 +150,6 @@ Congratulations, you’ve just built your first Kubernetes charm using `ops`!
 
 ## Next steps
 
-- Read the [docs](https://documentation.ubuntu.com/ops/2.x/).
+- Read the [docs](https://canonical.com/juju/docs/ops/2.x/).
 - Read our [Code of conduct](https://ubuntu.com/community/code-of-conduct) and join our [chat](https://matrix.to/#/#charmhub-ops:ubuntu.com) and [forum](https://discourse.charmhub.io/) or [open an issue](https://github.com/canonical/operator/issues).
 - Read our [CONTRIBUTING guide](https://github.com/canonical/operator/blob/main/HACKING.md) and contribute!

--- a/docs/.sphinx/_static/overwrite_links.js
+++ b/docs/.sphinx/_static/overwrite_links.js
@@ -1,0 +1,28 @@
+// Our docs are proxied through to canonical.com/juju/docs/ops.
+// If multiple doc versions are configured, Read the Docs renders a version switcher.
+// The version switcher has the readthedocs-hosted.com URL in links, which we don't want,
+// so this script overwrites those links to use the correct public-facing URL.
+
+// Replace oldDomain with newDomain
+const oldDomain = 'canonical-juju-ops.readthedocs-hosted.com';
+const newDomain = 'canonical.com/juju/docs/ops';
+
+// Use a MutationObserver to wait for the RTD flyout element to appear in the DOM
+const observer = new MutationObserver(function(mutations, obs) {
+    const rtdFlyout = document.querySelector('readthedocs-flyout');
+    if (!rtdFlyout) return;
+
+    obs.disconnect();
+
+    rtdFlyout.addEventListener('click', function() {
+        const shadowRoot = rtdFlyout.shadowRoot;
+        if (!shadowRoot) return;
+
+        const anchors = shadowRoot.querySelectorAll('a');
+        anchors.forEach(anchor => {
+            anchor.href = anchor.href.replace(new RegExp(oldDomain, 'g'), newDomain);
+        });
+    });
+});
+
+observer.observe(document.body, { childList: true, subtree: true });

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -153,8 +153,8 @@ if os.environ.get('READTHEDOCS', '') == 'True':
     html_context['github_version'] = '2.23-maintenance'
     html_context['slug'] = 'ops'
 
-# If your project is on documentation.ubuntu.com, specify the project
-# slug (for example, "lxd") here.
+# Project slug
+# Set to the path after https://canonical.com/
 slug = 'juju/docs/ops'
 
 ############################################################

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -307,7 +307,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'juju': ('https://documentation.ubuntu.com/juju/3.6', None),
     'charmcraft': ('https://canonical-charmcraft.readthedocs-hosted.com/en/latest', None),
-    'pebble': ('https://documentation.ubuntu.com/pebble', None),
+    'pebble': ('https://ubuntu.com/docs/pebble', None),
     'otel': ('https://opentelemetry-python.readthedocs.io/en/latest/', None),
 }
 

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -93,7 +93,8 @@ copyright = '%s, %s' % (datetime.date.today().year, author)  # noqa: A001
 # don't know yet)
 # NOTE: If no ogp_* variable is defined (e.g. if you remove this section) the
 # sphinxext.opengraph extension will be disabled.
-ogp_site_url = 'https://documentation.ubuntu.com/ops/2.x/'
+version_slug = f'{os.environ.get("READTHEDOCS_VERSION", "local")}'
+ogp_site_url = f'https://canonical.com/juju/docs/ops/{version_slug}/'
 # The documentation website name (usually the same as the product name)
 ogp_site_name = project
 # The URL of an image or logo that is used in the preview
@@ -154,7 +155,7 @@ if os.environ.get('READTHEDOCS', '') == 'True':
 
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.
-slug = 'ops'
+slug = 'juju/docs/ops'
 
 ############################################################
 ### Redirects
@@ -225,7 +226,9 @@ custom_excludes = [
 custom_html_css_files = []
 
 # Add JavaScript files (located in .sphinx/_static/)
-custom_html_js_files = []
+custom_html_js_files = [
+    'overwrite_links.js',
+]
 
 ## The following settings override the default configuration.
 

--- a/docs/howto/manage-metrics.md
+++ b/docs/howto/manage-metrics.md
@@ -1,6 +1,6 @@
 # How to manage metrics
 
-Pebble provides [metrics](https://documentation.ubuntu.com/pebble/reference/api/#/metrics/get_v1_metrics) for services and health checks in OpenMetrics format. Access to the Pebble metrics endpoint requires HTTP basic authentication with a username and password.
+Pebble provides [metrics](https://ubuntu.com/docs/pebble/reference/api/#/metrics/get_v1_metrics) for services and health checks in OpenMetrics format. Access to the Pebble metrics endpoint requires HTTP basic authentication with a username and password.
 
 Charms should use {external+juju:ref}`Juju secrets <secret>` to manage sensitive information such as authentication credentials.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ This is the documentation for version 2.x of Ops, which stopped being actively d
 - If your charm needs to support Python 3.8 (Ubuntu 20.04), use Ops 2.x.
 - Otherwise, use Ops 3.x.
 
-Ops 3.x removed support for Python 3.8, but is otherwise compatible with Ops 2.x. See the [latest documentation](https://documentation.ubuntu.com/ops/latest/).
+Ops 3.x removed support for Python 3.8, but is otherwise compatible with Ops 2.x. See the [latest documentation](https://canonical.com/juju/docs/ops/latest/).
 ```
 
 The Ops library (`ops`) is a Python framework for writing and testing Juju charms.

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -203,7 +203,7 @@ def _on_demo_server_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
     Learn more about interacting with Pebble at
         https://ops.readthedocs.io/en/latest/reference/pebble.html
     Learn more about Pebble layers at
-        https://documentation.ubuntu.com/pebble/how-to/use-layers/
+        https://ubuntu.com/docs/pebble/how-to/use-layers/
     """
     # Get a reference the container attribute on the PebbleReadyEvent
     container = event.workload

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -89,7 +89,7 @@ def _update_layer_and_restart(self) -> None:
     Learn more about interacting with Pebble at
         https://ops.readthedocs.io/en/latest/reference/pebble.html
     Learn more about Pebble layers at
-        https://documentation.ubuntu.com/pebble/how-to/use-layers/
+        https://ubuntu.com/docs/pebble/how-to/use-layers/
     """
     # Learn more about statuses at
     # https://documentation.ubuntu.com/juju/3.6/reference/status/

--- a/examples/k8s-1-minimal/src/charm.py
+++ b/examples/k8s-1-minimal/src/charm.py
@@ -43,7 +43,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         Learn more about interacting with Pebble at
             https://ops.readthedocs.io/en/latest/reference/pebble.html
         Learn more about Pebble layers at
-            https://documentation.ubuntu.com/pebble/how-to/use-layers/
+            https://ubuntu.com/docs/pebble/how-to/use-layers/
         """
         # Get a reference the container attribute on the PebbleReadyEvent
         container = event.workload

--- a/examples/k8s-2-configurable/src/charm.py
+++ b/examples/k8s-2-configurable/src/charm.py
@@ -59,7 +59,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         Learn more about interacting with Pebble at
             https://ops.readthedocs.io/en/latest/reference/pebble.html
         Learn more about Pebble layers at
-            https://documentation.ubuntu.com/pebble/how-to/use-layers/
+            https://ubuntu.com/docs/pebble/how-to/use-layers/
         """
         # Learn more about statuses at
         # https://documentation.ubuntu.com/juju/3.6/reference/status/

--- a/examples/k8s-3-postgresql/src/charm.py
+++ b/examples/k8s-3-postgresql/src/charm.py
@@ -97,7 +97,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         Learn more about interacting with Pebble at
             https://ops.readthedocs.io/en/latest/reference/pebble.html
         Learn more about Pebble layers at
-            https://documentation.ubuntu.com/pebble/how-to/use-layers/
+            https://ubuntu.com/docs/pebble/how-to/use-layers/
         """
         # Learn more about statuses at
         # https://documentation.ubuntu.com/juju/3.6/reference/status/

--- a/examples/k8s-4-action/src/charm.py
+++ b/examples/k8s-4-action/src/charm.py
@@ -127,7 +127,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         Learn more about interacting with Pebble at
             https://ops.readthedocs.io/en/latest/reference/pebble.html
         Learn more about Pebble layers at
-            https://documentation.ubuntu.com/pebble/how-to/use-layers/
+            https://ubuntu.com/docs/pebble/how-to/use-layers/
         """
         # Learn more about statuses at
         # https://documentation.ubuntu.com/juju/3.6/reference/status/

--- a/examples/k8s-5-observe/src/charm.py
+++ b/examples/k8s-5-observe/src/charm.py
@@ -143,7 +143,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         Learn more about interacting with Pebble at
             https://ops.readthedocs.io/en/latest/reference/pebble.html
         Learn more about Pebble layers at
-            https://documentation.ubuntu.com/pebble/how-to/use-layers/
+            https://ubuntu.com/docs/pebble/how-to/use-layers/
         """
         # Learn more about statuses at
         # https://documentation.ubuntu.com/juju/3.6/reference/status/

--- a/ops/_private/harness.py
+++ b/ops/_private/harness.py
@@ -323,7 +323,7 @@ class Harness(Generic[CharmType]):
 
         warnings.warn(
             'Harness is deprecated. For the recommended approach, see: '
-            'https://documentation.ubuntu.com/ops/2.x/howto/write-unit-tests-for-a-charm.html',
+            'https://canonical.com/juju/docs/ops/2.x/howto/write-unit-tests-for-a-charm.html',
             PendingDeprecationWarning,
             stacklevel=2,
         )

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -26,7 +26,7 @@ This module provides a way to interact with Pebble, including:
 
 For a command-line interface for local testing, see ``test/pebble_cli.py``.
 
-  See more: `Pebble documentation <https://documentation.ubuntu.com/pebble/>`_
+  See more: `Pebble documentation <https://ubuntu.com/docs/pebble/>`_
 """
 
 from __future__ import annotations
@@ -821,7 +821,7 @@ class Plan:
 
     A plan is the combined layer configuration. The layer configuration is
     documented at
-    https://documentation.ubuntu.com/pebble/reference/layer-specification/
+    https://ubuntu.com/docs/pebble/reference/layer-specification/
     """
 
     def __init__(self, raw: str | PlanDict | None = None):
@@ -900,7 +900,7 @@ class Layer:
     """Represents a Pebble configuration layer.
 
     The format of this is documented at
-    https://documentation.ubuntu.com/pebble/reference/layer-specification/
+    https://ubuntu.com/docs/pebble/reference/layer-specification/
     """
 
     #: Summary of the purpose of this layer.
@@ -1656,7 +1656,7 @@ class Notice:
     last_repeated: datetime.datetime
     """The time this notice was last repeated.
 
-    See Pebble's `Notices documentation <https://documentation.ubuntu.com/pebble/reference/notices/>`_
+    See Pebble's `Notices documentation <https://ubuntu.com/docs/pebble/reference/notices/>`_
     for an explanation of what "repeated" means.
     """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,10 +88,10 @@ integration = [
 ]
 
 [project.urls]
-"Homepage" = "https://documentation.ubuntu.com/ops/2.x/"
+"Homepage" = "https://canonical.com/juju/docs/ops/2.x/"
 "Repository" = "https://github.com/canonical/operator"
 "Issues" = "https://github.com/canonical/operator/issues"
-"Documentation" = "https://documentation.ubuntu.com/ops/2.x/"
+"Documentation" = "https://canonical.com/juju/docs/ops/2.x/"
 "Changelog" = "https://github.com/canonical/operator/blob/main/CHANGES.md"
 
 [build-system]

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,7 +1,7 @@
 # ops-scenario, the unit testing framework for ops charms
 
 `ops-scenario` is a Python library that provides state-transition testing for
-[Ops](https://documentation.ubuntu.com/ops/2.x/) charms. These tests are higher level than
+[Ops](https://canonical.com/juju/docs/ops/2.x/) charms. These tests are higher level than
 typical unit tests, but run at similar speeds and are the recommended approach
 for testing charms within requiring a full [Juju](https://juju.is) installation.
 
@@ -102,7 +102,7 @@ package.
    docs are also available via the standard Python `help()` functionality and in
    your IDE.
 
-[**Read the full documentation**](https://documentation.ubuntu.com/ops/2.x/)
+[**Read the full documentation**](https://canonical.com/juju/docs/ops/2.x/)
 
 ## Community
 

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -943,7 +943,7 @@ class Notice(_max_posargs(1)):
     last_repeated: datetime.datetime = dataclasses.field(default_factory=_now_utc)
     """The time this notice was last repeated.
 
-    See Pebble's `Notices documentation <https://documentation.ubuntu.com/pebble/reference/notices/>`_
+    See Pebble's `Notices documentation <https://ubuntu.com/docs/pebble/reference/notices/>`_
     for an explanation of what "repeated" means.
     """
 

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -18,7 +18,7 @@ Please add `ops[tracing]` to your charm's dependencies, rather than this package
 ## Documentation
 
 Comprehensive documentation for the Ops library, including the tracing feature, is available at:
-[Ops documentation](https://documentation.ubuntu.com/ops/2.x/).
+[Ops documentation](https://canonical.com/juju/docs/ops/2.x/).
 
 You’ll find setup instructions, usage examples, and best practices for leveraging the tracing functionality.
 

--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 [project.urls]
 "Repository" = "https://github.com/canonical/operator"
 "Issues" = "https://github.com/canonical/operator/issues"
-"Documentation" = "https://documentation.ubuntu.com/ops/2.x/"
+"Documentation" = "https://canonical.com/juju/docs/ops/2.x/"
 "Changelog" = "https://github.com/canonical/operator/blob/main/CHANGES.md"
 
 


### PR DESCRIPTION
This PR matches https://github.com/canonical/operator/pull/2545 for the 2.x docs.

<mark>**[Preview docs](https://canonical.com/juju/docs/ops/2.x/)** built from this branch. After this PR merges, I'll switch those docs to build from `2.23-maintenance` and redirect the existing docs.</mark>

**Main changes**

- Updated Ops doc URLs in `docs/custom_conf.py`.
- Updated hardcoded URLs for Ops, excluding `CHANGES.md`.
- Added a script `docs/.sphinx/_static/overwrite_links.js`. This script makes sure that the version switcher from Read the Docs has correct URLs. It's a standard part of the new docs setup at Canonical.

**Extra changes**

- Updated the intersphinx URL and hardcoded URLs for Pebble. To account for [pebble#882](https://github.com/canonical/pebble/pull/882).