### PR TITLE
test: fix mock_temp_dir fixture's open() patch

### DIFF
--- a/test/test_hookcmds.py
+++ b/test/test_hookcmds.py
@@ -165,13 +165,15 @@ def mock_temp_dir(monkeypatch: pytest.MonkeyPatch) -> Generator[TemporaryDirecto
     dir_mock = TemporaryDirectory()
     monkeypatch.setattr('tempfile.TemporaryDirectory', dir_mock)
 
-    def mock_open(path: str, *args: Any, **kwargs: Any) -> Any:
-        if path.startswith(f'{dir_mock.name}/'):
+    real_open = open
+
+    def mock_open(path: Any, *args: Any, **kwargs: Any) -> Any:
+        if str(path).startswith(f'{dir_mock.name}/'):
             file_mock = NamedTemporaryFile()
             file_mock.name = f'{dir_mock.name}/{file_mock.name}'
             dir_mock.files.append(file_mock)
             return file_mock
-        return open(path, *args, **kwargs)  # type: ignore
+        return real_open(path, *args, **kwargs)  # type: ignore
 
     monkeypatch.setattr('builtins.open', mock_open)
 


### PR DESCRIPTION
The `mock_open` defined inside the `mock_temp_dir` fixture in `test/test_hookcmds.py` has two latent issues that only surfaced when something other than the test body called `open()` while the fixture was active (specifically, I was running these tests under `pytest-memray`, which opens a metadata file via `pathlib.Path`):

- `path` was typed and treated as `str`, but `builtins.open` also accepts `os.PathLike`, so a `PosixPath` argument crashed on `.startswith`.
- The non-matching fallback path was `return open(path, *args, **kwargs)`, which resolved to the monkeypatched `open` itself and recursed until the stack ran out.

This PR changes the test to capture the real `builtins.open` into a local before the `monkeypatch.setattr`, and to use `str(path)` for the prefix check. There is no behaviour change for any current passing test; the fixture now also composes with other plugins/tools that open files during the test.