### PR TITLE
docs: update Concierge links and intersphinx URLs in doc source

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -327,7 +327,7 @@ intersphinx_mapping = {
     "charmcraft": ("https://canonical.com/juju/docs/charmcraft/latest", None),
     "charmlibs": ("https://canonical.com/juju/docs/charmlibs/", None),
     "concierge": ("https://canonical.com/juju/docs/concierge/", None),
-    "multipass": ("https://documentation.ubuntu.com/multipass/latest", None),
+    "multipass": ("https://canonical.com/multipass/docs/latest", None),
     "pebble": ("https://ubuntu.com/docs/pebble", None),
     "otel": ("https://opentelemetry-python.readthedocs.io/en/latest/", None),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -324,7 +324,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "jubilant": ("https://canonical.com/juju/docs/jubilant", None),
     "juju": ("https://canonical.com/juju/docs/juju-cli/3.6", None),
-    "charmcraft": ("https://documentation.ubuntu.com/charmcraft/latest", None),
+    "charmcraft": ("https://canonical.com/juju/docs/charmcraft/latest", None),
     "charmlibs": ("https://canonical.com/juju/docs/charmlibs/", None),
     "concierge": ("https://canonical.com/juju/docs/concierge/", None),
     "multipass": ("https://documentation.ubuntu.com/multipass/latest", None),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -326,6 +326,7 @@ intersphinx_mapping = {
     "juju": ("https://documentation.ubuntu.com/juju/3.6", None),
     "charmcraft": ("https://documentation.ubuntu.com/charmcraft/latest", None),
     "charmlibs": ("https://canonical.com/juju/docs/charmlibs/", None),
+    "concierge": ("https://canonical.com/juju/docs/concierge/", None),
     "multipass": ("https://documentation.ubuntu.com/multipass/latest", None),
     "pebble": ("https://ubuntu.com/docs/pebble", None),
     "otel": ("https://opentelemetry-python.readthedocs.io/en/latest/", None),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -323,7 +323,7 @@ html_js_files = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "jubilant": ("https://canonical.com/juju/docs/jubilant", None),
-    "juju": ("https://documentation.ubuntu.com/juju/3.6", None),
+    "juju": ("https://canonical.com/juju/docs/juju-cli/3.6", None),
     "charmcraft": ("https://documentation.ubuntu.com/charmcraft/latest", None),
     "charmlibs": ("https://canonical.com/juju/docs/charmlibs/", None),
     "concierge": ("https://canonical.com/juju/docs/concierge/", None),

--- a/docs/howto/manage-charms.md
+++ b/docs/howto/manage-charms.md
@@ -14,7 +14,7 @@ You'll need the following tools:
 
 To deploy your charm locally and to run integration tests, you'll also need a Juju controller.
 
-[Concierge](https://github.com/canonical/concierge) can automatically install and configure most of the tools that you'll need. Instead of installing everything on your host machine, consider using a [Multipass](https://canonical.com/multipass/install) virtual machine.
+{external+concierge:doc}`Concierge <index>` can automatically install and configure most of the tools that you'll need. Instead of installing everything on your host machine, consider using a [Multipass](https://canonical.com/multipass/install) virtual machine.
 
 See more:
 
@@ -52,7 +52,7 @@ command names and meanings that the profile provides.
 
 The following tools can also be useful during development:
 
-- To prepare an environment for running integration tests, such as in continuous integration, use [Concierge](https://github.com/canonical/concierge) or [`actions-operator`](https://github.com/charmed-kubernetes/actions-operator).
+- To prepare an environment for running integration tests, such as in continuous integration, use {external+concierge:doc}`Concierge <index>` or [`actions-operator`](https://github.com/charmed-kubernetes/actions-operator).
 - The [`charming-actions`](https://github.com/canonical/charming-actions) repository includes actions to ensure that libraries are up-to-date, publish charms and libraries, and more.
 
 The essence of a charm is the ``src/charm.py`` file. This is the entry point for

--- a/docs/howto/migrate/migrate-integration-tests-from-pytest-operator.md
+++ b/docs/howto/migrate/migrate-integration-tests-from-pytest-operator.md
@@ -113,7 +113,7 @@ commands =
 
 The `pytest-jubilant` plugin provides a module-scoped `juju` fixture that creates a temporary model, destroys it after the tests, and dumps debug logs on failure. It also provides CLI options such as `--no-juju-teardown` (to keep models) and `--juju-model` (to set a custom model name prefix).
 
-`pytest-jubilant` expects that a Juju controller has already been set up, either using [Concierge](https://github.com/canonical/concierge) or a manual approach. The plugin automatically creates a temporary model per test module and tears it down afterward.
+`pytest-jubilant` expects that a Juju controller has already been set up, either using {external+concierge:doc}`Concierge <index>` or a manual approach. The plugin automatically creates a temporary model per test module and tears it down afterward.
 
 In your tests, use the fixture like this:
 

--- a/docs/howto/set-up-continuous-integration-for-a-charm.md
+++ b/docs/howto/set-up-continuous-integration-for-a-charm.md
@@ -70,7 +70,7 @@ jobs:
 (set-up-ci-integration)=
 ## Run integration tests in CI
 
-Integration tests require a Juju controller and a cloud in which to deploy your charm. We recommend that you use [Concierge](https://github.com/canonical/concierge) to prepare the CI environment.
+Integration tests require a Juju controller and a cloud in which to deploy your charm. We recommend that you use {external+concierge:doc}`Concierge <index>` to prepare the CI environment.
 
 If your charm is a Kubernetes charm, add the following job to `.github/workflows/ci.yaml`:
 

--- a/docs/howto/write-integration-tests-for-a-charm.md
+++ b/docs/howto/write-integration-tests-for-a-charm.md
@@ -23,7 +23,7 @@ multipass launch --cpus 4 --memory 8G --disk 50G --name juju-sandbox 24.04
 multipass shell juju-sandbox  # Switch to your virtual machine.
 ```
 
-Then use [Concierge](https://github.com/canonical/concierge) to set up a Juju controller inside your virtual machine:
+Then use {external+concierge:doc}`Concierge <index>` to set up a Juju controller inside your virtual machine:
 
 ```text
 sudo snap install --classic concierge

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,7 @@ This documentation uses the [Diátaxis documentation structure](https://diataxis
   - The CLI tool for initialising charms, packing charms, and interacting with [Charmhub](https://charmhub.io/). You'll find the {external+charmcraft:ref}`charmcraft.yaml specification <charmcraft-yaml-file>` especially helpful.
 * - **{external+charmlibs:doc}`Charmlibs <index>`**
   - A listing of charm libraries and guidance on how to distribute your own libraries.
-* - **[Concierge](https://github.com/canonical/concierge)**
+* - **{external+concierge:doc}`Concierge <index>`**
   - A CLI tool for setting up charm development environments.
 * - **{external+jubilant:doc}`Jubilant <index>`**
   - A Python library that wraps the Juju CLI. Use Jubilant together with [`pytest-jubilant`](https://github.com/canonical/pytest-jubilant) for your integration tests.

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/create-a-minimal-kubernetes-charm.md
@@ -548,7 +548,7 @@ charmcraft init --profile test-kubernetes --force
 
 This creates the scaffolding of a Spread configuration; the `--force` argument is needed because there are already files in the directory. Our [httpbin-demo charm](https://github.com/canonical/operator/tree/main/examples/httpbin-demo) has a more complete configuration, which you can replicate in your charm. Pay particular attention to:
 
-- `spread.yaml` - Tells Spread how to provision a clean environment for each run, using [Concierge](https://github.com/canonical/concierge) to bootstrap Juju and the cloud substrate.
+- `spread.yaml` - Tells Spread how to provision a clean environment for each run, using {external+concierge:doc}`Concierge <index>` to bootstrap Juju and the cloud substrate.
 - The `spread` directory - Contains a file `integration/test_charm/task.yaml` that corresponds to `tests/integration/test_charm.py`.
 
 When you run `charmcraft test`, Charmcraft packs the charm, launches an LXD VM (or configures a CI runner), then invokes your pytest integration tests inside the VM.

--- a/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/set-up-your-development-environment.md
+++ b/docs/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/set-up-your-development-environment.md
@@ -49,7 +49,7 @@ Now that you have a virtual machine, you need to install the following tools on 
 - **uv** - Your charm will be a Python project. You'll use [uv](https://docs.astral.sh/uv/) to manage your charm's runtime and development dependencies.
 - **tox** - You'll use [tox](https://tox.wiki/en/) to run your charm's checks and tests.
 
-Instead of manually installing and configuring each tool, we recommend using [Concierge](https://github.com/canonical/concierge), Canonical's tool for setting up charm development environments.
+Instead of manually installing and configuring each tool, we recommend using {external+concierge:doc}`Concierge <index>`, Canonical's tool for setting up charm development environments.
 
 In your virtual machine, run:
 

--- a/docs/tutorial/write-your-first-machine-charm.md
+++ b/docs/tutorial/write-your-first-machine-charm.md
@@ -84,7 +84,7 @@ Now that you have a virtual machine, you need to install the following tools on 
 - **uv** - Your charm will be a Python project. You'll use [uv](https://docs.astral.sh/uv/) to manage your charm's runtime and development dependencies.
 - **tox** - You'll use [tox](https://tox.wiki/en/) to run your charm's checks and tests.
 
-Instead of manually installing and configuring each tool, we recommend using [Concierge](https://github.com/canonical/concierge), Canonical's tool for setting up charm development environments.
+Instead of manually installing and configuring each tool, we recommend using {external+concierge:doc}`Concierge <index>`, Canonical's tool for setting up charm development environments.
 
 In your virtual machine, run:
 


### PR DESCRIPTION
User-facing change: Link to the new [Concierge docs](https://canonical.com/juju/docs/concierge/) instead of the GitHub repo.

Internal changes: Update intersphinx URLs for Juju, Charmcraft, and Multipass. The rendered docs were already correct. This change avoids redirects when pulling inventories during our doc build.

**[Preview docs](https://canonical-juju-ops--2725.com.readthedocs.build/2725/)**