### PR TITLE
docs: revert to installed charmcraft for initing charms

### DIFF
--- a/docs/howto/initialise-your-project.md
+++ b/docs/howto/initialise-your-project.md
@@ -86,17 +86,6 @@ Or for a machine charm:
 charmcraft init --name mega-calendar --profile machine
 ```
 
-<!-- Remove this tip when the charmcraft stable version is up-to-date. -->
-````{tip}
-The `charmcraft` version that you have installed may come with older versions of the profiles.
-
-To use the latest profile versions, initialise your charm using `charmcraft` directly from Github, like this:
-
-```text
-uvx git+https://github.com/canonical/charmcraft@74d12bc init --name <name> --profile <profile>
-```
-````
-
 If you don't specify `--name` when running `charmcraft init`, Charmcraft uses the parent directory name for your charm. For example, `mega-calendar-k8s-operator`, from the name of the repository. So we recommend specifying `--name` to ensure that your charm's name doesn't end with `-operator`.
 
 ## Inspect your charm

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -31,14 +31,8 @@ In your virtual machine, go into your project directory and create the initial v
 
 ```text
 cd ~/fastapi-demo
-uvx git+https://github.com/canonical/charmcraft@74d12bc init --profile kubernetes
+charmcraft init --profile kubernetes
 ```
-
-<!--
-  When charmcraft stable is up-to-date, remove this info and switch to 'charmcraft init --profile kubernetes' above.
--->
-The `uvx ...` command runs Charmcraft directly from GitHub. We recommend doing this because the installed version of Charmcraft may come with an older version of the profile used in the tutorial. You should use the installed version of Charmcraft for everything else (as we'll do later in the tutorial).
-
 
 Charmcraft created several files, including:
 

--- a/docs/tutorial/write-your-first-machine-charm.md
+++ b/docs/tutorial/write-your-first-machine-charm.md
@@ -167,13 +167,8 @@ In your virtual machine, go into your project directory and create the initial v
 
 ```text
 cd ~/tinyproxy
-uvx git+https://github.com/canonical/charmcraft@74d12bc init --profile machine
+charmcraft init --profile machine
 ```
-
-<!--
-  When charmcraft stable is up-to-date, remove this info and switch to 'charmcraft init --profile machine' above.
--->
-The `uvx ...` command runs Charmcraft directly from GitHub. We recommend doing this because the installed version of Charmcraft may come with an older version of the profile used in the tutorial. You should use the installed version of Charmcraft for everything else (as we'll do later in the tutorial).
 
 Charmcraft created several files, including:
 


### PR DESCRIPTION
Now that Charmcraft 4.3 is available on `latest/stable`, we can remove the `uvx` methods of running `charmcraft init`. I did a diff locally to check that the profiles from snap Charmcraft are identical to what the `uvx` method produced.