### PR TITLE
docs: use autofunction for `layer_from_rockcraft`

### DIFF
--- a/docs/reference/ops-testing.rst
+++ b/docs/reference/ops-testing.rst
@@ -134,4 +134,4 @@ This API for testing was previously called 'Scenario'.
 .. autoclass:: ops.testing.errors.ActionMissingFromContextError
 .. autoclass:: ops.testing.errors.NoObserverError
 .. autoclass:: ops.testing.errors.BadOwnerPath
-.. automethod:: ops.testing.layer_from_rockcraft
+.. autofunction:: ops.testing.layer_from_rockcraft

--- a/test/test_infra.py
+++ b/test/test_infra.py
@@ -86,6 +86,7 @@ def test_ops_testing_doc():
                 if line.strip().startswith((
                     '.. autoclass:: ops.testing.',
                     '.. automethod:: ops.testing.',
+                    '.. autofunction:: ops.testing.',
                 ))
             })
 

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1413,7 +1413,7 @@ def layer_from_rockcraft(path: pathlib.Path | str) -> pebble.Layer:
     """Create a layer from a `rockcraft.yaml` file.
 
     This is a convenience function to create a Pebble layer from a
-    rockcraft.yaml file, that can then be passed to :class:`testing.Container`,
+    rockcraft.yaml file, that can then be passed to :class:`Container`,
     rather than duplicating the layer content in the test code. For example::
 
         container = Container(

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1416,7 +1416,7 @@ def layer_from_rockcraft(path: pathlib.Path | str) -> pebble.Layer:
     rockcraft.yaml file, that can then be passed to :class:`Container`,
     rather than duplicating the layer content in the test code. For example::
 
-        container = Container(
+        container = testing.Container(
             name='my-container',
             layers={'rock': layer_from_rockcraft(pathlib.Path('rockcraft.yaml'))},
         )


### PR DESCRIPTION
`layer_from_rockcraft` is a module-level function, but was documented with the `automethod` directive. Sphinx's method documenter assumes the first positional parameter is `self` and strips it from the rendered signature, which hid the path argument. Use `autofunction` so the full signature is shown.

[Current](https://canonical.com/juju/docs/ops/latest/reference/ops-testing/#ops.testing.layer_from_rockcraft), [preview](https://canonical-juju-ops--2648.com.readthedocs.build/2648/reference/ops-testing/#ops.testing.layer_from_rockcraft)