### PR TITLE
refactor: only import pdb when a debugger is actually requested

### DIFF
--- a/ops/framework.py
+++ b/ops/framework.py
@@ -22,7 +22,6 @@ import keyword
 import logging
 import marshal
 import pathlib
-import pdb
 import re
 import sys
 import types
@@ -1027,6 +1026,12 @@ class Framework(Object):
                                 event_is_from_juju or event_is_action
                             ) and self._juju_debug_at.intersection({'all', 'hook'}):
                                 # Present the welcome message and run under PDB.
+                                # `pdb` is imported here rather than at the top of the
+                                # module because it's expensive (it pulls in asyncio,
+                                # among other things) and is only needed when the user
+                                # has asked for a debugger via JUJU_DEBUG_AT.
+                                import pdb
+
                                 self._show_debug_code_message()
                                 pdb.runcall(custom_handler, event)
                             else:
@@ -1088,6 +1093,9 @@ class Framework(Object):
 
         if 'all' in indicated_breakpoints or name in indicated_breakpoints:
             self._show_debug_code_message()
+
+            # As above, `pdb` is only imported when a debugger is actually wanted.
+            import pdb
 
             # If we call set_trace() directly it will open the debugger *here*, so indicating
             # it to use our caller's frame

--- a/ops/framework.py
+++ b/ops/framework.py
@@ -1026,11 +1026,7 @@ class Framework(Object):
                                 event_is_from_juju or event_is_action
                             ) and self._juju_debug_at.intersection({'all', 'hook'}):
                                 # Present the welcome message and run under PDB.
-                                # `pdb` is imported here rather than at the top of the
-                                # module because it's expensive (it pulls in asyncio,
-                                # among other things) and is only needed when the user
-                                # has asked for a debugger via JUJU_DEBUG_AT.
-                                import pdb
+                                import pdb  # Import expensive module only when needed.
 
                                 self._show_debug_code_message()
                                 pdb.runcall(custom_handler, event)
@@ -1092,10 +1088,9 @@ class Framework(Object):
             return
 
         if 'all' in indicated_breakpoints or name in indicated_breakpoints:
-            self._show_debug_code_message()
+            import pdb  # Import expensive module only when needed.
 
-            # As above, `pdb` is only imported when a debugger is actually wanted.
-            import pdb
+            self._show_debug_code_message()
 
             # If we call set_trace() directly it will open the debugger *here*, so indicating
             # it to use our caller's frame

--- a/test/test_infra.py
+++ b/test/test_infra.py
@@ -52,6 +52,30 @@ def test_import(mod_name: str, tmp_path: pathlib.Path):
     assert proc.returncode == 0
 
 
+def test_import_does_not_pull_in_pdb(tmp_path: pathlib.Path):
+    """`pdb` is only needed when JUJU_DEBUG_AT is set, and is expensive to import.
+
+    It pulls in asyncio and the rest of the debugger stack, which is around 30ms
+    on every hook of every unit, so the import lives in the two functions that
+    use it rather than at the top of ops/framework.py. This test is here to stop
+    that quietly regressing.
+    """
+    testfile = tmp_path / 'foo.py'
+    testfile.write_text(
+        'import sys\nimport ops\nassert "pdb" not in sys.modules, sorted(sys.modules)\n',
+        encoding='utf8',
+    )
+
+    environ = os.environ.copy()
+    if 'PYTHONPATH' in environ:
+        environ['PYTHONPATH'] = os.getcwd() + os.pathsep + environ['PYTHONPATH']
+    else:
+        environ['PYTHONPATH'] = os.getcwd()
+
+    proc = subprocess.run([sys.executable, testfile], env=environ)
+    assert proc.returncode == 0
+
+
 def test_ops_testing_doc():
     """Ensure that ops.testing's documentation includes all the expected names."""
     # We only document public classes and functions.


### PR DESCRIPTION
ops/framework.py imports `pdb` at module scope, but uses it in exactly two places, both behind `JUJU_DEBUG_AT`, so every hook pays for a debugger that (comparatively) almost never runs. This PR moves the import into the two functions that use it.

The cost to import has grown with recent Python releases, because `pdb` now drags in `_colorize`, `_pyrepl` and (from 3.14) `asyncio` (nice changes in terms of what they add to `pdb`, but not free, and in the asyncio case presumably worthless for our use). Measured locally on `import ops`, dropping it is worth about 1ms on 3.10, 8ms on 3.14, and around 30ms on a 3.15.0rc2 build.

This is a significant saving if you compare it to specifically using ops. This is an insignificant saving if you compare it to using ops within a Juju hook, where there are many other operations that will dwarf the import time. I don't think it's worth trying to do other lazy imports to improve the import speed, but for this very targeted change, it does seem worthwhile.

An alternative to moving the imports would be to add them to `__lazy_modules__`. However, that would mean that the gain was only when the charm was using Python 3.15+, which is a long way off (presumably for almost every charm, that's 28.04 and later), and moving these right now is a win for existing charms.