### PR TITLE
chore: pin pydantic to 2-3

### DIFF
--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
     "opentelemetry-sdk~=1.30",
     "ops==2.23.3.dev0",
-    "pydantic",
+    "pydantic>=2.0,<3",
 ]
 
 [project.urls]

--- a/tracing/pyproject.toml
+++ b/tracing/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
     "opentelemetry-sdk~=1.30",
     "ops==2.23.3.dev0",
-    "pydantic>=2.0,<3",
+    "pydantic>=2,<3",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -2113,7 +2113,7 @@ testing = [
 requires-dist = [
     { name = "opentelemetry-sdk", specifier = "~=1.30" },
     { name = "ops", editable = "." },
-    { name = "pydantic" },
+    { name = "pydantic", specifier = ">=2.0,<3" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
We only really supported Pydantic 2 currently, and can't know whether Pydantic 3 would work, so this keeps us honest.

This also helps with tooling that figures out which dependencies match when mixing ops[...] with other dependencies.