### PR TITLE
docs: switch K8s tutorial charms to rock version of demo server

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -76,7 +76,7 @@ resources:
     # used by the 'canonical/charming-actions' GitHub action for automated releases.
     # The test_deploy function in tests/integration/test_charm.py reads upstream-source
     # to determine which OCI image to use when running the charm's integration tests.
-    upstream-source: ghcr.io/canonical/api_demo_server:1.0.4
+    upstream-source: ghcr.io/canonical/api_demo_server/api-demo-server:2.1.0
 ```
 
 ### Write a helper module
@@ -193,10 +193,10 @@ def _on_demo_server_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
 
 The custom Pebble layer that you just added is defined in the  `self._get_pebble_layer()` method. We'll now add this method.
 
-In the `__init__` method of your charm class, name your service to `fastapi-service` and add it as a class attribute:
+In the `__init__` method of your charm class, name your service to `fastapi` and add it as a class attribute:
 
 ```python
-self.pebble_service_name = "fastapi-service"
+self.pebble_service_name = "fastapi"
 ```
 
 Finally, define  the `_get_pebble_layer` function as below. The `command` variable represents a command line that should be executed in order to start our application.
@@ -206,10 +206,10 @@ def _get_pebble_layer(self) -> ops.pebble.Layer:
     """Pebble layer for the FastAPI demo services."""
     command = " ".join(
         [
-            "uvicorn",
+            "/bin/uvicorn",
             "api_demo_server.app:app",
-            "--host=0.0.0.0",
-            "--port=8000",
+            "--host 0.0.0.0",
+            "--port 8000",
         ]
     )
     pebble_layer: ops.pebble.LayerDict = {
@@ -217,10 +217,8 @@ def _get_pebble_layer(self) -> ops.pebble.Layer:
         "description": "pebble config layer for FastAPI demo server",
         "services": {
             self.pebble_service_name: {
-                "override": "replace",
-                "summary": "fastapi demo",
+                "override": "merge",
                 "command": command,
-                "startup": "enabled",
             }
         },
     }
@@ -281,7 +279,7 @@ Deploy the `.charm` file, as below. Juju will create a Kubernetes `StatefulSet` 
 
 ```text
 juju deploy ./fastapi-demo_amd64.charm --resource \
-     demo-server-image=ghcr.io/canonical/api_demo_server:1.0.4
+     demo-server-image=ghcr.io/canonical/api_demo_server/api-demo-server:2.1.0
 ```
 
 
@@ -305,7 +303,7 @@ Model    Controller     Cloud/Region  Version  SLA          Timestamp
 testing  concierge-k8s  k8s           3.6.13   unsupported  13:38:19+01:00
 
 App           Version  Status  Scale  Charm         Channel  Rev  Address         Exposed  Message
-fastapi-demo  1.0.4    active      1  fastapi-demo             0  10.152.183.215  no
+fastapi-demo  2.1.0    active      1  fastapi-demo             0  10.152.183.215  no
 
 Unit             Workload  Agent  Address      Ports  Message
 fastapi-demo/0*  active    idle   10.1.157.73
@@ -322,7 +320,7 @@ curl 10.1.157.73:8000/version
 You should see a JSON string with the version of the application:
 
 ```
-{"version":"1.0.4"}
+{"version":"2.1.0"}
 ```
 
 Congratulations, you've successfully created a minimal Kubernetes charm!
@@ -383,6 +381,24 @@ from ops import testing
 
 from charm import FastAPIDemoCharm
 
+# The default Pebble layer in the application image.
+# Defined in https://github.com/canonical/api_demo_server/blob/master/rockcraft.yaml
+ROCK_LAYER = ops.pebble.Layer(
+    {
+        "services": {
+            "fastapi": {
+                "override": "replace",
+                "summary": "FastAPI demo server",
+                "command": "/bin/uvicorn api_demo_server.app:app --host 0.0.0.0 --port 8000",
+                "startup": "enabled",
+                "environment": {"DEMO_SERVER_LOGFILE": "/tmp/demo_server.log"},
+                "on-success": "shutdown",
+                "on-failure": "shutdown",
+            }
+        },
+    }
+)
+
 
 def mock_get_version(port: int):
     """Get a mock version string without executing the workload code."""
@@ -396,25 +412,17 @@ def mock_version(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_pebble_layer(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         leader=True,
     )
     state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
     # Expected plan after Pebble ready with default config
-    expected_plan = {
-        "services": {
-            "fastapi-service": {
-                "override": "replace",
-                "summary": "fastapi demo",
-                "command": "uvicorn api_demo_server.app:app --host=0.0.0.0 --port=8000",
-                "startup": "enabled",
-                # Since the environment is empty, Layer.to_dict() will not
-                # include it.
-            }
-        }
-    }
+    expected_plan = ops.pebble.Plan(ROCK_LAYER.to_dict())
+    expected_plan.services["fastapi"].override = "merge"
 
     # Check that we have the plan we expected:
     assert state_out.get_container(container.name).plan == expected_plan
@@ -422,7 +430,7 @@ def test_pebble_layer(mock_version):
     assert state_out.unit_status == testing.ActiveStatus()
     # Check the service was started:
     assert (
-        state_out.get_container(container.name).service_statuses["fastapi-service"]
+        state_out.get_container(container.name).service_statuses["fastapi"]
         == ops.pebble.ServiceStatus.ACTIVE
     )
     # Check the workload version is set:
@@ -511,7 +519,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
     version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.
+    assert version == "2.1.0"  # Hardcoded for simplicity.
 ```
 
 These tests depend on two fixtures:

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -186,7 +186,7 @@ def _on_demo_server_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
 
 We're using the `ActiveStatus` class to set the charm status to active. Note that almost everything you need to define your charm is in the `ops` package that you imported earlier - there's no need to add additional imports.
 
-The `api_demo_server` application is packaged as a "rock" using Canonical's OCI-compliant format for container images. The image has a Pebble layer that defines how to run the app. Since our minimal charm doesn't need to change how the app runs, our charm just needs to call `replan()` to start the service defined in the Pebble layer.
+The `api_demo_server` application is packaged as a [rock](https://documentation.ubuntu.com/rockcraft/1.19/explanation/rocks/), which is an OCI-compliant container image. The image has a Pebble layer that defines how to run the app. Since our minimal charm doesn't need to change how the app runs, our charm just needs to call `replan()` to start the service defined in the Pebble layer.
 
 To inspect the Pebble layer, see [rockcraft.yaml](https://github.com/canonical/api_demo_server/blob/master/rockcraft.yaml). Look for a service called `fastapi`:
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -170,64 +170,44 @@ framework.observe(self.on["demo-server"].pebble_ready, self._on_demo_server_pebb
 
 ```
 
-Next, define the event handler, as follows:
-
-We'll use the `ActiveStatus` class to set the charm status to active. Note that almost everything you need to define your charm is in the `ops` package that you imported earlier - there's no need to add additional imports.
-
-Use `ActiveStatus` as well as further Ops constructs to define the event handler, as below. As you can see, what is happening is that, from the `event` argument, you extract the workload container object in which you add a custom layer. Once the layer is set you replan your service and set the charm status to active.
-
+Next, define the event handler:
 
 ```python
 def _on_demo_server_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
     """Define and start a workload using the Pebble API."""
     # Get a reference the container attribute on the PebbleReadyEvent
     container = event.workload
-    # Add initial Pebble config layer using the Pebble API
-    container.add_layer("fastapi_demo", self._get_pebble_layer(), combine=True)
-    # Make Pebble reevaluate its plan, ensuring any services are started if enabled.
+    # Start the service defined by the Pebble layer in the application image.
     container.replan()
     # Learn more about statuses at
     # https://documentation.ubuntu.com/juju/3.6/reference/status/
     self.unit.status = ops.ActiveStatus()
 ```
 
-The custom Pebble layer that you just added is defined in the  `self._get_pebble_layer()` method. We'll now add this method.
+We're using the `ActiveStatus` class to set the charm status to active. Note that almost everything you need to define your charm is in the `ops` package that you imported earlier - there's no need to add additional imports.
 
-In the `__init__` method of your charm class, name your service to `fastapi` and add it as a class attribute:
+The `api_demo_server` application is packaged as a "rock" using Canonical's OCI-compliant format for container images. The image has a Pebble layer that defines how to run the app. Since our minimal charm doesn't need to change how the app runs, our charm just needs to call `replan()` to start the service defined in the Pebble layer.
 
-```python
-self.pebble_service_name = "fastapi"
+To inspect the Pebble layer, see [rockcraft.yaml](https://github.com/canonical/api_demo_server/blob/master/rockcraft.yaml). Look for a service called `fastapi`:
+
+```yaml
+...
+services:
+  fastapi:
+    override: replace
+    summary: FastAPI demo server
+    command: /bin/uvicorn api_demo_server.app:app --host 0.0.0.0 --port 8000
+    startup: enabled
+    environment:
+      DEMO_SERVER_LOGFILE: /tmp/demo_server.log
+    ...
 ```
 
-Finally, define  the `_get_pebble_layer` function as below. The `command` variable represents a command line that should be executed in order to start our application.
-
-```python
-def _get_pebble_layer(self) -> ops.pebble.Layer:
-    """Pebble layer for the FastAPI demo services."""
-    command = " ".join(
-        [
-            "/bin/uvicorn",
-            "api_demo_server.app:app",
-            "--host 0.0.0.0",
-            "--port 8000",
-        ]
-    )
-    pebble_layer: ops.pebble.LayerDict = {
-        "summary": "FastAPI demo service",
-        "description": "pebble config layer for FastAPI demo server",
-        "services": {
-            self.pebble_service_name: {
-                "override": "merge",
-                "command": command,
-            }
-        },
-    }
-    return ops.pebble.Layer(pebble_layer)
-```
+The `fastapi` service has `startup: enabled`, so why does our charm need to start the service? When Juju creates the workload container, it tells Pebble not to start any services. It's the charm's job to decide when to start services.
 
 ### Set the workload version
 
-The workload version is available after the workload starts, which happens after Pebble reevaluates its plan. We'll use the `src/fastapi_demo.py` helper module for this step.
+The workload version is available after the workload starts, which happens after Pebble starts the `fastapi` service. We'll use the `src/fastapi_demo.py` helper module for this step.
 
 In `src/charm.py`, add the following lines to the `_on_demo_server_pebble_ready` function before the final `self.unit.status = ops.ActiveStatus()`:
 
@@ -237,7 +217,7 @@ version = fastapi_demo.get_version(port=8000)
 self.unit.set_workload_version(version)
 ```
 
-We get the workload version over port 8000 because `_get_pebble_layer` deploys the app on this port. Then `self.unit.set_workload_version` exposes the workload version to Juju. If the `get_version` call fails (for example, an `URLError` exception is raised), the charm will go into error status. The Juju logs will show the error message, to help you debug the error.
+We get the workload version over port 8000 because the `fastapi` service runs the app on this port. Then `self.unit.set_workload_version` exposes the workload version to Juju. If the `get_version` call fails (for example, an `URLError` exception is raised), the charm will go into error status. The Juju logs will show the error message, to help you debug the error.
 
 ### Add logger functionality
 
@@ -368,7 +348,7 @@ You can ensure all this by writing a rich battery of unit tests. In the context 
 
 We'll also use the Python testing tool [`tox`](https://tox.wiki/en/4.14.2/index.html) to automate our testing and set up our testing environment.
 
-In this section we'll write a test to check that Pebble is configured as expected.
+In this section we'll write a test to check that the `fastapi` service is started as expected.
 
 ### Write a test
 
@@ -420,9 +400,8 @@ def test_pebble_layer(mock_version):
         leader=True,
     )
     state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
-    # Expected plan after Pebble ready with default config
+    # Expected plan after Pebble ready (our charm doesn't add any layers).
     expected_plan = ops.pebble.Plan(ROCK_LAYER.to_dict())
-    expected_plan.services["fastapi"].override = "merge"
 
     # Check that we have the plan we expected:
     assert state_out.get_container(container.name).plan == expected_plan
@@ -438,6 +417,8 @@ def test_pebble_layer(mock_version):
 ```
 
 This test checks the behaviour of the `_on_demo_server_pebble_ready` function that you set up earlier. The test simulates your charm receiving the pebble-ready event, then checks that the unit and workload container have the correct state.
+
+The unit tests don't have access to the application image, so we provide `ROCK_LAYER` to represent the base configuration of the workload container. If you're developing a charm in the same repository as a rock workload, use [`testing.layer_from_rockcraft`](ops.testing.layer_from_rockcraft) to read `ROCK_LAYER` from `rockcraft.yaml`.
 
 In unit tests, we avoid any interaction with the outside world. The `get_version` method performs an HTTP call, which must be patched. We use the `mock_version` fixture to achieve this.
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -70,7 +70,7 @@ resources:
   # An OCI image resource for the container listed above.
   demo-server-image:
     type: oci-image
-    description: OCI image from GitHub Container Repository
+    description: OCI image from GitHub Container registry
     # The upstream-source field is ignored by Charmcraft and Juju, but it can be
     # useful to developers in identifying the source of the OCI image.  It is also
     # used by the 'canonical/charming-actions' GitHub action for automated releases.

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/expose-operational-tasks-via-actions.md
@@ -110,7 +110,7 @@ First, repack and refresh your charm:
 charmcraft pack
 juju refresh fastapi-demo --force-units \
   --path ./fastapi-demo_amd64.charm \
-  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.4
+  --resource demo-server-image=ghcr.io/canonical/api_demo_server/api-demo-server:2.1.0
 ```
 
 Next, test that the basic action invocation works:
@@ -168,7 +168,9 @@ def test_get_db_info_action():
             "password": "bar",
         },
     )
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         relations={relation},
@@ -198,7 +200,9 @@ def test_get_db_info_action_show_password():
             "password": "bar",
         },
     )
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         relations={relation},

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -250,10 +250,10 @@ def _get_pebble_layer(self, port: int, environment: dict[str, str]) -> ops.pebbl
     """Pebble layer for the FastAPI demo services."""
     command = " ".join(
         [
-            "uvicorn",
+            "/bin/uvicorn",
             "api_demo_server.app:app",
-            "--host=0.0.0.0",
-            f"--port={port}",
+            "--host 0.0.0.0",
+            f"--port {port}",
         ]
     )
     pebble_layer: ops.pebble.LayerDict = {
@@ -261,10 +261,8 @@ def _get_pebble_layer(self, port: int, environment: dict[str, str]) -> ops.pebbl
         "description": "pebble config layer for FastAPI demo server",
         "services": {
             self.pebble_service_name: {
-                "override": "replace",
-                "summary": "fastapi demo",
+                "override": "merge",
                 "command": command,
-                "startup": "enabled",
                 "environment": environment,
             }
         },
@@ -344,7 +342,7 @@ First, repack and refresh your charm:
 charmcraft pack
 juju refresh fastapi-demo --force-units \
   --path ./fastapi-demo_amd64.charm \
-  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.4
+  --resource demo-server-image=ghcr.io/canonical/api_demo_server/api-demo-server:2.1.0
 ```
 
 Next, deploy the `postgresql-k8s` charm:
@@ -434,7 +432,9 @@ def test_relation_data(mock_version):
             "password": "bar",
         },
     )
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         relations={relation},
@@ -443,9 +443,8 @@ def test_relation_data(mock_version):
 
     state_out = ctx.run(ctx.on.relation_changed(relation), state_in)
 
-    assert state_out.get_container(container.name).layers["fastapi_demo"].services[
-        "fastapi-service"
-    ].environment == {
+    assert state_out.get_container(container.name).plan.services["fastapi"].environment == {
+        **ROCK_LAYER.services["fastapi"].environment,
         "DEMO_SERVER_DB_HOST": "example.com",
         "DEMO_SERVER_DB_PORT": "5432",
         "DEMO_SERVER_DB_USER": "foo",
@@ -458,7 +457,9 @@ In this chapter, we also defined a new method `_on_collect_status` that checks v
 ```python
 def test_no_database_blocked(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         leader=True,

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -277,6 +277,10 @@ When Pebble starts or restarts the service:
 * If there's a database relation and database authentication data is available from the relation, our application can get the database authentication data from environment variables.
 * If there's no database relation or database authentication data, our application can't connect to the database. In this case, we'd like the unit to show `blocked` or `maintenance` status, depending on whether the Juju user needs to take action.
 
+```{note}
+The service defined in [rockcraft.yaml](https://github.com/canonical/api_demo_server/blob/master/rockcraft.yaml) has an environment variable related to logging. When Pebble combines the rock's layer with our constructed layer, the final service environment has variables from both layers (because our constructed layer sets `override` to `merge`).
+```
+
 We'll now make sure that the unit status is set correctly.
 
 (integrate-your-charm-with-postgresql-update-unit-status)=

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -275,7 +275,7 @@ With these changes, we've made sure that our application knows how to access the
 When Pebble starts or restarts the service:
 
 * If there's a database relation and database authentication data is available from the relation, our application can get the database authentication data from environment variables.
-* Otherwise, the service environment is empty, so our application can't get database authentication data. In this case, we'd like the unit to show `blocked` or `maintenance` status, depending on whether the Juju user needs to take action.
+* If there's no database relation or database authentication data, our application can't connect to the database. In this case, we'd like the unit to show `blocked` or `maintenance` status, depending on whether the Juju user needs to take action.
 
 We'll now make sure that the unit status is set correctly.
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -270,7 +270,7 @@ When Pebble starts or restarts the service:
 * If there's no database relation or database authentication data, our application can't connect to the database. In this case, we'd like the unit to show `blocked` or `maintenance` status, depending on whether the Juju user needs to take action.
 
 ```{note}
-The service defined in [rockcraft.yaml](https://github.com/canonical/api_demo_server/blob/master/rockcraft.yaml) has an environment variable related to logging. When Pebble combines the rock's layer with our constructed layer, the final service environment has variables from both layers (because our constructed layer sets `override` to `merge`).
+The service defined in [rockcraft.yaml](https://github.com/canonical/api_demo_server/blob/master/rockcraft.yaml) has an environment variable related to logging. When Pebble combines the rock's layer with our constructed layer, the final service has environment variables from both layers (because our constructed layer sets `override` to `merge`).
 ```
 
 We'll now make sure that the unit status is set correctly.
@@ -546,7 +546,7 @@ INFO     jubilant.wait:_juju.py:1491 wait: status changed:
 - .apps['fastapi-demo'].units['fastapi-demo/0'].juju_status.current = 'executing'
 - .apps['fastapi-demo'].units['fastapi-demo/0'].juju_status.message = 'running demo-server-pebble-ready hook'
 + .apps['fastapi-demo'].units['fastapi-demo/0'].juju_status.current = 'idle'
-+ .apps['fastapi-demo'].version = '1.0.4'
++ .apps['fastapi-demo'].version = '2.1.0'
 PASSED
 ```
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -246,28 +246,20 @@ We removed three `self.unit.status = ` lines from this version of the method. We
 Next, update `_get_pebble_layer()` to put the environment variables in the Pebble layer:
 
 ```python
-def _get_pebble_layer(self, port: int, environment: dict[str, str]) -> ops.pebble.Layer:
+def _get_pebble_layer(self, port: int, env: dict[str, str]) -> ops.pebble.Layer:
     """Pebble layer for the FastAPI demo services."""
-    command = " ".join(
-        [
-            "/bin/uvicorn",
-            "api_demo_server.app:app",
-            "--host 0.0.0.0",
-            f"--port {port}",
-        ]
-    )
-    pebble_layer: ops.pebble.LayerDict = {
+    cmd = f"/bin/uvicorn api_demo_server.app:app --host 0.0.0.0 --port {port}"
+    service: ops.pebble.ServiceDict = {
+        "override": "merge",
+        "command": cmd,
+        "environment": env,
+    }
+    layer: ops.pebble.LayerDict = {
         "summary": "FastAPI demo service",
         "description": "pebble config layer for FastAPI demo server",
-        "services": {
-            self.pebble_service_name: {
-                "override": "merge",
-                "command": command,
-                "environment": environment,
-            }
-        },
+        "services": {self.pebble_service_name: service},
     }
-    return ops.pebble.Layer(pebble_layer)
+    return ops.pebble.Layer(layer)
 ```
 
 With these changes, we've made sure that our application knows how to access the database.

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -115,7 +115,7 @@ def _get_pebble_layer(self, port: int) -> ops.pebble.Layer:
     return ops.pebble.Layer(layer)
 ```
 
-This method defines a service with `override` set to `merge`, which means that unspecified properties should match the existing service definition.
+This method defines a service with `override` set to `merge`, which means that unspecified properties should be copied from the existing service definition.
 
 Next, create the `_replan_workload` method, as below. This method will add our constructed layer to the workload container and restart the `fastapi` service if the service definition has changed.
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -87,14 +87,45 @@ We'll define `_replan_workload` shortly.
 A charm does not know which configuration option has been changed. Thus, make sure to validate all the values. This is especially important since multiple values can be changed in one call. Using a config class simplifies this, as all validation should be done when the config object is created.
 ```
 
-In the `__init__` function, add a new attribute to define a container object for your workload:
+In the `__init__` function, add attributes for the workload container and the name of the application service in the workload container:
 
 ```python
 # See 'containers' in charmcraft.yaml.
 self.container = self.unit.get_container("demo-server")
+self.pebble_service_name = "fastapi"
 ```
 
-Create a new method, as below. This method will get the current Pebble layer configuration and compare the new and the existing service definitions -- if they differ, it will update the layer and restart the service.
+As we saw in the previous chapter, the `fastapi` service exposes the app on port 8000. To be able to configure the port, our charm needs to add a Pebble layer that overrides the definition of the `fastapi` service.
+
+Create a method that constructs the Pebble layer:
+
+```python
+def _get_pebble_layer(self, port: int) -> ops.pebble.Layer:
+    """Pebble layer for the FastAPI demo services."""
+    command = " ".join(
+        [
+            "/bin/uvicorn",
+            "api_demo_server.app:app",
+            "--host 0.0.0.0",
+            f"--port {port}",
+        ]
+    )
+    pebble_layer: ops.pebble.LayerDict = {
+        "summary": "FastAPI demo service",
+        "description": "pebble config layer for FastAPI demo server",
+        "services": {
+            self.pebble_service_name: {
+                "override": "merge",
+                "command": command,
+            }
+        },
+    }
+    return ops.pebble.Layer(pebble_layer)
+```
+
+This method defines a service with `override` set to `merge`, which means that unspecified properties should match the existing service definition.
+
+Next, create the `_replan_workload` method, as below. This method will add our constructed layer to the workload container and restart the `fastapi` service if the service definition has changed.
 
 ```python
 def _replan_workload(self) -> None:
@@ -136,35 +167,9 @@ def _replan_workload(self) -> None:
     self.unit.status = ops.ActiveStatus()
 ```
 
-When the config is loaded as part of creating the Pebble layer, if the config is invalid (in our case, if the port is set to 22), then a `ValueError` will be raised. The `_replan_workload` method handles that by logging the error and setting the status of the unit to blocked, letting the Juju user know that they need to take action.
+When the config is loaded as part of constructing the Pebble layer, if the config is invalid (in our case, if the port is set to 22), then a `ValueError` will be raised. The `_replan_workload` method handles that by logging the error and setting the status of the unit to blocked, letting the Juju user know that they need to take action.
 
-Now, crucially, update the `_get_pebble_layer` method to make the layer definition dynamic, as shown below. This will replace the static port `8000` with the port passed to the method.
-
-```python
-def _get_pebble_layer(self, port: int) -> ops.pebble.Layer:
-    """Pebble layer for the FastAPI demo services."""
-    command = " ".join(
-        [
-            "/bin/uvicorn",
-            "api_demo_server.app:app",
-            "--host 0.0.0.0",
-            f"--port {port}",
-        ]
-    )
-    pebble_layer: ops.pebble.LayerDict = {
-        "summary": "FastAPI demo service",
-        "description": "pebble config layer for FastAPI demo server",
-        "services": {
-            self.pebble_service_name: {
-                "override": "merge",
-                "command": command,
-            }
-        },
-    }
-    return ops.pebble.Layer(pebble_layer)
-```
-
-As you may have noticed, the new `_replan_workload` method looks like a more advanced variant of the existing `_on_demo_server_pebble_ready` method. Remove the body of the `_on_demo_server_pebble_ready` method and replace it a call to `_replan_workload` like this:
+As you may have noticed, `_replan_workload` looks like a more advanced variant of the existing `_on_demo_server_pebble_ready` method. Update the `_on_demo_server_pebble_ready` method to call `_replan_workload` instead:
 
 ```python
 def _on_demo_server_pebble_ready(self, _: ops.PebbleReadyEvent) -> None:
@@ -239,7 +244,17 @@ juju status
 
 Since we added a new feature to configure `server-port` and use it in the Pebble layer dynamically, we should write tests for the feature.
 
-First, we'll add a test that sets the port in the input state and asserts that the port is used in the service's command in the container layer:
+First, in `tests/unit/test_charm.py`, find the `expected_plan = ` line then add a line that sets `override` for the `fastapi` service:
+
+```python
+# Expected plan after Pebble ready with default config.
+expected_plan = ops.pebble.Plan(ROCK_LAYER.to_dict())
+expected_plan.services["fastapi"].override = "merge"
+```
+
+This is needed because the charm's `_get_pebble_layer` method sets `override` to `merge` in the layer that it constructs.
+
+Next, we'll add a test that sets the port in the input state and asserts that the port is used in the service's command in the container layer:
 
 ```python
 def test_config_changed(mock_version):

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -159,7 +159,7 @@ def _replan_workload(self) -> None:
     self.unit.status = ops.ActiveStatus()
 ```
 
-When the config is loaded as part of constructing the Pebble layer, if the config is invalid (in our case, if the port is set to 22), then a `ValueError` will be raised. The `_replan_workload` method handles that by logging the error and setting the status of the unit to blocked, letting the Juju user know that they need to take action.
+If the loaded config is invalid (in our case, if the port is set to 22), we set the status of the unit to blocked. This lets the Juju user know that they need to take action.
 
 As you may have noticed, `_replan_workload` looks like a more advanced variant of the existing `_on_demo_server_pebble_ready` method. Update the `_on_demo_server_pebble_ready` method to call `_replan_workload` instead:
 
@@ -246,7 +246,7 @@ expected_plan.services["fastapi"].override = "merge"
 
 This is needed because the charm's `_get_pebble_layer` method sets `override` to `merge` in the layer that it constructs.
 
-Next, we'll add a test that sets the port in the input state and asserts that the port is used in the service's command in the container layer:
+Next, we'll add a test that sets the port in the input state and asserts that the port is used in the service's command in the Pebble layer:
 
 ```python
 def test_config_changed(mock_version):

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -102,25 +102,17 @@ Create a method that constructs the Pebble layer:
 ```python
 def _get_pebble_layer(self, port: int) -> ops.pebble.Layer:
     """Pebble layer for the FastAPI demo services."""
-    command = " ".join(
-        [
-            "/bin/uvicorn",
-            "api_demo_server.app:app",
-            "--host 0.0.0.0",
-            f"--port {port}",
-        ]
-    )
-    pebble_layer: ops.pebble.LayerDict = {
+    cmd = f"/bin/uvicorn api_demo_server.app:app --host 0.0.0.0 --port {port}"
+    service: ops.pebble.ServiceDict = {
+        "override": "merge",
+        "command": cmd,
+    }
+    layer: ops.pebble.LayerDict = {
         "summary": "FastAPI demo service",
         "description": "pebble config layer for FastAPI demo server",
-        "services": {
-            self.pebble_service_name: {
-                "override": "merge",
-                "command": command,
-            }
-        },
+        "services": {self.pebble_service_name: service},
     }
-    return ops.pebble.Layer(pebble_layer)
+    return ops.pebble.Layer(layer)
 ```
 
 This method defines a service with `override` set to `merge`, which means that unspecified properties should match the existing service definition.

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable.md
@@ -145,10 +145,10 @@ def _get_pebble_layer(self, port: int) -> ops.pebble.Layer:
     """Pebble layer for the FastAPI demo services."""
     command = " ".join(
         [
-            "uvicorn",
+            "/bin/uvicorn",
             "api_demo_server.app:app",
-            "--host=0.0.0.0",
-            f"--port={port}",
+            "--host 0.0.0.0",
+            f"--port {port}",
         ]
     )
     pebble_layer: ops.pebble.LayerDict = {
@@ -156,10 +156,8 @@ def _get_pebble_layer(self, port: int) -> ops.pebble.Layer:
         "description": "pebble config layer for FastAPI demo server",
         "services": {
             self.pebble_service_name: {
-                "override": "replace",
-                "summary": "fastapi demo",
+                "override": "merge",
                 "command": command,
-                "startup": "enabled",
             }
         },
     }
@@ -181,7 +179,7 @@ First, repack and refresh your charm:
 charmcraft pack
 juju refresh fastapi-demo --force-units \
   --path ./fastapi-demo_amd64.charm \
-  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.4
+  --resource demo-server-image=ghcr.io/canonical/api_demo_server/api-demo-server:2.1.0
 ```
 
 ```{tip}
@@ -206,7 +204,7 @@ Now, let's validate that the app is actually running and reachable on the new po
 curl 10.1.157.74:5000/version
 ```
 
-You should see JSON string with the version of the application: `{"version":"1.0.4"}`
+You should see JSON string with the version of the application: `{"version":"2.1.0"}`
 
 Let's also verify that our invalid port number check works by setting the port to `22` and then running `juju status`:
 
@@ -246,20 +244,17 @@ First, we'll add a test that sets the port in the input state and asserts that t
 ```python
 def test_config_changed(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         config={"server-port": 8080},
         leader=True,
     )
     state_out = ctx.run(ctx.on.config_changed(), state_in)
-    command = (
-        state_out.get_container(container.name)
-        .layers["fastapi_demo"]
-        .services["fastapi-service"]
-        .command
-    )
-    assert "--port=8080" in command
+    command = state_out.get_container(container.name).plan.services["fastapi"].command
+    assert "--port 8080" in command
 ```
 
 We need the `mock_version` fixture because `_on_config_changed` calls `_replan_workload`, which gets the workload version using `fastapi_demo.get_version`. The fixture patches `get_version` to avoid making a real HTTP call, so that the unit test deterministic.
@@ -269,7 +264,9 @@ In `_on_config_changed`, we specifically don't allow port 22 to be used. If port
 ```python
 def test_config_changed_invalid_port(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         config={"server-port": 22},

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/observe-your-charm-with-cos-lite.md
@@ -231,7 +231,7 @@ First, repack and refresh your charm:
 charmcraft pack
 juju refresh fastapi-demo --force-units \
   --path ./fastapi-demo_amd64.charm \
-  --resource demo-server-image=ghcr.io/canonical/api_demo_server:1.0.4
+  --resource demo-server-image=ghcr.io/canonical/api_demo_server/api-demo-server:2.1.0
 ```
 
 Next, test your charm's ability to integrate with Prometheus, Loki, and Grafana by following the steps below.
@@ -484,7 +484,7 @@ First, in `tests/integration/test_charm.py`, import `json` and `time` from the s
 
 ```text
 uv add --group integration requests
-``` 
+```
 
 Your imports should now look like this:
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/study-your-application.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/study-your-application.md
@@ -23,17 +23,14 @@ Finally, every time a user interacts with the database, our app writes logging i
 
 To summarize, our demo application is a minimal but real-life-like application that has external API endpoints, performs database read and write operations, and collects real-time metrics and logs for observability purposes.
 
-
 ## Structure
 
-The app source code is hosted at https://github.com/canonical/api_demo_server .
+The [app source](https://github.com/canonical/api_demo_server/tree/master/src/api_demo_server) has the following main files:
 
-As you can see [here](https://github.com/canonical/api_demo_server/tree/master/api_demo_server), the app consists of primarily the following two files:
-
-- `app.py`, which describes the API endpoints and the logging definition, and
+- `app.py`, which describes the API endpoints and the logging definition.
 - `database.py`, which describes the interaction with the PostgreSQL database.
 
-Furthermore, as you can see [here](https://github.com/canonical/api_demo_server/tree/master?tab=readme-ov-file#configuration-via-environment-variables), the application provides a way to configure the output logging file and the database access points (IP, port, username, password) via environment variables:
+The app supports environment variables to configure the output logging file and the database connection information:
 
 - `DEMO_SERVER_LOGFILE`
 - `DEMO_SERVER_DB_HOST`
@@ -41,21 +38,19 @@ Furthermore, as you can see [here](https://github.com/canonical/api_demo_server/
 - `DEMO_SERVER_DB_USER`
 - `DEMO_SERVER_DB_PASSWORD`
 
+For more detail about the structure of the app, see https://github.com/canonical/api_demo_server.
 
 ## API endpoints
 
-The application is set up such that, once deployed, you can access the deployed IP on port 8000. Specifically:
-
+The app is set up such that, once deployed, you can access the deployed IP on port 8000. Specifically:
 
 |||
 |-|-|
-| To get Prometheus metrics: | `http://<IP>:8000/metrics` |
-| To get a Swagger UI to interact with API: |`http://<IP>:8000/docs`|
-| To get the app's version |`http://<IP>:8000/version`|
+| Get Prometheus metrics | `http://<IP>:8000/metrics` |
+| Get a Swagger UI to interact with the API |`http://<IP>:8000/docs`|
+| Get the app's version |`http://<IP>:8000/version`|
 
 ## OCI image
-
-Our app's OCI image is at
 
 https://github.com/canonical/api_demo_server/pkgs/container/api_demo_server%2Fapi-demo-server
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/study-your-application.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/study-your-application.md
@@ -9,19 +9,19 @@ As such, if you want to charm an application, the first thing you need to unders
 
 Of course, what exactly you'll need to know and how exactly you'll have to go about getting this knowledge will very much depend on the application.
 
-In this part of the tutorial we will choose an application for you and tell you all you need to know about it to start charming. Our demo app is called  'FastAPI Demo' and we have designed it specifically for this tutorial so that, by creating a Kubernetes charm for it, you can master all the fundamentals of Kubernetes charming.
+In this part of the tutorial we will choose an application for you and tell you all you need to know about it to start charming. Our demo app is called 'FastAPI Demo' and we have designed it specifically for this tutorial so that, by creating a Kubernetes charm for it, you can master all the fundamentals of Kubernetes charming.
 
 ## Features
 
 The FastAPI app was built using the Python [FastAPI](https://fastapi.tiangolo.com/) framework to deliver a very simple web server. It offers a couple of API endpoints that the user can interact with.
 
-The app also has a connection to a  [PostgreSQL](https://www.postgresql.org/) database. It provides users with an API to create a table with user names, add a name to the database, and get all the names from the database.
+The app also has a connection to a [PostgreSQL](https://www.postgresql.org/) database. It provides users with an API to create a table with user names, add a name to the database, and get all the names from the database.
 
-Additionally, our app uses [starlette-exporter](https://pypi.org/project/starlette-exporter/) to generate real-time application metrics and to expose them via a `/metrics` endpoint that is designed to be scraped by [Prometheus](https://prometheus.io/).
+Additionally, our app uses [starlette-exporter](https://pypi.org/project/starlette-exporter/) to generate real-time app metrics and to expose them via a `/metrics` endpoint that is designed to be scraped by [Prometheus](https://prometheus.io/).
 
 Finally, every time a user interacts with the database, our app writes logging information to the log file and also streams it to standard output.
 
-To summarize, our demo application is a minimal but real-life-like application that has external API endpoints, performs database read and write operations, and collects real-time metrics and logs for observability purposes.
+To summarize, our demo app is a minimal but real-life-like app that has external API endpoints, performs database read and write operations, and collects real-time metrics and logs for observability purposes.
 
 ## Structure
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/study-your-application.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/study-your-application.md
@@ -57,6 +57,6 @@ The application is set up such that, once deployed, you can access the deployed 
 
 Our app's OCI image is at
 
-https://github.com/canonical/api_demo_server/pkgs/container/api_demo_server
+https://github.com/canonical/api_demo_server/pkgs/container/api_demo_server%2Fapi-demo-server
 
 > **See next: {ref}`Set up your development environment <set-up-your-development-environment>`**

--- a/examples/k8s-1-minimal/charmcraft.yaml
+++ b/examples/k8s-1-minimal/charmcraft.yaml
@@ -51,7 +51,7 @@ resources:
   # An OCI image resource for the container listed above.
   demo-server-image:
     type: oci-image
-    description: OCI image from GitHub Container Repository
+    description: OCI image from GitHub Container registry
     # The upstream-source field is ignored by Charmcraft and Juju, but it can be
     # useful to developers in identifying the source of the OCI image.  It is also
     # used by the 'canonical/charming-actions' GitHub action for automated releases.

--- a/examples/k8s-1-minimal/charmcraft.yaml
+++ b/examples/k8s-1-minimal/charmcraft.yaml
@@ -57,4 +57,4 @@ resources:
     # used by the 'canonical/charming-actions' GitHub action for automated releases.
     # The test_deploy function in tests/integration/test_charm.py reads upstream-source
     # to determine which OCI image to use when running the charm's integration tests.
-    upstream-source: ghcr.io/canonical/api_demo_server:1.0.4
+    upstream-source: ghcr.io/canonical/api_demo_server/api-demo-server:2.1.0

--- a/examples/k8s-1-minimal/src/charm.py
+++ b/examples/k8s-1-minimal/src/charm.py
@@ -31,16 +31,13 @@ class FastAPIDemoCharm(ops.CharmBase):
 
     def __init__(self, framework: ops.Framework) -> None:
         super().__init__(framework)
-        self.pebble_service_name = "fastapi"
         framework.observe(self.on["demo-server"].pebble_ready, self._on_demo_server_pebble_ready)
 
     def _on_demo_server_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
         """Define and start a workload using the Pebble API."""
         # Get a reference the container attribute on the PebbleReadyEvent
         container = event.workload
-        # Add initial Pebble config layer using the Pebble API
-        container.add_layer("fastapi_demo", self._get_pebble_layer(), combine=True)
-        # Make Pebble reevaluate its plan, ensuring any services are started if enabled.
+        # Start the service defined by the Pebble layer in the application image.
         container.replan()
         # Set the workload version of this charm.
         version = fastapi_demo.get_version(port=8000)
@@ -48,28 +45,6 @@ class FastAPIDemoCharm(ops.CharmBase):
         # Learn more about statuses at
         # https://documentation.ubuntu.com/juju/3.6/reference/status/
         self.unit.status = ops.ActiveStatus()
-
-    def _get_pebble_layer(self) -> ops.pebble.Layer:
-        """Pebble layer for the FastAPI demo services."""
-        command = " ".join(
-            [
-                "/bin/uvicorn",
-                "api_demo_server.app:app",
-                "--host 0.0.0.0",
-                "--port 8000",
-            ]
-        )
-        pebble_layer: ops.pebble.LayerDict = {
-            "summary": "FastAPI demo service",
-            "description": "pebble config layer for FastAPI demo server",
-            "services": {
-                self.pebble_service_name: {
-                    "override": "merge",
-                    "command": command,
-                }
-            },
-        }
-        return ops.pebble.Layer(pebble_layer)
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/examples/k8s-1-minimal/src/charm.py
+++ b/examples/k8s-1-minimal/src/charm.py
@@ -31,7 +31,7 @@ class FastAPIDemoCharm(ops.CharmBase):
 
     def __init__(self, framework: ops.Framework) -> None:
         super().__init__(framework)
-        self.pebble_service_name = "fastapi-service"
+        self.pebble_service_name = "fastapi"
         framework.observe(self.on["demo-server"].pebble_ready, self._on_demo_server_pebble_ready)
 
     def _on_demo_server_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
@@ -53,10 +53,10 @@ class FastAPIDemoCharm(ops.CharmBase):
         """Pebble layer for the FastAPI demo services."""
         command = " ".join(
             [
-                "uvicorn",
+                "/bin/uvicorn",
                 "api_demo_server.app:app",
-                "--host=0.0.0.0",
-                "--port=8000",
+                "--host 0.0.0.0",
+                "--port 8000",
             ]
         )
         pebble_layer: ops.pebble.LayerDict = {
@@ -64,10 +64,8 @@ class FastAPIDemoCharm(ops.CharmBase):
             "description": "pebble config layer for FastAPI demo server",
             "services": {
                 self.pebble_service_name: {
-                    "override": "replace",
-                    "summary": "fastapi demo",
+                    "override": "merge",
                     "command": command,
-                    "startup": "enabled",
                 }
             },
         }

--- a/examples/k8s-1-minimal/tests/integration/test_charm.py
+++ b/examples/k8s-1-minimal/tests/integration/test_charm.py
@@ -44,4 +44,4 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
     version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.
+    assert version == "2.1.0"  # Hardcoded for simplicity.

--- a/examples/k8s-1-minimal/tests/unit/test_charm.py
+++ b/examples/k8s-1-minimal/tests/unit/test_charm.py
@@ -59,9 +59,8 @@ def test_pebble_layer(mock_version):
         leader=True,
     )
     state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
-    # Expected plan after Pebble ready with default config
+    # Expected plan after Pebble ready (our charm doesn't add any layers).
     expected_plan = ops.pebble.Plan(ROCK_LAYER.to_dict())
-    expected_plan.services["fastapi"].override = "merge"
 
     # Check that we have the plan we expected:
     assert state_out.get_container(container.name).plan == expected_plan

--- a/examples/k8s-1-minimal/tests/unit/test_charm.py
+++ b/examples/k8s-1-minimal/tests/unit/test_charm.py
@@ -20,6 +20,24 @@ from ops import testing
 
 from charm import FastAPIDemoCharm
 
+# The default Pebble layer in the application image.
+# Defined in https://github.com/canonical/api_demo_server/blob/master/rockcraft.yaml
+ROCK_LAYER = ops.pebble.Layer(
+    {
+        "services": {
+            "fastapi": {
+                "override": "replace",
+                "summary": "FastAPI demo server",
+                "command": "/bin/uvicorn api_demo_server.app:app --host 0.0.0.0 --port 8000",
+                "startup": "enabled",
+                "environment": {"DEMO_SERVER_LOGFILE": "/tmp/demo_server.log"},
+                "on-success": "shutdown",
+                "on-failure": "shutdown",
+            }
+        },
+    }
+)
+
 
 def mock_get_version(port: int):
     """Get a mock version string without executing the workload code."""
@@ -33,25 +51,17 @@ def mock_version(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_pebble_layer(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         leader=True,
     )
     state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
     # Expected plan after Pebble ready with default config
-    expected_plan = {
-        "services": {
-            "fastapi-service": {
-                "override": "replace",
-                "summary": "fastapi demo",
-                "command": "uvicorn api_demo_server.app:app --host=0.0.0.0 --port=8000",
-                "startup": "enabled",
-                # Since the environment is empty, Layer.to_dict() will not
-                # include it.
-            }
-        }
-    }
+    expected_plan = ops.pebble.Plan(ROCK_LAYER.to_dict())
+    expected_plan.services["fastapi"].override = "merge"
 
     # Check that we have the plan we expected:
     assert state_out.get_container(container.name).plan == expected_plan
@@ -59,7 +69,7 @@ def test_pebble_layer(mock_version):
     assert state_out.unit_status == testing.ActiveStatus()
     # Check the service was started:
     assert (
-        state_out.get_container(container.name).service_statuses["fastapi-service"]
+        state_out.get_container(container.name).service_statuses["fastapi"]
         == ops.pebble.ServiceStatus.ACTIVE
     )
     # Check the workload version is set:

--- a/examples/k8s-2-configurable/charmcraft.yaml
+++ b/examples/k8s-2-configurable/charmcraft.yaml
@@ -46,4 +46,4 @@ resources:
     # used by the 'canonical/charming-actions' GitHub action for automated releases.
     # The test_deploy function in tests/integration/test_charm.py reads upstream-source
     # to determine which OCI image to use when running the charm's integration tests.
-    upstream-source: ghcr.io/canonical/api_demo_server:1.0.4
+    upstream-source: ghcr.io/canonical/api_demo_server/api-demo-server:2.1.0

--- a/examples/k8s-2-configurable/charmcraft.yaml
+++ b/examples/k8s-2-configurable/charmcraft.yaml
@@ -40,7 +40,7 @@ resources:
   # An OCI image resource for the container listed above.
   demo-server-image:
     type: oci-image
-    description: OCI image from GitHub Container Repository
+    description: OCI image from GitHub Container registry
     # The upstream-source field is ignored by Charmcraft and Juju, but it can be
     # useful to developers in identifying the source of the OCI image.  It is also
     # used by the 'canonical/charming-actions' GitHub action for automated releases.

--- a/examples/k8s-2-configurable/src/charm.py
+++ b/examples/k8s-2-configurable/src/charm.py
@@ -47,7 +47,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         super().__init__(framework)
         # See 'containers' in charmcraft.yaml.
         self.container = self.unit.get_container("demo-server")
-        self.pebble_service_name = "fastapi-service"
+        self.pebble_service_name = "fastapi"
         framework.observe(self.on["demo-server"].pebble_ready, self._on_demo_server_pebble_ready)
         framework.observe(self.on.config_changed, self._on_config_changed)
 
@@ -99,10 +99,10 @@ class FastAPIDemoCharm(ops.CharmBase):
         """Pebble layer for the FastAPI demo services."""
         command = " ".join(
             [
-                "uvicorn",
+                "/bin/uvicorn",
                 "api_demo_server.app:app",
-                "--host=0.0.0.0",
-                f"--port={port}",
+                "--host 0.0.0.0",
+                f"--port {port}",
             ]
         )
         pebble_layer: ops.pebble.LayerDict = {
@@ -110,10 +110,8 @@ class FastAPIDemoCharm(ops.CharmBase):
             "description": "pebble config layer for FastAPI demo server",
             "services": {
                 self.pebble_service_name: {
-                    "override": "replace",
-                    "summary": "fastapi demo",
+                    "override": "merge",
                     "command": command,
-                    "startup": "enabled",
                 }
             },
         }

--- a/examples/k8s-2-configurable/src/charm.py
+++ b/examples/k8s-2-configurable/src/charm.py
@@ -97,25 +97,17 @@ class FastAPIDemoCharm(ops.CharmBase):
 
     def _get_pebble_layer(self, port: int) -> ops.pebble.Layer:
         """Pebble layer for the FastAPI demo services."""
-        command = " ".join(
-            [
-                "/bin/uvicorn",
-                "api_demo_server.app:app",
-                "--host 0.0.0.0",
-                f"--port {port}",
-            ]
-        )
-        pebble_layer: ops.pebble.LayerDict = {
+        cmd = f"/bin/uvicorn api_demo_server.app:app --host 0.0.0.0 --port {port}"
+        service: ops.pebble.ServiceDict = {
+            "override": "merge",
+            "command": cmd,
+        }
+        layer: ops.pebble.LayerDict = {
             "summary": "FastAPI demo service",
             "description": "pebble config layer for FastAPI demo server",
-            "services": {
-                self.pebble_service_name: {
-                    "override": "merge",
-                    "command": command,
-                }
-            },
+            "services": {self.pebble_service_name: service},
         }
-        return ops.pebble.Layer(pebble_layer)
+        return ops.pebble.Layer(layer)
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/examples/k8s-2-configurable/tests/integration/test_charm.py
+++ b/examples/k8s-2-configurable/tests/integration/test_charm.py
@@ -44,4 +44,4 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
     version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.
+    assert version == "2.1.0"  # Hardcoded for simplicity.

--- a/examples/k8s-2-configurable/tests/unit/test_charm.py
+++ b/examples/k8s-2-configurable/tests/unit/test_charm.py
@@ -20,6 +20,24 @@ from ops import testing
 
 from charm import FastAPIDemoCharm
 
+# The default Pebble layer in the application image.
+# Defined in https://github.com/canonical/api_demo_server/blob/master/rockcraft.yaml
+ROCK_LAYER = ops.pebble.Layer(
+    {
+        "services": {
+            "fastapi": {
+                "override": "replace",
+                "summary": "FastAPI demo server",
+                "command": "/bin/uvicorn api_demo_server.app:app --host 0.0.0.0 --port 8000",
+                "startup": "enabled",
+                "environment": {"DEMO_SERVER_LOGFILE": "/tmp/demo_server.log"},
+                "on-success": "shutdown",
+                "on-failure": "shutdown",
+            }
+        },
+    }
+)
+
 
 def mock_get_version(port: int):
     """Get a mock version string without executing the workload code."""
@@ -33,25 +51,17 @@ def mock_version(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_pebble_layer(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         leader=True,
     )
     state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
     # Expected plan after Pebble ready with default config
-    expected_plan = {
-        "services": {
-            "fastapi-service": {
-                "override": "replace",
-                "summary": "fastapi demo",
-                "command": "uvicorn api_demo_server.app:app --host=0.0.0.0 --port=8000",
-                "startup": "enabled",
-                # Since the environment is empty, Layer.to_dict() will not
-                # include it.
-            }
-        }
-    }
+    expected_plan = ops.pebble.Plan(ROCK_LAYER.to_dict())
+    expected_plan.services["fastapi"].override = "merge"
 
     # Check that we have the plan we expected:
     assert state_out.get_container(container.name).plan == expected_plan
@@ -59,7 +69,7 @@ def test_pebble_layer(mock_version):
     assert state_out.unit_status == testing.ActiveStatus()
     # Check the service was started:
     assert (
-        state_out.get_container(container.name).service_statuses["fastapi-service"]
+        state_out.get_container(container.name).service_statuses["fastapi"]
         == ops.pebble.ServiceStatus.ACTIVE
     )
     # Check the workload version is set:
@@ -68,25 +78,24 @@ def test_pebble_layer(mock_version):
 
 def test_config_changed(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         config={"server-port": 8080},
         leader=True,
     )
     state_out = ctx.run(ctx.on.config_changed(), state_in)
-    command = (
-        state_out.get_container(container.name)
-        .layers["fastapi_demo"]
-        .services["fastapi-service"]
-        .command
-    )
-    assert "--port=8080" in command
+    command = state_out.get_container(container.name).plan.services["fastapi"].command
+    assert "--port 8080" in command
 
 
 def test_config_changed_invalid_port(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         config={"server-port": 22},

--- a/examples/k8s-2-configurable/tests/unit/test_charm.py
+++ b/examples/k8s-2-configurable/tests/unit/test_charm.py
@@ -59,7 +59,7 @@ def test_pebble_layer(mock_version):
         leader=True,
     )
     state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
-    # Expected plan after Pebble ready with default config
+    # Expected plan after Pebble ready with default config.
     expected_plan = ops.pebble.Plan(ROCK_LAYER.to_dict())
     expected_plan.services["fastapi"].override = "merge"
 

--- a/examples/k8s-3-postgresql/charmcraft.yaml
+++ b/examples/k8s-3-postgresql/charmcraft.yaml
@@ -50,7 +50,7 @@ resources:
   # An OCI image resource for the container listed above.
   demo-server-image:
     type: oci-image
-    description: OCI image from GitHub Container Repository
+    description: OCI image from GitHub Container registry
     # The upstream-source field is ignored by Charmcraft and Juju, but it can be
     # useful to developers in identifying the source of the OCI image.  It is also
     # used by the 'canonical/charming-actions' GitHub action for automated releases.

--- a/examples/k8s-3-postgresql/charmcraft.yaml
+++ b/examples/k8s-3-postgresql/charmcraft.yaml
@@ -56,4 +56,4 @@ resources:
     # used by the 'canonical/charming-actions' GitHub action for automated releases.
     # The test_deploy function in tests/integration/test_charm.py reads upstream-source
     # to determine which OCI image to use when running the charm's integration tests.
-    upstream-source: ghcr.io/canonical/api_demo_server:1.0.4
+    upstream-source: ghcr.io/canonical/api_demo_server/api-demo-server:2.1.0

--- a/examples/k8s-3-postgresql/src/charm.py
+++ b/examples/k8s-3-postgresql/src/charm.py
@@ -145,8 +145,8 @@ class FastAPIDemoCharm(ops.CharmBase):
             [
                 "/bin/uvicorn",
                 "api_demo_server.app:app",
-                "--host=0.0.0.0",
-                f"--port={port}",
+                "--host 0.0.0.0",
+                f"--port {port}",
             ]
         )
         pebble_layer: ops.pebble.LayerDict = {

--- a/examples/k8s-3-postgresql/src/charm.py
+++ b/examples/k8s-3-postgresql/src/charm.py
@@ -139,28 +139,20 @@ class FastAPIDemoCharm(ops.CharmBase):
         version = fastapi_demo.get_version(config.server_port)
         self.unit.set_workload_version(version)
 
-    def _get_pebble_layer(self, port: int, environment: dict[str, str]) -> ops.pebble.Layer:
+    def _get_pebble_layer(self, port: int, env: dict[str, str]) -> ops.pebble.Layer:
         """Pebble layer for the FastAPI demo services."""
-        command = " ".join(
-            [
-                "/bin/uvicorn",
-                "api_demo_server.app:app",
-                "--host 0.0.0.0",
-                f"--port {port}",
-            ]
-        )
-        pebble_layer: ops.pebble.LayerDict = {
+        cmd = f"/bin/uvicorn api_demo_server.app:app --host 0.0.0.0 --port {port}"
+        service: ops.pebble.ServiceDict = {
+            "override": "merge",
+            "command": cmd,
+            "environment": env,
+        }
+        layer: ops.pebble.LayerDict = {
             "summary": "FastAPI demo service",
             "description": "pebble config layer for FastAPI demo server",
-            "services": {
-                self.pebble_service_name: {
-                    "override": "merge",
-                    "command": command,
-                    "environment": environment,
-                }
-            },
+            "services": {self.pebble_service_name: service},
         }
-        return ops.pebble.Layer(pebble_layer)
+        return ops.pebble.Layer(layer)
 
     def get_app_environment(self) -> dict[str, str]:
         """Return a dictionary of environment variables for the application."""

--- a/examples/k8s-3-postgresql/src/charm.py
+++ b/examples/k8s-3-postgresql/src/charm.py
@@ -56,7 +56,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         super().__init__(framework)
         # See 'containers' in charmcraft.yaml.
         self.container = self.unit.get_container("demo-server")
-        self.pebble_service_name = "fastapi-service"
+        self.pebble_service_name = "fastapi"
         framework.observe(self.on["demo-server"].pebble_ready, self._on_demo_server_pebble_ready)
         framework.observe(self.on.config_changed, self._on_config_changed)
         # Report the unit status after each event.
@@ -143,7 +143,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         """Pebble layer for the FastAPI demo services."""
         command = " ".join(
             [
-                "uvicorn",
+                "/bin/uvicorn",
                 "api_demo_server.app:app",
                 "--host=0.0.0.0",
                 f"--port={port}",
@@ -154,10 +154,8 @@ class FastAPIDemoCharm(ops.CharmBase):
             "description": "pebble config layer for FastAPI demo server",
             "services": {
                 self.pebble_service_name: {
-                    "override": "replace",
-                    "summary": "fastapi demo",
+                    "override": "merge",
                     "command": command,
-                    "startup": "enabled",
                     "environment": environment,
                 }
             },

--- a/examples/k8s-3-postgresql/tests/integration/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/integration/test_charm.py
@@ -49,7 +49,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
     version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.
+    assert version == "2.1.0"  # Hardcoded for simplicity.
 
 
 @pytest.mark.juju_setup

--- a/examples/k8s-3-postgresql/tests/unit/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/unit/test_charm.py
@@ -20,6 +20,24 @@ from ops import testing
 
 from charm import FastAPIDemoCharm
 
+# The default Pebble layer in the application image.
+# Defined in https://github.com/canonical/api_demo_server/blob/master/rockcraft.yaml
+ROCK_LAYER = ops.pebble.Layer(
+    {
+        "services": {
+            "fastapi": {
+                "override": "replace",
+                "summary": "FastAPI demo server",
+                "command": "/bin/uvicorn api_demo_server.app:app --host 0.0.0.0 --port 8000",
+                "startup": "enabled",
+                "environment": {"DEMO_SERVER_LOGFILE": "/tmp/demo_server.log"},
+                "on-success": "shutdown",
+                "on-failure": "shutdown",
+            }
+        },
+    }
+)
+
 
 def mock_get_version(port: int):
     """Get a mock version string without executing the workload code."""
@@ -33,25 +51,17 @@ def mock_version(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_pebble_layer(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         leader=True,
     )
     state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
     # Expected plan after Pebble ready with default config
-    expected_plan = {
-        "services": {
-            "fastapi-service": {
-                "override": "replace",
-                "summary": "fastapi demo",
-                "command": "uvicorn api_demo_server.app:app --host=0.0.0.0 --port=8000",
-                "startup": "enabled",
-                # Since the environment is empty, Layer.to_dict() will not
-                # include it.
-            }
-        }
-    }
+    expected_plan = ops.pebble.Plan(ROCK_LAYER.to_dict())
+    expected_plan.services["fastapi"].override = "merge"
 
     # Check that we have the plan we expected:
     assert state_out.get_container(container.name).plan == expected_plan
@@ -59,7 +69,7 @@ def test_pebble_layer(mock_version):
     assert state_out.unit_status == testing.BlockedStatus("Waiting for database relation")
     # Check the service was started:
     assert (
-        state_out.get_container(container.name).service_statuses["fastapi-service"]
+        state_out.get_container(container.name).service_statuses["fastapi"]
         == ops.pebble.ServiceStatus.ACTIVE
     )
     # Check the workload version is set:
@@ -68,25 +78,24 @@ def test_pebble_layer(mock_version):
 
 def test_config_changed(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         config={"server-port": 8080},
         leader=True,
     )
     state_out = ctx.run(ctx.on.config_changed(), state_in)
-    command = (
-        state_out.get_container(container.name)
-        .layers["fastapi_demo"]
-        .services["fastapi-service"]
-        .command
-    )
-    assert "--port=8080" in command
+    command = state_out.get_container(container.name).plan.services["fastapi"].command
+    assert "--port 8080" in command
 
 
 def test_config_changed_invalid_port(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         config={"server-port": 22},
@@ -110,7 +119,9 @@ def test_relation_data(mock_version):
             "password": "bar",
         },
     )
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         relations={relation},
@@ -119,9 +130,8 @@ def test_relation_data(mock_version):
 
     state_out = ctx.run(ctx.on.relation_changed(relation), state_in)
 
-    assert state_out.get_container(container.name).layers["fastapi_demo"].services[
-        "fastapi-service"
-    ].environment == {
+    assert state_out.get_container(container.name).plan.services["fastapi"].environment == {
+        **ROCK_LAYER.services["fastapi"].environment,
         "DEMO_SERVER_DB_HOST": "example.com",
         "DEMO_SERVER_DB_PORT": "5432",
         "DEMO_SERVER_DB_USER": "foo",
@@ -131,7 +141,9 @@ def test_relation_data(mock_version):
 
 def test_no_database_blocked(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         leader=True,

--- a/examples/k8s-3-postgresql/tests/unit/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/unit/test_charm.py
@@ -59,7 +59,7 @@ def test_pebble_layer(mock_version):
         leader=True,
     )
     state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
-    # Expected plan after Pebble ready with default config
+    # Expected plan after Pebble ready with default config.
     expected_plan = ops.pebble.Plan(ROCK_LAYER.to_dict())
     expected_plan.services["fastapi"].override = "merge"
 

--- a/examples/k8s-4-action/charmcraft.yaml
+++ b/examples/k8s-4-action/charmcraft.yaml
@@ -66,4 +66,4 @@ resources:
     # used by the 'canonical/charming-actions' GitHub action for automated releases.
     # The test_deploy function in tests/integration/test_charm.py reads upstream-source
     # to determine which OCI image to use when running the charm's integration tests.
-    upstream-source: ghcr.io/canonical/api_demo_server:1.0.4
+    upstream-source: ghcr.io/canonical/api_demo_server/api-demo-server:2.1.0

--- a/examples/k8s-4-action/charmcraft.yaml
+++ b/examples/k8s-4-action/charmcraft.yaml
@@ -60,7 +60,7 @@ resources:
   # An OCI image resource for the container listed above.
   demo-server-image:
     type: oci-image
-    description: OCI image from GitHub Container Repository
+    description: OCI image from GitHub Container registry
     # The upstream-source field is ignored by Charmcraft and Juju, but it can be
     # useful to developers in identifying the source of the OCI image.  It is also
     # used by the 'canonical/charming-actions' GitHub action for automated releases.

--- a/examples/k8s-4-action/src/charm.py
+++ b/examples/k8s-4-action/src/charm.py
@@ -179,28 +179,20 @@ class FastAPIDemoCharm(ops.CharmBase):
         version = fastapi_demo.get_version(config.server_port)
         self.unit.set_workload_version(version)
 
-    def _get_pebble_layer(self, port: int, environment: dict[str, str]) -> ops.pebble.Layer:
+    def _get_pebble_layer(self, port: int, env: dict[str, str]) -> ops.pebble.Layer:
         """Pebble layer for the FastAPI demo services."""
-        command = " ".join(
-            [
-                "/bin/uvicorn",
-                "api_demo_server.app:app",
-                "--host 0.0.0.0",
-                f"--port {port}",
-            ]
-        )
-        pebble_layer: ops.pebble.LayerDict = {
+        cmd = f"/bin/uvicorn api_demo_server.app:app --host 0.0.0.0 --port {port}"
+        service: ops.pebble.ServiceDict = {
+            "override": "merge",
+            "command": cmd,
+            "environment": env,
+        }
+        layer: ops.pebble.LayerDict = {
             "summary": "FastAPI demo service",
             "description": "pebble config layer for FastAPI demo server",
-            "services": {
-                self.pebble_service_name: {
-                    "override": "merge",
-                    "command": command,
-                    "environment": environment,
-                }
-            },
+            "services": {self.pebble_service_name: service},
         }
-        return ops.pebble.Layer(pebble_layer)
+        return ops.pebble.Layer(layer)
 
     def get_app_environment(self) -> dict[str, str]:
         """Return a dictionary of environment variables for the application."""

--- a/examples/k8s-4-action/src/charm.py
+++ b/examples/k8s-4-action/src/charm.py
@@ -64,7 +64,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         super().__init__(framework)
         # See 'containers' in charmcraft.yaml.
         self.container = self.unit.get_container("demo-server")
-        self.pebble_service_name = "fastapi-service"
+        self.pebble_service_name = "fastapi"
         framework.observe(self.on["demo-server"].pebble_ready, self._on_demo_server_pebble_ready)
         framework.observe(self.on.config_changed, self._on_config_changed)
         # Report the unit status after each event.
@@ -183,10 +183,10 @@ class FastAPIDemoCharm(ops.CharmBase):
         """Pebble layer for the FastAPI demo services."""
         command = " ".join(
             [
-                "uvicorn",
+                "/bin/uvicorn",
                 "api_demo_server.app:app",
-                "--host=0.0.0.0",
-                f"--port={port}",
+                "--host 0.0.0.0",
+                f"--port {port}",
             ]
         )
         pebble_layer: ops.pebble.LayerDict = {
@@ -194,10 +194,8 @@ class FastAPIDemoCharm(ops.CharmBase):
             "description": "pebble config layer for FastAPI demo server",
             "services": {
                 self.pebble_service_name: {
-                    "override": "replace",
-                    "summary": "fastapi demo",
+                    "override": "merge",
                     "command": command,
-                    "startup": "enabled",
                     "environment": environment,
                 }
             },

--- a/examples/k8s-4-action/tests/integration/test_charm.py
+++ b/examples/k8s-4-action/tests/integration/test_charm.py
@@ -49,7 +49,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
     version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.
+    assert version == "2.1.0"  # Hardcoded for simplicity.
 
 
 @pytest.mark.juju_setup

--- a/examples/k8s-4-action/tests/unit/test_charm.py
+++ b/examples/k8s-4-action/tests/unit/test_charm.py
@@ -59,7 +59,7 @@ def test_pebble_layer(mock_version):
         leader=True,
     )
     state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
-    # Expected plan after Pebble ready with default config
+    # Expected plan after Pebble ready with default config.
     expected_plan = ops.pebble.Plan(ROCK_LAYER.to_dict())
     expected_plan.services["fastapi"].override = "merge"
 

--- a/examples/k8s-4-action/tests/unit/test_charm.py
+++ b/examples/k8s-4-action/tests/unit/test_charm.py
@@ -20,6 +20,24 @@ from ops import testing
 
 from charm import FastAPIDemoCharm
 
+# The default Pebble layer in the application image.
+# Defined in https://github.com/canonical/api_demo_server/blob/master/rockcraft.yaml
+ROCK_LAYER = ops.pebble.Layer(
+    {
+        "services": {
+            "fastapi": {
+                "override": "replace",
+                "summary": "FastAPI demo server",
+                "command": "/bin/uvicorn api_demo_server.app:app --host 0.0.0.0 --port 8000",
+                "startup": "enabled",
+                "environment": {"DEMO_SERVER_LOGFILE": "/tmp/demo_server.log"},
+                "on-success": "shutdown",
+                "on-failure": "shutdown",
+            }
+        },
+    }
+)
+
 
 def mock_get_version(port: int):
     """Get a mock version string without executing the workload code."""
@@ -33,25 +51,17 @@ def mock_version(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_pebble_layer(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         leader=True,
     )
     state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
     # Expected plan after Pebble ready with default config
-    expected_plan = {
-        "services": {
-            "fastapi-service": {
-                "override": "replace",
-                "summary": "fastapi demo",
-                "command": "uvicorn api_demo_server.app:app --host=0.0.0.0 --port=8000",
-                "startup": "enabled",
-                # Since the environment is empty, Layer.to_dict() will not
-                # include it.
-            }
-        }
-    }
+    expected_plan = ops.pebble.Plan(ROCK_LAYER.to_dict())
+    expected_plan.services["fastapi"].override = "merge"
 
     # Check that we have the plan we expected:
     assert state_out.get_container(container.name).plan == expected_plan
@@ -59,7 +69,7 @@ def test_pebble_layer(mock_version):
     assert state_out.unit_status == testing.BlockedStatus("Waiting for database relation")
     # Check the service was started:
     assert (
-        state_out.get_container(container.name).service_statuses["fastapi-service"]
+        state_out.get_container(container.name).service_statuses["fastapi"]
         == ops.pebble.ServiceStatus.ACTIVE
     )
     # Check the workload version is set:
@@ -68,25 +78,24 @@ def test_pebble_layer(mock_version):
 
 def test_config_changed(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         config={"server-port": 8080},
         leader=True,
     )
     state_out = ctx.run(ctx.on.config_changed(), state_in)
-    command = (
-        state_out.get_container(container.name)
-        .layers["fastapi_demo"]
-        .services["fastapi-service"]
-        .command
-    )
-    assert "--port=8080" in command
+    command = state_out.get_container(container.name).plan.services["fastapi"].command
+    assert "--port 8080" in command
 
 
 def test_config_changed_invalid_port(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         config={"server-port": 22},
@@ -110,7 +119,9 @@ def test_relation_data(mock_version):
             "password": "bar",
         },
     )
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         relations={relation},
@@ -119,9 +130,8 @@ def test_relation_data(mock_version):
 
     state_out = ctx.run(ctx.on.relation_changed(relation), state_in)
 
-    assert state_out.get_container(container.name).layers["fastapi_demo"].services[
-        "fastapi-service"
-    ].environment == {
+    assert state_out.get_container(container.name).plan.services["fastapi"].environment == {
+        **ROCK_LAYER.services["fastapi"].environment,
         "DEMO_SERVER_DB_HOST": "example.com",
         "DEMO_SERVER_DB_PORT": "5432",
         "DEMO_SERVER_DB_USER": "foo",
@@ -131,7 +141,9 @@ def test_relation_data(mock_version):
 
 def test_no_database_blocked(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         leader=True,
@@ -154,7 +166,9 @@ def test_get_db_info_action():
             "password": "bar",
         },
     )
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         relations={relation},
@@ -181,7 +195,9 @@ def test_get_db_info_action_show_password():
             "password": "bar",
         },
     )
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         relations={relation},

--- a/examples/k8s-5-observe/charmcraft.yaml
+++ b/examples/k8s-5-observe/charmcraft.yaml
@@ -79,7 +79,7 @@ resources:
   # An OCI image resource for the container listed above.
   demo-server-image:
     type: oci-image
-    description: OCI image from GitHub Container Repository
+    description: OCI image from GitHub Container registry
     # The upstream-source field is ignored by Charmcraft and Juju, but it can be
     # useful to developers in identifying the source of the OCI image.  It is also
     # used by the 'canonical/charming-actions' GitHub action for automated releases.

--- a/examples/k8s-5-observe/charmcraft.yaml
+++ b/examples/k8s-5-observe/charmcraft.yaml
@@ -85,4 +85,4 @@ resources:
     # used by the 'canonical/charming-actions' GitHub action for automated releases.
     # The test_deploy function in tests/integration/test_charm.py reads upstream-source
     # to determine which OCI image to use when running the charm's integration tests.
-    upstream-source: ghcr.io/canonical/api_demo_server:1.0.4
+    upstream-source: ghcr.io/canonical/api_demo_server/api-demo-server:2.1.0

--- a/examples/k8s-5-observe/src/charm.py
+++ b/examples/k8s-5-observe/src/charm.py
@@ -67,7 +67,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         super().__init__(framework)
         # See 'containers' in charmcraft.yaml.
         self.container = self.unit.get_container("demo-server")
-        self.pebble_service_name = "fastapi-service"
+        self.pebble_service_name = "fastapi"
         framework.observe(self.on["demo-server"].pebble_ready, self._on_demo_server_pebble_ready)
         framework.observe(self.on.config_changed, self._on_config_changed)
         # Report the unit status after each event.
@@ -204,10 +204,10 @@ class FastAPIDemoCharm(ops.CharmBase):
         """Pebble layer for the FastAPI demo services."""
         command = " ".join(
             [
-                "uvicorn",
+                "/bin/uvicorn",
                 "api_demo_server.app:app",
-                "--host=0.0.0.0",
-                f"--port={port}",
+                "--host 0.0.0.0",
+                f"--port {port}",
             ]
         )
         pebble_layer: ops.pebble.LayerDict = {
@@ -215,10 +215,8 @@ class FastAPIDemoCharm(ops.CharmBase):
             "description": "pebble config layer for FastAPI demo server",
             "services": {
                 self.pebble_service_name: {
-                    "override": "replace",
-                    "summary": "fastapi demo",
+                    "override": "merge",
                     "command": command,
-                    "startup": "enabled",
                     "environment": environment,
                 }
             },

--- a/examples/k8s-5-observe/src/charm.py
+++ b/examples/k8s-5-observe/src/charm.py
@@ -200,28 +200,20 @@ class FastAPIDemoCharm(ops.CharmBase):
         version = fastapi_demo.get_version(config.server_port)
         self.unit.set_workload_version(version)
 
-    def _get_pebble_layer(self, port: int, environment: dict[str, str]) -> ops.pebble.Layer:
+    def _get_pebble_layer(self, port: int, env: dict[str, str]) -> ops.pebble.Layer:
         """Pebble layer for the FastAPI demo services."""
-        command = " ".join(
-            [
-                "/bin/uvicorn",
-                "api_demo_server.app:app",
-                "--host 0.0.0.0",
-                f"--port {port}",
-            ]
-        )
-        pebble_layer: ops.pebble.LayerDict = {
+        cmd = f"/bin/uvicorn api_demo_server.app:app --host 0.0.0.0 --port {port}"
+        service: ops.pebble.ServiceDict = {
+            "override": "merge",
+            "command": cmd,
+            "environment": env,
+        }
+        layer: ops.pebble.LayerDict = {
             "summary": "FastAPI demo service",
             "description": "pebble config layer for FastAPI demo server",
-            "services": {
-                self.pebble_service_name: {
-                    "override": "merge",
-                    "command": command,
-                    "environment": environment,
-                }
-            },
+            "services": {self.pebble_service_name: service},
         }
-        return ops.pebble.Layer(pebble_layer)
+        return ops.pebble.Layer(layer)
 
     def get_app_environment(self) -> dict[str, str]:
         """Return a dictionary of environment variables for the application."""

--- a/examples/k8s-5-observe/tests/integration/test_charm.py
+++ b/examples/k8s-5-observe/tests/integration/test_charm.py
@@ -53,7 +53,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
     version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.
+    assert version == "2.1.0"  # Hardcoded for simplicity.
 
 
 @pytest.mark.juju_setup

--- a/examples/k8s-5-observe/tests/unit/test_charm.py
+++ b/examples/k8s-5-observe/tests/unit/test_charm.py
@@ -59,7 +59,7 @@ def test_pebble_layer(mock_version):
         leader=True,
     )
     state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
-    # Expected plan after Pebble ready with default config
+    # Expected plan after Pebble ready with default config.
     expected_plan = ops.pebble.Plan(ROCK_LAYER.to_dict())
     expected_plan.services["fastapi"].override = "merge"
 

--- a/examples/k8s-5-observe/tests/unit/test_charm.py
+++ b/examples/k8s-5-observe/tests/unit/test_charm.py
@@ -20,6 +20,24 @@ from ops import testing
 
 from charm import FastAPIDemoCharm
 
+# The default Pebble layer in the application image.
+# Defined in https://github.com/canonical/api_demo_server/blob/master/rockcraft.yaml
+ROCK_LAYER = ops.pebble.Layer(
+    {
+        "services": {
+            "fastapi": {
+                "override": "replace",
+                "summary": "FastAPI demo server",
+                "command": "/bin/uvicorn api_demo_server.app:app --host 0.0.0.0 --port 8000",
+                "startup": "enabled",
+                "environment": {"DEMO_SERVER_LOGFILE": "/tmp/demo_server.log"},
+                "on-success": "shutdown",
+                "on-failure": "shutdown",
+            }
+        },
+    }
+)
+
 
 def mock_get_version(port: int):
     """Get a mock version string without executing the workload code."""
@@ -33,25 +51,17 @@ def mock_version(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_pebble_layer(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         leader=True,
     )
     state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
     # Expected plan after Pebble ready with default config
-    expected_plan = {
-        "services": {
-            "fastapi-service": {
-                "override": "replace",
-                "summary": "fastapi demo",
-                "command": "uvicorn api_demo_server.app:app --host=0.0.0.0 --port=8000",
-                "startup": "enabled",
-                # Since the environment is empty, Layer.to_dict() will not
-                # include it.
-            }
-        }
-    }
+    expected_plan = ops.pebble.Plan(ROCK_LAYER.to_dict())
+    expected_plan.services["fastapi"].override = "merge"
 
     # Check that we have the plan we expected:
     assert state_out.get_container(container.name).plan == expected_plan
@@ -59,7 +69,7 @@ def test_pebble_layer(mock_version):
     assert state_out.unit_status == testing.BlockedStatus("Waiting for database relation")
     # Check the service was started:
     assert (
-        state_out.get_container(container.name).service_statuses["fastapi-service"]
+        state_out.get_container(container.name).service_statuses["fastapi"]
         == ops.pebble.ServiceStatus.ACTIVE
     )
     # Check the workload version is set:
@@ -68,25 +78,24 @@ def test_pebble_layer(mock_version):
 
 def test_config_changed(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         config={"server-port": 8080},
         leader=True,
     )
     state_out = ctx.run(ctx.on.config_changed(), state_in)
-    command = (
-        state_out.get_container(container.name)
-        .layers["fastapi_demo"]
-        .services["fastapi-service"]
-        .command
-    )
-    assert "--port=8080" in command
+    command = state_out.get_container(container.name).plan.services["fastapi"].command
+    assert "--port 8080" in command
 
 
 def test_config_changed_invalid_port(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         config={"server-port": 22},
@@ -110,7 +119,9 @@ def test_relation_data(mock_version):
             "password": "bar",
         },
     )
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         relations={relation},
@@ -119,9 +130,8 @@ def test_relation_data(mock_version):
 
     state_out = ctx.run(ctx.on.relation_changed(relation), state_in)
 
-    assert state_out.get_container(container.name).layers["fastapi_demo"].services[
-        "fastapi-service"
-    ].environment == {
+    assert state_out.get_container(container.name).plan.services["fastapi"].environment == {
+        **ROCK_LAYER.services["fastapi"].environment,
         "DEMO_SERVER_DB_HOST": "example.com",
         "DEMO_SERVER_DB_PORT": "5432",
         "DEMO_SERVER_DB_USER": "foo",
@@ -131,7 +141,9 @@ def test_relation_data(mock_version):
 
 def test_no_database_blocked(mock_version):
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         leader=True,
@@ -154,7 +166,9 @@ def test_get_db_info_action():
             "password": "bar",
         },
     )
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         relations={relation},
@@ -181,7 +195,9 @@ def test_get_db_info_action_show_password():
             "password": "bar",
         },
     )
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(
+        name="demo-server", can_connect=True, layers={"rock": ROCK_LAYER}
+    )
     state_in = testing.State(
         containers={container},
         relations={relation},


### PR DESCRIPTION
This PR updates the K8s tutorial and example charms to use version 2 of the demo server image, which is built as a rock. The rock is defined here: https://github.com/canonical/api_demo_server/blob/master/rockcraft.yaml

Switching to a rock lets us take advantage of the baked-in Pebble layer.

- `k8s-1-minimal` doesn't need to add a layer. The unit tests reference the rock's layer and verify that Pebble's plan exactly matches that layer. Notable changes to **[Create a minimal Kubernetes charm](https://canonical-juju-ops--2649.com.readthedocs.build/2649/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm/)**:
    - Added an explanation of the rock and its layer. See the text after `_on_demo_server_pebble_ready` is defined.
    - Explained when you'd be able to use `testing.layer_from_rockcraft`. See the text after the unit tests are written.

- `k8s-2-configurable` is now the first charm that adds a layer to the workload container, so that we can redefine `command`. Notable changes to **[Make your charm configurable](https://canonical-juju-ops--2649.com.readthedocs.build/2649/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/make-your-charm-configurable/)**:
    - Define `_get_pebble_layer` before `_replan_workload`.
    - Explained about `override: merge`. See the text after `_get_pebble_layer` is defined.
    - Update the `test_pebble_layer` test so that it expects `override: merge` in Pebble's plan.  See the beginning of the "Write unit tests" section.

- `k8s-3-configurable` extends the layer construction, so that we can add to `environment`. Notable change to **[Integrate your charm with PostgreSQL](https://canonical-juju-ops--2649.com.readthedocs.build/2649/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql/)**:
    - Explained what `override: merge` does to `environment`. See the note after `_get_pebble_layer` is updated.

    <mark>To review the changes to `k8s-3-configurable` in isolation, look at [these commits](https://github.com/canonical/operator/pull/2649/changes/BASE..74f664a580fef32ed15e53c61508ea487b3dd82d).</mark>

As I was working on the changes, I did some cleanup in **[Study your application](https://canonical-juju-ops--2649.com.readthedocs.build/2649/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/study-your-application/)** -- from "Structure" onward.