### PR TITLE
docs: reword text that vale 3.17 flags as misspelled

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -6,6 +6,7 @@ borescope
 breakpoint
 callables
 Canonical's
+Charmlibs
 configurator
 cosl
 databag

--- a/docs/explanation/charm-maturity.md
+++ b/docs/explanation/charm-maturity.md
@@ -57,7 +57,7 @@ Submit any newly-proposed public interfaces for review, to ensure that:
 - Interface names and structure are consistent with the charming ecosystem.
 - Tests cover integration with the applications consuming or providing the relations.
 
-> See more: [Charm libraries documentation](https://canonical.com/juju/docs/charmlibs/)
+> See more: [Charmlibs documentation](https://canonical.com/juju/docs/charmlibs/)
 
 ### The charm respects the Juju proxy options
 

--- a/docs/explanation/charm-maturity.md
+++ b/docs/explanation/charm-maturity.md
@@ -57,7 +57,7 @@ Submit any newly-proposed public interfaces for review, to ensure that:
 - Interface names and structure are consistent with the charming ecosystem.
 - Tests cover integration with the applications consuming or providing the relations.
 
-> See more: [Charmlibs documentation](https://canonical.com/juju/docs/charmlibs/)
+> See more: [Charm libraries documentation](https://canonical.com/juju/docs/charmlibs/)
 
 ### The charm respects the Juju proxy options
 

--- a/docs/explanation/versions.md
+++ b/docs/explanation/versions.md
@@ -39,7 +39,7 @@ Juju releases new minor versions approximately every 3 months, which are support
 
 Ops releases new minor versions approximately once per month. Major versions are supported with security fixes for one year from the latest release. To receive bug and security fixes within a major version, charms must update to the latest minor release within that major version. Long Term Support (LTS) releases receive 5 years of support and up to 10 additional years of [extended support](https://ubuntu.com/security/esm).
 
-> See more: [Ops support time frames](https://github.com/canonical/operator/blob/main/SECURITY.md)
+> See more: [Ops support commitments](https://github.com/canonical/operator/blob/main/SECURITY.md)
 
 ### Juju
 

--- a/docs/explanation/versions.md
+++ b/docs/explanation/versions.md
@@ -39,7 +39,7 @@ Juju releases new minor versions approximately every 3 months, which are support
 
 Ops releases new minor versions approximately once per month. Major versions are supported with security fixes for one year from the latest release. To receive bug and security fixes within a major version, charms must update to the latest minor release within that major version. Long Term Support (LTS) releases receive 5 years of support and up to 10 additional years of [extended support](https://ubuntu.com/security/esm).
 
-> See more: [Ops support timeframes](https://github.com/canonical/operator/blob/main/SECURITY.md)
+> See more: [Ops support time frames](https://github.com/canonical/operator/blob/main/SECURITY.md)
 
 ### Juju
 

--- a/docs/howto/manage-interfaces.md
+++ b/docs/howto/manage-interfaces.md
@@ -354,7 +354,7 @@ cd path/to/my-fancy-database-operator
 
 Create a `conftest.py` file under `tests/interface`:
 
-```text
+```shell
 mkdir ./tests/interface
 touch ./tests/interface/conftest.py
 ```

--- a/docs/howto/manage-interfaces.md
+++ b/docs/howto/manage-interfaces.md
@@ -354,8 +354,10 @@ cd path/to/my-fancy-database-operator
 
 Create a `conftest.py` file under `tests/interface`:
 
-> mkdir ./tests/interface
-> touch ./tests/interface/conftest.py
+```text
+mkdir ./tests/interface
+touch ./tests/interface/conftest.py
+```
 
 Write in `conftest.py`:
 

--- a/docs/howto/migrate/migrate-from-a-hooks-based-charm.md
+++ b/docs/howto/migrate/migrate-from-a-hooks-based-charm.md
@@ -312,7 +312,7 @@ The fact is, hooks charms can be written in Assembly, or any other language, so 
 
 Ops charms, on the other hand, are Python charms. As such, even though Ops is not especially large in and of itself, Ops charms bring a virtual environment with them. That makes the resulting charm package somewhat heavier. That might be a consideration when the charm target is a resource-constrained system.
 
-### Todo's / disclaimers
+### Remaining work and disclaimers
 
 
 Above, the `website` relation has not been tested; implementing the `Requires` part of it is also left as an exercise to the reader.


### PR DESCRIPTION
Vale 3.17 (CI installs the latest matching `vale~=3.13`, while cached local venvs may still have 3.13) spellchecks link text, `>` prompt blocks, and possessives in headings, which 3.13 skipped. Reword rather than extend the custom wordlist.