### PR TITLE
docs: add more guidance about charm naming

### DIFF
--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -68,7 +68,7 @@ Examples:
 - [kafka-k8s-operator](https://github.com/canonical/kafka-k8s-operator) - Contains a single charm that operates a K8s workload.
 - [katib-operators](https://github.com/canonical/katib-operators) - Contains multiple charms.
 - [data-integrator](https://github.com/canonical/data-integrator) - Contains a charm that integrates an externally managed service (such as a client application).
-- [s3-integrator](https://github.com/canonical/object-storage--integrators) - Contains multiple charms that integrate an externally managed service (such as different kinds of object storage backends).
+- [s3-integrator](https://github.com/canonical/object-storage-integrators) - Contains multiple charms that integrate an externally managed service (such as different kinds of object storage backends).
 - [request-authentication-configurator](https://github.com/canonical/request-authentication-configurator) - Contains a charm that configures Gateway to perform request authentication.
 
 (initialise-the-repository)=

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -25,6 +25,16 @@ To check that your preferred name isn't already in use, visit the (future) Charm
 https://charmhub.io/mega-calendar-k8s
 ```
 
+```{admonition} Best practice
+:class: hint
+
+Your charm's name should be slug-oriented (ASCII lowercase letters, numbers, and hyphens) and follow the pattern `<workload name in full>[<function>][-k8s]`.
+
+For a Kubernetes charm, include the `k8s` suffix if there is (or could be in the future) a machine variant of your charm. If your charm is inherently tied to Kubernetes and there could never be a machine variant, don't include the `k8s` suffix.
+
+Don't add an `operator` or `charm` prefix/suffix. Don't include an organisation or publisher name.
+```
+
 Some charms do not operate a workload, such as integrator and configurator charms. These categories serve different purposes:
 
 * An integrator charm allows integration with a service that is not managed through Juju. This can both apply to server side integrations (such as `s3-integrator`, which integrates an externally managed S3 object storage) or to client side integrations (such as `data-integrator`, representing the integration of external client application that needs a database).

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -25,15 +25,13 @@ To check that your preferred name isn't already in use, visit the (future) Charm
 https://charmhub.io/mega-calendar-k8s
 ```
 
-```{admonition} Best practice
-:class: hint
+Make sure that your charm's name only contains ASCII lowercase letters, numbers, and hyphens.
 
-Your charm's name should be slug-oriented (ASCII lowercase letters, numbers, and hyphens) and follow the pattern `<workload name in full>[<function>][-k8s]`.
-
-For a Kubernetes charm, include the `k8s` suffix if there is (or could be in the future) a machine variant of your charm. If your charm is inherently tied to Kubernetes and there could never be a machine variant, don't include the `k8s` suffix.
+The general naming pattern is `<workload name>[-<function>][-k8s]`, where `<function>` could be `server`, `dashboard`, and so on.
 
 Don't add an `operator` or `charm` prefix/suffix. Don't include an organisation or publisher name.
-```
+
+### Charms without a workload
 
 Some charms do not operate a workload, such as integrator and configurator charms. These categories serve different purposes:
 
@@ -41,9 +39,15 @@ Some charms do not operate a workload, such as integrator and configurator charm
 
 * A configurator charm provides logic to configure a particular charm or relation that is already in Juju. Examples include `cos-configuration` when it applies to a single charm (such as providing more fine-grained configuration of the Prometheus scraping) or for a relation (such as `ingress-configurator` to provide additional configuration of ingress requests).
 
-Since workload-less charms can work both on machines and on Kubernetes, avoid using the `k8s` suffix when naming integrator charms and configurator charms, unless the charm is only relevant for Kubernetes (for example, managing K8s resources within the charm logic using `lightkube`).
+When naming your charm, use `-integrator` and `-configurator` to signal the category. For example, `foo-integrator` or `bar-configurator`.
 
-When naming the charm, use `-integrator` and `-configurator` to signal the category of the charm. For example, `foo-integrator` or `bar-configurator`.
+### Kubernetes charms
+
+The `k8s` suffix is for disambiguation, not classification. Only use `-k8s` in the name of a Kubernetes charm if there is (or could be in the future) a machine variant of your charm.
+
+Don't use `-k8s` if your charm is inherently tied to Kubernetes and there could never be a machine variant. For example, a charm that uses `lightkube` to manage Kubernetes resources.
+
+Don't use `-k8s` for workload-less charms. These charms work on machines and Kubernetes.
 
 (create-a-repository)=
 ## Create a repository
@@ -64,7 +68,7 @@ Examples:
 - [kafka-k8s-operator](https://github.com/canonical/kafka-k8s-operator) - Contains a single charm that operates a K8s workload.
 - [katib-operators](https://github.com/canonical/katib-operators) - Contains multiple charms.
 - [data-integrator](https://github.com/canonical/data-integrator) - Contains a charm that integrates an externally managed service (such as a client application).
-- [s3-integrator](https://github.com/canonical/object-storage-integrators) - Contains multiple charms that integrate an externally managed service (such as different kinds of object storage backends).
+- [s3-integrator](https://github.com/canonical/object-storage--integrators) - Contains multiple charms that integrate an externally managed service (such as different kinds of object storage backends).
 - [request-authentication-configurator](https://github.com/canonical/request-authentication-configurator) - Contains a charm that configures Gateway to perform request authentication.
 
 (initialise-the-repository)=

--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -45,7 +45,7 @@ When naming your charm, use `-integrator` and `-configurator` to signal the cate
 
 The `k8s` suffix is for disambiguation, not classification. Only use `-k8s` in the name of a Kubernetes charm if there is (or could be in the future) a machine variant of your charm.
 
-Don't use `-k8s` if your charm is inherently tied to Kubernetes and there could never be a machine variant. For example, a charm that uses `lightkube` to manage Kubernetes resources.
+For example, a charm that manages Kubernetes resources with `lightkube` shouldn't use `-k8s` in the name, as the charm is inherently tied to Kubernetes.
 
 Don't use `-k8s` for workload-less charms. These charms work on machines and Kubernetes.
 


### PR DESCRIPTION
This PR adds more detail to [Decide your charm's name](https://canonical.com/juju/docs/ops/latest/howto/initialise-your-project/#decide-your-charm-s-name):

* The general naming pattern, no `operator` or `charm` prefix/suffix, and no org or publisher name.

    These are taken from the best practice note in [name](https://canonical.com/juju/docs/charmcraft/4.3/reference/files/charmcraft-yaml-file/#name) in the `charmcraft.yaml` reference. [charmcraft#2748](https://github.com/canonical/charmcraft/pull/2748) will replace that best practice note with a link to "Decide your charm's name".

    @tonyandrewmeyer and I had some internal discussion and felt that a best practice note isn't sufficient to cover the naming guidance. Instead, in the listing review process, we'll have a manually-added check that asks charmers to follow "Decide your charm's name".

* Clarification about when `-k8s` should be used. Note that we're inverting this recent addition to the doc:

    > Since workload-less charms can work both on machines and on Kubernetes, avoid using the `k8s` suffix when naming integrator charms and configurator charms, <mark>unless the charm is only relevant for Kubernetes</mark> [...]

    Actually, if a charm is only relevant for Kubernetes, the charm name _shouldn't_ use `-k8s`.

**[Preview doc](https://canonical-juju-ops--2610.com.readthedocs.build/2610/howto/initialise-your-project/#decide-your-charm-s-name)**