### PR TITLE
fix: only decode fields used by the data class in Relation.load()

### DIFF
--- a/ops/model.py
+++ b/ops/model.py
@@ -1826,11 +1826,10 @@ class Relation:
         if decoder is None:
             decoder = json.loads
         for key, value in sorted(self.data[src].items()):
-            value = decoder(value)
             if fields is None:
-                data[key] = value
+                data[key] = decoder(value)
             elif key in fields:
-                data[fields[key]] = value
+                data[fields[key]] = decoder(value)
         return cls(*args, **data)
 
     def save(

--- a/test/test_model_relation_data_class.py
+++ b/test/test_model_relation_data_class.py
@@ -502,6 +502,25 @@ def test_relation_load_then_save(charm_class: type[BaseTestCharm]):
     }
 
 
+@pytest.mark.parametrize('charm_class', [c for c in _test_classes if c is not MyCharm])
+def test_relation_load_unit_data_ignores_juju_keys(charm_class: type[BaseTestCharm]):
+    class Charm(charm_class):
+        def _on_relation_changed(self, event: ops.RelationChangedEvent):
+            saved = self.databag_class(foo='value', bar=1, baz=['a', 'b'])
+            event.relation.save(saved, self.unit, encoder=self.encoder)
+            self.data = event.relation.load(self.databag_class, self.unit, decoder=self.decoder)
+
+    ctx = testing.Context(Charm, meta={'name': 'foo', 'requires': {'db': {'interface': 'db-int'}}})
+    rel = testing.Relation('db')
+    state_in = testing.State(leader=True, relations={rel})
+    with ctx(ctx.on.relation_changed(rel), state_in) as mgr:
+        mgr.run()
+        obj = mgr.charm.data
+    assert obj.foo == 'value'
+    assert obj.bar == 1
+    assert obj.baz == ['a', 'b']
+
+
 @pytest.mark.parametrize('charm_class', _test_classes)
 def test_relation_save_invalid(charm_class: type[BaseTestCharm], monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv('SCENARIO_BARE_CHARM_ERRORS', 'true')

--- a/test/test_model_relation_data_class.py
+++ b/test/test_model_relation_data_class.py
@@ -508,10 +508,19 @@ def test_relation_load_unit_data_ignores_juju_keys(charm_class: type[BaseTestCha
         def _on_relation_changed(self, event: ops.RelationChangedEvent):
             saved = self.databag_class(foo='value', bar=1, baz=['a', 'b'])
             event.relation.save(saved, self.unit, encoder=self.encoder)
+            assert 'ingress-address' in event.relation.data[self.unit]
+            assert 'private-address' in event.relation.data[self.unit]
             self.data = event.relation.load(self.databag_class, self.unit, decoder=self.decoder)
 
     ctx = testing.Context(Charm, meta={'name': 'foo', 'requires': {'db': {'interface': 'db-int'}}})
-    rel = testing.Relation('db')
+    rel = testing.Relation(
+        'db',
+        local_unit_data={
+            'egress-subnets': '192.0.2.0',
+            'ingress-address': '192.0.2.0',
+            'private-address': '192.0.2.0',
+        },
+    )
     state_in = testing.State(leader=True, relations={rel})
     with ctx(ctx.on.relation_changed(rel), state_in) as mgr:
         mgr.run()


### PR DESCRIPTION
## Description

`Relation.load()` decodes every value in the databag before filtering by the class fields. Unit databags always contain keys automatically set by Juju (`egress-subnets`, `ingress-address`, `private-address`) whose values are plain strings, not JSON, so loading unit data into a dataclass or Pydantic model raised `json.decoder.JSONDecodeError: Extra data` — even when the class doesn't declare those fields.

This change filters by the class fields first and only decodes matching values, so keys that are not part of the data class are ignored without ever reaching the decoder. Round-trip semantics are unchanged: declared fields are still decoded with `json.loads` (or the custom `decoder`), so types survive `save()`/`load()` round trips.

Out of scope: for classes that are neither dataclasses nor Pydantic models, `_juju_fields()` cannot determine the fields, so the whole databag is still decoded and passed to `__init__` (documented behaviour — such classes were already incompatible with unit databags via the unexpected keyword arguments).

## Testing

- New regression test `test_relation_load_unit_data_ignores_juju_keys`, parametrized over dataclass, Pydantic dataclass and `BaseModel`: saves to and loads from the unit databag with the Juju-populated keys present (ops-scenario's defaults). It fails with `JSONDecodeError: Extra data` before the fix and passes after.
- Also reproduced the exact charm from the issue (peer relation, `save`/`load` in `_on_start`) via ops-scenario: same traceback as reported before the fix, loads correctly after.
- `test_model_relation_data_class.py`  and `test_model.py`  all pass; `tox -e lint` clean.

Fixes #2591

