### PR TITLE
docs: point the interface docs at charmlibs

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -25,6 +25,7 @@ liveness
 manpages
 misconfiguration
 mitigations
+monorepo
 pathops
 Parca
 protobuf

--- a/docs/explanation/charm-relation-interfaces.md
+++ b/docs/explanation/charm-relation-interfaces.md
@@ -7,12 +7,12 @@ Interface definitions live in the [`interfaces` directory of the `charmlibs` mon
 
 ```{note}
 
-Interface definitions used to live in a standalone repository, `canonical/charm-relation-interfaces`, which was archived in November 2025. All interfaces have been migrated into the [`charmlibs` monorepo](https://github.com/canonical/charmlibs), where new interfaces and updates should now be contributed. The rendered interface reference is published at https://canonical.com/juju/docs/charmlibs/.
+Interface definitions used to live in a standalone repository, `canonical/charm-relation-interfaces`, which was archived in November 2025. All interfaces have been migrated into the [`charmlibs` monorepo](https://github.com/canonical/charmlibs), where new interfaces and updates should now be contributed. See https://canonical.com/juju/docs/charmlibs/ for more information.
 ```
 
-The purpose of consolidating interface definitions is to provide uniformity in the landscape of all possible relations and promote charm interoperability.
+The purpose of consolidating interface definitions is to provide and promote charm interoperability.
 
-Juju interfaces are untyped, which means that for Juju to think two charms can be integrated all it looks at is whether the interface names of the two endpoints you're trying to connect are the same string. But it might be that the two charms have different, incompatible implementations of two different relations that happen to have the same name.
+Juju interfaces are untyped, which means that for Juju to think two charms can be integrated all that is required is for the interface names of the two endpoints you're trying to connect to be the same string. But it might be that the two charms have different, incompatible implementations of two different relations that happen to have the same name.
 
 In order to prevent two separate charms from rolling their own relation with the same name, and prevent a sprawl of many subtly different interfaces with similar semantics and similar purposes, interface definitions are kept in a single, canonical location.
 
@@ -25,7 +25,7 @@ Conversely, if the charm you are developing needs some service (a database, an i
 There are three actors in play:
 
 * **the owner of the specification** of the interface, which also owns the tests that can be used to verify "does charm X 'really' support this interface?". This is the relevant interface directory in the [`charmlibs` monorepo](https://github.com/canonical/charmlibs).
-* **the owner of the implementation** of an interface. In practice, this often is the charm that owns the charm library with the reference implementation for an interface.
+* **the owner of the implementation** of an interface. In practice, this often is the team whose charm provides a workload implementing one side of the interface.
 * **the interface user**: a charm that wants to use the interface (either as requirer or as provider).
 
 The interface user needs the implementation (typically, the provider also happens to be the owner and so it already has the implementation). Interface libraries are published on PyPI as `charmlibs-interfaces-<interface name>` and can be imported as `charmlibs.interfaces.<interface name>`.
@@ -42,5 +42,3 @@ For each interface, the [`interfaces` directory in `charmlibs`](https://github.c
 - the **interface tests**: Python tests that can be run to verify that a charm complies with the interface specification (`interface/v<N>/tests/`).
 
 
-## Interface definitions on Charmhub
-Charmhub will, for all charms using the interface, verify that they implement it correctly (regardless of whether they use the 'official' implementation or they roll their own) in order to give the charm a happy checkmark on `charmhub.io`. In order to do that it will need to fetch the specification (from the `charmlibs` monorepo) *and* the charm repo, because we can't know what implementation they are using: we need the source code.

--- a/docs/explanation/charm-relation-interfaces.md
+++ b/docs/explanation/charm-relation-interfaces.md
@@ -3,11 +3,13 @@
 
 See also: {ref}`manage-interfaces`
 
-Interface definitions live in the [`interfaces` directory of the `charmlibs` monorepo](https://github.com/canonical/charmlibs/tree/main/interfaces). For each interface they record specifications, databag schemas, and interface tests for Juju relation interfaces. In other words, they are the source of truth for the data and behaviour of providers and requirers of relations.
+An interface definition records what a Juju relation interface means: the semantics that providers and requirers of the interface are expected to implement, and the schema of the data they exchange. In other words, it is the source of truth for the data and behaviour of both sides of a relation.
+
+Interface definitions are maintained in the [`charmlibs` monorepo](https://github.com/canonical/charmlibs). To browse the interfaces that already exist, see the [`charmlibs` documentation](https://canonical.com/juju/docs/charmlibs/).
 
 ```{note}
 
-Interface definitions used to live in a standalone repository, `canonical/charm-relation-interfaces`, which was archived in November 2025. All interfaces have been migrated into the [`charmlibs` monorepo](https://github.com/canonical/charmlibs), where new interfaces and updates should now be contributed. See https://canonical.com/juju/docs/charmlibs/ for more information.
+Interface definitions used to live in a standalone repository, `canonical/charm-relation-interfaces`, which was archived in November 2025. All interfaces have been migrated into `charmlibs`, where new interfaces and updates should now be contributed.
 ```
 
 The purpose of consolidating interface definitions is to provide and promote charm interoperability.
@@ -18,13 +20,11 @@ In order to prevent two separate charms from rolling their own relation with the
 
 ## Using interface definitions
 
-If you have a charm that provides a service, you should search the [`interfaces` directory in `charmlibs`](https://github.com/canonical/charmlibs/tree/main/interfaces) (or directly Charmhub in the future) and see if an interface exists already, or perhaps a similar one exists that lacks the semantics you need and can be extended to support it.
-
-Conversely, if the charm you are developing needs some service (a database, an ingress URL, an authentication endpoint...)  you should search the interface definitions to see if there is an interface you can use, and to find existing charms that provide it.
+If you have a charm that provides a service, you should check whether an interface for it exists already, or whether a similar one exists that lacks the semantics you need and can be extended to support it. Conversely, if the charm you are developing needs some service (a database, an ingress URL, an authentication endpoint...) you should check whether there is an interface you can use, and which charms provide it.
 
 There are three actors in play:
 
-* **the owner of the specification** of the interface, which also owns the tests that can be used to verify "does charm X 'really' support this interface?". This is the relevant interface directory in the [`charmlibs` monorepo](https://github.com/canonical/charmlibs).
+* **the owner of the specification** of the interface. This is the relevant interface definition in the [`charmlibs` monorepo](https://github.com/canonical/charmlibs).
 * **the owner of the implementation** of an interface. In practice, this often is the team whose charm provides a workload implementing one side of the interface.
 * **the interface user**: a charm that wants to use the interface (either as requirer or as provider).
 
@@ -32,13 +32,10 @@ The interface user needs the implementation (typically, the provider also happen
 
 The owner of the implementation needs the specification, to help check that the implementation is in fact compliant.
 
-## Repository structure
+## What an interface definition contains
 
-For each interface, the [`interfaces` directory in `charmlibs`](https://github.com/canonical/charmlibs/tree/main/interfaces) hosts a per-interface folder (for example, `interfaces/ingress/`), with the per-version specification under `interface/v<N>/`:
+For each interface, `charmlibs` records:
 
-- the **specification**: a semi-formal definition of the interface's semantics and what its implementations are expected to do, in terms of both the provider and the requirer (`interface/v<N>/README.md`).
-- a list of **reference charms**: the charms that implement this interface, typically the owner of the charm library providing the original implementation (`interface/v<N>/interface.yaml`).
-- the **schema**: pydantic models unambiguously defining the accepted unit and application databag contents for provider and requirer (`interface/v<N>/schema.py`).
-- the **interface tests**: Python tests that can be run to verify that a charm complies with the interface specification (`interface/v<N>/tests/`).
-
-
+- the **specification**: a semi-formal definition of the interface's semantics and what its implementations are expected to do, in terms of both the provider and the requirer.
+- a list of **reference charms**: the charms that implement this interface, typically the owner of the charm library providing the original implementation.
+- the **schema**: pydantic models unambiguously defining the accepted unit and application databag contents for provider and requirer.

--- a/docs/explanation/charm-relation-interfaces.md
+++ b/docs/explanation/charm-relation-interfaces.md
@@ -1,40 +1,46 @@
 (charm-relation-interfaces)=
-# Charm-relation-interfaces
+# Interface definitions
 
 See also: {ref}`manage-interfaces`
 
-[`charm-relation-interfaces`](https://github.com/canonical/charm-relation-interfaces) is a repository containing specifications, databag schemas and interface tests for Juju relation interfaces. In other words, it is the source of truth for data and behavior of providers and requirers of relations.
+Interface definitions live in the [`interfaces` directory of the `charmlibs` monorepo](https://github.com/canonical/charmlibs/tree/main/interfaces). For each interface they record specifications, databag schemas, and interface tests for Juju relation interfaces. In other words, they are the source of truth for the data and behaviour of providers and requirers of relations.
 
-The purpose of this project is to provide uniformity in the landscape of all possible relations and promote charm interoperability.
+```{note}
 
-Juju interfaces are untyped, which means that for juju to think two charms can be integrated all it looks at is whether the interface names of the two endpoints you're trying to connect are the same string. But it might be that the two charms have different, incompatible implementations of two different relations that happen to have the same name.
+Interface definitions used to live in a standalone repository, `canonical/charm-relation-interfaces`, which was archived in November 2025. All interfaces have been migrated into the [`charmlibs` monorepo](https://github.com/canonical/charmlibs), where new interfaces and updates should now be contributed. The rendered interface reference is published at https://canonical.com/juju/docs/charmlibs/.
+```
 
-In order to prevent two separate charms from rolling their own relation with the same name, and prevent a sprawl of many subtly different interfaces with similar semantics and similar purposes, we introduced `charm-relation-interfaces`.
+The purpose of consolidating interface definitions is to provide uniformity in the landscape of all possible relations and promote charm interoperability.
 
-## Using `charm-relation-interfaces`
+Juju interfaces are untyped, which means that for Juju to think two charms can be integrated all it looks at is whether the interface names of the two endpoints you're trying to connect are the same string. But it might be that the two charms have different, incompatible implementations of two different relations that happen to have the same name.
 
-If you have a charm that provides a service, you should search `charm-relation-interfaces` (or directly charmhub in the future) and see if it exists already, or perhaps a similar one exists that lacks the semantics you need and can be extended to support it.
+In order to prevent two separate charms from rolling their own relation with the same name, and prevent a sprawl of many subtly different interfaces with similar semantics and similar purposes, interface definitions are kept in a single, canonical location.
 
-Conversely, if the charm you are developing needs some service (a database, an ingress URL, an authentication endpoint...)  you should search `charm-relation-interfaces` to see if there is an interface you can use, and to find existing charms that provide it.
+## Using interface definitions
+
+If you have a charm that provides a service, you should search the [`interfaces` directory in `charmlibs`](https://github.com/canonical/charmlibs/tree/main/interfaces) (or directly Charmhub in the future) and see if an interface exists already, or perhaps a similar one exists that lacks the semantics you need and can be extended to support it.
+
+Conversely, if the charm you are developing needs some service (a database, an ingress URL, an authentication endpoint...)  you should search the interface definitions to see if there is an interface you can use, and to find existing charms that provide it.
 
 There are three actors in play:
 
-* **the owner of the specification** of the interface, which also owns the tests that can be used to verify "does charm X 'really' support this interface?". This is the `charm-relation-interfaces` repo.
+* **the owner of the specification** of the interface, which also owns the tests that can be used to verify "does charm X 'really' support this interface?". This is the relevant interface directory in the [`charmlibs` monorepo](https://github.com/canonical/charmlibs).
 * **the owner of the implementation** of an interface. In practice, this often is the charm that owns the charm library with the reference implementation for an interface.
 * **the interface user**: a charm that wants to use the interface (either as requirer or as provider).
 
-The interface user needs the implementation (typically, the provider also happens to be the owner and so it already has the implementation). This is addressed by `charmcraft fetch-lib`.
+The interface user needs the implementation (typically, the provider also happens to be the owner and so it already has the implementation). Interface libraries are published on PyPI as `charmlibs-interfaces-<interface name>` and can be imported as `charmlibs.interfaces.<interface name>`.
 
 The owner of the implementation needs the specification, to help check that the implementation is in fact compliant.
 
 ## Repository structure
 
-For each interface, the charm-relation-interfaces repository hosts:
-- the **specification**: a semi-formal definition of what the semantics of the interface is, and what its implementations are expected to do in terms of both the provider and the requirer
-- a list of **reference charms**: these are the charms that implement this interface, typically, the owner of the charm library providing the original implementation.
-- the **schema**: pydantic models unambiguously defining the accepted unit and application databag contents for provider and requirer.
-- the **interface tests**: python tests that can be run to verify that a charm complies with the interface specification.
+For each interface, the [`interfaces` directory in `charmlibs`](https://github.com/canonical/charmlibs/tree/main/interfaces) hosts a per-interface folder (for example, `interfaces/ingress/`), with the per-version specification under `interface/v<N>/`:
+
+- the **specification**: a semi-formal definition of the interface's semantics and what its implementations are expected to do, in terms of both the provider and the requirer (`interface/v<N>/README.md`).
+- a list of **reference charms**: the charms that implement this interface, typically the owner of the charm library providing the original implementation (`interface/v<N>/interface.yaml`).
+- the **schema**: pydantic models unambiguously defining the accepted unit and application databag contents for provider and requirer (`interface/v<N>/schema.py`).
+- the **interface tests**: Python tests that can be run to verify that a charm complies with the interface specification (`interface/v<N>/tests/`).
 
 
-## Charm relation interfaces in Charmhub
-Charmhub will, for all charms using the interface, verify that they implement it correctly (regardless of whether they use the 'official' implementation or they roll their own) in order to give the charm a happy checkmark on `charmhub.io`. In order to do that it will need to fetch the specification (from `charm-relation-interfaces`) *and* the charm repo, because we can't know what implementation they are using: we need the source code.
+## Interface definitions on Charmhub
+Charmhub will, for all charms using the interface, verify that they implement it correctly (regardless of whether they use the 'official' implementation or they roll their own) in order to give the charm a happy checkmark on `charmhub.io`. In order to do that it will need to fetch the specification (from the `charmlibs` monorepo) *and* the charm repo, because we can't know what implementation they are using: we need the source code.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -5,7 +5,7 @@ These guides explain how Ops works.
 
 ## Interface definitions
 
-The `charm-relation-interfaces` repository contains specifications, schemas, and tests for Juju interfaces.
+The [`charmlibs` monorepo](https://github.com/canonical/charmlibs/tree/main/interfaces) contains specifications, schemas, and tests for Juju interfaces.
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -5,7 +5,7 @@ These guides explain how Ops works.
 
 ## Interface definitions
 
-The [`charmlibs` monorepo](https://github.com/canonical/charmlibs/tree/main/interfaces) contains specifications, schemas, and tests for Juju interfaces.
+Juju interface definitions are maintained in the [`charmlibs` monorepo](https://github.com/canonical/charmlibs).
 
 ```{toctree}
 :maxdepth: 1
@@ -15,7 +15,7 @@ charm-relation-interfaces
 
 ## Testing
 
-Your charm should have unit tests and integration tests. If your charm uses relations, it should also have interface tests.
+Your charm should have unit tests and integration tests.
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/explanation/testing.md
+++ b/docs/explanation/testing.md
@@ -53,16 +53,16 @@ The `ops.testing` framework provides `State`, which mocks inputs and outputs. Th
 
 Interface tests validate charm library behavior against mock Juju APIs, ensuring compliance with an interface specification without requiring individual charm code.
 
-Interface specifications, stored in {ref}`charm-relation-interfaces <charm-relation-interfaces>`, are contract definitions that mandate how a charm should behave when integrated with another charm over a registered interface. For information about how to create an interface, see {ref}`register-an-interface`.
+Interface specifications, stored in the {ref}`charmlibs monorepo <charm-relation-interfaces>`, are contract definitions that mandate how a charm should behave when integrated with another charm over a registered interface. For information about how to create an interface, see {ref}`register-an-interface`.
 
 See also: {ref}`write-tests-for-an-interface`
 
 ### Coverage
 
-Interface tests enable Charmhub to validate the relations of a charm and verify that your charm supports the registered interface. For example, if your charm supports an interface called "ingress", interface tests enable Charmhub to verify that your charm supports the [registered `ingress` interface](https://github.com/canonical/charm-relation-interfaces/tree/main/interfaces/ingress/v2).
+Interface tests enable Charmhub to validate the relations of a charm and verify that your charm supports the registered interface. For example, if your charm supports an interface called "ingress", interface tests enable Charmhub to verify that your charm supports the [registered `ingress` interface](https://github.com/canonical/charmlibs/tree/main/interfaces/ingress/interface/v2).
 
 Interface tests also:
-- Enable alternative implementations of an interface to validate themselves against the contractual specification stored in `charm-relation-interfaces`.
+- Enable alternative implementations of an interface to validate themselves against the contractual specification stored in the [`charmlibs` monorepo](https://github.com/canonical/charmlibs/tree/main/interfaces).
 - Help verify compliance with multiple versions of an interface.
 
 An interface test has the following pattern:
@@ -80,7 +80,7 @@ In addition to checking that the databag state is valid, we could check for more
 
 ### Examples
 
-- [Ingress interface tests](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/ingress/v2/interface_tests/test_provider.py)
+- [Ingress interface tests](https://github.com/canonical/charmlibs/blob/main/interfaces/ingress/interface/v2/tests/test_provider.py)
 
 Interface tests enable us to check whether our charm complies with the behavioural specification of the interface, independently from whichever charm is integrated with our charm.
 

--- a/docs/explanation/testing.md
+++ b/docs/explanation/testing.md
@@ -48,42 +48,6 @@ The `ops.testing` framework provides `State`, which mocks inputs and outputs. Th
 
 - [Ubuntu manpages charm unit tests](https://github.com/canonical/ubuntu-manpages-operator/blob/main/tests/unit/test_charm.py)
 
-(interface-tests)=
-## Interface testing
-
-Interface tests validate charm library behavior against mock Juju APIs, ensuring compliance with an interface specification without requiring individual charm code.
-
-Interface specifications, stored in the {ref}`charmlibs monorepo <charm-relation-interfaces>`, are contract definitions that mandate how a charm should behave when integrated with another charm over a registered interface. For information about how to create an interface, see {ref}`register-an-interface`.
-
-See also: {ref}`write-tests-for-an-interface`
-
-### Coverage
-
-Interface tests enable Charmhub to validate the relations of a charm and verify that your charm supports the registered interface. For example, if your charm supports an interface called "ingress", interface tests enable Charmhub to verify that your charm supports the [registered `ingress` interface](https://github.com/canonical/charmlibs/tree/main/interfaces/ingress/interface/v2).
-
-Interface tests also:
-- Enable alternative implementations of an interface to validate themselves against the contractual specification stored in the [`charmlibs` monorepo](https://github.com/canonical/charmlibs/tree/main/interfaces).
-- Help verify compliance with multiple versions of an interface.
-
-An interface test has the following pattern:
-
-1) **Given** - An initial state of the relation over the interface under test.
-2) **When** - A specific relation event fires.
-3) **Then** - The state of the databags is valid. For example, the state satisfies a [pydantic](https://docs.pydantic.dev/latest/) schema.
-
-In addition to checking that the databag state is valid, we could check for more elaborate conditions.
-
-### Tools
-
-- [`ops.testing`](ops_testing)
-- A pytest plugin called [`pytest-interface-tester`](https://github.com/canonical/pytest-interface-tester)
-
-### Examples
-
-- [Ingress interface tests](https://github.com/canonical/charmlibs/blob/main/interfaces/ingress/interface/v2/tests/test_provider.py)
-
-Interface tests enable us to check whether our charm complies with the behavioural specification of the interface, independently from whichever charm is integrated with our charm.
-
 (integration-testing)=
 ## Integration testing
 

--- a/docs/howto/manage-interfaces.md
+++ b/docs/howto/manage-interfaces.md
@@ -11,34 +11,40 @@ Suppose that your interface specification has the following data model:
 - the requirer app is supposed to forward a list of tables that it wants to be provisioned by the database provider
 - the provider app (the database) at that point will reply with an API endpoint and, for each replica, it will provide a separate secret ID to authenticate the requests
 
-These are the steps you need to take in order to  register it with [`charm-relation-interfaces`](#charm-relation-interfaces).
+These are the steps you need to take in order to register it in the [`charmlibs` monorepo](#charm-relation-interfaces).
 
-### 1. Clone (a fork of) [the `charm-relation-interfaces` repo](https://github.com/canonical/charm-relation-interfaces) and set up an interface specification folder
-
-```bash
-git clone https://github.com/canonical/charm-relation-interfaces
-cd /path/to/charm-relation-interfaces
-```
-
-### 2. Make a copy of the template folder
-Copy the template folder to a new folder called the same as your interface (with underscores instead of dashes).
+### 1. Clone (a fork of) [the `charmlibs` repo](https://github.com/canonical/charmlibs) and create an interface package
 
 ```bash
-cp -r ./interfaces/__template__ ./interfaces/my_fancy_database
+git clone https://github.com/canonical/charmlibs
+cd /path/to/charmlibs
 ```
 
-At this point you should see this directory structure:
+### 2. Run the interface initialiser
+
+From the repository root, run `just init --interface` and answer the prompts. The project name should be the canonical interface name, as it appears in `charmcraft.yaml` files -- for example `my_fancy_database`. You'll also be asked for the minimum Python version and the PyPI author field; press enter to accept the defaults shown in brackets.
+
+```bash
+just init --interface
+```
+
+This creates a new package under `interfaces/<your_interface>/`.
+
+At this point you should see a directory structure similar to:
 
 ```
 # tree ./interfaces/my_fancy_database
 ./interfaces/my_fancy_database
-└── v0
-    ├── README.md
-    ├── interface.yaml
-    ├── interface_tests
-    └── schema.py
-2 directories, 3 files
+├── interface
+│   └── v0
+│       ├── README.md
+│       ├── interface.yaml
+│       ├── schema.py
+│       └── tests
+└── ruff.toml
 ```
+
+(The package also includes packaging files such as `pyproject.toml`, `CHANGELOG.md`, and a `src/` tree for the library implementation; those are not relevant to registering the interface specification itself.)
 
 (edit-interface-yaml)=
 ### 3. Edit `interface.yaml`
@@ -98,7 +104,7 @@ class RequirerSchema(DataBagSchema):
     # we can omit `unit` because the requirer makes no use of the unit databags
 ```
 
-To verify that things work as they should, you can `pip install pytest-interface-tester` and then run `interface_tester discover --include my_fancy_database` from the `charm-relation-interfaces` root.
+To verify that things work as they should, you can `pip install pytest-interface-tester` and then run `interface_tester discover --include my_fancy_database` from the `charmlibs` root.
 
 You should see:
 
@@ -197,34 +203,34 @@ units_data : {
 
 See more: {ref}`write-tests-for-an-interface`
 
-### 7. Open a PR to [the `charm-relation-interfaces` repo](https://github.com/canonical/charm-relation-interfaces)
+### 7. Open a PR to [the `charmlibs` repo](https://github.com/canonical/charmlibs)
 
-Finally, open a pull request to the `charm-relation-interfaces` repo and drive it to completion, addressing any feedback or concerns that the maintainers may have.
+Finally, open a pull request to the `charmlibs` repo and drive it to completion, addressing any feedback or concerns that the maintainers may have.
 
 ## Example
 
-For an example of a registered interface, see [`ingress`](https://github.com/canonical/charm-relation-interfaces/tree/main/interfaces/ingress/v1):
-   - As you can see from the [`interface.yaml`](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/ingress/v1/interface.yaml) file, the [`canonical/traefik-k8s-operator` charm](https://github.com/canonical/traefik-k8s-operator) plays the provider role in the interface.
-   - The schema of this interface is defined in [`schema.py`](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/ingress/v1/schema.py).
-   - You can find out more information about this interface in the [README](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/ingress/v1/README.md).
+For an example of a registered interface, see [`ingress`](https://github.com/canonical/charmlibs/tree/main/interfaces/ingress/interface/v1):
+   - As you can see from the [`interface.yaml`](https://github.com/canonical/charmlibs/blob/main/interfaces/ingress/interface/v1/interface.yaml) file, the [`canonical/traefik-k8s-operator` charm](https://github.com/canonical/traefik-k8s-operator) plays the provider role in the interface.
+   - The schema of this interface is defined in [`schema.py`](https://github.com/canonical/charmlibs/blob/main/interfaces/ingress/interface/v1/schema.py).
+   - You can find out more information about this interface in the [README](https://github.com/canonical/charmlibs/blob/main/interfaces/ingress/interface/v1/README.md).
 
 (write-tests-for-an-interface)=
 ## Write tests for an interface
 
 See also: {ref}`interface-tests`
 
-Suppose you have an interface specification in [`charm-relation-interfaces`](#charm-relation-interfaces), or you are working on one, and you want to add interface tests. These are the steps you need to take.
+Suppose you have an interface specification in the [`charmlibs` monorepo](#charm-relation-interfaces), or you are working on one, and you want to add interface tests. These are the steps you need to take.
 
 We will continue from the running example from {ref}`register-an-interface`. Your starting setup should look like this:
 
 ```text
-$ tree ./interfaces/my_fancy_database
-./interfaces/my_fancy_database
+$ tree ./interfaces/my_fancy_database/interface
+./interfaces/my_fancy_database/interface
 └── v0
     ├── interface.yaml
-    ├── interface_tests
     ├── README.md
-    └── schema.py
+    ├── schema.py
+    └── tests
 
 2 directories, 3 files
 ```
@@ -232,10 +238,10 @@ $ tree ./interfaces/my_fancy_database
 
 ### Create the test module
 
-Add a file to the `interface_tests` directory called `test_provider.py`.
+Add a file to the `tests` directory called `test_provider.py`.
 
 ```bash
-touch ./interfaces/my_fancy_database/interface_tests/test_provider.py
+touch ./interfaces/my_fancy_database/interface/v0/tests/test_provider.py
 ```
 
 ### Write a test for the 'negative' path
@@ -302,7 +308,7 @@ def test_contract_happy_path():
 
 This test verifies that the databags of the 'my-fancy-database' relation are valid according to the pydantic schema you have specified in `schema.py`.
 
-To check that things work as they should, you can run `interface_tester discover --include my_fancy_database` from the `charm-relation-interfaces` root.
+To check that things work as they should, you can run `interface_tester discover --include my_fancy_database` from the `charmlibs` root.
 
 ```{note}
 
@@ -329,15 +335,15 @@ You should see:
 
 In particular, pay attention to the `provider` field. If it says `<no tests>` then there is something wrong with your setup, and the collector isn't able to find your test or identify it as a valid test.
 
-Similarly, you can add tests for requirer in `./interfaces/my_fancy_database/v0/interface_tests/test_requirer.py`. Don't forget to [edit the `interface.yaml`](#edit-interface-yaml) file in the "requirers" section to add the name of the charm and the URL.
+Similarly, you can add tests for requirer in `./interfaces/my_fancy_database/interface/v0/tests/test_requirer.py`. Don't forget to [edit the `interface.yaml`](#edit-interface-yaml) file in the "requirers" section to add the name of the charm and the URL.
 
-### Merge in charm-relation-interfaces
+### Merge in `charmlibs`
 
-You are ready to merge this files in the charm-relation-interfaces repository. Open a PR and drive it to completion.
+You are ready to merge these files in the `charmlibs` repository. Open a PR and drive it to completion.
 
 #### Prepare the charm
 
-In order to be testable by charm-relation-interfaces, the charm needs to expose and configure a fixture.
+In order to be testable from `charmlibs`, the charm needs to expose and configure a fixture.
 
 ```{note}
 
@@ -389,7 +395,7 @@ This fixture overrides a homonym pytest fixture that comes with `pytest-interfac
 
 ````{note}
 
-You can configure the fixture name, as well as its location, but that needs to happen in the `charm-relation-interfaces` repo. Example:
+You can configure the fixture name, as well as its location, but that needs to happen in the `charmlibs` repo. Example:
 ```
 providers:
   - name: my-fancy-database-provider
@@ -404,51 +410,28 @@ providers:
 
 #### Verifying the `interface_tester` configuration
 
-To verify that the fixture is good enough to pass the interface tests, run the `run_matrix.py` script from the `charm-relation-interfaces` repo:
+To verify that the fixture is good enough to pass the interface tests, run the interface tests from the `charmlibs` repo. First, list the targets that will be tested:
 
 ```bash
-cd path/to/charm-relation-interfaces
-python run_matrix.py --include my_fancy_database
+cd path/to/charmlibs
+.scripts/get-interface-test-targets.py interfaces/my_fancy_database
 ```
 
-If you run this test, unless you have already merged the interface tests PR to `charm-relation-interfaces`, it will fail with some error message telling you that it's failing to collect the tests for the interface, because by default, `pytest-interface-tester` will try to find tests in the `canonical/charm-relation-interfaces` repo's `main` branch.
-
-To run tests with a branch in your forked repo, run:
+Each entry in the output gives you the arguments for one test run: the interface version, the role, the charm name, and the endpoint. Run one of them with:
 
 ```bash
-cd path/to/my-forked/charm-relation-interfaces
-python run_matrix.py --include my_fancy_database --repo https://github.com/your-github-slug/charm-relation-interfaces --branch my-fancy-database
+.scripts/run-interface-tests.py my_fancy_database v0 provide my-fancy-database-provider my-fancy-database
 ```
 
-```{note}
-
-In the above command, remember to replace `your-github-slug` to your own slug, change the repo name accordingly (if you have renamed the forked repo), and update the `my-fance-database` branch name from the above command to the branch that contains your tests.
-
-```
-
-Now the tests should be collected and executed. You should get similar output to the following:
+The charm repository and branch come from the `interface.yaml` you edited above, so unless you have already merged your interface tests to `charmlibs`, point the run at your own charm branch instead:
 
 ```bash
-INFO:root:Running tests for interface: my_fancy_database
-INFO:root:Running tests for version: v0
-INFO:root:Running tests for role: provider
-
-...
-
-+++ Results +++
-{
-  "my_fancy_database": {
-    "v0": {
-      "provider": {
-        "my-fancy-database-operator": true
-      },
-      "requirer": {
-        "my-fancy-database-operator": true
-      }
-    }
-  }
-}
+.scripts/run-interface-tests.py my_fancy_database v0 provide my-fancy-database-provider my-fancy-database \
+  --charm-repo https://github.com/your-github-slug/my-fancy-database-operator \
+  --charm-branch branch-with-my-conftest-changes
 ```
+
+Pass `--keep` if you want to inspect the charm that was cloned to run the tests.
 
 ### Troubleshooting and debugging the tests
 
@@ -459,7 +442,7 @@ Essentially, you need to make it so that the charm runtime 'thinks' that everyth
 This may mean mocking the presence and connectivity of a container, system calls, substrate API calls, and more.
 If you have unit tests in your codebase, you most likely already have all the necessary patches scattered around and it's a matter of collecting them.
 
-Remember that if you run your tests using `run_matrix.py` locally, in your troubleshooting you need to point `interface.yaml` to the branch where you committed your changes as `run_matrix` fetches the charm repositories in order to run the charms:
+Remember that if you run the tests locally, in your troubleshooting you need to point `interface.yaml` to the branch where you committed your changes (or pass `--charm-repo` and `--charm-branch`), because the test runner clones the charm repositories in order to run the charms:
 
 ```text
 requirers:
@@ -467,9 +450,9 @@ requirers:
     url: https://my-fancy-database-operator-repo
     branch: branch-with-my-conftest-changes
 ```
-Remember, however, to merge the changes first in the operator repository before merging the pull request to `charm-relation-interfaces`.
+Remember, however, to merge the changes first in the operator repository before merging the pull request to `charmlibs`.
 
 See more:
 
-- [`test_provider.py`](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/ingress/v1/interface_tests/test_provider.py) for the `ingress` interface defined in `charm-relation-interfaces`.
+- [`test_provider.py`](https://github.com/canonical/charmlibs/blob/main/interfaces/ingress/interface/v1/tests/test_provider.py) for the `ingress` interface defined in the `charmlibs` monorepo.
 - [`conftest.py`](https://github.com/canonical/traefik-k8s-operator/blob/main/tests/interface/conftest.py) for the [`traefik-k8s-operator`](https://github.com/canonical/traefik-k8s-operator) charm.

--- a/docs/howto/manage-interfaces.md
+++ b/docs/howto/manage-interfaces.md
@@ -13,38 +13,26 @@ Suppose that your interface specification has the following data model:
 
 These are the steps you need to take in order to register it in the [`charmlibs` monorepo](#charm-relation-interfaces).
 
-### 1. Clone (a fork of) [the `charmlibs` repo](https://github.com/canonical/charmlibs) and create an interface package
+### 1. Clone (a fork of) [the `charmlibs` repo](https://github.com/canonical/charmlibs)
 
 ```bash
 git clone https://github.com/canonical/charmlibs
 cd /path/to/charmlibs
 ```
 
-### 2. Scaffold the interface
+### 2. Create the interface directory
 
-From the repository root, run `just init --interface` and answer the prompts. The project name should be the canonical interface name, as it appears in `charmcraft.yaml` files -- for example `my_fancy_database`. You'll also be asked for the minimum Python version and the PyPI author field; press enter to accept the defaults shown in brackets.
+Registering an interface means adding its definition to `charmlibs`; you don't need to publish a Python package to do that. Create a directory for the interface under `interfaces/`, named with the canonical interface name as it appears in `charmcraft.yaml` files -- for example `my_fancy_database` -- and add the three files that make up the definition:
 
 ```bash
-just init --interface
+mkdir -p ./interfaces/my_fancy_database
+touch ./interfaces/my_fancy_database/{README.md,interface.yaml,schema.py}
 ```
 
-This creates a new package under `interfaces/<your_interface>/`.
+```{note}
 
-At this point you should see a directory structure similar to:
-
+If you also want to ship a charm library implementing the interface, run `just init --interface` from the repository root instead, and answer the prompts. That scaffolds a full `charmlibs.interfaces.<name>` package, which is published to PyPI. See the [`charmlibs` documentation](https://canonical.com/juju/docs/charmlibs/) for how to develop and release one.
 ```
-# tree ./interfaces/my_fancy_database
-./interfaces/my_fancy_database
-├── interface
-│   └── v0
-│       ├── README.md
-│       ├── interface.yaml
-│       ├── schema.py
-│       └── tests
-└── ruff.toml
-```
-
-(The package also includes packaging files such as `pyproject.toml`, `CHANGELOG.md`, and a `src/` tree for the library implementation; those are not relevant to registering the interface specification itself.)
 
 (edit-interface-yaml)=
 ### 3. Edit `interface.yaml`
@@ -104,14 +92,7 @@ class RequirerSchema(DataBagSchema):
     # we can omit `unit` because the requirer makes no use of the unit databags
 ```
 
-To verify that the schema is valid, run it the same way `charmlibs` CI does, from the `charmlibs` root:
-
-```bash
-uv run --no-project --with-requirements schema-requirements.txt \
-  interfaces/my_fancy_database/interface/v0/schema.py
-```
-
-The command exits successfully if the module imports and the pydantic models are well formed. If it fails, there is something wrong with the models.
+`DataBagSchema` currently comes from `pytest-interface-tester`; `charmlibs` intends to replace it, so check the schemas of existing interfaces for the current base class before you write yours.
 
 ### 5. Edit `README.md`
 
@@ -188,249 +169,13 @@ units_data : {
 \```
 ```
 
-### 6. Add interface tests
-
-See more: {ref}`write-tests-for-an-interface`
-
-### 7. Open a PR to [the `charmlibs` repo](https://github.com/canonical/charmlibs)
+### 6. Open a PR to [the `charmlibs` repo](https://github.com/canonical/charmlibs)
 
 Finally, open a pull request to the `charmlibs` repo and drive it to completion, addressing any feedback or concerns that the maintainers may have.
 
 ## Example
 
-For an example of a registered interface, see [`ingress`](https://github.com/canonical/charmlibs/tree/main/interfaces/ingress/interface/v1):
-   - As you can see from the [`interface.yaml`](https://github.com/canonical/charmlibs/blob/main/interfaces/ingress/interface/v1/interface.yaml) file, the [`canonical/traefik-k8s-operator` charm](https://github.com/canonical/traefik-k8s-operator) plays the provider role in the interface.
-   - The schema of this interface is defined in [`schema.py`](https://github.com/canonical/charmlibs/blob/main/interfaces/ingress/interface/v1/schema.py).
-   - You can find out more information about this interface in the [README](https://github.com/canonical/charmlibs/blob/main/interfaces/ingress/interface/v1/README.md).
-
-(write-tests-for-an-interface)=
-## Write tests for an interface
-
-See also: {ref}`interface-tests`
-
-Suppose you have an interface specification in the [`charmlibs` monorepo](#charm-relation-interfaces), or you are working on one, and you want to add interface tests. These are the steps you need to take.
-
-We will continue from the running example from {ref}`register-an-interface`. Your starting setup should look like this:
-
-```text
-$ tree ./interfaces/my_fancy_database/interface
-./interfaces/my_fancy_database/interface
-└── v0
-    ├── interface.yaml
-    ├── README.md
-    ├── schema.py
-    └── tests
-
-2 directories, 3 files
-```
-
-
-### Create the test module
-
-Add a file to the `tests` directory called `test_provider.py`.
-
-```bash
-touch ./interfaces/my_fancy_database/interface/v0/tests/test_provider.py
-```
-
-### Write a test for the 'negative' path
-
-Write to `test_provider.py` the code below:
-
-```python
-from interface_tester import Tester
-from scenario import State, Relation
-
-
-def test_nothing_happens_if_remote_empty():
-    # GIVEN that the remote end has not published any tables
-    t = Tester(
-        State(
-            leader=True,
-            relations={
-                Relation(
-                    endpoint='my-fancy-database',  # the name doesn't matter
-                    interface='my_fancy_database',
-                )
-            },
-        )
-    )
-    # WHEN the database charm receives a relation-joined event
-    state_out = t.run('my-fancy-database-relation-joined')
-    # THEN no data is published to the (local) databags
-    t.assert_relation_data_empty()
-```
-
-This test verifies part of a 'negative' path: it verifies that if the remote end did not (yet) comply with its part of the contract, then our side did not either.
-
-### Write a test for the 'positive' path
-
-Append to `test_provider.py` the code below:
-
-```python
-import json
-
-from interface_tester import Tester
-from scenario import State, Relation
-
-
-def test_contract_happy_path():
-    # GIVEN that the remote end has requested tables in the right format
-    tables_json = json.dumps(['users', 'passwords'])
-    t = Tester(
-        State(
-            leader=True,
-            relations=[
-                Relation(
-                    endpoint='my-fancy-database',  # the name doesn't matter
-                    interface='my_fancy_database',
-                    remote_app_data={'tables': tables_json},
-                )
-            ],
-        )
-    )
-    # WHEN the database charm receives a relation-changed event
-    state_out = t.run('my-fancy-database-relation-changed')
-    # THEN the schema is satisfied (the database charm published all required fields)
-    t.assert_schema_valid()
-```
-
-This test verifies that the databags of the 'my-fancy-database' relation are valid according to the pydantic schema you have specified in `schema.py`.
-
-These tests are collected and run from the charm side, so the way to check that they work is to run them against a charm that implements the interface, as described in {ref}`prepare-the-charm`.
-
-Similarly, you can add tests for requirer in `./interfaces/my_fancy_database/interface/v0/tests/test_requirer.py`. Don't forget to [edit the `interface.yaml`](#edit-interface-yaml) file in the "requirers" section to add the name of the charm and the URL.
-
-### Merge in `charmlibs`
-
-You are ready to merge these files in the `charmlibs` repository. Open a PR and drive it to completion.
-
-(prepare-the-charm)=
-#### Prepare the charm
-
-In order to be testable from `charmlibs`, the charm needs to expose and configure a fixture.
-
-```{note}
-
-This is because the `fancy-database` interface specification is only supported if the charm is well-configured and has leadership, since it will need to publish data to the application databag.
-Also, interface tests are Scenario tests and as such they are mock-based: there is no cloud substrate running, no Juju, no real charm unit in the background. So you need to patch out all calls that cannot be mocked by Scenario, as well as provide enough mocks through State so that the charm is 'ready' to support the interface you are testing.
-
-```
-
-Go to the Fancy Database charm repository root.
-
-```text
-cd path/to/my-fancy-database-operator
-```
-
-Install the interface tester:
-
-```shell
-pip install pytest-interface-tester
-```
-
-Create a `conftest.py` file under `tests/interface`:
-
-```shell
-mkdir ./tests/interface
-touch ./tests/interface/conftest.py
-```
-
-Write in `conftest.py`:
-
-```python
-import pytest
-from charm import MyFancyDatabaseCharm
-from interface_tester import InterfaceTester
-from scenario.state import State
-
-
-@pytest.fixture
-def interface_tester(interface_tester: InterfaceTester):
-    interface_tester.configure(
-        charm_type=MyFancyDatabaseCharm,
-        # `pytest-interface-tester` still defaults to the archived
-        # `charm-relation-interfaces` repo and its layout, so point it at `charmlibs`.
-        repo='https://github.com/canonical/charmlibs',
-        base_path='interfaces',
-        interface_subdir='interface',
-        tests_dir='tests',
-        state_template=State(
-            leader=True,  # we need leadership
-        ),
-    )
-    # this fixture needs to yield (NOT RETURN!) interface_tester again
-    yield interface_tester
-```
-
-```{note}
-
-This fixture overrides a homonym pytest fixture that comes with `pytest-interface-tester`.
-
-```
-
-
-````{note}
-
-You can configure the fixture name, as well as its location, but that needs to happen in the `charmlibs` repo. Example:
-```
-providers:
-  - name: my-fancy-database-provider
-    url: YOUR_REPO_URL
-    test_setup:
-      location: tests/interface/conftest.py
-      identifier: database_tester
-```
-
-````
-
-
-#### Verifying the `interface_tester` configuration
-
-To verify that the fixture is good enough to pass the interface tests, run them from the charm repository. Add a test that drives the fixture:
-
-```python
-# ./tests/interface/test_interfaces.py
-from interface_tester import InterfaceTester
-
-
-def test_my_fancy_database_interface(interface_tester: InterfaceTester):
-    interface_tester.configure(
-        interface_name='my_fancy_database',
-        interface_version=0,
-    )
-    interface_tester.run()
-```
-
-Then run it:
-
-```bash
-cd path/to/my-fancy-database-operator
-pytest ./tests/interface
-```
-
-The tester clones `charmlibs` and collects the tests and schema for the interface, so unless you have already merged your interface tests, point it at your own branch by adding `branch='my-fancy-database'` to the `configure()` call in `conftest.py`.
-
-### Troubleshooting and debugging the tests
-
-#### Your charm is missing some configuration or mocks
-
-Solution to this is to add the missing mocks/patches to the `interface_tester` fixture in `conftest.py`.
-Essentially, you need to make it so that the charm runtime 'thinks' that everything is normal and ready to process and accept the interface you are testing.
-This may mean mocking the presence and connectivity of a container, system calls, substrate API calls, and more.
-If you have unit tests in your codebase, you most likely already have all the necessary patches scattered around and it's a matter of collecting them.
-
-Remember that if you run the tests locally, in your troubleshooting you need to point `interface.yaml` to the branch where you committed your changes, because the test runner clones the charm repositories in order to run the charms:
-
-```text
-requirers:
-  - name: my-fancy-database-operator
-    url: https://my-fancy-database-operator-repo
-    branch: branch-with-my-conftest-changes
-```
-Remember, however, to merge the changes first in the operator repository before merging the pull request to `charmlibs`.
-
-See more:
-
-- [`test_provider.py`](https://github.com/canonical/charmlibs/blob/main/interfaces/ingress/interface/v1/tests/test_provider.py) for the `ingress` interface defined in the `charmlibs` monorepo.
-- [`conftest.py`](https://github.com/canonical/traefik-k8s-operator/blob/main/tests/interface/conftest.py) for the [`traefik-k8s-operator`](https://github.com/canonical/traefik-k8s-operator) charm.
+For an example of a registered interface, see [`ingress`](https://github.com/canonical/charmlibs/tree/main/interfaces/ingress):
+   - As you can see from its `interface.yaml` file, the [`canonical/traefik-k8s-operator` charm](https://github.com/canonical/traefik-k8s-operator) plays the provider role in the interface.
+   - The schema of this interface is defined in `schema.py`.
+   - You can find out more information about this interface in its `README.md`.

--- a/docs/howto/manage-interfaces.md
+++ b/docs/howto/manage-interfaces.md
@@ -20,7 +20,7 @@ git clone https://github.com/canonical/charmlibs
 cd /path/to/charmlibs
 ```
 
-### 2. Run the interface initialiser
+### 2. Scaffold the interface
 
 From the repository root, run `just init --interface` and answer the prompts. The project name should be the canonical interface name, as it appears in `charmcraft.yaml` files -- for example `my_fancy_database`. You'll also be asked for the minimum Python version and the PyPI author field; press enter to accept the defaults shown in brackets.
 

--- a/docs/howto/manage-interfaces.md
+++ b/docs/howto/manage-interfaces.md
@@ -104,25 +104,14 @@ class RequirerSchema(DataBagSchema):
     # we can omit `unit` because the requirer makes no use of the unit databags
 ```
 
-To verify that things work as they should, you can `pip install pytest-interface-tester` and then run `interface_tester discover --include my_fancy_database` from the `charmlibs` root.
+To verify that the schema is valid, run it the same way `charmlibs` CI does, from the `charmlibs` root:
 
-You should see:
-
-```yaml
-- my_fancy_database:
-  - v0:
-   - provider:
-     - <no tests>
-     - schema OK
-     - charms:
-       - my_fancy_database_charm (https://github.com/your-github-slug/my-fancy-database-operator) custom_test_setup=no
-   - requirer:
-     - <no tests>
-     - schema OK
-     - <no charms>
+```bash
+uv run --no-project --with-requirements schema-requirements.txt \
+  interfaces/my_fancy_database/interface/v0/schema.py
 ```
 
-In particular pay attention to `schema`. If it says `NOT OK` then there is something wrong with the pydantic model.
+The command exits successfully if the module imports and the pydantic models are well formed. If it fails, there is something wrong with the models.
 
 ### 5. Edit `README.md`
 
@@ -308,32 +297,7 @@ def test_contract_happy_path():
 
 This test verifies that the databags of the 'my-fancy-database' relation are valid according to the pydantic schema you have specified in `schema.py`.
 
-To check that things work as they should, you can run `interface_tester discover --include my_fancy_database` from the `charmlibs` root.
-
-```{note}
-
-Note that the `interface_tester` is installed in {ref}`Register an interface <register-an-interface>`. If you haven't done it yet, install it by running: `pip install pytest-interface-tester `.
-
-```
-
-You should see:
-
-```yaml
-- my_fancy_database:
-  - v0:
-   - provider:
-       - test_contract_happy_path
-       - test_nothing_happens_if_remote_empty
-     - schema OK
-     - charms:
-       - my_fancy_database_charm (https://github.com/your-github-slug/my-fancy-database-operator) custom_test_setup=no
-   - requirer:
-     - <no tests>
-     - schema OK
-     - <no charms>
-```
-
-In particular, pay attention to the `provider` field. If it says `<no tests>` then there is something wrong with your setup, and the collector isn't able to find your test or identify it as a valid test.
+These tests are collected and run from the charm side, so the way to check that they work is to run them against a charm that implements the interface, as described in {ref}`prepare-the-charm`.
 
 Similarly, you can add tests for requirer in `./interfaces/my_fancy_database/interface/v0/tests/test_requirer.py`. Don't forget to [edit the `interface.yaml`](#edit-interface-yaml) file in the "requirers" section to add the name of the charm and the URL.
 
@@ -341,6 +305,7 @@ Similarly, you can add tests for requirer in `./interfaces/my_fancy_database/int
 
 You are ready to merge these files in the `charmlibs` repository. Open a PR and drive it to completion.
 
+(prepare-the-charm)=
 #### Prepare the charm
 
 In order to be testable from `charmlibs`, the charm needs to expose and configure a fixture.
@@ -356,6 +321,12 @@ Go to the Fancy Database charm repository root.
 
 ```text
 cd path/to/my-fancy-database-operator
+```
+
+Install the interface tester:
+
+```shell
+pip install pytest-interface-tester
 ```
 
 Create a `conftest.py` file under `tests/interface`:
@@ -378,6 +349,12 @@ from scenario.state import State
 def interface_tester(interface_tester: InterfaceTester):
     interface_tester.configure(
         charm_type=MyFancyDatabaseCharm,
+        # `pytest-interface-tester` still defaults to the archived
+        # `charm-relation-interfaces` repo and its layout, so point it at `charmlibs`.
+        repo='https://github.com/canonical/charmlibs',
+        base_path='interfaces',
+        interface_subdir='interface',
+        tests_dir='tests',
         state_template=State(
             leader=True,  # we need leadership
         ),
@@ -410,28 +387,29 @@ providers:
 
 #### Verifying the `interface_tester` configuration
 
-To verify that the fixture is good enough to pass the interface tests, run the interface tests from the `charmlibs` repo. First, list the targets that will be tested:
+To verify that the fixture is good enough to pass the interface tests, run them from the charm repository. Add a test that drives the fixture:
 
-```bash
-cd path/to/charmlibs
-.scripts/get-interface-test-targets.py interfaces/my_fancy_database
+```python
+# ./tests/interface/test_interfaces.py
+from interface_tester import InterfaceTester
+
+
+def test_my_fancy_database_interface(interface_tester: InterfaceTester):
+    interface_tester.configure(
+        interface_name='my_fancy_database',
+        interface_version=0,
+    )
+    interface_tester.run()
 ```
 
-Each entry in the output gives you the arguments for one test run: the interface version, the role, the charm name, and the endpoint. Run one of them with:
+Then run it:
 
 ```bash
-.scripts/run-interface-tests.py my_fancy_database v0 provide my-fancy-database-provider my-fancy-database
+cd path/to/my-fancy-database-operator
+pytest ./tests/interface
 ```
 
-The charm repository and branch come from the `interface.yaml` you edited above, so unless you have already merged your interface tests to `charmlibs`, point the run at your own charm branch instead:
-
-```bash
-.scripts/run-interface-tests.py my_fancy_database v0 provide my-fancy-database-provider my-fancy-database \
-  --charm-repo https://github.com/your-github-slug/my-fancy-database-operator \
-  --charm-branch branch-with-my-conftest-changes
-```
-
-Pass `--keep` if you want to inspect the charm that was cloned to run the tests.
+The tester clones `charmlibs` and collects the tests and schema for the interface, so unless you have already merged your interface tests, point it at your own branch by adding `branch='my-fancy-database'` to the `configure()` call in `conftest.py`.
 
 ### Troubleshooting and debugging the tests
 
@@ -442,7 +420,7 @@ Essentially, you need to make it so that the charm runtime 'thinks' that everyth
 This may mean mocking the presence and connectivity of a container, system calls, substrate API calls, and more.
 If you have unit tests in your codebase, you most likely already have all the necessary patches scattered around and it's a matter of collecting them.
 
-Remember that if you run the tests locally, in your troubleshooting you need to point `interface.yaml` to the branch where you committed your changes (or pass `--charm-repo` and `--charm-branch`), because the test runner clones the charm repositories in order to run the charms:
+Remember that if you run the tests locally, in your troubleshooting you need to point `interface.yaml` to the branch where you committed your changes, because the test runner clones the charm repositories in order to run the charms:
 
 ```text
 requirers:

--- a/docs/howto/manage-libraries.md
+++ b/docs/howto/manage-libraries.md
@@ -258,7 +258,7 @@ Alternatively, the interface documentation can be found in the
 
 In the interface documentation, find the description of the various
 databags. For example, for
-[v2 of the `tracing` interface](https://github.com/canonical/charmlibs/blob/main/interfaces/tracing/interface/v2/README.md):
+[the `tracing` interface](https://github.com/canonical/charmlibs/tree/main/interfaces/tracing):
 
 ```yaml
 # unit_data: <empty>

--- a/docs/howto/manage-libraries.md
+++ b/docs/howto/manage-libraries.md
@@ -254,12 +254,11 @@ See more: {ref}`manage-interfaces`
 
 If the library is implementing an existing interface, find the interface documentation by following links from the Integrations tab on Charmhub, or by navigating to `https://charmhub.io/integrations/{integration-name}`.
 Alternatively, the interface documentation can be found in the
-[charm-relation-interfaces](https://github.com/canonical/charm-relation-interfaces)
-repository.
+[`interfaces` directory of the `charmlibs` monorepo](https://github.com/canonical/charmlibs/tree/main/interfaces).
 
 In the interface documentation, find the description of the various
 databags. For example, for
-[v2 of the `tracing` interface](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/tracing/v2/README.md):
+[v2 of the `tracing` interface](https://github.com/canonical/charmlibs/blob/main/interfaces/tracing/interface/v2/README.md):
 
 ```yaml
 # unit_data: <empty>


### PR DESCRIPTION
`canonical/charm-relation-interfaces` was archived in November 2025 and the interfaces now live in the `interfaces/` directory of the `charmlibs` monorepo, so the explanation page, the interface and library how-tos, and the testing docs all point at a repository that isn't the source of truth any more. This updates the repository, the paths (each interface is now `interfaces/<name>/interface/v<N>/`, with `tests/` rather than `interface_tests/`), and the URLs.

The tooling changed as well, so the how-to now uses `just init --interface` rather than copying the `__template__` directory, and the local test-run section uses `.scripts/get-interface-test-targets.py` and `.scripts/run-interface-tests.py`, since `run_matrix.py` doesn't exist in `charmlibs`.

I've left the `charm-relation-interfaces.md` filename and its MyST anchor alone, because three other pages reference it - renaming both is an easy follow-up if you'd prefer that.

[Preview](https://canonical-juju-ops--2710.com.readthedocs.build/2710/).

Fixes #2525, #2549