### PR TITLE
fix: drop unsupported cooldown.semver-major-days from github-actions block

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -19,7 +19,6 @@ updates:
       prefix: "chore"
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       actions:
         patterns:


### PR DESCRIPTION
The GitHub Actions ecosystem supports only `cooldown.default-days`; `semver-major-days` / `semver-minor-days` / `semver-patch-days` are supported on the `uv` / `pip` / `gomod` ecosystems but not on `github-actions`.