### PR TITLE
docs: fix first unit tests command in machine charm tutorial

### DIFF
--- a/docs/tutorial/write-your-first-machine-charm.md
+++ b/docs/tutorial/write-your-first-machine-charm.md
@@ -707,7 +707,7 @@ def test_version(monkeypatch: pytest.MonkeyPatch):
 We'll run all the tests later in the tutorial. But if you'd like to see whether this test passes, run:
 
 ```text
-tox -e unit -- tests/unit/test_tinyproxy.py
+tox -e unit -- -k test_version
 ```
 
 ### Write state-transition tests


### PR DESCRIPTION
In [Write tests for the helper module](https://documentation.ubuntu.com/ops/latest/tutorial/write-your-first-machine-charm/#write-tests-for-the-helper-module) in the machine charm tutorial, we add a test for the workload module, then say that the test can be run with:

```
tox -e unit -- tests/unit/test_tinyproxy.py
```

But this command fails with an AssertionError on the unit status. Cause:

- The `tox` command isn't restricting to a single file; it's running the state-transition tests (`test_charm.py`) as well as the workload module tests. Because in the profile's `tox.ini`, args are inserted after the test path. [See here](https://github.com/canonical/charmcraft/blob/main/charmcraft/templates/init-machine/tox.ini.j2#L56-L57)

- At this point in the tutorial, the charm code has been updated to install and configure tinyproxy, but we haven't yet mocked tinyproxy in the state-transition tests. The placeholder test (from the profile) triggers the start event, which sets the wrong status because tinyproxy isn't installed on the host.

I figure the simplest fix is to use `-k` to select the only test we want to run.