### PR TITLE
docs: recommend spread directly, rather than charmcraft test

### DIFF
--- a/docs/howto/set-up-continuous-integration-for-a-charm.md
+++ b/docs/howto/set-up-continuous-integration-for-a-charm.md
@@ -127,7 +127,7 @@ Your charm needs two things:
 
 Adding a new `task.yaml`, which should run a single new `test_*.py` module, automatically adds a new CI job.
 
-`charmcraft init --profile test-machine` and `--profile test-kubernetes` generate both files for you, but you don't need those profiles: any charm can add a `spread.yaml` and a `spread` directory by hand. For a configuration you can copy, see the [httpbin-demo charm](https://github.com/canonical/operator/tree/main/examples/httpbin-demo).
+For a configuration you can copy, see the [httpbin-demo charm](https://github.com/canonical/operator/tree/main/examples/httpbin-demo).
 
 Charmcraft also has an experimental `charmcraft test` command, which is a wrapper around spread. It's not finalised yet, so we suggest using spread directly for now, and moving to the wrapper when it's stable. The workflow below uses `charmcraft test` because it installs and configures spread for you.
 

--- a/docs/howto/set-up-continuous-integration-for-a-charm.md
+++ b/docs/howto/set-up-continuous-integration-for-a-charm.md
@@ -116,18 +116,18 @@ The "Upload logs" step assumes that your integration tests use Jubilant together
 This single job runs every integration test module sequentially. As your suite grows, split tests across modules and run each module in its own CI job — see {ref}`write-integration-tests-for-a-charm-split-across-modules`.
 
 (set-up-ci-spread)=
-## Run integration tests in parallel with spread
+## Run integration tests in parallel with Spread
 
-We recommend running integration tests with [spread](https://github.com/canonical/spread), which runs each test module as its own job. Total wall-clock time is then bounded by the slowest module rather than the sum of all modules.
+We recommend running integration tests with [Spread](https://github.com/canonical/spread), which runs each test module as its own job. Total time is then bounded by the slowest module rather than the sum of all modules.
 
 Your charm needs two things:
 
-- A spread configuration file called `spread.yaml`.
+- A Spread configuration file called `spread.yaml`.
 - One file `spread/integration/<module>/task.yaml` per test module.
 
 For a configuration you can copy, see the [httpbin-demo charm](https://github.com/canonical/operator/tree/main/examples/httpbin-demo).
 
-Charmcraft also has an experimental `charmcraft test` command, which is a wrapper around spread. It's not finalised yet, so we suggest using spread directly for now, and moving to the wrapper when it's stable. The workflow below uses `charmcraft test` because it installs and configures spread for you.
+Charmcraft also has an experimental `charmcraft test` command, which is a wrapper around Spread. We suggest using Spread directly until `charmcraft test` is finalised. The workflow below uses `charmcraft test` as a convenient way to install and configure Spread.
 
 A minimal workflow looks like:
 

--- a/docs/howto/set-up-continuous-integration-for-a-charm.md
+++ b/docs/howto/set-up-continuous-integration-for-a-charm.md
@@ -116,14 +116,20 @@ The "Upload logs" step assumes that your integration tests use Jubilant together
 This single job runs every integration test module sequentially. As your suite grows, split tests across modules and run each module in its own CI job — see {ref}`write-integration-tests-for-a-charm-split-across-modules`.
 
 (set-up-ci-charmcraft-test)=
-## Run integration tests in parallel with `charmcraft test`
+## Run integration tests in parallel with spread
 
-If you initialised your charm with `charmcraft init --profile test-machine` or `--profile test-kubernetes` (both currently experimental), your charm includes extra testing machinery:
+We recommend running integration tests with [spread](https://github.com/canonical/spread), which runs each test module as its own job. Total wall-clock time is then bounded by the slowest module rather than the sum of all modules.
 
-- A [spread](https://github.com/canonical/spread) configuration file called `spread.yaml`.
+Your charm needs two things:
+
+- A spread configuration file called `spread.yaml`.
 - One file `spread/integration/<module>/task.yaml` per test module.
 
-You can use `charmcraft test` in CI to run each module as its own matrix job, so total wall-clock time is bounded by the slowest module rather than the sum of all modules. Adding a new `task.yaml`, which should run a single new `test_*.py` module, automatically adds a new CI job.
+Adding a new `task.yaml`, which should run a single new `test_*.py` module, automatically adds a new CI job.
+
+`charmcraft init --profile test-machine` and `--profile test-kubernetes` generate both files for you, but you don't need those profiles: any charm can add a `spread.yaml` and a `spread` directory by hand. For a configuration you can copy, see the [httpbin-demo charm](https://github.com/canonical/operator/tree/main/examples/httpbin-demo).
+
+Charmcraft also has an experimental `charmcraft test` command, which is a wrapper around spread. It's not finalised yet, so we suggest using spread directly for now, and moving to the wrapper when it's stable. The workflow below uses `charmcraft test` because it installs and configures spread for you.
 
 A minimal workflow looks like:
 

--- a/docs/howto/set-up-continuous-integration-for-a-charm.md
+++ b/docs/howto/set-up-continuous-integration-for-a-charm.md
@@ -115,7 +115,7 @@ The "Upload logs" step assumes that your integration tests use Jubilant together
 
 This single job runs every integration test module sequentially. As your suite grows, split tests across modules and run each module in its own CI job — see {ref}`write-integration-tests-for-a-charm-split-across-modules`.
 
-(set-up-ci-charmcraft-test)=
+(set-up-ci-spread)=
 ## Run integration tests in parallel with spread
 
 We recommend running integration tests with [spread](https://github.com/canonical/spread), which runs each test module as its own job. Total wall-clock time is then bounded by the slowest module rather than the sum of all modules.

--- a/docs/howto/set-up-continuous-integration-for-a-charm.md
+++ b/docs/howto/set-up-continuous-integration-for-a-charm.md
@@ -125,8 +125,6 @@ Your charm needs two things:
 - A spread configuration file called `spread.yaml`.
 - One file `spread/integration/<module>/task.yaml` per test module.
 
-Adding a new `task.yaml`, which should run a single new `test_*.py` module, automatically adds a new CI job.
-
 For a configuration you can copy, see the [httpbin-demo charm](https://github.com/canonical/operator/tree/main/examples/httpbin-demo).
 
 Charmcraft also has an experimental `charmcraft test` command, which is a wrapper around spread. It's not finalised yet, so we suggest using spread directly for now, and moving to the wrapper when it's stable. The workflow below uses `charmcraft test` because it installs and configures spread for you.

--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -161,7 +161,7 @@ A common split:
 
 There are two main benefits to splitting. Firstly, it makes it easier to investigate test failures when they are more isolated. Secondly, it's much simpler to have parallel test execution, where each module runs as a separate job, so total wall-clock time is governed by the slowest module rather than the sum of all modules.
 
-`tox -e integration` runs every module sequentially on a single machine. `charmcraft test` will automatically run each task separately on your local machine, and you can set up a CI matrix (see {ref}`set-up-ci-integration`) that has the same behaviour in CI. Once done, adding a new `test_*.py` file and corresponding task.yaml then automatically adds a new CI job — no workflow changes needed.
+`tox -e integration` runs every module sequentially on a single machine. [spread](https://github.com/canonical/spread) runs each module as a separate task, both on your local machine and in a CI matrix (see {ref}`set-up-ci-integration`). Once done, adding a new `test_*.py` file and corresponding task.yaml then automatically adds a new CI job — no workflow changes needed.
 
 For real-world examples of split tests, see:
 

--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -161,7 +161,7 @@ A common split:
 
 There are two main benefits to splitting. Firstly, it makes it easier to investigate test failures when they are more isolated. Secondly, it's much simpler to have parallel test execution, where each module runs as a separate job, so total wall-clock time is governed by the slowest module rather than the sum of all modules.
 
-`tox -e integration` runs every module sequentially on a single machine. [spread](https://github.com/canonical/spread) runs each module as a separate task, both on your local machine and in a CI matrix (see {ref}`set-up-ci-integration`). Once done, adding a new `test_*.py` file and corresponding task.yaml then automatically adds a new CI job — no workflow changes needed.
+`tox -e integration` runs every module sequentially on a single machine. [Spread](https://github.com/canonical/spread) runs each module as a separate task, whether on your local machine or in a CI matrix (see {ref}`set-up-ci-spread`). Once done, adding a new `test_*.py` file and corresponding task.yaml then automatically adds a new CI job, with no workflow changes needed.
 
 For real-world examples of split tests, see:
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -540,7 +540,7 @@ The Juju model is destroyed at the end of the tests. If you want to run the test
 
 For a real charm, we recommend running integration tests with [spread](https://github.com/canonical/spread), so that each test module runs as its own task. Charmcraft has an experimental `charmcraft test` command that wraps spread and installs it for you, which is what we use here.
 
-If you're interested in trying `charmcraft test`, run the following command in your project directory:
+Run the following command in your project directory:
 
 ```text
 charmcraft init --profile test-kubernetes --force

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -536,9 +536,9 @@ The result should be similar to the following output:
 
 The Juju model is destroyed at the end of the tests. If you want to run the tests and keep the model for further exploration, see the example commands in [](#write-integration-tests-for-a-charm-run-your-tests). The `@pytest.mark.juju_setup` marker on `test_deploy` gives you the option of skipping this test on subsequent runs, for iterative testing on a deployed application.
 
-### Run tests with spread
+### Run tests with Spread
 
-For a real charm, we recommend running integration tests with [spread](https://github.com/canonical/spread), so that each test module runs as its own task. Charmcraft has an experimental `charmcraft test` command that wraps spread and installs it for you, which is what we use here.
+For a real charm, we recommend running integration tests with [Spread](https://github.com/canonical/spread), so that each test module runs as its own task. Charmcraft has an experimental `charmcraft test` command that wraps Spread and installs it for you, which is what we use here.
 
 Run the following command in your project directory:
 
@@ -546,16 +546,16 @@ Run the following command in your project directory:
 charmcraft init --profile test-kubernetes --force
 ```
 
-This creates the scaffolding of a spread configuration; the `--force` argument is needed because there are already files in the directory. Our [httpbin-demo charm](https://github.com/canonical/operator/tree/main/examples/httpbin-demo) has a more complete configuration, which you can replicate in your charm. Pay particular attention to:
+This creates the scaffolding of a Spread configuration; the `--force` argument is needed because there are already files in the directory. Our [httpbin-demo charm](https://github.com/canonical/operator/tree/main/examples/httpbin-demo) has a more complete configuration, which you can replicate in your charm. Pay particular attention to:
 
-- `spread.yaml` - Tells spread how to provision a clean environment for each run, using [Concierge](https://github.com/canonical/concierge) to bootstrap Juju and the cloud substrate.
+- `spread.yaml` - Tells Spread how to provision a clean environment for each run, using [Concierge](https://github.com/canonical/concierge) to bootstrap Juju and the cloud substrate.
 - The `spread` directory - Contains a file `integration/test_charm/task.yaml` that corresponds to `tests/integration/test_charm.py`.
 
 When you run `charmcraft test`, Charmcraft packs the charm, launches an LXD VM (or configures a CI runner), then invokes your pytest integration tests inside the VM.
 
-Because `charmcraft test` is experimental, its interface may still change. The `spread.yaml` and `task.yaml` files are the durable part: you can run them with spread directly, and they'll keep working if the wrapper changes.
+Because `charmcraft test` is experimental, its interface may still change. However, even if `charmcraft test` changes, you can continue to run your tests with Spread directly, using the same `spread.yaml` and `task.yaml`.
 
-It's also possible to set up CI so that each `tests/integration/test_*.py` module becomes its own spread job (fanned out as a parallel matrix). Adding a new test module automatically adds a new job. See {ref}`set-up-ci-spread`.
+It's also possible to set up CI so that each `tests/integration/test_*.py` module becomes its own Spread job (fanned out as a parallel matrix). Adding a new test module automatically adds a new job. See {ref}`set-up-ci-spread`.
 
 ## Review the final code
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -555,7 +555,7 @@ When you run `charmcraft test`, Charmcraft packs the charm, launches an LXD VM (
 
 Because `charmcraft test` is experimental, its interface may still change. The `spread.yaml` and `task.yaml` files are the durable part: you can run them with spread directly, and they'll keep working if the wrapper changes.
 
-It's also possible to set up CI so that each `tests/integration/test_*.py` module becomes its own spread job (fanned out as a parallel matrix). Adding a new test module automatically adds a new job. See {ref}`set-up-ci-charmcraft-test`.
+It's also possible to set up CI so that each `tests/integration/test_*.py` module becomes its own spread job (fanned out as a parallel matrix). Adding a new test module automatically adds a new job. See {ref}`set-up-ci-spread`.
 
 ## Review the final code
 

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -540,7 +540,7 @@ The Juju model is destroyed at the end of the tests. If you want to run the test
 
 For a real charm, we recommend running integration tests with [spread](https://github.com/canonical/spread), so that each test module runs as its own task. Charmcraft has an experimental `charmcraft test` command that wraps spread and installs it for you, which is what we use here.
 
-To generate a spread configuration, run the following command in your project directory:
+If you're interested in trying `charmcraft test`, run the following command in your project directory:
 
 ```text
 charmcraft init --profile test-kubernetes --force

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -536,11 +536,11 @@ The result should be similar to the following output:
 
 The Juju model is destroyed at the end of the tests. If you want to run the tests and keep the model for further exploration, see the example commands in [](#write-integration-tests-for-a-charm-run-your-tests). The `@pytest.mark.juju_setup` marker on `test_deploy` gives you the option of skipping this test on subsequent runs, for iterative testing on a deployed application.
 
-### Run tests with `charmcraft test`
+### Run tests with spread
 
-Charmcraft has an experimental command `charmcraft test` that uses [spread](https://github.com/canonical/spread) to run tests.
+For a real charm, we recommend running integration tests with [spread](https://github.com/canonical/spread), so that each test module runs as its own task. Charmcraft has an experimental `charmcraft test` command that wraps spread and installs it for you, which is what we use here.
 
-If you're interested in trying `charmcraft test`, run the following command in your project directory:
+To generate a spread configuration, run the following command in your project directory:
 
 ```text
 charmcraft init --profile test-kubernetes --force
@@ -552,6 +552,8 @@ This creates the scaffolding of a spread configuration; the `--force` argument i
 - The `spread` directory - Contains a file `integration/test_charm/task.yaml` that corresponds to `tests/integration/test_charm.py`.
 
 When you run `charmcraft test`, Charmcraft packs the charm, launches an LXD VM (or configures a CI runner), then invokes your pytest integration tests inside the VM.
+
+Because `charmcraft test` is experimental, its interface may still change. The `spread.yaml` and `task.yaml` files are the durable part: you can run them with spread directly, and they'll keep working if the wrapper changes.
 
 It's also possible to set up CI so that each `tests/integration/test_*.py` module becomes its own spread job (fanned out as a parallel matrix). Adding a new test module automatically adds a new job. See {ref}`set-up-ci-charmcraft-test`.
 


### PR DESCRIPTION
The integration testing docs presented `charmcraft test` as the way to run tests in parallel, with spread only appearing as a description of what the experimental `charmcraft init` test profiles generate. Since `charmcraft test` is a wrapper around spread and isn't finalised, the advice we want to be giving is to use spread, which is also what is currently recommended to charm teams.

* The CI how-to now recommends spread and drops the implication that you need the `charmcraft init` test profiles to get the parallel setup - any charm can add `spread.yaml` and a `spread` directory by hand.
* The workflow example still runs `charmcraft test`, since it installs and configures spread for you, but says that's why.
* The tutorial keeps `charmcraft test` for convenience, and notes that the `spread.yaml` and `task.yaml` files are the part that survives if the wrapper changes.