### PR TITLE
test: canary for the tempo-coordinator nginx image missing update-ca-certificates

### DIFF
--- a/test/integration/test_infra_canary.py
+++ b/test/integration/test_infra_canary.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/integration/test_infra_canary.py
+++ b/test/integration/test_infra_canary.py
@@ -1,0 +1,65 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Canaries for upstream regressions that block tracing integration tests."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import pytest
+
+# This is the tag pinned in conftest.py via the ``nginx-image`` resource for
+# tempo-coordinator-k8s; it is also the charm's own ``upstream-source``.
+TEMPO_NGINX_IMAGE = 'ubuntu/nginx:1.24-24.04_beta'
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        'tempo-coordinator-k8s rev 143 crashes in upgrade-charm because '
+        'coordinated_workers/nginx.py:_delete_certificates calls '
+        '`update-ca-certificates --fresh` in the nginx workload container, '
+        'and the pinned ubuntu/nginx image does not ship that binary. '
+        'When this xfail unexpectedly passes, the upstream image has been '
+        'fixed and the tracing integration tests gated on it can be '
+        're-enabled.'
+    ),
+)
+def test_tempo_nginx_image_ships_update_ca_certificates():
+    """When this xpasses, the integration tests in test_tracing.py can run again."""
+    docker = shutil.which('docker') or shutil.which('podman')
+    if docker is None:
+        pytest.skip('needs docker or podman to pull and inspect the upstream image')
+
+    result = subprocess.run(
+        [
+            docker,
+            'run',
+            '--rm',
+            '--entrypoint',
+            '/bin/sh',
+            TEMPO_NGINX_IMAGE,
+            '-c',
+            'command -v update-ca-certificates',
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, (
+        f'{TEMPO_NGINX_IMAGE} still lacks update-ca-certificates '
+        f'(stdout={result.stdout!r}, stderr={result.stderr!r})'
+    )


### PR DESCRIPTION
`tempo-coordinator-k8s` rev 143 (every `2/*` channel) crashes in `upgrade-charm`, because `coordinated_workers/nginx.py:_delete_certificates` calls `update-ca-certificates --fresh` in the nginx workload container and the pinned `ubuntu/nginx:1.24-24.04_beta` image doesn't ship that binary. That blocks tracing integration tests, and there's nothing on our side to fix - so this is a canary rather than a fix.

It's a strict xfail, so it fails as soon as the upstream image gains the binary, which is the signal to re-enable the tests gated on it. Without `strict`, a fixed image would just quietly keep passing as an xpass and nobody would notice. It skips where neither docker nor podman is available.

This was originally part of #2557, which is de-pydantic'ing the tracing databag models and has nothing to do with an upstream image bug, so it's split out here to be reviewed on its own.