### PR TITLE
docs: separate test_workload_version_is_set in k8s tutorial chapter 3

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -478,11 +478,9 @@ For example, it should be able to pack, deploy, and integrate without throwing e
 
 You can ensure this by writing integration tests for your charm. In the charming world, these are usually written with {external+jubilant:doc}`Jubilant <reference/jubilant>` and [`pytest-jubilant`](https://github.com/canonical/pytest-jubilant).
 
-In this section we'll write a small integration test to check that the charm packs and deploys correctly.
-
 ### Write integration tests
 
-Let's write some simplest possible integration tests, [smoke tests](https://en.wikipedia.org/wiki/Smoke_testing_(software)). These tests will deploy the charm, verify that the installation event is handled without errors and the workload version is set correctly.
+Let's write some integration tests as [smoke tests](https://en.wikipedia.org/wiki/Smoke_testing_(software)). These tests will deploy the charm, verify that the installation event is handled without errors and the workload version is set correctly.
 
 Replace the contents of `tests/integration/test_charm.py` with:
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -510,16 +510,18 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_active)
 
 
-def test_workload_version_is_set(juju: jubilant.Juju):
-    # Verify that the workload version has been set.
+def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
+    """Verify that the workload version has been set."""
     version = juju.status().apps[APP_NAME].version
     assert version == "1.0.4"  # Hardcoded for simplicity.
 ```
 
-This test depends on two fixtures:
+These tests depend on two fixtures:
 
 - `charm` - The `.charm` file to deploy. This fixture is defined in `tests/integration/conftest.py`.
 - `juju` - A Jubilant object for interacting with a temporary Juju model. This fixture is provided by the `pytest-jubilant` plugin.
+
+Both tests depend on the `charm` fixture even though only `test_deploy` uses the fixture. This ensures that the tests fail immediately if a `.charm` file isn't available.
 
 ### Run the test
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -480,9 +480,9 @@ You can ensure this by writing integration tests for your charm. In the charming
 
 In this section we'll write a small integration test to check that the charm packs and deploys correctly.
 
-### Write a test
+### Write integration tests
 
-Let's write the simplest possible integration test, a [smoke test](https://en.wikipedia.org/wiki/Smoke_testing_(software)). This test will deploy the charm, then verify that the installation event is handled without errors.
+Let's write some simplest possible integration tests, [smoke tests](https://en.wikipedia.org/wiki/Smoke_testing_(software)). These tests will deploy the charm, verify that the installation event is handled without errors and the workload version is set correctly.
 
 Replace the contents of `tests/integration/test_charm.py` with:
 
@@ -523,7 +523,7 @@ These tests depend on two fixtures:
 
 Both tests depend on the `charm` fixture even though only `test_deploy` uses the fixture. This ensures that the tests fail immediately if a `.charm` file isn't available.
 
-### Run the test
+### Run tests
 
 Run the following command from anywhere in the `~/fastapi-demo` directory:
 
@@ -531,14 +531,14 @@ Run the following command from anywhere in the `~/fastapi-demo` directory:
 tox -e integration
 ```
 
-The test takes some time to run as a new Juju model is created and your charm is deployed. If successful, it'll verify that your packed charm can be deployed as expected.
+These tests take some time to run as a new Juju model is created and your charm is deployed. If successful, they'll verify that your packed charm can be deployed as expected.
 
 The result should be similar to the following output:
 
 ```text
 ...
 
-============================= 1 passed in 55.43s =============================
+============================= 2 passed in 55.43s =============================
   integration: OK (57.79=setup[0.23]+cmd[57.57] seconds)
   congratulations :) (57.84 seconds)
 ```
@@ -547,7 +547,7 @@ The result should be similar to the following output:
 `tox -e integration` doesn't pack your charm. If you modify the charm code and want to run the integration tests again, run `charmcraft pack` before `tox -e integration`.
 ```
 
-The Juju model is destroyed at the end of the test. If you want to run the test and keep the model for further exploration, see the example commands in [](#write-integration-tests-for-a-charm-run-your-tests). The `@pytest.mark.juju_setup` marker on `test_deploy` gives you the option of skipping this test on subsequent runs, for iterative testing on a deployed application.
+The Juju model is destroyed at the end of the tests. If you want to run the tests and keep the model for further exploration, see the example commands in [](#write-integration-tests-for-a-charm-run-your-tests). The `@pytest.mark.juju_setup` marker on `test_deploy` gives you the option of skipping this test on subsequent runs, for iterative testing on a deployed application.
 
 ### Run tests with `charmcraft test`
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -525,7 +525,7 @@ Both tests depend on the `charm` fixture even though only `test_deploy` uses the
 
 Run the following command from anywhere in the `~/fastapi-demo` directory:
 
-```text
+```shell
 tox -e integration
 ```
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -480,7 +480,7 @@ Now run `tox -e unit` to make sure all test cases pass.
 
 ## Write an integration test
 
-Now that our charm integrates with the database, if there's not a database relation, the app will be in `blocked` status instead of `active`. In your `tests/integration/test_charm.py` file, update `test_deploy` to expect blocked status:
+Now that our charm integrates with the database, if there's not a database relation, the app will be in `blocked` status instead of `active`. In `tests/integration/test_charm.py`, update `test_deploy` to expect blocked status:
 
 ```diff
 -    juju.wait(jubilant.all_active)
@@ -489,7 +489,7 @@ Now that our charm integrates with the database, if there's not a database relat
 
 Then, let's add another test case to check the integration is successful. For that, we need to deploy a database to the test cluster and integrate both applications. If everything works as intended, the charm should report an active status.
 
-In your `tests/integration/test_charm.py` file add the following test case after `test_workload_version_is_set`:
+In `tests/integration/test_charm.py`, add the following test case after `test_workload_version_is_set`:
 
 ```python
 @pytest.mark.juju_setup

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -503,10 +503,10 @@ def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_active)
 ```
 
-In your Multipass Ubuntu VM, run the tests again:
+Run the following command from anywhere in the `~/fastapi-demo` directory:
 
 ```text
-ubuntu@juju-sandbox-k8s:~/fastapi-demo$ tox -e integration
+tox -e integration
 ```
 
 The tests may take some time to run, depending on your computer and network.

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -482,9 +482,20 @@ Now run `tox -e unit` to make sure all test cases pass.
 
 Now that our charm integrates with the database, if there's not a database relation, the app will be in `blocked` status instead of `active`. In `tests/integration/test_charm.py`, update `test_deploy` to expect blocked status:
 
-```diff
--    juju.wait(jubilant.all_active)
-+    juju.wait(jubilant.all_blocked)
+```python
+@pytest.mark.juju_setup
+def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
+    """Deploy the charm under test.
+
+    Assert on the unit status before any relations/configurations take place.
+    """
+    resources = {
+        "demo-server-image": METADATA["resources"]["demo-server-image"]["upstream-source"]
+    }
+
+    # Deploy the charm and wait for it to report blocked, as it needs Postgres.
+    juju.deploy(charm, app=APP_NAME, resources=resources)
+    juju.wait(jubilant.all_blocked)
 ```
 
 Then, let's add another test case to check the integration is successful. For that, we need to deploy a database to the test cluster and integrate both applications. If everything works as intended, the charm should report an active status.
@@ -505,7 +516,7 @@ def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
 
 Run the following command from anywhere in the `~/fastapi-demo` directory:
 
-```text
+```shell
 tox -e integration
 ```
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -480,46 +480,16 @@ Now run `tox -e unit` to make sure all test cases pass.
 
 ## Write an integration test
 
-Now that our charm integrates with the database, if there's not a database relation, the app will be in `blocked` status instead of `active`. Let's tweak our existing integration test `test_deploy` accordingly, to expect blocked status in `juju.wait`. Replace the contents of `tests/integration/test_charm.py` with:
+Now that our charm integrates with the database, if there's not a database relation, the app will be in `blocked` status instead of `active`. In your `tests/integration/test_charm.py` file, update `test_deploy` to expect blocked status:
 
-```python
-import logging
-import pathlib
-
-import jubilant
-import pytest
-import yaml
-
-logger = logging.getLogger(__name__)
-
-METADATA = yaml.safe_load(pathlib.Path("charmcraft.yaml").read_text())
-APP_NAME = METADATA["name"]
-
-
-@pytest.mark.juju_setup
-def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
-    """Deploy the charm under test.
-
-    Assert on the unit status before any relations/configurations take place.
-    """
-    resources = {
-        "demo-server-image": METADATA["resources"]["demo-server-image"]["upstream-source"]
-    }
-
-    # Deploy the charm and wait for it to report blocked, as it needs Postgres.
-    juju.deploy(charm, app=APP_NAME, resources=resources)
-    juju.wait(jubilant.all_blocked)
-
-
-def test_workload_version_is_set(juju: jubilant.Juju):
-    # Verify that the workload version has been set.
-    version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.
+```diff
+-    juju.wait(jubilant.all_active)
++    juju.wait(jubilant.all_blocked)
 ```
 
 Then, let's add another test case to check the integration is successful. For that, we need to deploy a database to the test cluster and integrate both applications. If everything works as intended, the charm should report an active status.
 
-In your `tests/integration/test_charm.py` file add the following test case:
+In your `tests/integration/test_charm.py` file add the following test case after `test_workload_version_is_set`:
 
 ```python
 @pytest.mark.juju_setup
@@ -532,8 +502,6 @@ def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     juju.integrate(APP_NAME, "postgresql-k8s")
     juju.wait(jubilant.all_active)
 ```
-
-This test depends on the `charm` fixture so that the test fails immediately if a `.charm` file isn't available.
 
 In your Multipass Ubuntu VM, run the tests again:
 
@@ -564,6 +532,12 @@ PASSED
 ```
 
 ```text
+tests/integration/test_charm.py::test_workload_version_is_set
+...
+PASSED
+```
+
+```text
 tests/integration/test_charm.py::test_database_integration
 ...
 INFO     jubilant.wait:_juju.py:1164 wait: status changed:
@@ -575,12 +549,6 @@ INFO     jubilant.wait:_juju.py:1164 wait: status changed:
 - .apps['postgresql-k8s'].units['postgresql-k8s/0'].workload_status.message = 'awaiting for cluster to start'
 + .apps['postgresql-k8s'].units['postgresql-k8s/0'].workload_status.current = 'active'
 + .apps['postgresql-k8s'].units['postgresql-k8s/0'].workload_status.message = 'Primary'
-PASSED
-```
-
-```text
-tests/integration/test_charm.py::test_workload_version_is_set
-...
 PASSED
 ```
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -492,7 +492,7 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text())
+METADATA = yaml.safe_load(pathlib.Path("charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
@@ -579,7 +579,9 @@ PASSED
 ```
 
 ```text
-tests/integration/test_charm.py::test_workload_version_is_set PASSED
+tests/integration/test_charm.py::test_workload_version_is_set
+...
+PASSED
 ```
 
 Congratulations, with this integration test you have verified that your charm's relation to PostgreSQL works as well!

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -509,6 +509,12 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     # Deploy the charm and wait for it to report blocked, as it needs Postgres.
     juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_blocked)
+
+
+def test_workload_version_is_set(juju: jubilant.Juju):
+    # Verify that the workload version has been set.
+    version = juju.status().apps[APP_NAME].version
+    assert version == "1.0.4"  # Hardcoded for simplicity.
 ```
 
 Then, let's add another test case to check the integration is successful. For that, we need to deploy a database to the test cluster and integrate both applications. If everything works as intended, the charm should report an active status.
@@ -525,9 +531,6 @@ def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     juju.deploy("postgresql-k8s", channel="14/stable", trust=True)
     juju.integrate(APP_NAME, "postgresql-k8s")
     juju.wait(jubilant.all_active)
-
-    version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.
 ```
 
 This test depends on the `charm` fixture so that the test fails immediately if a `.charm` file isn't available.
@@ -548,7 +551,7 @@ If the tests fail with a timeout error, override the default timeout in `test_da
 
 Then run `tox -e integration` again. If the tests still fail, try [our example charm for this chapter](https://github.com/canonical/operator/tree/main/examples/k8s-3-postgresql) instead, in case there's a mistake in your code.
 
-When the tests are done, the output should show two passing tests:
+When the tests are done, the output should show these passing tests:
 
 ```text
 tests/integration/test_charm.py::test_deploy
@@ -573,6 +576,10 @@ INFO     jubilant.wait:_juju.py:1164 wait: status changed:
 + .apps['postgresql-k8s'].units['postgresql-k8s/0'].workload_status.current = 'active'
 + .apps['postgresql-k8s'].units['postgresql-k8s/0'].workload_status.message = 'Primary'
 PASSED
+```
+
+```text
+tests/integration/test_charm.py::test_workload_version_is_set PASSED
 ```
 
 Congratulations, with this integration test you have verified that your charm's relation to PostgreSQL works as well!

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -576,7 +576,7 @@ For more information, see:
 
 Run the following command from anywhere in the `~/fastapi-demo` directory:
 
-```text
+```shell
 tox -e integration
 ```
 

--- a/docs/tutorial/write-your-first-machine-charm.md
+++ b/docs/tutorial/write-your-first-machine-charm.md
@@ -942,7 +942,7 @@ If you wanted isolated tests, you could change `juju` to be function-scoped (pyt
 
 Now run the tests:
 
-```text
+```shell
 tox -e integration
 ```
 

--- a/examples/k8s-1-minimal/tests/integration/test_charm.py
+++ b/examples/k8s-1-minimal/tests/integration/test_charm.py
@@ -41,7 +41,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_active)
 
 
-def test_workload_version_is_set(juju: jubilant.Juju):
-    # Verify that the workload version has been set.
+def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
+    """Verify that the workload version has been set."""
     version = juju.status().apps[APP_NAME].version
     assert version == "1.0.4"  # Hardcoded for simplicity.

--- a/examples/k8s-2-configurable/tests/integration/test_charm.py
+++ b/examples/k8s-2-configurable/tests/integration/test_charm.py
@@ -41,7 +41,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_active)
 
 
-def test_workload_version_is_set(juju: jubilant.Juju):
-    # Verify that the workload version has been set.
+def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
+    """Verify that the workload version has been set."""
     version = juju.status().apps[APP_NAME].version
     assert version == "1.0.4"  # Hardcoded for simplicity.

--- a/examples/k8s-3-postgresql/tests/integration/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/integration/test_charm.py
@@ -56,5 +56,8 @@ def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     juju.integrate(APP_NAME, "postgresql-k8s")
     juju.wait(jubilant.all_active, timeout=10 * 60)
 
+
+def test_workload_version_is_set(juju: jubilant.Juju):
+    # Verify that the workload version has been set.
     version = juju.status().apps[APP_NAME].version
     assert version == "1.0.4"  # Hardcoded for simplicity.

--- a/examples/k8s-3-postgresql/tests/integration/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/integration/test_charm.py
@@ -27,7 +27,7 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text())
+METADATA = yaml.safe_load(pathlib.Path("charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
@@ -46,6 +46,12 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_blocked)
 
 
+def test_workload_version_is_set(juju: jubilant.Juju):
+    # Verify that the workload version has been set.
+    version = juju.status().apps[APP_NAME].version
+    assert version == "1.0.4"  # Hardcoded for simplicity.
+
+
 @pytest.mark.juju_setup
 def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the charm integrates with the database.
@@ -55,9 +61,3 @@ def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     juju.deploy("postgresql-k8s", channel="14/stable", trust=True)
     juju.integrate(APP_NAME, "postgresql-k8s")
     juju.wait(jubilant.all_active, timeout=10 * 60)
-
-
-def test_workload_version_is_set(juju: jubilant.Juju):
-    # Verify that the workload version has been set.
-    version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.

--- a/examples/k8s-3-postgresql/tests/integration/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/integration/test_charm.py
@@ -33,10 +33,15 @@ APP_NAME = METADATA["name"]
 
 @pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
-    """Deploy the charm under test."""
+    """Deploy the charm under test.
+
+    Assert on the unit status before any relations/configurations take place.
+    """
     resources = {
         "demo-server-image": METADATA["resources"]["demo-server-image"]["upstream-source"]
     }
+
+    # Deploy the charm and wait for it to report blocked, as it needs Postgres.
     juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_blocked)
 

--- a/examples/k8s-3-postgresql/tests/integration/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/integration/test_charm.py
@@ -33,21 +33,16 @@ APP_NAME = METADATA["name"]
 
 @pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
-    """Deploy the charm under test.
-
-    Assert on the unit status before any relations/configurations take place.
-    """
+    """Deploy the charm under test."""
     resources = {
         "demo-server-image": METADATA["resources"]["demo-server-image"]["upstream-source"]
     }
-
-    # Deploy the charm and wait for it to report blocked, as it needs Postgres.
     juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_blocked)
 
 
-def test_workload_version_is_set(juju: jubilant.Juju):
-    # Verify that the workload version has been set.
+def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
+    """Verify that the workload version has been set."""
     version = juju.status().apps[APP_NAME].version
     assert version == "1.0.4"  # Hardcoded for simplicity.
 
@@ -60,4 +55,4 @@ def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     """
     juju.deploy("postgresql-k8s", channel="14/stable", trust=True)
     juju.integrate(APP_NAME, "postgresql-k8s")
-    juju.wait(jubilant.all_active, timeout=10 * 60)
+    juju.wait(jubilant.all_active)

--- a/examples/k8s-4-action/tests/integration/test_charm.py
+++ b/examples/k8s-4-action/tests/integration/test_charm.py
@@ -33,10 +33,15 @@ APP_NAME = METADATA["name"]
 
 @pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
-    """Deploy the charm under test."""
+    """Deploy the charm under test.
+
+    Assert on the unit status before any relations/configurations take place.
+    """
     resources = {
         "demo-server-image": METADATA["resources"]["demo-server-image"]["upstream-source"]
     }
+
+    # Deploy the charm and wait for it to report blocked, as it needs Postgres.
     juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_blocked)
 

--- a/examples/k8s-4-action/tests/integration/test_charm.py
+++ b/examples/k8s-4-action/tests/integration/test_charm.py
@@ -56,5 +56,8 @@ def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     juju.integrate(APP_NAME, "postgresql-k8s")
     juju.wait(jubilant.all_active)
 
+
+def test_workload_version_is_set(juju: jubilant.Juju):
+    # Verify that the workload version has been set.
     version = juju.status().apps[APP_NAME].version
     assert version == "1.0.4"  # Hardcoded for simplicity.

--- a/examples/k8s-4-action/tests/integration/test_charm.py
+++ b/examples/k8s-4-action/tests/integration/test_charm.py
@@ -27,7 +27,7 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text())
+METADATA = yaml.safe_load(pathlib.Path("charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
@@ -46,6 +46,12 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_blocked)
 
 
+def test_workload_version_is_set(juju: jubilant.Juju):
+    # Verify that the workload version has been set.
+    version = juju.status().apps[APP_NAME].version
+    assert version == "1.0.4"  # Hardcoded for simplicity.
+
+
 @pytest.mark.juju_setup
 def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the charm integrates with the database.
@@ -55,9 +61,3 @@ def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     juju.deploy("postgresql-k8s", channel="14/stable", trust=True)
     juju.integrate(APP_NAME, "postgresql-k8s")
     juju.wait(jubilant.all_active)
-
-
-def test_workload_version_is_set(juju: jubilant.Juju):
-    # Verify that the workload version has been set.
-    version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.

--- a/examples/k8s-4-action/tests/integration/test_charm.py
+++ b/examples/k8s-4-action/tests/integration/test_charm.py
@@ -33,21 +33,16 @@ APP_NAME = METADATA["name"]
 
 @pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
-    """Deploy the charm under test.
-
-    Assert on the unit status before any relations/configurations take place.
-    """
+    """Deploy the charm under test."""
     resources = {
         "demo-server-image": METADATA["resources"]["demo-server-image"]["upstream-source"]
     }
-
-    # Deploy the charm and wait for it to report blocked, as it needs Postgres.
     juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_blocked)
 
 
-def test_workload_version_is_set(juju: jubilant.Juju):
-    # Verify that the workload version has been set.
+def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
+    """Verify that the workload version has been set."""
     version = juju.status().apps[APP_NAME].version
     assert version == "1.0.4"  # Hardcoded for simplicity.
 

--- a/examples/k8s-5-observe/tests/integration/test_charm.py
+++ b/examples/k8s-5-observe/tests/integration/test_charm.py
@@ -60,6 +60,9 @@ def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     juju.integrate(APP_NAME, "postgresql-k8s")
     juju.wait(jubilant.all_active)
 
+
+def test_workload_version_is_set(juju: jubilant.Juju):
+    # Verify that the workload version has been set.
     version = juju.status().apps[APP_NAME].version
     assert version == "1.0.4"  # Hardcoded for simplicity.
 

--- a/examples/k8s-5-observe/tests/integration/test_charm.py
+++ b/examples/k8s-5-observe/tests/integration/test_charm.py
@@ -31,7 +31,7 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text())
+METADATA = yaml.safe_load(pathlib.Path("charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
@@ -50,6 +50,12 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_blocked)
 
 
+def test_workload_version_is_set(juju: jubilant.Juju):
+    # Verify that the workload version has been set.
+    version = juju.status().apps[APP_NAME].version
+    assert version == "1.0.4"  # Hardcoded for simplicity.
+
+
 @pytest.mark.juju_setup
 def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the charm integrates with the database.
@@ -59,12 +65,6 @@ def test_database_integration(charm: pathlib.Path, juju: jubilant.Juju):
     juju.deploy("postgresql-k8s", channel="14/stable", trust=True)
     juju.integrate(APP_NAME, "postgresql-k8s")
     juju.wait(jubilant.all_active)
-
-
-def test_workload_version_is_set(juju: jubilant.Juju):
-    # Verify that the workload version has been set.
-    version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.
 
 
 @pytest.fixture(scope="module")

--- a/examples/k8s-5-observe/tests/integration/test_charm.py
+++ b/examples/k8s-5-observe/tests/integration/test_charm.py
@@ -37,21 +37,16 @@ APP_NAME = METADATA["name"]
 
 @pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
-    """Deploy the charm under test.
-
-    Assert on the unit status before any relations/configurations take place.
-    """
+    """Deploy the charm under test."""
     resources = {
         "demo-server-image": METADATA["resources"]["demo-server-image"]["upstream-source"]
     }
-
-    # Deploy the charm and wait for it to report blocked, as it needs Postgres.
     juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_blocked)
 
 
-def test_workload_version_is_set(juju: jubilant.Juju):
-    # Verify that the workload version has been set.
+def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
+    """Verify that the workload version has been set."""
     version = juju.status().apps[APP_NAME].version
     assert version == "1.0.4"  # Hardcoded for simplicity.
 

--- a/examples/k8s-5-observe/tests/integration/test_charm.py
+++ b/examples/k8s-5-observe/tests/integration/test_charm.py
@@ -37,10 +37,15 @@ APP_NAME = METADATA["name"]
 
 @pytest.mark.juju_setup
 def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
-    """Deploy the charm under test."""
+    """Deploy the charm under test.
+
+    Assert on the unit status before any relations/configurations take place.
+    """
     resources = {
         "demo-server-image": METADATA["resources"]["demo-server-image"]["upstream-source"]
     }
+
+    # Deploy the charm and wait for it to report blocked, as it needs Postgres.
     juju.deploy(charm, app=APP_NAME, resources=resources)
     juju.wait(jubilant.all_blocked)
 


### PR DESCRIPTION
This PR brought `test_workload_version_is_set` back to life in chapter 3, and propagate that change to chapter 4 and 5. It also updated the example `examples/k8s-*/tests/integration/test_charm.py` files.

[Doc preview](https://canonical-juju-ops--2638.com.readthedocs.build/2638/)

It was raised by David:

> In the k8s tutorial Chapter, section [write an integration test](https://canonical.com/juju/docs/ops/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql/#write-an-integration-test), we replace the contents of test_charm.py. That loses `test_workload_version_is_set` and we never recreate it. In the corresponding file in the example charm, we keep the version check as part of test_database_integration, but we don't have that in the tutorial.

