### PR TITLE
docs: wait longer for Loki data in K8s tutorial integration tests

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -550,7 +550,7 @@ def test_loki_data(cos: jubilant.Juju):
 
 def _get_loki_logs(loki_api_url: str) -> list[str] | None:
     """Wait for logs to be available from Loki and return them."""
-    for attempt in range(60):
+    for attempt in range(3 * 60):
         if attempt:  # If not the first attempt, wait before retrying.
             time.sleep(1)
         response = requests.get(loki_api_url)

--- a/examples/k8s-5-observe/tests/integration/test_charm.py
+++ b/examples/k8s-5-observe/tests/integration/test_charm.py
@@ -99,7 +99,7 @@ def test_loki_data(charm: pathlib.Path, cos: jubilant.Juju):
 
 def _get_loki_logs(loki_api_url: str) -> list[str] | None:
     """Wait for logs to be available from Loki and return them."""
-    for attempt in range(60):
+    for attempt in range(3 * 60):
         if attempt:  # If not the first attempt, wait before retrying.
             time.sleep(1)
         response = requests.get(loki_api_url)


### PR DESCRIPTION
Integration tests sometimes fail for the COS-integrated charm from our K8s tutorial. For example, https://github.com/canonical/operator/actions/runs/28460231844/job/84345818442

After asking an agent to run experiments to investigate the cause, it seems there is nothing fundamentally wrong with the tests - we just need to wait longer.

We need to account for delays in Pebble forwarding request data from the workload, Loki indexing the data, and the Loki endpoint propagating across the cross-model relation.

Waiting for 180 seconds (instead of 60) ought to be enough time.