### PR TITLE
ci: switch example charm integration tests to Concierge `k8s` preset

### DIFF
--- a/.github/workflows/example-charm-integration-tests.yaml
+++ b/.github/workflows/example-charm-integration-tests.yaml
@@ -28,6 +28,7 @@ jobs:
         run: sudo snap install --classic concierge
       - name: Prepare for deploying machine charms
         run: sudo concierge prepare -p machine
+        timeout-minutes: 90  # Abandon the job if the GHA runner gets stuck.
       - name: Pack charm
         run: |
           cd ${{ matrix.dir }}
@@ -66,7 +67,7 @@ jobs:
         # regularly fails on slow GHA runners with `unable to contact api server
         # after 60 attempts` because the default --bootstrap-timeout is too short.
         run: sudo concierge prepare -c .github/integration/concierge-k8s.yaml
-        timeout-minutes: 90
+        timeout-minutes: 90  # Abandon the job if the GHA runner gets stuck.
       - name: Fetch any charmlibs
         run: |
           cd ${{ matrix.dir }}

--- a/.github/workflows/example-charm-integration-tests.yaml
+++ b/.github/workflows/example-charm-integration-tests.yaml
@@ -61,7 +61,11 @@ jobs:
       - name: Install Concierge
         run: sudo snap install --classic concierge
       - name: Prepare for deploying K8s charms
-        run: sudo concierge prepare -p microk8s
+        # .github/integration/concierge-k8s.yaml mirrors the upstream concierge
+        # k8s preset and adds juju.extra-bootstrap-args: `juju bootstrap`
+        # regularly fails on slow GHA runners with `unable to contact api server
+        # after 60 attempts` because the default --bootstrap-timeout is too short.
+        run: sudo concierge prepare -c .github/integration/concierge-k8s.yaml
       - name: Fetch any charmlibs
         run: |
           cd ${{ matrix.dir }}

--- a/.github/workflows/example-charm-integration-tests.yaml
+++ b/.github/workflows/example-charm-integration-tests.yaml
@@ -66,6 +66,7 @@ jobs:
         # regularly fails on slow GHA runners with `unable to contact api server
         # after 60 attempts` because the default --bootstrap-timeout is too short.
         run: sudo concierge prepare -c .github/integration/concierge-k8s.yaml
+        timeout-minutes: 90
       - name: Fetch any charmlibs
         run: |
           cd ${{ matrix.dir }}


### PR DESCRIPTION
The integration tests for our COS-enabled K8s charm (k8s-5-observe) keep failing in CI. For example, https://github.com/canonical/operator/actions/runs/32157684730.

The root cause is an IP range issue with microk8s. See https://github.com/canonical/concierge/issues/251.

This PR switches to Canonical K8s, to match our K8s tutorial. I'm using the same custom `k8s` Concierge preset as elsewhere in our CI. Our custom preset allows 30 mins for bootstrap to complete.

In addition, I'm setting a 90 min timeout for the whole Concierge job. During testing yesterday, I observed several runs that spun indefinitely - presumably a transient issue with the runner, as the problem didn't appear today. The problem didn't seem to be related to the Concierge preset, so I've set the same timeout for the machine charm job.

**[Passing run in my fork](https://github.com/dwilding/operator/actions/runs/32230089789)**. The k8s-4-action failure is unrelated; it's related to https://github.com/canonical/operator/pull/2689.