### PR TITLE
fix: compare full event paths when skipping duplicate notices

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -849,7 +849,7 @@ class Framework(Object):
                 # The notices all have paths that include [id] at the end. If one
                 # was somehow missing, then the split would be the empty string and
                 # match anyway.
-                or existing_event_path.split('[')[0] != event_path.split('[')[0]
+                or existing_event_path.rsplit('[', 1)[0] != event_path.rsplit('[', 1)[0]
             ):
                 continue
             # Check if the snapshot for this notice is the same.

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -846,9 +846,7 @@ class Framework(Object):
             if (
                 existing_observer_path != observer_path
                 or existing_method_name != method_name
-                # The notices all have paths that include [id] at the end. If one
-                # was somehow missing, then the split would be the empty string and
-                # match anyway.
+                # The notices all have paths that include [id] at the end.
                 or existing_event_path.rsplit('[', 1)[0] != event_path.rsplit('[', 1)[0]
             ):
                 continue

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -574,12 +574,11 @@ class TestFramework:
             def __init__(self, parent: ops.Object, key: str):
                 super().__init__(parent, key)
                 self.seen: list[str] = []
-                self.defer_next = 0
 
             def on_any(self, event: ops.EventBase):
+                first = len(self.seen) == 0
                 self.seen.append(event.handle.path)
-                if self.defer_next:
-                    self.defer_next -= 1
+                if first:
                     event.defer()
 
         pub1 = MyNotifier(framework, 'db1')
@@ -590,7 +589,6 @@ class TestFramework:
         framework.observe(pub1.gone, obs.on_any)
 
         # Defer the first event so that its notice stays in the queue.
-        obs.defer_next = 1
         pub1.ready.emit()
 
         # An event from a different (keyed) emitter instance and an event of a

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -576,9 +576,8 @@ class TestFramework:
                 self.seen: list[str] = []
 
             def on_any(self, event: ops.EventBase):
-                first = len(self.seen) == 0
                 self.seen.append(event.handle.path)
-                if first:
+                if len(self.seen) == 1:
                     event.defer()
 
         pub1 = MyNotifier(framework, 'db1')
@@ -597,7 +596,11 @@ class TestFramework:
         pub2.ready.emit()
         pub1.gone.emit()
 
-        assert len(obs.seen) == 3, obs.seen
+        assert obs.seen == [
+            'MyNotifier[db1]/ready[1]',
+            'MyNotifier[db2]/ready[2]',
+            'MyNotifier[db1]/gone[3]',
+        ]
 
     def test_two_observers_one_deferring(self, request: pytest.FixtureRequest):
         framework = create_framework(request)

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -557,6 +557,50 @@ class TestFramework:
         assert len(notices_for_observer(1)) == 0
         assert len(notices_for_observer(2)) == 4
 
+    def test_repeated_defer_distinct_events_not_skipped(self, request: pytest.FixtureRequest):
+        framework = create_framework(request)
+
+        class ReadyEvent(ops.EventBase):
+            pass
+
+        class GoneEvent(ops.EventBase):
+            pass
+
+        class MyNotifier(ops.Object):
+            ready = ops.EventSource(ReadyEvent)
+            gone = ops.EventSource(GoneEvent)
+
+        class MyObserver(ops.Object):
+            def __init__(self, parent: ops.Object, key: str):
+                super().__init__(parent, key)
+                self.seen: list[str] = []
+                self.defer_next = 0
+
+            def on_any(self, event: ops.EventBase):
+                self.seen.append(event.handle.path)
+                if self.defer_next:
+                    self.defer_next -= 1
+                    event.defer()
+
+        pub1 = MyNotifier(framework, 'db1')
+        pub2 = MyNotifier(framework, 'db2')
+        obs = MyObserver(framework, 'obs')
+        framework.observe(pub1.ready, obs.on_any)
+        framework.observe(pub2.ready, obs.on_any)
+        framework.observe(pub1.gone, obs.on_any)
+
+        # Defer the first event so that its notice stays in the queue.
+        obs.defer_next = 1
+        pub1.ready.emit()
+
+        # An event from a different (keyed) emitter instance and an event of a
+        # different kind share the observer method and an empty snapshot, but
+        # they are not duplicates of the queued notice and must be delivered.
+        pub2.ready.emit()
+        pub1.gone.emit()
+
+        assert len(obs.seen) == 3, obs.seen
+
     def test_two_observers_one_deferring(self, request: pytest.FixtureRequest):
         framework = create_framework(request)
 


### PR DESCRIPTION
The dedup check in `Framework._event_is_in_storage()` compared notice paths truncated at the first `[`, which erases the emitter's key and the event kind for events emitted by keyed objects. While one such event sat deferred, distinct events (a different instance, or a different event kind) with equal snapshots and the same observer method were skipped as duplicates and lost.

This changes the comparison to strip only the trailing `[id]`, matching the intent described in the comment above it.

Added a regression test with two keyed emitters and two event kinds sharing one observer: it fails before the change (only 1 of 3 events delivered, `assert 1 == 3`) and passes after. The full `test/test_framework.py` suite passes (100/100).

Fixes https://github.com/canonical/operator/issues/2683