### PR TITLE
docs: (don't merge) snapshot docs build before #2649

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 # Ops documentation
 
+<!-- Don't merge this branch into main. -->
+
 ```{toctree}
 :maxdepth: 2
 :hidden: true


### PR DESCRIPTION
The purpose of this PR is to build a snapshot of the docs before I merge #2649. People who are already working through the K8s tutorial need to continue on the existing version of the tutorial, otherwise their code will break.

Don't merge. Don't update branch. Close after a few weeks.