### PR TITLE
fix: don't pass a message when converting an unknown status by name

### DIFF
--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1483,7 +1483,10 @@ class _EntityStatus:
         message: str = '',
     ) -> _EntityStatus:
         """Convert the status name, such as 'active', to the class, such as ActiveStatus."""
-        # Note that this won't work for UnknownStatus.
+        if name == 'unknown':
+            # Like ops.StatusBase.from_name, unknown is special: it has no
+            # message, so it must not be passed one.
+            return UnknownStatus()
         # All subclasses have a default 'name' attribute, but the type checker can't tell that.
         return cls._entity_statuses[name](message=message)  # type:ignore
 

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -1482,10 +1482,19 @@ class _EntityStatus:
         name: _RawStatusLiteral,
         message: str = '',
     ) -> _EntityStatus:
-        """Convert the status name, such as 'active', to the class, such as ActiveStatus."""
+        """Convert the status name, such as 'active', to the class, such as ActiveStatus.
+
+        If ``name`` is "unknown", ``message`` is ignored, because unknown status
+        does not have an associated message, and a warning is issued if it is
+        not empty.
+        """
         if name == 'unknown':
-            # Like ops.StatusBase.from_name, unknown is special: it has no
-            # message, so it must not be passed one.
+            # UnknownStatus has no message. We ignore message, following ops.StatusBase.from_name.
+            if message:
+                warnings.warn(
+                    f'Unknown status has no message; ignoring {message!r}.',
+                    stacklevel=2,
+                )
             return UnknownStatus()
         # All subclasses have a default 'name' attribute, but the type checker can't tell that.
         return cls._entity_statuses[name](message=message)  # type:ignore

--- a/testing/tests/test_e2e/test_status.py
+++ b/testing/tests/test_e2e/test_status.py
@@ -178,6 +178,23 @@ def test_status_comparison(status: ops.StatusBase):
         WaitingStatus('bar'),
         BlockedStatus('baz'),
         MaintenanceStatus('qux'),
+        ErrorStatus('fiz'),
+        UnknownStatus(),
+    ),
+)
+def test_status_from_ops_round_trip(status: ops.StatusBase):
+    from scenario.state import _EntityStatus
+
+    assert _EntityStatus.from_ops(status._to_ops()) == status  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    'status',
+    (
+        ActiveStatus('foo'),
+        WaitingStatus('bar'),
+        BlockedStatus('baz'),
+        MaintenanceStatus('qux'),
     ),
 )
 def test_status_success(status: ops.StatusBase):

--- a/testing/tests/test_e2e/test_status.py
+++ b/testing/tests/test_e2e/test_status.py
@@ -13,6 +13,7 @@ from scenario.state import (
     MaintenanceStatus,
     UnknownStatus,
     WaitingStatus,
+    _EntityStatus,
 )
 
 import ops
@@ -183,8 +184,6 @@ def test_status_comparison(status: ops.StatusBase):
     ),
 )
 def test_status_from_ops_round_trip(status: ops.StatusBase):
-    from scenario.state import _EntityStatus
-
     assert _EntityStatus.from_ops(status._to_ops()) == status  # type: ignore[attr-defined]
 
 

--- a/testing/tests/test_e2e/test_status.py
+++ b/testing/tests/test_e2e/test_status.py
@@ -188,6 +188,27 @@ def test_status_from_ops_round_trip(status: ops.StatusBase):
 
 
 @pytest.mark.parametrize(
+    ('name', 'message', 'expected'),
+    (
+        ('active', 'foo', ActiveStatus('foo')),
+        ('waiting', 'bar', WaitingStatus('bar')),
+        ('blocked', 'baz', BlockedStatus('baz')),
+        ('maintenance', 'qux', MaintenanceStatus('qux')),
+        ('error', 'fiz', ErrorStatus('fiz')),
+        ('unknown', '', UnknownStatus()),
+    ),
+)
+def test_from_status_name(name: str, message: str, expected: ops.StatusBase):
+    assert _EntityStatus.from_status_name(name, message) == expected  # type: ignore[arg-type]
+
+
+def test_unknown_status_from_name_with_message_warns():
+    with pytest.warns(UserWarning, match='no message'):
+        status = _EntityStatus.from_status_name('unknown', 'ignored')
+    assert status == UnknownStatus()
+
+
+@pytest.mark.parametrize(
     'status',
     (
         ActiveStatus('foo'),


### PR DESCRIPTION
_EntityStatus.from_status_name('unknown', ...) tried to construct UnknownStatus(message=...), but UnknownStatus.__init__ takes no arguments, so any round trip through from_ops() (e.g. _EntityStatus.from_ops(some_status._to_ops())) raised a TypeError.

Special-case 'unknown' in from_status_name to construct UnknownStatus() directly, mirroring ops.StatusBase.from_name, which already documents and implements this same special case: unknown status has no message to preserve. The other status types all accept a message, so no other special-casing is needed.

In Ops you wouldn't create an Unknown status, because you can't set it. But in Scenario you might create one to indicate a starting status.