### PR TITLE
docs: remove log_cli and log_file ini options; keep them as cli arguments for integration tests

### DIFF
--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -477,7 +477,6 @@ Jubilant logs at three levels:
 ```toml
 [tool.pytest.ini_options]
 ...
-log_cli = true
 log_cli_level = "INFO"
 log_cli_format = "%(levelname)s %(name)s %(message)s"
 ```
@@ -497,7 +496,6 @@ INFO jubilant.wait [fastapi-demo/0] status changed: waiting (installing agent) -
 ```toml
 [tool.pytest.ini_options]
 ...
-log_cli = true
 log_cli_level = "DEBUG"
 log_cli_format = "%(asctime)s %(levelname)s %(name)s %(message)s"
 log_cli_date_format = "%Y-%m-%dT%H:%M:%SZ"
@@ -544,7 +542,7 @@ Sample output:
 + .apps['fastapi-demo'].units['fastapi-demo/0'].address = '10.1.0.108'
 ```
 
-You can also configure pytest logging options on the command line.
+You can also configure these options on the command line. If you don't see the live Jubilant logs, make sure the pytest command (for example, in `tox.ini`) has the `--log-cli-level=INFO` argument.
 
 See more: [pytest | How to manage logging](https://docs.pytest.org/en/stable/how-to/logging.html)
 
@@ -569,14 +567,18 @@ This is an ideal configuration for long-running integration tests (for example, 
 # Otherwise, that section will have DEBUG logs (coming from log_file_level).
 log_level = "INFO"
 
-log_cli = true
 log_cli_level = "INFO"
 log_cli_format = "%(levelname)s %(name)s %(message)s"
 
-log_file = "logs/verbose.log"
 log_file_level = "DEBUG"
 log_file_format = "%(asctime)s %(levelname)s %(name)s %(message)s"
 log_file_date_format = "%Y-%m-%dT%H:%M:%SZ"
+```
+
+Use the `--log-file` option from pytest to enable file logging:
+
+```text
+tox -e integration -- --log-file logs/verbose.log
 ```
 
 If you run the integration tests multiple times, `logs/verbose.log` only contains logs from the last pytest session. To use a separate file for each session, override `log_file` for each pytest invocation:
@@ -602,7 +604,7 @@ In CI, you can use `actions/upload-artifact` to make `logs/verbose.log` availabl
 
 ```yaml
   # In your integration test job
-  - run: tox -e integration
+  - run: tox -e integration -- --log-file logs/verbose.log
   - name: Upload logs
     if: ${{ !cancelled() }}
     uses: actions/upload-artifact@v7
@@ -624,7 +626,7 @@ In CI, you can use `--juju-dump-logs` with `actions/upload-artifact` to make `ju
 
 ```yaml
   # In your integration test job
-  - run: tox -e integration -- --juju-dump-logs logs
+  - run: tox -e integration -- --log-file logs/verbose.log --juju-dump-logs logs
   - name: Upload logs
     if: ${{ !cancelled() }}
     uses: actions/upload-artifact@v7

--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -474,14 +474,17 @@ Jubilant logs at three levels:
 
 ### Example of brief logging
 
+In `pyproject.toml`:
+
 ```toml
 [tool.pytest.ini_options]
 ...
-log_cli_level = "INFO"
 log_cli_format = "%(levelname)s %(name)s %(message)s"
 ```
 
-Sample output:
+Also check the `[testenv:integration]` environment in `tox.ini` to make sure the pytest command has `--log-cli-level=INFO`.
+
+Sample output of `tox -e integration`:
 
 ```text
 INFO jubilant cli: juju deploy --model jubilant-b3578475-test-charm ...
@@ -493,10 +496,11 @@ INFO jubilant.wait [fastapi-demo/0] status changed: waiting (installing agent) -
 
 ### Example of verbose logging
 
+In `pyproject.toml`:
+
 ```toml
 [tool.pytest.ini_options]
 ...
-log_cli_level = "DEBUG"
 log_cli_format = "%(asctime)s %(levelname)s %(name)s %(message)s"
 log_cli_date_format = "%Y-%m-%dT%H:%M:%SZ"
 ```
@@ -505,7 +509,9 @@ The timestamp format follows ISO 8601.
 
 See more: {external+python:ref}`strftime() and strptime() behavior <strftime-strptime-behavior>`
 
-Sample output:
+Also modify the `[testenv:integration]` environment in `tox.ini` so that the pytest command has `--log-cli-level=DEBUG`.
+
+Sample output of `tox -e integration`:
 
 ```text
 2026-07-15T09:42:15Z INFO jubilant cli: juju deploy --model jubilant-6966ceb1-test-charm ...
@@ -542,7 +548,7 @@ Sample output:
 + .apps['fastapi-demo'].units['fastapi-demo/0'].address = '10.1.0.108'
 ```
 
-You can also configure these options on the command line. If you don't see the live Jubilant logs, make sure the pytest command (for example, in `tox.ini`) has the `--log-cli-level=INFO` argument.
+You can also configure pytest logging options on the command line.
 
 See more: [pytest | How to manage logging](https://docs.pytest.org/en/stable/how-to/logging.html)
 
@@ -567,7 +573,6 @@ This is an ideal configuration for long-running integration tests (for example, 
 # Otherwise, that section will have DEBUG logs (coming from log_file_level).
 log_level = "INFO"
 
-log_cli_level = "INFO"
 log_cli_format = "%(levelname)s %(name)s %(message)s"
 
 log_file_level = "DEBUG"

--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -580,6 +580,8 @@ log_file_format = "%(asctime)s %(levelname)s %(name)s %(message)s"
 log_file_date_format = "%Y-%m-%dT%H:%M:%SZ"
 ```
 
+Also check the `[testenv:integration]` environment in `tox.ini` to make sure the pytest command has `--log-cli-level=INFO`.
+
 Use the `--log-file` option from pytest to enable file logging:
 
 ```text


### PR DESCRIPTION
In https://github.com/canonical/operator/pull/2619, I added the `Configure Jubilant logs` howto section. 

In this guide, I set `log_cli` and `log_file` in the `[tool.pytest.ini_options]` table in `pyproject.toml`.

- `log_cli = true` enables live logging for all pytest invocation.
- `log_file = <path>` enables file logging for all pytest invocation.

This works well for `tox -e integration`. However, as a side effect, `tox -e unit` emitted live logs from the charm's code. This was mentioned by @dwilding.

```
tests/unit/test_charm.py::test_one PASSED
tests/unit/test_charm.py::test_two 
------------------------- live log call -------------------------
ERROR <error_level_message>
PASSED
```

We don't want this behaviour in unit tests.

This PR fixes the howto guide:
- Remove `log_cli = true`, `log_cli_level = <level>` and `log_file = <path>` from all suggested configs.
- Add instructions to enable them from the CLI:
    - `tox -e integration` provides `--log-cli-level=INFO` to the pytest command, which enable live logging.
    - `tox -e integration -- --log-file logs/verbose.log` will emit the verbose logs to `logs/verbose.log`. This requires changes to the GitHub Action workflow example.
    - For `juju debug-log` from `pytest-jubilant` the command will be `tox -e integration -- --log-file logs/verbose.log --juju-dump-logs logs`. See a test run [here](https://github.com/tromai/api-demo-server/actions/runs/29784841172/job/88494128435#step:6:1)
    
[Preview](https://canonical-juju-ops--2654.com.readthedocs.build/2654/howto/write-integration-tests-for-a-charm/#configure-jubilant-logs)