### PR TITLE
ci: test Ops 2.23 with Python 3.14

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.10", "3.12"]
+        python-version: ["3.8", "3.10", "3.12", "3.14"]
         exclude:
         - {python-version: "3.8", os: "macos-latest"}  # macos-14 is arm64, and there's no Python 3.8 build for arm64
 

--- a/test/test_model_relation_data_class.py
+++ b/test/test_model_relation_data_class.py
@@ -129,8 +129,8 @@ nested_decode = functools.partial(json.loads, object_hook=json_nested_hook)
 
 
 class MyCharm(BaseTestCharm):
-    encoder = staticmethod(nested_encode)
-    decoder = staticmethod(nested_decode)
+    encoder = staticmethod(nested_encode)  # type: ignore[reportAssignmentType]
+    decoder = staticmethod(nested_decode)  # type: ignore[reportAssignmentType]
 
     @property
     def databag_class(self) -> type[DatabagProtocol]:
@@ -782,8 +782,8 @@ class _CommonTypesDataclass:
 
 
 class CommonTypesDataclasses(BaseTestCharmCommonTypes):
-    encoder = staticmethod(json_ip_and_country_encode)
-    decoder = staticmethod(json_ip_decode)
+    encoder = staticmethod(json_ip_and_country_encode)  # type: ignore[reportAssignmentType]
+    decoder = staticmethod(json_ip_decode)  # type: ignore[reportAssignmentType]
 
     @property
     def databag_class(self):
@@ -802,7 +802,7 @@ if pydantic:
         origin: Country
 
     class CommonTypesPydanticDataclass(BaseTestCharmCommonTypes):
-        encoder = staticmethod(json_ip_and_country_encode)
+        encoder = staticmethod(json_ip_and_country_encode)  # type: ignore[reportAssignmentType]
 
         @property
         def databag_class(self):

--- a/test/test_model_relation_data_class.py
+++ b/test/test_model_relation_data_class.py
@@ -129,8 +129,8 @@ nested_decode = functools.partial(json.loads, object_hook=json_nested_hook)
 
 
 class MyCharm(BaseTestCharm):
-    encoder = nested_encode
-    decoder = nested_decode
+    encoder = staticmethod(nested_encode)
+    decoder = staticmethod(nested_decode)
 
     @property
     def databag_class(self) -> type[DatabagProtocol]:
@@ -782,8 +782,8 @@ class _CommonTypesDataclass:
 
 
 class CommonTypesDataclasses(BaseTestCharmCommonTypes):
-    encoder = json_ip_and_country_encode
-    decoder = json_ip_decode
+    encoder = staticmethod(json_ip_and_country_encode)
+    decoder = staticmethod(json_ip_decode)
 
     @property
     def databag_class(self):
@@ -802,7 +802,7 @@ if pydantic:
         origin: Country
 
     class CommonTypesPydanticDataclass(BaseTestCharmCommonTypes):
-        encoder = json_ip_and_country_encode
+        encoder = staticmethod(json_ip_and_country_encode)
 
         @property
         def databag_class(self):

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ allowlist_externals = cp
 dependency_groups = unit, static
 commands = pyright {posargs}
 
-[testenv:py{3.8,3.10,3.12}-unit]
+[testenv:py{3.8,3.10,3.12,3.14}-unit]
 runner = uv-venv-lock-runner
 base=unit
 

--- a/tracing/tox.ini
+++ b/tracing/tox.ini
@@ -7,7 +7,7 @@ deps =
     -e ../testing
     -e .
 
-[testenv:py{3.8,3.10,3.12}-unit]
+[testenv:py{3.8,3.10,3.12,3.14}-unit]
 base=unit
 
 [testenv:unit]


### PR DESCRIPTION
#2546 is blocked because we don't run the tests on this branch with Python 3.14, but these are configured as required checks. Since Ops 2.23 only specifies Python `>=3.8`, we'd expect it to run fine with Python 3.14.

<img width="972" height="137" alt="image" src="https://github.com/user-attachments/assets/687172c7-90dc-4a95-9379-332207823817" />

In addition to adding 3.14 to the list of versions in CI, we also need to add it to the list of environments in `tox.ini`, and follow #2091 in patching some of the tests: we now need to wrap our `functools.partial` objects in `staticmethod` due to `partial` implementing the decriptor protocol in Python 3.14 (https://github.com/python/cpython/issues/121027, https://github.com/python/cpython/pull/121089). However, because we're on an older `pyright` version in this maintenance branch, this leads to type checking errors which we ignore (bumping `pyright` resolves this but introduces 20+ other errors which would add noise to this PR).