### PR TITLE
fix: use juju.wait for workload version tests in k8s tutorial

### DIFF
--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -510,8 +510,8 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.
+    expected_version = "1.0.4"  # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == expected_version)
 ```
 
 These tests depend on two fixtures:

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/integrate-your-charm-with-postgresql.md
@@ -545,6 +545,11 @@ PASSED
 ```text
 tests/integration/test_charm.py::test_workload_version_is_set
 ...
+INFO     jubilant.wait:_juju.py:1491 wait: status changed:
+- .apps['fastapi-demo'].units['fastapi-demo/0'].juju_status.current = 'executing'
+- .apps['fastapi-demo'].units['fastapi-demo/0'].juju_status.message = 'running demo-server-pebble-ready hook'
++ .apps['fastapi-demo'].units['fastapi-demo/0'].juju_status.current = 'idle'
++ .apps['fastapi-demo'].version = '1.0.4'
 PASSED
 ```
 

--- a/examples/k8s-1-minimal/tests/integration/test_charm.py
+++ b/examples/k8s-1-minimal/tests/integration/test_charm.py
@@ -43,4 +43,5 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    juju.wait(lambda status: status.apps[APP_NAME].version == "1.0.4")  # Hardcoded for simplicity.
+    expected_version = "1.0.4"  # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == expected_version)

--- a/examples/k8s-1-minimal/tests/integration/test_charm.py
+++ b/examples/k8s-1-minimal/tests/integration/test_charm.py
@@ -43,5 +43,4 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == '1.0.4') # Hardcoded for simplicity.

--- a/examples/k8s-1-minimal/tests/integration/test_charm.py
+++ b/examples/k8s-1-minimal/tests/integration/test_charm.py
@@ -43,4 +43,4 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    juju.wait(lambda status: status.apps[APP_NAME].version == '1.0.4') # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == "1.0.4")  # Hardcoded for simplicity.

--- a/examples/k8s-2-configurable/tests/integration/test_charm.py
+++ b/examples/k8s-2-configurable/tests/integration/test_charm.py
@@ -43,4 +43,5 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    juju.wait(lambda status: status.apps[APP_NAME].version == "1.0.4")  # Hardcoded for simplicity.
+    expected_version = "1.0.4"  # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == expected_version)

--- a/examples/k8s-2-configurable/tests/integration/test_charm.py
+++ b/examples/k8s-2-configurable/tests/integration/test_charm.py
@@ -43,5 +43,4 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == '1.0.4') # Hardcoded for simplicity.

--- a/examples/k8s-2-configurable/tests/integration/test_charm.py
+++ b/examples/k8s-2-configurable/tests/integration/test_charm.py
@@ -43,4 +43,4 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    juju.wait(lambda status: status.apps[APP_NAME].version == '1.0.4') # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == "1.0.4")  # Hardcoded for simplicity.

--- a/examples/k8s-3-postgresql/tests/integration/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/integration/test_charm.py
@@ -48,7 +48,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    juju.wait(lambda status: status.apps[APP_NAME].version == '1.0.4') # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == "1.0.4")  # Hardcoded for simplicity.
 
 
 @pytest.mark.juju_setup

--- a/examples/k8s-3-postgresql/tests/integration/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/integration/test_charm.py
@@ -48,7 +48,8 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    juju.wait(lambda status: status.apps[APP_NAME].version == "1.0.4")  # Hardcoded for simplicity.
+    expected_version = "1.0.4"  # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == expected_version)
 
 
 @pytest.mark.juju_setup

--- a/examples/k8s-3-postgresql/tests/integration/test_charm.py
+++ b/examples/k8s-3-postgresql/tests/integration/test_charm.py
@@ -48,8 +48,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == '1.0.4') # Hardcoded for simplicity.
 
 
 @pytest.mark.juju_setup

--- a/examples/k8s-4-action/tests/integration/test_charm.py
+++ b/examples/k8s-4-action/tests/integration/test_charm.py
@@ -48,7 +48,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    juju.wait(lambda status: status.apps[APP_NAME].version == '1.0.4') # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == "1.0.4")  # Hardcoded for simplicity.
 
 
 @pytest.mark.juju_setup

--- a/examples/k8s-4-action/tests/integration/test_charm.py
+++ b/examples/k8s-4-action/tests/integration/test_charm.py
@@ -48,7 +48,8 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    juju.wait(lambda status: status.apps[APP_NAME].version == "1.0.4")  # Hardcoded for simplicity.
+    expected_version = "1.0.4"  # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == expected_version)
 
 
 @pytest.mark.juju_setup

--- a/examples/k8s-4-action/tests/integration/test_charm.py
+++ b/examples/k8s-4-action/tests/integration/test_charm.py
@@ -48,8 +48,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == '1.0.4') # Hardcoded for simplicity.
 
 
 @pytest.mark.juju_setup

--- a/examples/k8s-5-observe/tests/integration/test_charm.py
+++ b/examples/k8s-5-observe/tests/integration/test_charm.py
@@ -52,8 +52,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    version = juju.status().apps[APP_NAME].version
-    assert version == "1.0.4"  # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == '1.0.4') # Hardcoded for simplicity.
 
 
 @pytest.mark.juju_setup

--- a/examples/k8s-5-observe/tests/integration/test_charm.py
+++ b/examples/k8s-5-observe/tests/integration/test_charm.py
@@ -52,7 +52,8 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    juju.wait(lambda status: status.apps[APP_NAME].version == "1.0.4")  # Hardcoded for simplicity.
+    expected_version = "1.0.4"  # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == expected_version)
 
 
 @pytest.mark.juju_setup

--- a/examples/k8s-5-observe/tests/integration/test_charm.py
+++ b/examples/k8s-5-observe/tests/integration/test_charm.py
@@ -52,7 +52,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Verify that the workload version has been set."""
-    juju.wait(lambda status: status.apps[APP_NAME].version == '1.0.4') # Hardcoded for simplicity.
+    juju.wait(lambda status: status.apps[APP_NAME].version == "1.0.4")  # Hardcoded for simplicity.
 
 
 @pytest.mark.juju_setup


### PR DESCRIPTION
Fixes https://github.com/canonical/operator/issues/2646

This PR fixes the `test_workload_version_set` integration tests in the Example Charms in `example/k8-*`

## The bug

From Chapter 3 onward, `test_deploy` waits for the charm to block, which happens immediately on the first config-changed event, as there is no database yet. This is before Pebble is ready. Then the tests move on to `test_workload_version_is_set`, which fails because Pebble is still not ready.

You can see it in the CI run https://github.com/canonical/operator/actions/runs/29348881449/job/87139670139#step:9:79 

```
tests/integration/test_charm.py::test_deploy 
...
INFO     jubilant.wait:_juju.py:1491 wait: status changed:
- .apps['fastapi-demo'].app_status.current = 'waiting'
- .apps['fastapi-demo'].app_status.message = 'installing agent'
- .apps['fastapi-demo'].units['fastapi-demo/0'].workload_status.current = 'waiting'
- .apps['fastapi-demo'].units['fastapi-demo/0'].workload_status.message = 'installing agent'
- .apps['fastapi-demo'].units['fastapi-demo/0'].juju_status.current = 'allocating'
+ .apps['fastapi-demo'].app_status.current = 'blocked'
+ .apps['fastapi-demo'].app_status.message = 'Waiting for database relation'
+ .apps['fastapi-demo'].units['fastapi-demo/0'].workload_status.current = 'blocked'
+ .apps['fastapi-demo'].units['fastapi-demo/0'].workload_status.message = 'Waiting for database relation'
...
PASSED
tests/integration/test_charm.py::test_workload_version_is_set 
-------------------------------- live log call ---------------------------------
INFO     jubilant:_juju.py:398 cli: juju status --model jubilant-0a5d413e-test-charm --format json
FAILED
tests/integration/test_charm.py::test_database_integration 
```

## Why this happened. 

In https://github.com/canonical/operator/pull/2638, I changed the order of `test_workload_version_is_set` to before `test_database_integration`. Previously, it ran after `test_database_integration`, so everything was okay.

## The fix

We wanted to make `test_workload_version_is_set` independent from `test_database_integration`. This is okay because the workload version depends on Pebble readiness, and not the database integration.

Therefore, I use `juju.wait` until the workload version is available from juju status. This fits nicely into how we use Jubilant in charm integration tests.

## I validated this on my fork

`test_workload_version_is_set` passed in CI run for Example Charm Integration Tests: https://github.com/tromai/operator/actions/runs/29554228387

I also validated that the CI still pass whether `test_workload_version_is_set` is before or after `test_database_integration`.