### PR TITLE
fix: don't leak exec I/O threads when waiting on the change fails

### DIFF
--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -431,6 +431,10 @@ def _force_close_websocket(ws: _WebSocket):
     closing a socket doesn't wake up other threads that are blocked in
     ``recv()`` on the same socket; an OS-level shutdown of the connection
     does.
+
+    This reaches into websocket-client's ``WebSocket.sock`` (the underlying
+    ``socket.socket``) because the library exposes no public way to shut the
+    connection down without first closing the fd.
     """
     sock = ws.sock
     if sock is not None:
@@ -1828,15 +1832,19 @@ class ExecProcess(Generic[AnyStr]):
         # If stdin reader thread is running, stop it
         if self._cancel_stdin is not None:
             self._cancel_stdin()
+            self._cancel_stdin = None
 
         # Wait for all threads to finish (e.g., message barrier sent)
         for thread in self._threads:
             thread.join()
 
         # If we opened a cancel_reader pipe, close the read side now (write
-        # side was already closed by _cancel_stdin().
+        # side was already closed by _cancel_stdin()). Clear it afterwards so
+        # that a second call to _wait() (e.g. wait() then wait_output()) can't
+        # close the same fd again, matching _teardown_after_error().
         if self._cancel_reader is not None:
             os.close(self._cancel_reader)
+            self._cancel_reader = None
 
         # Close websockets (shutdown doesn't send CLOSE message or wait for response).
         self._control_ws.shutdown()

--- a/ops/pebble.py
+++ b/ops/pebble.py
@@ -340,6 +340,8 @@ if TYPE_CHECKING:
 
 
 class _WebSocket(Protocol):
+    sock: socket.socket | None
+
     def connect(self, url: str, socket: socket.socket): ...
 
     def shutdown(self): ...
@@ -410,10 +412,33 @@ def _format_timeout(timeout: float) -> str:
 
 
 def _start_thread(target: Callable[..., Any], *args: Any, **kwargs: Any) -> threading.Thread:
-    """Helper to simplify starting a thread."""
-    thread = threading.Thread(target=target, args=args, kwargs=kwargs)
+    """Helper to simplify starting a thread.
+
+    The thread is marked as daemon so that exec I/O threads can never keep
+    the interpreter alive at exit, even when teardown is missed (for
+    example, if wait() is never called and the server holds the websockets
+    open).
+    """
+    thread = threading.Thread(target=target, args=args, kwargs=kwargs, daemon=True)
     thread.start()
     return thread
+
+
+def _force_close_websocket(ws: _WebSocket):
+    """Close a websocket so that reads and writes blocked on it unblock.
+
+    ``WebSocket.shutdown()`` only closes the socket's file descriptor, and
+    closing a socket doesn't wake up other threads that are blocked in
+    ``recv()`` on the same socket; an OS-level shutdown of the connection
+    does.
+    """
+    sock = ws.sock
+    if sock is not None:
+        try:
+            sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass  # Already disconnected or closed.
+    ws.shutdown()
 
 
 class Error(Exception):
@@ -1787,7 +1812,18 @@ class ExecProcess(Generic[AnyStr]):
         if timeout is not None:
             # A bit more than the command timeout to ensure that happens first
             timeout += 1
-        change = self._client.wait_change(self._change_id, timeout=timeout)
+        try:
+            change = self._client.wait_change(self._change_id, timeout=timeout)
+        except BaseException:
+            # The wait failed or was interrupted, for example because the
+            # change didn't finish before the client-side timeout above. The
+            # I/O threads may still be blocked on their websockets, so tear
+            # the connections down to unblock them, and reap the threads
+            # before propagating the error, otherwise they're left running
+            # and at interpreter shutdown block the join of non-daemon
+            # threads (#2556).
+            self._teardown_after_error()
+            raise
 
         # If stdin reader thread is running, stop it
         if self._cancel_stdin is not None:
@@ -1815,6 +1851,35 @@ class ExecProcess(Generic[AnyStr]):
         if change.tasks:
             exit_code = change.tasks[0].data.get('exit-code', -1)
         return exit_code
+
+    def _teardown_after_error(self):
+        # If stdin reader thread is running, stop it.
+        if self._cancel_stdin is not None:
+            self._cancel_stdin()
+            self._cancel_stdin = None
+
+        # Unlike the success path, close the websockets before joining the
+        # I/O threads: the server hasn't finished the exec, so the threads
+        # are still blocked reading from the websockets and would never
+        # finish on their own.
+        _force_close_websocket(self._control_ws)
+        _force_close_websocket(self._stdio_ws)
+        if self._stderr_ws is not None:
+            _force_close_websocket(self._stderr_ws)
+
+        for thread in self._threads:
+            # With the websockets closed the threads exit almost immediately;
+            # the timeout is belt-and-braces (they're daemon threads, so even
+            # a leak here can't block interpreter shutdown).
+            thread.join(timeout=1.0)
+            if thread.is_alive():
+                logger.warning('exec I/O thread did not finish after error in wait')
+
+        # If we opened a cancel_reader pipe, close the read side now (write
+        # side was already closed by _cancel_stdin()).
+        if self._cancel_reader is not None:
+            os.close(self._cancel_reader)
+            self._cancel_reader = None
 
     def wait_output(self) -> tuple[AnyStr, AnyStr | None]:
         """Wait for the process to finish and return tuple of (stdout, stderr).
@@ -1896,29 +1961,43 @@ def _reader_to_websocket(
     bufsize: int = 16 * 1024,
 ):
     """Read reader through to EOF and send each chunk read to the websocket."""
-    while True:
-        if cancel_reader is not None:
-            # Wait for either a read to be ready or the caller to cancel stdin.
-            # If the reader is also ready, drain it first so a cancel that
-            # arrives before this thread runs doesn't drop pending input.
-            result = select.select([cancel_reader, reader], [], [])
-            if reader not in result[0]:
+    try:
+        while True:
+            if cancel_reader is not None:
+                # Wait for either a read to be ready or the caller to cancel stdin.
+                # If the reader is also ready, drain it first so a cancel that
+                # arrives before this thread runs doesn't drop pending input.
+                result = select.select([cancel_reader, reader], [], [])
+                if reader not in result[0]:
+                    break
+
+            chunk = reader.read(bufsize)
+            if not chunk:
                 break
+            if isinstance(chunk, str):
+                chunk = chunk.encode(encoding)
+            ws.send_binary(chunk)
 
-        chunk = reader.read(bufsize)
-        if not chunk:
-            break
-        if isinstance(chunk, str):
-            chunk = chunk.encode(encoding)
-        ws.send_binary(chunk)
-
-    ws.send('{"command":"end"}')  # Send "end" command as TEXT frame to signal EOF
+        ws.send('{"command":"end"}')  # Send "end" command as TEXT frame to signal EOF
+    except (websocket.WebSocketException, OSError) as e:
+        # The websocket or cancel pipe was closed underneath us (for example,
+        # because the exec failed and ExecProcess._wait tore the connection
+        # down), so there's nowhere to send the rest of the input to.
+        logger.debug('exec stdin forwarder stopped: %s', e)
 
 
 def _websocket_to_writer(ws: _WebSocket, writer: _WebsocketWriter, encoding: str | None):
     """Receive messages from websocket (until end signal) and write to writer."""
     while True:
-        chunk = ws.recv()
+        try:
+            chunk = ws.recv()
+        except (websocket.WebSocketException, OSError) as e:
+            # The websocket was closed underneath us (for example, because
+            # the exec failed and ExecProcess._wait tore the connection
+            # down): treat it as end-of-stream rather than crashing the
+            # thread.
+            logger.debug('exec output forwarder stopped: %s', e)
+            break
 
         if isinstance(chunk, str):
             try:
@@ -1996,7 +2075,16 @@ class _WebsocketReader(io.BufferedIOBase):
             return b''
 
         while not self.remaining:
-            chunk = self.ws.recv()
+            try:
+                chunk = self.ws.recv()
+            except (websocket.WebSocketException, OSError) as e:
+                # The websocket was closed underneath us (for example,
+                # because the exec failed and ExecProcess._wait tore the
+                # connection down): treat it as end-of-file. The error that
+                # caused the teardown is reported by wait()/wait_output().
+                logger.debug('exec output stream closed: %s', e)
+                self.eof = True
+                return b''
 
             if isinstance(chunk, str):
                 try:
@@ -3155,14 +3243,21 @@ class Client:
             task_id = resp['result']['task-id']
 
             stderr_ws: _WebSocket | None = None
+            connected: list[_WebSocket] = []
             try:
                 control_ws = self._connect_websocket(task_id, 'control')
+                connected.append(control_ws)
                 stdio_ws = self._connect_websocket(task_id, 'stdio')
+                connected.append(stdio_ws)
                 if not combine_stderr:
                     stderr_ws = self._connect_websocket(task_id, 'stderr')
+                    connected.append(stderr_ws)
             except websocket.WebSocketException as e:
                 # Error connecting to websockets, probably due to the exec/change
-                # finishing early with an error. Call wait_change to pick that up.
+                # finishing early with an error. Close any websockets that did
+                # connect, then call wait_change to pick up the change error.
+                for ws in connected:
+                    ws.shutdown()
                 change = self.wait_change(ChangeID(change_id))
                 if change.err:
                     raise ChangeError(change.err, change) from e

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -4177,6 +4177,30 @@ class TestExec:
         assert process._threads
         assert all(thread.daemon for thread in process._threads)
 
+    def test_wait_twice_does_not_double_close_cancel_pipe(self, client: MockClient):
+        """A successful _wait() must clear the cancel pipe so a second call is safe.
+
+        wait() and wait_output() both call _wait(); calling them in turn (or
+        wait() twice) used to os.close() the already-closed cancel_reader fd
+        and re-run _cancel_stdin(), raising OSError on the second call.
+        """
+        self.add_responses(client, '123', 0)
+        # A second wait_change response for the second _wait() call.
+        change = build_mock_change_dict('123')
+        assert 'tasks' in change and change['tasks'] is not None
+        change['tasks'][0]['data'] = {'exit-code': 0}
+        client.responses.append({'result': change})
+
+        with tempfile.TemporaryFile() as stdin:
+            stdin.write(b'foo\n')
+            stdin.seek(0)
+            process = client.exec(['foo'], stdin=stdin, encoding=None)
+            process.wait()
+            assert process._cancel_stdin is None
+            assert process._cancel_reader is None
+            # Must not raise (e.g. OSError from closing the fd a second time).
+            process._wait()
+
     def test_connect_websocket_error_closes_connected_websockets(self):
         """If a websocket fails to connect, the connected ones must be closed."""
 

--- a/test/test_pebble.py
+++ b/test/test_pebble.py
@@ -21,7 +21,9 @@ import email.parser
 import io
 import json
 import signal
+import socket
 import tempfile
+import threading
 import typing
 import unittest
 import unittest.util
@@ -3383,8 +3385,10 @@ class TestExecError:
 
 class MockWebsocket:
     def __init__(self):
+        self.sock: socket.socket | None = None
         self.sends: list[tuple[str, str | bytes]] = []
         self.receives: list[str | bytes] = []
+        self.shutdown_calls = 0
 
     def send_binary(self, b: bytes):
         self.sends.append(('BIN', b))
@@ -3396,7 +3400,33 @@ class MockWebsocket:
         return self.receives.pop(0)
 
     def shutdown(self):
-        pass
+        self.shutdown_calls += 1
+
+
+class BlockingMockWebsocket(MockWebsocket):
+    """Websocket mock whose recv() blocks on a real socket until it's closed."""
+
+    def __init__(self):
+        super().__init__()
+        self.sock, self._peer = socket.socketpair()
+
+    def recv(self):
+        assert self.sock is not None
+        try:
+            data = self.sock.recv(16)
+        except OSError:
+            data = b''
+        if not data:
+            raise websocket.WebSocketConnectionClosedException(
+                'Connection to remote host was lost.'
+            )
+        return data
+
+    def shutdown(self):
+        super().shutdown()
+        assert self.sock is not None
+        self.sock.close()
+        self._peer.close()
 
 
 class TestExec:
@@ -4061,6 +4091,158 @@ class TestExec:
         test_websocket_recv_raises = pytest.mark.filterwarnings(
             'ignore::pytest.PytestUnhandledThreadExceptionWarning'
         )(test_websocket_recv_raises)
+
+    def add_blocking_responses(self, client: MockClient, change_id: str):
+        """Set up an exec response whose websockets block in recv() until closed."""
+        task_id = f'T{change_id}'
+        client.responses.append({
+            'change': change_id,
+            'result': {'task-id': task_id},
+        })
+        stdio = BlockingMockWebsocket()
+        stderr = BlockingMockWebsocket()
+        control = BlockingMockWebsocket()
+        client.websockets = {
+            (task_id, 'stdio'): stdio,
+            (task_id, 'stderr'): stderr,
+            (task_id, 'control'): control,
+        }
+        return (stdio, stderr, control)
+
+    def test_wait_change_error_reaps_io_threads(
+        self, client: MockClient, time: MockTime, monkeypatch: pytest.MonkeyPatch
+    ):
+        """If wait_change raises, the I/O threads must be unblocked and reaped.
+
+        Regression test for canonical/operator#2556. The exec change didn't
+        finish before the client-side timeout, so wait_change() raises; the
+        I/O threads were left blocked in recv() on the still-open websockets,
+        and being non-daemon they then hung interpreter shutdown.
+        """
+        thread_errors: list[threading.ExceptHookArgs] = []
+        monkeypatch.setattr(threading, 'excepthook', thread_errors.append)
+
+        stdio, stderr, control = self.add_blocking_responses(client, '123')
+
+        def timeout_response():
+            time.sleep(3)  # simulate passing of time due to wait_change call
+            raise pebble.APIError({}, 504, 'Gateway Timeout', 'timed out')
+
+        client.responses.append(timeout_response)
+
+        process = client.exec(['foo'], timeout=1)
+        with pytest.raises(pebble.TimeoutError):
+            process.wait_output()
+
+        for thread in process._threads:
+            thread.join(timeout=5)
+        assert [t.name for t in process._threads if t.is_alive()] == []
+        assert thread_errors == []
+        for ws in (stdio, stderr, control):
+            assert ws.shutdown_calls > 0
+
+    def test_wait_change_error_with_stdin(self, client: MockClient, time: MockTime):
+        """A failed wait must also stop the stdin thread and close the cancel pipe."""
+        self.add_blocking_responses(client, '123')
+
+        def timeout_response():
+            time.sleep(3)  # simulate passing of time due to wait_change call
+            raise pebble.APIError({}, 504, 'Gateway Timeout', 'timed out')
+
+        client.responses.append(timeout_response)
+
+        with tempfile.TemporaryFile() as stdin:
+            stdin.write(b'foo\n')
+            stdin.seek(0)
+            process = client.exec(['foo'], stdin=stdin, encoding=None, timeout=1)
+            with pytest.raises(pebble.TimeoutError):
+                process.wait()
+
+        for thread in process._threads:
+            thread.join(timeout=5)
+        assert [t.name for t in process._threads if t.is_alive()] == []
+        # The cancel pipe must have been closed (and not be double-closed if
+        # wait() is called again).
+        assert process._cancel_stdin is None
+        assert process._cancel_reader is None
+
+    def test_io_threads_are_daemon(self, client: MockClient):
+        stdio, stderr, _ = self.add_responses(client, '123', 0)
+        stdio.receives.append('{"command":"end"}')
+        stderr.receives.append('{"command":"end"}')
+
+        process = client.exec(['true'])
+        process.wait_output()
+
+        assert process._threads
+        assert all(thread.daemon for thread in process._threads)
+
+    def test_connect_websocket_error_closes_connected_websockets(self):
+        """If a websocket fails to connect, the connected ones must be closed."""
+
+        class Client(MockClient):
+            def _connect_websocket(self, task_id: str, websocket_id: str):
+                if websocket_id == 'stderr':
+                    raise websocket.WebSocketException('conn!')
+                return super()._connect_websocket(task_id, websocket_id)
+
+        client = Client()
+        stdio, stderr, control = self.add_responses(client, '123', 0, change_err='change error!')
+        with pytest.raises(pebble.ChangeError):
+            client.exec(['foo'])
+        assert control.shutdown_calls == 1
+        assert stdio.shutdown_calls == 1
+        assert stderr.shutdown_calls == 0
+
+    def test_websocket_reader_eof_on_closed_connection(self):
+        """A websocket closed underneath a reader is EOF, not an error.
+
+        The reader is read from threads (shutil.copyfileobj in wait_output)
+        and from user code streaming process.stdout, and the websocket may be
+        torn down by ExecProcess._wait at any point, most notably when the
+        wait fails (canonical/operator#2556).
+        """
+        ws = MockWebsocket()
+
+        def recv():
+            raise websocket.WebSocketConnectionClosedException('socket is already closed.')
+
+        ws.recv = recv
+        reader = pebble._WebsocketReader(typing.cast('pebble._WebSocket', ws))
+        assert reader.read() == b''
+        assert reader.read() == b''  # Still EOF when called again.
+
+    def test_websocket_to_writer_stops_on_closed_connection(self):
+        ws = MockWebsocket()
+        chunks: list[bytes] = [b'foo']
+
+        def recv():
+            if chunks:
+                return chunks.pop(0)
+            raise websocket.WebSocketConnectionClosedException('socket is already closed.')
+
+        ws.recv = recv
+        out = io.BytesIO()
+        pebble._websocket_to_writer(
+            typing.cast('pebble._WebSocket', ws),
+            typing.cast('pebble._WebsocketWriter', out),
+            None,
+        )  # Must return cleanly rather than raise.
+        assert out.getvalue() == b'foo'
+
+    def test_reader_to_websocket_stops_on_closed_connection(self):
+        ws = MockWebsocket()
+
+        def send_binary(b: bytes):
+            raise websocket.WebSocketConnectionClosedException('socket is already closed.')
+
+        ws.send_binary = send_binary
+        reader = io.BytesIO(b'foo')
+        pebble._reader_to_websocket(
+            typing.cast('pebble._WebsocketReader', reader),
+            typing.cast('pebble._WebSocket', ws),
+            'utf-8',
+        )  # Must return cleanly rather than raise.
 
 
 class TestIdentity:

--- a/test/test_real_pebble.py
+++ b/test/test_real_pebble.py
@@ -268,6 +268,20 @@ class TestRealPebble:
             process.wait()
         assert 'timed out' in excinfo.value.err
 
+    def test_exec_wait_timeout_reaps_io_threads(self, client: pebble.Client):
+        # Regression test for canonical/operator#2556. The orphaned grandchild
+        # keeps the exec's stdio pipe open, so the change can't finish even
+        # after Pebble kills the command at the 0.1s timeout, and the wait
+        # then times out client-side. The I/O threads were left blocked on the
+        # websockets, and being non-daemon they then hung interpreter
+        # shutdown.
+        process = client.exec(['/bin/sh', '-c', 'setsid sleep 3 & sleep 3'], timeout=0.1)
+        with pytest.raises(pebble.TimeoutError):
+            process.wait_output()
+        for thread in process._threads:
+            thread.join(timeout=2)
+        assert [t.name for t in process._threads if t.is_alive()] == []
+
     def test_exec_working_dir(self, client: pebble.Client):
         with tempfile.TemporaryDirectory() as temp_dir:
             process = client.exec(['pwd'], working_dir=temp_dir)

--- a/test/test_real_pebble.py
+++ b/test/test_real_pebble.py
@@ -269,12 +269,16 @@ class TestRealPebble:
         assert 'timed out' in excinfo.value.err
 
     def test_exec_wait_timeout_reaps_io_threads(self, client: pebble.Client):
-        # Regression test for canonical/operator#2556. The orphaned grandchild
-        # keeps the exec's stdio pipe open, so the change can't finish even
-        # after Pebble kills the command at the 0.1s timeout, and the wait
-        # then times out client-side. The I/O threads were left blocked on the
-        # websockets, and being non-daemon they then hung interpreter
-        # shutdown.
+        # Regression test for canonical/operator#2556.
+        #
+        # Repro: the orphaned grandchild keeps the exec's stdio pipe open, so
+        # the change can't finish even after Pebble kills the command at the
+        # 0.1s timeout, and the wait then times out client-side.
+        #
+        # Before the fix, the I/O threads were left blocked on the websockets,
+        # and being non-daemon they hung interpreter shutdown. This test
+        # asserts that after wait_output() raises TimeoutError, the I/O
+        # threads exit promptly.
         process = client.exec(['/bin/sh', '-c', 'setsid sleep 3 & sleep 3'], timeout=0.1)
         with pytest.raises(pebble.TimeoutError):
             process.wait_output()


### PR DESCRIPTION
If the change for an exec doesn't finish before the client-side timeout, or waiting on it fails in any other way, `ExecProcess._wait()` propagates the exception without any teardown. The I/O pump threads are left blocked in `recv()` on the still open websockets, and being non-daemon threads they then block interpreter shutdown indefinitely, wedging the Juju hook. See #2556 for the reproduction details (note that the leak needs the change to outlive the client-side wait, for example an orphan holding the exec's stdio pipe open; a plain exec timeout completes the change server-side and already cleans up correctly).

This tears the exec down when the wait fails:

* Shut the websocket connections down at the OS level (`SHUT_RDWR`) rather than only closing the file descriptors. Closing a socket doesn't wake other threads blocked in `recv()` on it, so the `finally` approach suggested in the issue (or joining the threads first, as the success path does) would hang the hook immediately instead of at exit.
* Treat a connection closed underneath an I/O pump thread (`WebSocketException` or `OSError`) as end-of-stream rather than letting the exception escape the thread, which printed noisy `WebSocketConnectionClosedException` tracebacks via `threading.excepthook`.
* Create the exec I/O threads as daemon threads, so any teardown path that's still missed (including never calling `wait()` at all) can't block interpreter shutdown.
* Close any already-connected websockets when connecting the exec websockets fails partway through, rather than leaking them (found while auditing for related leaks).

The behaviour of the success path is unchanged: the threads are still joined before the websockets are shut down, so output is never truncated.

Verified against a real Pebble (v1.31.0) on Python 3.10 through 3.14: before the fix the reproduction from #2556 leaks two `copyfileobj` threads and hangs at exit; with the fix it raises `ops.pebble.TimeoutError` as before, leaves no threads behind, and exits cleanly.

Fixes #2556
