### PR TITLE
fix: avoid errors in finalisation due to already-closed websocket

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -1958,8 +1958,23 @@ class _WebsocketWriter(io.BufferedIOBase):
         return len(chunk)
 
     def close(self):
-        """Send end-of-file message to websocket."""
-        self.ws.send('{"command":"end"}')
+        """Send end-of-file message to websocket.
+
+        Idempotent and tolerant of the underlying websocket already being
+        closed: ``ExecProcess._wait`` shuts the stdio websocket down before
+        the writer (or the ``TextIOWrapper`` wrapping it) is finalised, so
+        ``IOBase.__del__`` would otherwise surface a
+        ``WebSocketConnectionClosedException`` as an "Exception ignored
+        while finalizing file" warning on Python 3.13+ (see CPython
+        gh-62948).
+        """
+        if self.closed:
+            return
+        try:
+            self.ws.send('{"command":"end"}')
+        except websocket.WebSocketConnectionClosedException:
+            pass
+        super().close()
 
 
 class _WebsocketReader(io.BufferedIOBase):

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -3952,6 +3952,35 @@ class TestExec:
             ('TXT', '{"command":"end"}'),
         ]
 
+    def test_writer_close_after_shutdown(self):
+        """Closing the writer after the websocket is shut down must not raise.
+
+        Regression test for canonical/operator#2547. In the normal exec
+        lifecycle ``ExecProcess._wait`` shuts the stdio websocket down
+        before the ``_WebsocketWriter`` (or the ``TextIOWrapper`` wrapping
+        it) is finalised by the garbage collector. On Python 3.13+ a raised
+        ``WebSocketConnectionClosedException`` from ``IOBase.__del__`` is
+        surfaced as an "Exception ignored while finalizing file" warning.
+        """
+        ws = MockWebsocket()
+
+        def send(_s: str):
+            raise websocket.WebSocketConnectionClosedException('socket is already closed.')
+
+        ws.send = send
+        writer = pebble._WebsocketWriter(ws)
+        writer.close()  # must not raise
+        assert writer.closed
+        assert ws.sends == []
+
+    def test_writer_close_is_idempotent(self):
+        """A second close() must be a no-op (no duplicate "end" sent)."""
+        ws = MockWebsocket()
+        writer = pebble._WebsocketWriter(ws)
+        writer.close()
+        writer.close()
+        assert ws.sends == [('TXT', '{"command":"end"}')]
+
     def test_connect_websocket_error(self):
         class Client(MockClient):
             def _connect_websocket(self, change_id: str, websocket_id: str):

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -3964,11 +3964,11 @@ class TestExec:
         """
         ws = MockWebsocket()
 
-        def send(_s: str):
+        def send(s: str):
             raise websocket.WebSocketConnectionClosedException('socket is already closed.')
 
         ws.send = send
-        writer = pebble._WebsocketWriter(ws)
+        writer = pebble._WebsocketWriter(typing.cast('pebble._WebSocket', ws))
         writer.close()  # must not raise
         assert writer.closed
         assert ws.sends == []
@@ -3976,7 +3976,7 @@ class TestExec:
     def test_writer_close_is_idempotent(self):
         """A second close() must be a no-op (no duplicate "end" sent)."""
         ws = MockWebsocket()
-        writer = pebble._WebsocketWriter(ws)
+        writer = pebble._WebsocketWriter(typing.cast('pebble._WebSocket', ws))
         writer.close()
         writer.close()
         assert ws.sends == [('TXT', '{"command":"end"}')]


### PR DESCRIPTION
This PR ensures that when closing the Pebble websocket:
* If the socket is already closed, we do nothing.
* If we get an error because it's already closed while closing (presumably a race), we ignore that.

#2547 has more details on why we have issues in Python 3.13+ when finalising at the moment.

An alternative would be to change `_wait` to close, but that is riskier, since it would be a behaviour change and could in theory trigger issues if someone is doing something odd with a wrapped websocket. Quite unlikely in our case, but the change in this PR solves the issue and seems clean enough, and doesn't have the risk.

Fixes #2547