### PR TITLE
fix: make _CharmSpec covariant in its charm type

### DIFF
--- a/testing/src/scenario/context.py
+++ b/testing/src/scenario/context.py
@@ -722,7 +722,7 @@ class Context(Generic[CharmType]):
         if not any((meta, actions, config)):
             logger.debug('Autoloading charmspec...')
             try:
-                spec: _CharmSpec[CharmType] = _CharmSpec.autoload(charm_type)  # pyright: ignore[reportAssignmentType]
+                spec: _CharmSpec[CharmType] = _CharmSpec.autoload(charm_type)
             except MetadataNotFoundError as e:
                 raise ContextSetupError(
                     f'Cannot setup scenario with `charm_type`={charm_type}. '

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -72,7 +72,7 @@ RawSecretRevisionContents = RawDataBagContents = Mapping[str, str]
 UnitID = int
 
 CharmType = TypeVar('CharmType', bound=CharmBase)
-# Covariant variant used by :class:`_CharmSpec` so that, for example,
+# Covariant version used by :class:`_CharmSpec` so that, for example,
 # ``_CharmSpec[MyCharm]`` is assignable to ``_CharmSpec[CharmBase]``.
 # ``_CharmSpec`` is a frozen dataclass, so covariance is sound here.
 _CharmTypeCo = TypeVar('_CharmTypeCo', bound=CharmBase, covariant=True)

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -72,7 +72,7 @@ RawSecretRevisionContents = RawDataBagContents = Mapping[str, str]
 UnitID = int
 
 CharmType = TypeVar('CharmType', bound=CharmBase)
-# Covariant variant used by :class:`_CharmSpec` so that, e.g.,
+# Covariant variant used by :class:`_CharmSpec` so that, for example,
 # ``_CharmSpec[MyCharm]`` is assignable to ``_CharmSpec[CharmBase]``.
 # ``_CharmSpec`` is a frozen dataclass, so covariance is sound here.
 _CharmTypeCo = TypeVar('_CharmTypeCo', bound=CharmBase, covariant=True)

--- a/testing/src/scenario/state.py
+++ b/testing/src/scenario/state.py
@@ -72,6 +72,10 @@ RawSecretRevisionContents = RawDataBagContents = Mapping[str, str]
 UnitID = int
 
 CharmType = TypeVar('CharmType', bound=CharmBase)
+# Covariant variant used by :class:`_CharmSpec` so that, e.g.,
+# ``_CharmSpec[MyCharm]`` is assignable to ``_CharmSpec[CharmBase]``.
+# ``_CharmSpec`` is a frozen dataclass, so covariance is sound here.
+_CharmTypeCo = TypeVar('_CharmTypeCo', bound=CharmBase, covariant=True)
 _RelationType = TypeVar('_RelationType', bound='RelationBase')
 
 logger = scenario_logger.getChild('state')
@@ -2242,10 +2246,10 @@ def _apply_extensions(meta: dict[str, Any], extensions: list[str]) -> None:
 
 
 @dataclasses.dataclass(frozen=True)
-class _CharmSpec(Generic[CharmType]):
+class _CharmSpec(Generic[_CharmTypeCo]):
     """Charm spec."""
 
-    charm_type: type[CharmType]
+    charm_type: type[_CharmTypeCo]
     meta: Mapping[str, Any]
     actions: Mapping[str, Any] | None = None
     config: Mapping[str, Any] | None = None
@@ -2297,7 +2301,7 @@ class _CharmSpec(Generic[CharmType]):
         return meta, config, actions
 
     @staticmethod
-    def autoload(charm_type: type[CharmBase]) -> _CharmSpec[CharmBase]:
+    def autoload(charm_type: type[CharmType]) -> _CharmSpec[CharmType]:
         """Construct a ``_CharmSpec`` object by looking up the metadata from the charm's repo root.
 
         Will attempt to load the metadata off the ``charmcraft.yaml`` file

--- a/testing/tests/test_consistency_checker.py
+++ b/testing/tests/test_consistency_checker.py
@@ -66,6 +66,17 @@ def test_base():
     assert_consistent(state, event, spec)
 
 
+def test_charm_spec_is_covariant():
+    # _CharmSpec[Subclass] must be assignable where _CharmSpec[CharmBase] is
+    # expected, so charm libraries can pass a spec for their own CharmBase
+    # subclass into a callable typed against the base class. See #2242.
+    def takes_base_spec(spec: _CharmSpec[ops.CharmBase]) -> type[ops.CharmBase]:
+        return spec.charm_type
+
+    spec_specific: _CharmSpec[MyCharm] = _CharmSpec(MyCharm, {})
+    assert takes_base_spec(spec_specific) is MyCharm
+
+
 def test_workload_event_without_container():
     assert_inconsistent(
         State(),


### PR DESCRIPTION
`_CharmSpec[MyCharm]` isn't assignable where `_CharmSpec[ops.CharmBase]` is expected, because the type parameter is invariant. `_CharmSpec` is a frozen dataclass, so a covariant parameter is sound, and this adds a separate covariant `TypeVar` for it rather than changing the public `CharmType`, which is also used in input positions on `Context` and `Manager` and is exported, so flipping its variance would be a change for anyone annotating against it.

`autoload` is generic now too. It was typed `(type[CharmBase]) -> _CharmSpec[CharmBase]`, so it erased the subclass even before variance came into it, which is why `Context.__init__` needed a `# pyright: ignore[reportAssignmentType]` on the call. That ignore is gone, which is a reasonable check that the fix does what it says.

James asked on the issue whether to add a `TypeVar` default at the same time, for the ergonomics in cases like #2248. I've left that out: it needs `typing_extensions.TypeVar` for the Pythons we support, #2248 has since merged with a `Context[Any]` workaround, and it seems like a separate decision to the variance one.

Fixes #2242
